### PR TITLE
fix: make _temp_run top-level to resolve M1 pickle error

### DIFF
--- a/evalscope/benchmarks/live_code_bench/evaluate_utils.py
+++ b/evalscope/benchmarks/live_code_bench/evaluate_utils.py
@@ -8,9 +8,9 @@ from .pass_k_utils import compute_metrics_from_results
 
 logger = get_logger()
 
+
 def _temp_run(sample, generation, debug, result, metadata_list, timeout):
     """Runs a test in a separate process to enforce a timeout.
-
     This function is defined at the module's top level to ensure it can be
     pickled by `multiprocessing.Process`. This is a requirement on platforms
     like macOS (on Apple Silicon) which use the 'spawn' start method, as
@@ -21,13 +21,13 @@ def _temp_run(sample, generation, debug, result, metadata_list, timeout):
     result.append(res)
     metadata_list.append(metadata)
 
+
 def codegen_check_correctness(sample, generation, timeout, debug=True):
     """Check correctness of code generation with a global timeout.
 
     The global timeout is to catch some extreme/rare cases not handled by the
     timeouts inside `run_test`
     """
-
 
     manager = multiprocessing.Manager()
     result = manager.list()


### PR DESCRIPTION
**Bug:**  
On Apple-Silicon Macs the sandbox process crashes with  
`AttributeError: Can't pickle local object 'codegen_check_correctness.<locals>._temp_run'`  
because Python 3.9+ uses *spawn* mode and nested functions are not picklable.

**Fix:**  
Move `_temp_run` to module top-level; no logic change, no new deps.  
Now `multiprocessing.Process` can pickle the target function and **Pass@1 evaluation on *live_code_bench*** succeeds on M1/M2 machines while remaining fully backward-compatible with Linux/Intel systems.

**Eval command with full debug logs:**  

```bash
(evalscope) mou@moudeMac-mini dataset % evalscope eval \
  --model qwen3-30b-a3b-mxfp4 \
  --api-url http://localhost:44441/v1 \
  --eval-type openai_api \
  --datasets live_code_bench \
  --dataset-args '{"live_code_bench": {"few_shot_num": 0, "few_shot_random": false, "extra_params": {"debug": true}}}' \
  --debug \
  --limit 1
2025-09-11 14:47:20 - evalscope - INFO: Args: Task config is provided with CommandLine type.
2025-09-11 14:47:20 - evalscope - model.py - get_model - 366 - INFO: Creating model qwen3-30b-a3b-mxfp4 with eval_type=openai_api base_url=http://localhost:44441/v1, api_key=EMPTY, config=timeout=None batch_size=1 stream=None system_message=None max_tokens=2048 top_p=None temperature=0.0 stop_seqs=None best_of=None frequency_penalty=None presence_penalty=None logit_bias=None seed=None do_sample=None top_k=None n=None logprobs=None top_logprobs=None parallel_tool_calls=None internal_tools=None max_tool_output=None cache_prompt=None reasoning_effort=None reasoning_tokens=None reasoning_summary=None reasoning_history=None response_schema=None extra_body=None height=None width=None num_inference_steps=None guidance_scale=None, model_args={}
2025-09-11 14:47:20 - evalscope - config.py - dump_yaml - 235 - INFO: Dump task config to ./outputs/20250911_144720/configs/task_config_ec8c4f.yaml
2025-09-11 14:47:20 - evalscope - run.py - evaluate_model - 140 - INFO: {
    "model": "qwen3-30b-a3b-mxfp4",
    "model_id": "qwen3-30b-a3b-mxfp4",
    "model_args": {},
    "model_task": "text_generation",
    "chat_template": null,
    "datasets": [
        "live_code_bench"
    ],
    "dataset_args": {
        "live_code_bench": {
            "name": "live_code_bench",
            "dataset_id": "AI-ModelScope/code_generation_lite",
            "output_types": [
                "generation"
            ],
            "subset_list": [
                "release_latest"
            ],
            "default_subset": "default",
            "few_shot_num": 0,
            "few_shot_random": false,
            "train_split": null,
            "eval_split": "test",
            "prompt_template": "### Question:\n{question_content}\n\n{format_prompt} ### Answer: (use the provided format with backticks)\n\n",
            "few_shot_prompt_template": null,
            "system_prompt": null,
            "query_template": null,
            "pretty_name": "Live-Code-Bench",
            "description": "Live Code Bench is a benchmark for evaluating code generation models on real-world coding tasks. It includes a variety of programming problems with test cases to assess the model's ability to generate correct and efficient code solutions.",
            "tags": [
                "Coding"
            ],
            "filters": null,
            "metric_list": [
                "Pass@1"
            ],
            "aggregation": "mean",
            "shuffle": false,
            "shuffle_choices": false,
            "extra_params": {
                "debug": true
            }
        }
    },
    "dataset_dir": "/Users/mou/.cache/modelscope/hub/datasets",
    "dataset_hub": "modelscope",
    "repeats": 1,
    "generation_config": {
        "batch_size": 1,
        "max_tokens": 2048,
        "temperature": 0.0
    },
    "eval_type": "openai_api",
    "eval_backend": "Native",
    "eval_config": null,
    "limit": 1,
    "eval_batch_size": 1,
    "use_cache": null,
    "rerun_review": false,
    "work_dir": "./outputs/20250911_144720",
    "ignore_errors": false,
    "debug": true,
    "seed": 42,
    "api_url": "http://localhost:44441/v1",
    "timeout": null,
    "stream": null,
    "judge_strategy": "auto",
    "judge_worker_num": 1,
    "judge_model_args": {},
    "analysis_report": false
}
Processing records: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 2071.26it/s]
2025-09-11 14:47:20 - evalscope - evaluator.py - _predict_sample - 210 - DEBUG: 
Sample ID: 0
Input: **User**: 
### Question:
There are three cards with letters $\texttt{a}$, $\texttt{b}$, $\texttt{c}$ placed in a row in some order. You can do the following operation at most once: 

 
-  Pick two cards, and swap them.  Is it possible that the row becomes $\texttt{abc}$ after the operation? Output "YES" if it is possible, and "NO" otherwise.

Input

The first line contains a single integer $t$ ($1 \leq t \leq 6$) — the number of test cases.

The only line of each test case contains a single string consisting of each of the three characters $\texttt{a}$, $\texttt{b}$, and $\texttt{c}$ exactly once, representing the cards.

Output

For each test case, output "YES" if you can make the row $\texttt{abc}$ with at most one operation, or "NO" otherwise.

You can output the answer in any case (for example, the strings "yEs", "yes", "Yes" and "YES" will be recognized as a positive answer).Sample Input 1:
6

abc

acb

bac

bca

cab

cba



Sample Output 1:

YES
YES
YES
NO
NO
YES


Note

In the first test case, we don't need to do any operations, since the row is already $\texttt{abc}$.

In the second test case, we can swap $\texttt{c}$ and $\texttt{b}$: $\texttt{acb} \to \texttt{abc}$.

In the third test case, we can swap $\texttt{b}$ and $\texttt{a}$: $\texttt{bac} \to \texttt{abc}$.

In the fourth test case, it is impossible to make $\texttt{abc}$ using at most one operation.

### Format: Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows.
```python
# YOUR CODE HERE
```

 ### Answer: (use the provided format with backticks)


Target: 
Predicting[live_code_bench@release_latest]:   0%|                                                                                         | 0/1 [00:00<?, ?it/s]2025-09-11 14:47:36 - evalscope - evaluator.py - get_answers - 186 - DEBUG: Model result: 
{
  "index": 0,
  "model": "qwen3-30b-a3b-mxfp4",
  "model_output": {
    "model": "qwen3-30b-a3b-mxfp4",
    "choices": [
      {
        "message": {
          "id": "c98da801",
          "content": "I'll solve this step by step.\n\n## Problem Understanding\n\n1. We have three cards with letters 'a', 'b', 'c' in some order\n2. We can perform at most one swap operation (swap any two cards)\n3. We want to know if we can make the row become \"abc\"\n4. We need to output \"YES\" if possible, \"NO\" otherwise\n\n## Analysis\n\nLet's think about when it's possible to get \"abc\" with at most one swap:\n\n1. **If the string is already \"abc\"**: No operation needed → YES\n2. **If we can reach \"abc\" with exactly one swap**: We need to check if swapping any two positions gives us \"abc\"\n3. **If it's impossible with one swap**: NO\n\nLet me analyze each possible permutation:\n\n- \"abc\": Already correct → YES\n- \"acb\": Swap 'c' and 'b' → \"abc\" → YES\n- \"bac\": Swap 'b' and 'a' → \"abc\" → YES  \n- \"bca\": Let's check all swaps:\n  - Swap pos 0,1: \"cba\" ≠ \"abc\"\n  - Swap pos 0,2: \"acb\" ≠ \"abc\"\n  - Swap pos 1,2: \"bac\" ≠ \"abc\"\n  → NO\n- \"cab\": Let's check all swaps:\n  - Swap pos 0,1: \"acb\" ≠ \"abc\"\n  - Swap pos 0,2: \"bac\" ≠ \"abc\"\n  - Swap pos 1,2: \"cba\" ≠ \"abc\"\n  → NO\n- \"cba\": Swap 'c' and 'a' → \"abc\" → YES\n\nWait, let me double-check \"cab\":\n- Original: \"cab\"\n- Swap positions 0 and 1: \"acb\" (not \"abc\")\n- Swap positions 0 and 2: \"bac\" (not \"abc\") \n- Swap positions 1 and 2: \"cba\" (not \"abc\")\n\nSo \"cab\" cannot become \"abc\" with one swap → NO\n\nFor \"bca\":\n- Original: \"bca\"\n- Swap pos 0,1: \"cba\" ≠ \"abc\"\n- Swap pos 0,2: \"acb\" ≠ \"abc\"\n- Swap pos 1,2: \"bac\" ≠ \"abc\"\n\nSo \"bca\" cannot become \"abc\" with one swap → NO\n\nFor \"cba\":\n- Original: \"cba\"\n- Swap pos 0,1: \"bca\" ≠ \"abc\"\n- Swap pos 0,2: \"abc\" = \"abc\" ✓\n- Swap pos 1,2: \"cab\" ≠ \"abc\"\n\nSo \"cba\" can become \"abc\" by swapping first and last positions → YES\n\n## Solution Logic\n\nA string can be transformed to \"abc\" with at most one swap if:\n- It's already \"abc\", OR\n- It differs from \"abc\" in exactly two positions (since a single swap fixes two positions)\n\nLet me check the number of mismatched positions:\n\n- \"abc\": 0 mismatches → YES\n- \"acb\": positions 1,2 differ → 2 mismatches → YES  \n- \"bac\": positions 0,1 differ → 2 mismatches → YES\n- \"bca\": all three positions differ → 3 mismatches → NO\n- \"cab\": all three positions differ → 3 mismatches → NO\n- \"cba\": positions 0,2 differ → 2 mismatches → YES\n\nSo the rule is: if the number of mismatched positions with \"abc\" is 0 or 2, then answer is YES; otherwise (3 mismatches), answer is NO.\n\n## Implementation\n\n```python\nt = int(input())\nfor _ in range(t):\n    s = input().strip()\n    target = \"abc\"\n    \n    # Count number of positions where characters differ\n    mismatch_count = 0\n    for i in range(3):\n        if s[i] != target[i]:\n            mismatch_count += 1\n    \n    # If 0 or 2 mismatches, we can fix with at most one swap\n    if mismatch_count == 0 or mismatch_count == 2:\n        print(\"YES\")\n    else:\n        print(\"NO\")\n```",
          "source": "generate",
          "metadata": null,
          "internal": null,
          "role": "assistant",
          "tool_calls": null,
          "model": "qwen3-30b-a3b-mxfp4"
        },
        "stop_reason": "stop",
        "logprobs": null
      }
    ],
    "usage": {
      "input_tokens": 474,
      "output_tokens": 909,
      "total_tokens": 1383,
      "input_tokens_cache_write": null,
      "input_tokens_cache_read": null,
      "reasoning_tokens": null
    },
    "time": null,
    "metadata": null,
    "error": null
  },
  "messages": [
    {
      "id": "c98da801",
      "content": "I'll solve this step by step.\n\n## Problem Understanding\n\n1. We have three cards with letters 'a', 'b', 'c' in some order\n2. We can perform at most one swap operation (swap any two cards)\n3. We want to know if we can make the row become \"abc\"\n4. We need to output \"YES\" if possible, \"NO\" otherwise\n\n## Analysis\n\nLet's think about when it's possible to get \"abc\" with at most one swap:\n\n1. **If the string is already \"abc\"**: No operation needed → YES\n2. **If we can reach \"abc\" with exactly one swap**: We need to check if swapping any two positions gives us \"abc\"\n3. **If it's impossible with one swap**: NO\n\nLet me analyze each possible permutation:\n\n- \"abc\": Already correct → YES\n- \"acb\": Swap 'c' and 'b' → \"abc\" → YES\n- \"bac\": Swap 'b' and 'a' → \"abc\" → YES  \n- \"bca\": Let's check all swaps:\n  - Swap pos 0,1: \"cba\" ≠ \"abc\"\n  - Swap pos 0,2: \"acb\" ≠ \"abc\"\n  - Swap pos 1,2: \"bac\" ≠ \"abc\"\n  → NO\n- \"cab\": Let's check all swaps:\n  - Swap pos 0,1: \"acb\" ≠ \"abc\"\n  - Swap pos 0,2: \"bac\" ≠ \"abc\"\n  - Swap pos 1,2: \"cba\" ≠ \"abc\"\n  → NO\n- \"cba\": Swap 'c' and 'a' → \"abc\" → YES\n\nWait, let me double-check \"cab\":\n- Original: \"cab\"\n- Swap positions 0 and 1: \"acb\" (not \"abc\")\n- Swap positions 0 and 2: \"bac\" (not \"abc\") \n- Swap positions 1 and 2: \"cba\" (not \"abc\")\n\nSo \"cab\" cannot become \"abc\" with one swap → NO\n\nFor \"bca\":\n- Original: \"bca\"\n- Swap pos 0,1: \"cba\" ≠ \"abc\"\n- Swap pos 0,2: \"acb\" ≠ \"abc\"\n- Swap pos 1,2: \"bac\" ≠ \"abc\"\n\nSo \"bca\" cannot become \"abc\" with one swap → NO\n\nFor \"cba\":\n- Original: \"cba\"\n- Swap pos 0,1: \"bca\" ≠ \"abc\"\n- Swap pos 0,2: \"abc\" = \"abc\" ✓\n- Swap pos 1,2: \"cab\" ≠ \"abc\"\n\nSo \"cba\" can become \"abc\" by swapping first and last positions → YES\n\n## Solution Logic\n\nA string can be transformed to \"abc\" with at most one swap if:\n- It's already \"abc\", OR\n- It differs from \"abc\" in exactly two positions (since a single swap fixes two positions)\n\nLet me check the number of mismatched positions:\n\n- \"abc\": 0 mismatches → YES\n- \"acb\": positions 1,2 differ → 2 mismatches → YES  \n- \"bac\": positions 0,1 differ → 2 mismatches → YES\n- \"bca\": all three positions differ → 3 mismatches → NO\n- \"cab\": all three positions differ → 3 mismatches → NO\n- \"cba\": positions 0,2 differ → 2 mismatches → YES\n\nSo the rule is: if the number of mismatched positions with \"abc\" is 0 or 2, then answer is YES; otherwise (3 mismatches), answer is NO.\n\n## Implementation\n\n```python\nt = int(input())\nfor _ in range(t):\n    s = input().strip()\n    target = \"abc\"\n    \n    # Count number of positions where characters differ\n    mismatch_count = 0\n    for i in range(3):\n        if s[i] != target[i]:\n            mismatch_count += 1\n    \n    # If 0 or 2 mismatches, we can fix with at most one swap\n    if mismatch_count == 0 or mismatch_count == 2:\n        print(\"YES\")\n    else:\n        print(\"NO\")\n```",
      "source": "generate",
      "metadata": null,
      "internal": null,
      "role": "assistant",
      "tool_calls": null,
      "model": "qwen3-30b-a3b-mxfp4"
    }
  ],
  "metadata": {}
}
Predicting[live_code_bench@release_latest]: 100%|█████████████████████████████████████████████████████████████████████████████████| 1/1 [00:16<00:00, 16.05s/it]
Reviewing[live_code_bench@release_latest]:   0%|                                                                                          | 0/1 [00:00<?, ?it/s]2025-09-11 14:47:37 - evalscope - evaluate_utils.py - evaluate_generations_by_problem - 84 - INFO: Compilation failed, test framework exception = AttributeError("Can't pickle local object 'codegen_check_correctness.<locals>._temp_run'")Can't pickle local object 'codegen_check_correctness.<locals>._temp_run'

2025-09-11 14:47:37 - evalscope - evaluate_utils.py - evaluate_generations_by_problem - 95 - INFO: Sample
t = int(input())
for _ in range(t):
    s = input().strip()
    target = "abc"
    
    # Count number of positions where characters differ
    mismatch_count = 0
    for i in range(3):
        if s[i] != target[i]:
            mismatch_count += 1
    
    # If 0 or 2 mismatches, we can fix with at most one swap
    if mismatch_count == 0 or mismatch_count == 2:
        print("YES")
    else:
        print("NO")
Result
[-2]
2025-09-11 14:47:37 - evalscope - evaluate_utils.py - evaluate_generations_by_problem - 96 - INFO: ******************************


2025-09-11 14:47:37 - evalscope - evaluator.py - get_reviews - 266 - DEBUG: Review result: 
Review Result for Sample 0:
Target: 
Score: {
  "score": {
    "value": {
      "pass": 0.0
    },
    "extracted_prediction": "t = int(input())\nfor _ in range(t):\n    s = input().strip()\n    target = \"abc\"\n    \n    # Count number of positions where characters differ\n    mismatch_count = 0\n    for i in range(3):\n        if s[i] != target[i]:\n            mismatch_count += 1\n    \n    # If 0 or 2 mismatches, we can fix with at most one swap\n    if mismatch_count == 0 or mismatch_count == 2:\n        print(\"YES\")\n    else:\n        print(\"NO\")",
    "prediction": "I'll solve this step by step.\n\n## Problem Understanding\n\n1. We have three cards with letters 'a', 'b', 'c' in some order\n2. We can perform at most one swap operation (swap any two cards)\n3. We want to know if we can make the row become \"abc\"\n4. We need to output \"YES\" if possible, \"NO\" otherwise\n\n## Analysis\n\nLet's think about when it's possible to get \"abc\" with at most one swap:\n\n1. **If the string is already \"abc\"**: No operation needed → YES\n2. **If we can reach \"abc\" with exactly one swap**: We need to check if swapping any two positions gives us \"abc\"\n3. **If it's impossible with one swap**: NO\n\nLet me analyze each possible permutation:\n\n- \"abc\": Already correct → YES\n- \"acb\": Swap 'c' and 'b' → \"abc\" → YES\n- \"bac\": Swap 'b' and 'a' → \"abc\" → YES  \n- \"bca\": Let's check all swaps:\n  - Swap pos 0,1: \"cba\" ≠ \"abc\"\n  - Swap pos 0,2: \"acb\" ≠ \"abc\"\n  - Swap pos 1,2: \"bac\" ≠ \"abc\"\n  → NO\n- \"cab\": Let's check all swaps:\n  - Swap pos 0,1: \"acb\" ≠ \"abc\"\n  - Swap pos 0,2: \"bac\" ≠ \"abc\"\n  - Swap pos 1,2: \"cba\" ≠ \"abc\"\n  → NO\n- \"cba\": Swap 'c' and 'a' → \"abc\" → YES\n\nWait, let me double-check \"cab\":\n- Original: \"cab\"\n- Swap positions 0 and 1: \"acb\" (not \"abc\")\n- Swap positions 0 and 2: \"bac\" (not \"abc\") \n- Swap positions 1 and 2: \"cba\" (not \"abc\")\n\nSo \"cab\" cannot become \"abc\" with one swap → NO\n\nFor \"bca\":\n- Original: \"bca\"\n- Swap pos 0,1: \"cba\" ≠ \"abc\"\n- Swap pos 0,2: \"acb\" ≠ \"abc\"\n- Swap pos 1,2: \"bac\" ≠ \"abc\"\n\nSo \"bca\" cannot become \"abc\" with one swap → NO\n\nFor \"cba\":\n- Original: \"cba\"\n- Swap pos 0,1: \"bca\" ≠ \"abc\"\n- Swap pos 0,2: \"abc\" = \"abc\" ✓\n- Swap pos 1,2: \"cab\" ≠ \"abc\"\n\nSo \"cba\" can become \"abc\" by swapping first and last positions → YES\n\n## Solution Logic\n\nA string can be transformed to \"abc\" with at most one swap if:\n- It's already \"abc\", OR\n- It differs from \"abc\" in exactly two positions (since a single swap fixes two positions)\n\nLet me check the number of mismatched positions:\n\n- \"abc\": 0 mismatches → YES\n- \"acb\": positions 1,2 differ → 2 mismatches → YES  \n- \"bac\": positions 0,1 differ → 2 mismatches → YES\n- \"bca\": all three positions differ → 3 mismatches → NO\n- \"cab\": all three positions differ → 3 mismatches → NO\n- \"cba\": positions 0,2 differ → 2 mismatches → YES\n\nSo the rule is: if the number of mismatched positions with \"abc\" is 0 or 2, then answer is YES; otherwise (3 mismatches), answer is NO.\n\n## Implementation\n\n```python\nt = int(input())\nfor _ in range(t):\n    s = input().strip()\n    target = \"abc\"\n    \n    # Count number of positions where characters differ\n    mismatch_count = 0\n    for i in range(3):\n        if s[i] != target[i]:\n            mismatch_count += 1\n    \n    # If 0 or 2 mismatches, we can fix with at most one swap\n    if mismatch_count == 0 or mismatch_count == 2:\n        print(\"YES\")\n    else:\n        print(\"NO\")\n```",
    "explanation": "Pass@1: 0.0%",
    "metadata": {
      "pass_rate": 0.0,
      "timeout": 6,
      "debug": true,
      "eval_results": {
        "0": [
          [
            -2
          ]
        ]
      },
      "final_metadata": [
        [
          "{}"
        ]
      ]
    },
    "main_score_name": "pass"
  },
  "sample_id": 0,
  "group_id": 0,
  "sample_metadata": null
}
Reviewing[live_code_bench@release_latest]: 100%|██████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.84it/s]
2025-09-11 14:47:37 - evalscope - evaluator.py - get_report - 323 - INFO: 
live_code_bench report table:
+---------------------+-----------------+----------+----------------+-------+---------+---------+
| Model               | Dataset         | Metric   | Subset         |   Num |   Score | Cat.0   |
+=====================+=================+==========+================+=======+=========+=========+
| qwen3-30b-a3b-mxfp4 | live_code_bench | pass@1   | release_latest |     1 |       0 | default |
+---------------------+-----------------+----------+----------------+-------+---------+---------+ 

2025-09-11 14:47:37 - evalscope - evaluator.py - get_report - 334 - INFO: Skipping report analysis (`analysis_report=False`).
2025-09-11 14:47:37 - evalscope - evaluator.py - get_report - 338 - INFO: Dump report to: ./outputs/20250911_144720/reports/qwen3-30b-a3b-mxfp4/live_code_bench.json 

2025-09-11 14:47:37 - evalscope - run.py - evaluate_model - 150 - INFO: Overall report table: 
+---------------------+-----------------+----------+----------------+-------+---------+---------+
| Model               | Dataset         | Metric   | Subset         |   Num |   Score | Cat.0   |
+=====================+=================+==========+================+=======+=========+=========+
| qwen3-30b-a3b-mxfp4 | live_code_bench | pass@1   | release_latest |     1 |       0 | default |
+---------------------+-----------------+----------+----------------+-------+---------+---------+ 

2025-09-11 14:47:37 - evalscope - run.py - run_single_task - 43 - INFO: Finished evaluation for qwen3-30b-a3b-mxfp4 on ['live_code_bench']
2025-09-11 14:47:37 - evalscope - run.py - run_single_task - 44 - INFO: Output directory: ./outputs/20250911_144720
```