### PR TITLE
fix: update Python version requirement to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,11 @@ authors = [
   {email = "contact@modelscope.cn"}
 ]
 keywords = ["python", "llm", "evaluation"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## 🧩 Problem

The project was configured with  
`requires-python = ">=3.9"`  
but the dependency `gradio==5.4.0` requires **Python >=3.10**,  
causing a dependency resolution conflict when using `uv sync`.

---

## ✅ Solution

- Updated `pyproject.toml` to change `requires-python` from `>=3.9` → `>=3.10`  
- Removed the `Programming Language :: Python :: 3.9` classifier since Python 3.9 is no longer supported with the current dependencies

---

## 🔧 Changes Made

| File | Line | Change |
|------|------|---------|
| `pyproject.toml` | 12 | `requires-python = ">=3.9"` → `requires-python = ">=3.10"` |
| `pyproject.toml` | 17 | Removed `"Programming Language :: Python :: 3.9"` classifier |

---

## 🧪 Verification

- Running `uv sync` now completes successfully without Python version conflicts  
- All dependencies (including `gradio==5.4.0`) are properly resolved and installed

---

## 💡 Summary

This fix ensures compatibility with the project's dependencies  
while maintaining support for **Python 3.10, 3.11, and 3.12**.
