### PR TITLE
 Bug Fix: Allow Custom SwanLab Project Name

### DIFF
--- a/evalscope/perf/utils/log_utils.py
+++ b/evalscope/perf/utils/log_utils.py
@@ -35,7 +35,7 @@ def init_swanlab(args: Arguments) -> None:
     name = args.name if args.name else f'{args.model_id}_{current_time}'
     swanlab.config.update({'framework': '📏evalscope'})
     swanlab.init(
-        project='perf_benchmark',
+        project=os.getenv('SWANLAB_PROJ_NAME', 'perf_benchmark'),
         name=name,
         config=args.to_dict(),
         mode='local' if args.swanlab_api_key == 'local' else None)


### PR DESCRIPTION
Previously, there was no way to specify a custom project name for SwanLab logging — it would always default to 'perf_benchmark'. This PR fixes that by reading the project name from the environment variable SWANLAB_PROJ_NAME, falling back to 'perf_benchmark' if not set, ensuring users can now customize the project name as needed.

**Changes Made:**

Updated swanlab.init() call to use os.getenv('SWANLAB_PROJ_NAME', 'perf_benchmark') for dynamic project naming.
Usage Example:

```bash
export SWANLAB_PROJ_NAME=my_custom_project_name
python run_benchmark.py --name my_experiment
```

This change improves flexibility for tracking experiments under different project names in SwanLab.

Hope you can merge 😊