### PR TITLE
feat: The evalscope perf command supports the `--outputs-dir` configuration.

### DIFF
--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -32,6 +32,9 @@ class Arguments:
     wandb_api_key: Optional[str] = None  # WandB API key for logging
     name: Optional[str] = None  # Name for the run
 
+    # Output settings
+    outputs_dir: str = 'outputs'
+
     # Prompt settings
     max_prompt_length: int = sys.maxsize  # Maximum length of the prompt
     min_prompt_length: int = 0  # Minimum length of the prompt
@@ -57,7 +60,6 @@ class Arguments:
 
     @staticmethod
     def from_args(args):
-
         return Arguments(
             model=args.model,
             attn_implementation=args.attn_implementation,
@@ -72,6 +74,7 @@ class Arguments:
             headers=args.headers,
             wandb_api_key=args.wandb_api_key,
             name=args.name,
+            outputs_dir=args.outputs_dir,
             debug=args.debug,
             tokenizer_path=args.tokenizer_path,
             api=args.api,
@@ -152,6 +155,9 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--prompt', type=str, required=False, default=None, help='Specified the request prompt')
     parser.add_argument('--query-template', type=str, default=None, help='Specify the query template')
 
+    # Output settings
+    parser.add_argument('--outputs-dir', help='Outputs dir.', default='outputs')
+
     # Dataset settings
     parser.add_argument('--dataset', type=str, default='openqa', help='Specify the dataset')
     parser.add_argument('--dataset-path', type=str, required=False, help='Path to the dataset file')
@@ -170,6 +176,7 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--stream', action='store_true', help='Stream output with SSE', default=None)
     parser.add_argument('--temperature', type=float, help='The sample temperature', default=None)
     parser.add_argument('--top-p', type=float, help='Sampling top p', default=None)
+
     # yapf: enable
 
 

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -138,7 +138,7 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
     api_plugin_class = ApiRegistry(args.api)
     api_plugin = api_plugin_class(args.tokenizer_path)
 
-    result_db_path = get_result_db_path(args.name, args.model)
+    result_db_path = get_result_db_path(args.name, args.model, args.outputs_dir)
     # Initialize wandb
     if args.wandb_api_key:
         import wandb
@@ -192,7 +192,7 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
 async def start_server(args: Arguments) -> bool:
     if args.api.startswith('local'):
         #  start local server
-        server = threading.Thread(target=start_app, args=(copy.deepcopy(args), ), daemon=True)
+        server = threading.Thread(target=start_app, args=(copy.deepcopy(args),), daemon=True)
         server.start()
 
         if args.dataset.startswith('speed_benchmark'):

--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -88,9 +88,8 @@ def insert_benchmark_data(cursor: sqlite3.Cursor, benchmark_data: BenchmarkData)
         cursor.execute(query, common_columns)
 
 
-def get_result_db_path(name, model):
+def get_result_db_path(name, model, output_dir):
     current_time = datetime.now().strftime('%Y%m%d_%H%M%S')
-    output_dir = './outputs'
     result_db_path = os.path.join(output_dir, f'{name or model}_perf', current_time, 'benchmark_data.db')
 
     if not os.path.exists(os.path.dirname(result_db_path)):


### PR DESCRIPTION
For example, when writing automated benchmark scenarios, reports can be generated in different directories based on varying test conditions.

```
#!/bin/bash

# Define an array of concurrency levels
concurrency_levels=(1 10 20 30 50 100 150 200 250 300)

# Set other fixed parameters
model="Qwen2.5-72B-Instruct"
url="http://localhost:8000/v1/chat/completions"
service_kind="openai"
dataset_path="/datasets/open_qa.jsonl"
dataset="openqa"
read_timeout=120
log_every_n_query=10
stream="--stream"

# Define the GPU status endpoint
GPU_STATUS_URL="http://localhost:5000/gpu_status"

# Define the base directory for output reports
outputs_base_dir="./outputs"

# Create a log file
log_file="genai_perf_log.txt"
echo "Logging output to $log_file" > $log_file

# Function to fetch GPU status
fetch_gpu_status() {
  local outputs_dir="$1"
  while true; do
    local timestamp=$(date "+%Y%m%d_%H%M%S")
    local gpu_log_file="${outputs_dir}/gpu_status_${timestamp}.json"
    curl -s "$GPU_STATUS_URL" >> "$gpu_log_file"
    echo "" >> "$gpu_log_file"  # Add a newline for readability between JSON entries
    sleep 5
  done
}

# Iterate over each concurrency level
for concurrency in "${concurrency_levels[@]}"; do
  # Calculate the number based on concurrency
  number=$((concurrency * 10))
  echo "Running evalscope perf with concurrency: $concurrency and number: $number" | tee -a $log_file

  # Dynamically generate the artifact-dir path
  outputs_dir="${outputs_base_dir}/${model}-concurrency${concurrency}"
  mkdir -p "$outputs_dir"  # Ensure the directory exists

  # Run the command and record output with tee
  evalscope perf \
    --url "$url" \
    --parallel "$concurrency" \
    --model "$model" \
    --number "$number" \
    --log-every-n-query "$log_every_n_query" \
    --read-timeout="$read_timeout" \
    --dataset-path "$dataset_path" \
    --api "$service_kind" \
    --dataset "$dataset" \
    --outputs-dir "$outputs_dir" \
    $stream | tee -a $log_file &

  # Capture the PID of the background evalscope process
  evalscope_pid=$!

  # Fetch GPU status while evalscope is running
  fetch_gpu_status "$outputs_dir" &
  fetch_gpu_status_pid=$!

  # Wait for evalscope to complete
  wait $evalscope_pid

  # Kill the fetch_gpu_status process
  kill $fetch_gpu_status_pid

  # Only sleep if there are more items to process
  if [[ $concurrency -ne ${concurrency_levels[-1]} ]]; then
    echo "Sleeping for 30 seconds..." | tee -a $log_file
    sleep 30
  fi
done

echo "All tasks completed." | tee -a $log_file

```