### PR TITLE
make sure the stream parameter is included in the request_json

### DIFF
--- a/evalscope/models/adapters/server_adapter.py
+++ b/evalscope/models/adapters/server_adapter.py
@@ -97,8 +97,8 @@ class ServerModelAdapter(BaseModelAdapter):
         if self.timeout:
             request_json['timeout'] = self.timeout
 
+        request_json['stream'] = self.stream
         if self.stream:
-            request_json['stream'] = self.stream
             request_json['stream_options'] = {'include_usage': True}
 
         logger.debug(f'Request to remote API: {request_json}')


### PR DESCRIPTION
Make sure the `stream` parameter is included in the `request_json`, because some privately deployed large model services set the `stream` parameter to `True` by default.