### PR TITLE
fix multi shape mean

### DIFF
--- a/evalscope/metrics/metrics.py
+++ b/evalscope/metrics/metrics.py
@@ -17,7 +17,10 @@ def mean(arr: list):
         return 0.0
 
     if isinstance(arr[0], list):
-        arr = [item for sublist in arr for item in sublist]
+        if isinstance(arr[0][0], list):
+            arr = [item for sublist in arr for item in sublist]
+        else:
+            arr = [item for item in arr]
     return sum(arr) / len(arr)
 
 


### PR DESCRIPTION
Traceback (most recent call last):

File "/home/jeeves/.local/bin/evalscope", line 33, in <module>

sys.exit(load_entry_point('evalscope', 'console_scripts', 'evalscope')())

File "/local/apps/evalscope/evalscope/cli/cli.py", line 25, in run_cmd

cmd.execute()

File "/local/apps/evalscope/evalscope/cli/start_eval.py", line 32, in execute

run_task(self.args)

File "/local/apps/evalscope/evalscope/run.py", line 31, in run_task

return run_single_task(task_cfg, run_time)

File "/local/apps/evalscope/evalscope/run.py", line 44, in run_single_task

return evaluate_model(task_cfg, outputs)

File "/local/apps/evalscope/evalscope/run.py", line 117, in evaluate_model

res_dict = evaluator.eval()

File "/local/apps/evalscope/evalscope/evaluator/evaluator.py", line 378, in eval

metric_res = self.compute_metrics(reviews_list=reviews_list)

File "/local/apps/evalscope/evalscope/evaluator/evaluator.py", line 296, in compute_metrics

metric_score: List[dict] = self.data_adapter.compute_metric(

File "/local/apps/evalscope/evalscope/benchmarks/data_adapter.py", line 240, in compute_metric

res_list.append({'metric_name': metric_name, 'score': metric_func(review_res), 'num': len(review_res)})

File "/local/apps/evalscope/evalscope/metrics/metrics.py", line 20, in mean

arr = [item for sublist in arr for item in sublist]

File "/local/apps/evalscope/evalscope/metrics/metrics.py", line 20, in <listcomp>

arr = [item for sublist in arr for item in sublist]

TypeError: 'int' object is not iterable