### PR TITLE
Fix: Incorrect keyword argument in call to csv_to_list()

### DIFF
--- a/evalscope/summarizer.py
+++ b/evalscope/summarizer.py
@@ -80,7 +80,7 @@ class Summarizer:
 
                 summary_file_path = summary_files[0]
                 # Example: [{'dataset': 'gsm8k', 'version': '1d7fe4', 'metric': 'accuracy', 'mode': 'gen', 'qwen-7b-chat': '53.98'} # noqa: E501
-                summary_res: List[dict] = csv_to_list(file_path=summary_file_path)
+                summary_res: List[dict] = csv_to_list(summary_file_path)
                 final_res_list.extend(summary_res)
             elif eval_backend == EvalBackend.VLM_EVAL_KIT:
                 eval_config = Summarizer.parse_eval_config(candidate_task)


### PR DESCRIPTION
### Summary

This PR fixes a `TypeError` caused by an incorrect keyword argument (`file_path=...`) passed to the `csv_to_list()` function in `summarizer.py`.

### Problem

The current call:

```python
csv_to_list(file_path=summary_file_path)
````

raises the following error at runtime:

```
TypeError: csv_to_list() got an unexpected keyword argument 'file_path'
```

This happens because the `csv_to_list()` function only accepts a single positional argument:

```python
def csv_to_list(csv_file)
```

### Fix

Changed the call to:

```python
csv_to_list(summary_file_path)
```

which correctly matches the function's signature.

### Impact

This fix allows the summarizer to work as expected when generating reports via `Summarizer.get_report_from_cfg(...)`.

No other functionality is affected.
