### PR TITLE
新增judge模型的缓存利用

### DIFF
--- a/evalscope/collections/evaluator.py
+++ b/evalscope/collections/evaluator.py
@@ -263,8 +263,7 @@ class EvaluatorCollection:
             else:
                 os.remove(review_file_path)
         elif self.task_cfg.use_cache and os.path.exists(review_file_path):
-            logger.warning(
-                f'use_cache={self.task_cfg.use_cache}, reloading the review file: {review_file_path} ...')
+            logger.warning(f'use_cache={self.task_cfg.use_cache}, reloading the review file: {review_file_path} ...')
             if os.path.isdir(review_file_path):
                 for filename in os.listdir(review_file_path):
                     if '.ipynb_checkpoints' in filename:

--- a/evalscope/collections/evaluator.py
+++ b/evalscope/collections/evaluator.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from tabulate import tabulate
 from tqdm import tqdm
-from typing import List
+from typing import Any, Dict, List
 
 from evalscope.benchmarks import Benchmark, DataAdapter
 from evalscope.collections.sampler import DatasetEntry
@@ -244,48 +244,78 @@ class EvaluatorCollection:
                             pbar.update(len(batch_ids))
         return answers
 
-    def get_reviews(self, answers):
+    def get_reviews(self, answers: Dict[int, Any]) -> Dict[int, Any]:
+        """
+        Retrieve or generate reviews for given answers.
+
+        Args:
+            answers: Dictionary of answers indexed by sample index.
+
+        Returns:
+            Dictionary of reviews indexed by sample index.
+        """
+        # Set up the review file path
         review_file_path = os.path.join(self.outputs.reviews_dir, self.task_cfg.model_id)
         os.makedirs(review_file_path, exist_ok=True)
 
         review_history_map = defaultdict(dict)
-        if not self.task_cfg.use_cache and os.path.exists(review_file_path):
-            logger.warning(
-                f'Ignore use_cache={self.task_cfg.use_cache}, updating the review file: {review_file_path} ...')
-            if os.path.isdir(review_file_path):
-                for filename in os.listdir(review_file_path):
-                    file_path = os.path.join(review_file_path, filename)
-                    try:
-                        if os.path.isfile(file_path):
-                            os.remove(file_path)
-                    except Exception as e:
-                        logger.error(f'Error deleting file {file_path}: {e}')
-            else:
-                os.remove(review_file_path)
-        elif self.task_cfg.use_cache and os.path.exists(review_file_path):
-            logger.warning(f'use_cache={self.task_cfg.use_cache}, reloading the review file: {review_file_path} ...')
-            if os.path.isdir(review_file_path):
-                for filename in os.listdir(review_file_path):
-                    if '.ipynb_checkpoints' in filename:
-                        continue
-                    file_path = os.path.join(review_file_path, filename)
-                    review_history = [json.loads(line.strip()) for line in open(file_path)]
-                    review_history_map[filename] = {item['index']: item for item in review_history}
 
-        reviews = defaultdict(dict)
+        # Handle caching logic
+        if os.path.exists(review_file_path):
+            if not self.task_cfg.use_cache:
+                # Clear existing reviews if not using cache
+                self._clear_review_files(review_file_path)
+            else:
+                # Load existing reviews if using cache
+                self._load_existing_reviews(review_file_path, review_history_map)
+
+        reviews = {}
         for sample in tqdm(self.dataset, desc='Getting reviews'):
             file_name = f'{self.dataset_name}_{sample.dataset_name}_{sample.subset_name}.jsonl'
+
             if self.task_cfg.use_cache and sample.index in review_history_map.get(file_name, {}):
+                # Use cached review if available
                 review_d = review_history_map[file_name][sample.index]
             else:
+                # Generate new review
                 evaluator = self.evaluators[sample.dataset_name]
                 review_d = evaluator.get_review(answers[sample.index])
+                # Only save the review if it's not in the cache
+                self._save_review(review_file_path, file_name, review_d)
+
             reviews[sample.index] = review_d
-            dump_jsonl_data(
-                review_d,
-                os.path.join(review_file_path, f'{self.dataset_name}_{sample.dataset_name}_{sample.subset_name}.jsonl'),
-                dump_mode=DumpMode.APPEND)
+
         return reviews
+
+    def _clear_review_files(self, review_file_path: str) -> None:
+        """Clear existing review files."""
+        if os.path.isdir(review_file_path):
+            for filename in os.listdir(review_file_path):
+                file_path = os.path.join(review_file_path, filename)
+                try:
+                    if os.path.isfile(file_path):
+                        os.remove(file_path)
+                except Exception as e:
+                    logger.error(f'Error deleting file {file_path}: {e}')
+        else:
+            os.remove(review_file_path)
+
+    def _load_existing_reviews(self, review_file_path: str, review_history_map: Dict[str, Dict[int, Any]]) -> None:
+        """Load existing reviews from files."""
+        logger.info(f'use_cache={self.task_cfg.use_cache}, reloading the review file: {review_file_path}')
+        if os.path.isdir(review_file_path):
+            for filename in os.listdir(review_file_path):
+                if '.ipynb_checkpoints' in filename:
+                    continue
+                file_path = os.path.join(review_file_path, filename)
+                with open(file_path, 'r') as f:
+                    review_history = [json.loads(line.strip()) for line in f]
+                review_history_map[filename] = {item['index']: item for item in review_history}
+
+    def _save_review(self, review_file_path: str, file_name: str, review_d: Dict[str, Any]) -> None:
+        """Save a single review to file."""
+        file_path = os.path.join(review_file_path, file_name)
+        dump_jsonl_data(review_d, file_path, dump_mode=DumpMode.APPEND)
 
     def get_scores(self, reviews) -> float:
         scores = defaultdict(dict)

--- a/tests/cli/test_collection.py
+++ b/tests/cli/test_collection.py
@@ -78,7 +78,8 @@ class TestCollection(unittest.TestCase):
                 'model_id': 'qwen2.5-7b-instruct',
                 'api_url': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
                 'api_key': os.getenv('DASHSCOPE_API_KEY'),
-            }
+            },
+            use_cache='outputs/20250519_114427'
         )
         res = run_task(task_cfg=task_cfg)
         print(res)


### PR DESCRIPTION
当前代码在设置use-cache时，inference会复用之前的结果，但是eval阶段，judge-model不会复用之前的predict结果。现在修改了对应的逻辑，使得use-cache时能够使用judge model的cache结果。

本地测试效果正确