### PR TITLE
add SwanLab Support 添加SwanLab可视化支持

### DIFF
--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -70,4 +70,5 @@ Here's the English translation:
 
 ## Data Storage
 - `--wandb-api-key`: wandb API key, if set, metrics will be saved to wandb.
+- `--swanlab-api-key`: swanlab API key, if set, metrics will be saved to swanlab.
 - `--outputs-dir` specifies the output file path, with a default value of `./outputs`.

--- a/docs/en/user_guides/stress_test/quick_start.md
+++ b/docs/en/user_guides/stress_test/quick_start.md
@@ -157,6 +157,8 @@ Percentile results:
 
 ## Visualizing Test Results
 
+### Visualizing with WandB
+
 First, install wandb and obtain the corresponding [API Key](https://wandb.ai/settings):
 ```bash
 pip install wandb
@@ -172,3 +174,35 @@ To upload the test results to the wandb server and visualize them, add the follo
 For example:
 
 ![wandb sample](https://modelscope.oss-cn-beijing.aliyuncs.com/resource/wandb_sample.png)
+
+
+### Visualizing Test Results with SwanLab
+
+First, install SwanLab and obtain the corresponding [API Key](https://swanlab.cn/space/~/settings):
+```bash
+pip install swanlab
+```
+
+To upload the test results to the wandb server and visualize them, add the following parameters when launching the evaluation:
+```bash
+# ...
+--swanlab-api-key 'swanlab_api_key'
+--name 'name_of_swanlab_log'
+```
+
+For example:
+
+![swanlab sample](waiting for link)
+
+If you prefer to use [SwanLab in local dashboard mode](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html), install swanlab dashboard first:
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+and set the following parameters instead:
+```bash
+--swanlab-api-key local
+```
+
+Then, use `swanlab watch <log_path>` to launch the local visualization dashboard.

--- a/docs/zh/user_guides/stress_test/examples.md
+++ b/docs/zh/user_guides/stress_test/examples.md
@@ -164,6 +164,21 @@ evalscope perf \
   --debug
 ```
 
+## 使用SwanLab记录测试结果
+
+请使用如下命令安装SwanLab:
+```bash
+pip install swanlab
+```
+
+启动测试前添加如下参数:
+```bash
+--swanlab-api-key 'swanlab_api_key'
+--name 'name_of_swanlab_log'
+```  
+
+![swanlab sample](waiting for link)
+
 ## 调试请求
 使用 `--debug` 选项，我们将输出请求和响应，输出示例如下：
 

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -69,4 +69,5 @@
 
 ## 数据存储
 - `--wandb-api-key` wandb API密钥，如果设置，则度量将保存到wandb。
+- `--swanlab-api-key` swanlab API密钥，如果设置，则度量将保存到swanlab。
 - `--outputs-dir` 输出文件路径，默认为`./outputs`。

--- a/docs/zh/user_guides/stress_test/quick_start.md
+++ b/docs/zh/user_guides/stress_test/quick_start.md
@@ -155,6 +155,8 @@ Percentile results:
 
 ## 可视化测试结果
 
+### 使用WandB进行可视化测试结果
+
 请先安装wandb，并获取对应的[API Key](https://wandb.ai/settings)：
 ```bash
 pip install wandb
@@ -170,3 +172,36 @@ pip install wandb
 例如：
 
 ![wandb sample](https://modelscope.oss-cn-beijing.aliyuncs.com/resource/wandb_sample.png)
+
+### 使用SwanLab进行可视化测试结果
+
+请先安装SwanLab，并获取对应的[API Key](https://swanlab.cn/space/~/settings)
+
+```bash
+pip install swanlab
+```
+
+在评测启动时，额外添加以下参数，即可将测试结果上传swanlab server并进行可视化：
+```bash
+# ...
+--swanlab-api-key 'swanlab_api_key'
+--name 'name_of_swanlab_log'
+```
+
+例如：
+
+![swanlab sample](waiting for link)
+
+如果希望仅[使用SwanLab本地看板模式](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)，先安装swanlab离线看板：
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+再通过设置如下参数：
+
+```bash
+--swanlab-api-key local
+```
+
+并通过`swanlab watch <日志路径>`打开本地可视化看板。

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -35,6 +35,7 @@ class Arguments:
     log_every_n_query: int = 10  # Log every N queries
     debug: bool = False  # Debug mode
     wandb_api_key: Optional[str] = None  # WandB API key for logging
+    swanlab_api_key: Optional[str] = None  # SwanLab API key for logging
     name: Optional[str] = None  # Name for the run
 
     # Output settings
@@ -135,7 +136,8 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--log-every-n-query', type=int, default=10, help='Logging every n query')
     parser.add_argument('--debug', action='store_true', default=False, help='Debug request send')
     parser.add_argument('--wandb-api-key', type=str, default=None, help='The wandb API key')
-    parser.add_argument('--name', type=str, help='The wandb db result name and result db name')
+    parser.add_argument('--swanlab-api-key', type=str, default=None, help='The swanlab API key')
+    parser.add_argument('--name', type=str, help='The wandb/swanlab db result name and result db name')
 
     # Prompt settings
     parser.add_argument('--max-prompt-length', type=int, default=sys.maxsize, help='Maximum input prompt length')

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -139,11 +139,11 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
                 "Cannot import swanlab. Please install it with command: \n pip install swanlab"
             )
         os.environ['SWANLAB_LOG_DIR'] = args.outputs_dir
-
-        swanlab.login(api_key=args.swanlab_api_key)
+        if not args.swanlab_api_key=="local":
+            swanlab.login(api_key=args.swanlab_api_key)
         current_time = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
         name = args.name if args.name else f'{args.model_id}_{current_time}'
-        swanlab.init(project='perf_benchmark', name=name, config=args.to_dict(),)
+        swanlab.init(project='perf_benchmark', name=name, config=args.to_dict(), mode="local" if args.swanlab_api_key=="local" else None)
 
 
     collected_benchmark_data = []

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -116,7 +116,12 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
     # Initialize wandb if the api key is provided
     if args.wandb_api_key:
         import datetime
-        import wandb
+        try:
+            import wandb
+        except ImportError:
+            raise RuntimeError(
+                "Cannot import wandb. Please install it with command: \n pip install wandb"
+            )
         os.environ['WANDB_SILENT'] = 'true'
         os.environ['WANDB_DIR'] = args.outputs_dir
 
@@ -127,7 +132,12 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
     # Initialize SwanLab if the api key is provided
     if args.swanlab_api_key:
         import datetime
-        import swanlab
+        try:
+            import swanlab
+        except ImportError:
+            raise RuntimeError(
+                "Cannot import swanlab. Please install it with command: \n pip install swanlab"
+            )
         os.environ['SWANLAB_SAVE_DIR'] = args.outputs_dir
 
         swanlab.login(api_key=args.swanlab_api_key)

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -138,12 +138,12 @@ async def statistic_benchmark_metric_worker(benchmark_data_queue: asyncio.Queue,
             raise RuntimeError(
                 "Cannot import swanlab. Please install it with command: \n pip install swanlab"
             )
-        os.environ['SWANLAB_SAVE_DIR'] = args.outputs_dir
+        os.environ['SWANLAB_LOG_DIR'] = args.outputs_dir
 
         swanlab.login(api_key=args.swanlab_api_key)
         current_time = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
         name = args.name if args.name else f'{args.model_id}_{current_time}'
-        swanlab.init(project='perf_benchmark', name=name, config=args.to_dict())
+        swanlab.init(project='perf_benchmark', name=name, config=args.to_dict(),)
 
 
     collected_benchmark_data = []


### PR DESCRIPTION
## 贡献简介

希望为Evalscope项目增加SwanLab作为可视化支持之一，使用户能够更方便地跟踪和分析评测结果。

## 主要改动

1. 新增SwanLab集成功能，支持将评测结果可视化

2. 添加相关命令行参数和环境变量配置选项

3. 更新文档说明SwanLab的使用方法

## 使用说明

安装SwanLab，并获取对应的[API Key](https://swanlab.cn/space/~/settings)

```bash
pip install swanlab
```

在评测启动时，额外添加以下参数，即可将测试结果上传swanlab server并进行可视化：
```bash
# ...
--swanlab-api-key 'swanlab_api_key'
--name 'name_of_swanlab_log'
```

效果如下

<img width="2532" alt="Screenshot 2025-04-06 at 15 27 55" src="https://github.com/user-attachments/assets/c1174060-0fe3-4fcf-ad22-7697caa8bdf7" />

<img width="2205" alt="Screenshot 2025-04-06 at 16 03 27" src="https://github.com/user-attachments/assets/3735799a-d36c-4874-9c3e-b51c294eaea8" />

效果对齐WandB:

<img width="2535" alt="Screenshot 2025-04-06 at 15 28 42" src="https://github.com/user-attachments/assets/044933ef-b72e-4514-b83e-1f88a8e5d13e" />

如果希望仅[使用SwanLab本地看板模式](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)，先安装swanlab离线看板：

```bash
pip install 'swanlab[dashboard]'
```

再通过设置如下参数：

```bash
--swanlab-api-key local
```

并通过`swanlab watch <日志路径>`打开本地可视化看板。

## 补充说明：

我看到此前文档中的图片都来自阿里云的对象存储，因此我将所有添加到文档中的图片标注为`![swanlab example](waiting for link)`，如果合并的话烦请替换一下😊