### PR TITLE
Fix #159, change request format 

### DIFF
--- a/evalscope/perf/http_client.py
+++ b/evalscope/perf/http_client.py
@@ -209,7 +209,7 @@ async def dispatch_requests_worker(request_queue: asyncio.Queue, args):
                 prompt = f.read()
         else:
             prompt = args.prompt
-        messages = {'role': 'user', 'content': prompt}
+        messages = [{'role': 'user', 'content': prompt}]
         request = query_generator.build_request(messages, query_parameters)
         if args.number is None:
             await request_queue.put(request)

--- a/evalscope/perf/openai_api.py
+++ b/evalscope/perf/openai_api.py
@@ -39,6 +39,8 @@ class OpenaiPlugin(ApiPluginBase):
         try:
             if param.query_template is not None:
                 query = json.loads(param.query_template)
+                if 'stream' in query.keys():
+                    param.stream = query['stream']
                 query['messages'] = messages   # replace template messages with input messages.
                 return self.__compose_query_from_parameter(query, param)
             else:


### PR DESCRIPTION
1. The Messages field in the Request should be a List object.
2. When the user specifies the stream parameter in the Query-template, it should be recognized.