### PR TITLE
fix: improve multi-choice result handling in evaluator

### DIFF
--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -317,6 +317,8 @@ class Evaluator(object):
         """
 
         review_res_list = []
+        max_choices = max(
+            len(review_d[AnswerKeys.CHOICES]) for review_d in reviews_list if review_d[ReviewKeys.REVIEWED])
         for review_d in reviews_list:
             if not review_d[ReviewKeys.REVIEWED]:
                 logger.warning(f'Review not finished for answer_id: {review_d[AnswerKeys.ANSWER_ID]}')
@@ -325,10 +327,14 @@ class Evaluator(object):
             if len(review_d[AnswerKeys.CHOICES]) == 0:
                 logger.warning(f'No choices found for answer_id: {review_d[AnswerKeys.ANSWER_ID]}')
                 continue
-            elif len(review_d[AnswerKeys.CHOICES]) == 1:
+            elif len(review_d[AnswerKeys.CHOICES]) == 1 and max_choices == 1:
                 review_res = review_d[AnswerKeys.CHOICES][0][ReviewKeys.REVIEW][ReviewKeys.RESULT]
             else:
                 review_res = [choice[ReviewKeys.REVIEW][ReviewKeys.RESULT] for choice in review_d[AnswerKeys.CHOICES]]
+                if len(review_d[AnswerKeys.CHOICES]) < max_choices:
+                    logger.warning(
+                        f'Less choices found for answer_id: {review_d[AnswerKeys.ANSWER_ID]}, '
+                        f'max_choices is {max_choices}, but only {len(review_d[AnswerKeys.CHOICES])} choices found')
 
             review_res_list.append(review_res)
 


### PR DESCRIPTION
## 问题描述
当使用 `n>1` 进行模型生成时，我们发现模型返回的选项数量可能少于请求数量。这导致 `review_res_list` 中出现了格式不一致的情况，同时包含列表和非列表元素，从而引发评估错误。

例如：
- 当请求 n=3 个选项时，某些响应可能只返回 1 个（出现这个的原因很多，比如服务不稳定）
- 当前逻辑对单选项（len=1）的响应采用了与多选项不同的处理方式
- 这导致 `review_res_list` 中出现混合类型：`[review_res1, [review_res2, review_res3], review_res4]`

https://github.com/modelscope/evalscope/issues/512 这个 issue 中的问题也是这个原因

## 解决方案
1. 添加了对所有响应中最大选项数的追踪
2. 修改了单选项处理逻辑：
   - 仅当当前选项数量为 1 且最大选项数也为 1 时，才作为单一结果处理
   - 其他情况下，始终将结果包装为列表以保持格式一致
3. 添加了警告日志，以帮助识别响应选项数量少于预期的情况

## 测试验证
- 测试了 n>1 场景下模型返回不同数量选项的情况
- 验证了评估结果现在保持一致的格式（n>1 时始终为列表）
- 添加的警告日志有助于追踪潜在的模型响应问题

## 影响范围
这个修复确保了在使用多选项生成时评估结果的一致性，防止因结果格式混合而导致的指标计算错误。