### PR TITLE
fix predict 

### DIFF
--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -114,7 +114,9 @@ class TaskConfig:
     def from_args(args: Namespace):
         # Convert Namespace to a dictionary and filter out None values
         args_dict = {k: v for k, v in vars(args).items() if v is not None}
-        del args_dict['func']  # Note: compat CLI arguments
+
+        if 'func' in args_dict:
+            del args_dict['func']  # Note: compat CLI arguments
 
         return TaskConfig.from_dict(args_dict)
 

--- a/evalscope/models/model_adapter.py
+++ b/evalscope/models/model_adapter.py
@@ -429,7 +429,7 @@ class ChatGenerationModelAdapter(BaseModelAdapter):
         fix_do_sample_warning(self.generation_config)
 
         # Run inference
-        output_ids = self.model.generate(**inputs, generation_config=self.generation_config)
+        output_ids = self.model.generate(input_ids, generation_config=self.generation_config)
 
         response = self.tokenizer.decode(output_ids[0, len(input_ids[0]):], skip_special_tokens=True)
         return response


### PR DESCRIPTION
fix error: 
```
`model_kwargs` are not used by the model: ['token_type_ids'] (note: typos in the generate arguments will also show up in this list)
```