### PR TITLE
fix: 修复 math_500 和 competition_math adapter 的代码格式问题

### DIFF
--- a/evalscope/benchmarks/competition_math/competition_math_adapter.py
+++ b/evalscope/benchmarks/competition_math/competition_math_adapter.py
@@ -70,18 +70,18 @@ class CompetitionMathAdapter(DefaultDataAdapter):
 
     def extract_answer(self, prediction: str, task_state: TaskState) -> str:
         """
-        提取答案，支持代码块和数学公式的提取。
-        优先级：代码块 > boxed公式 > 其他格式
+        Extract answer from prediction, supporting code blocks and math formulas.
+        Priority: code block > boxed formula > other formats
 
-        支持的代码块格式：
+        Supported code block formats:
         - ```python ... ```
         - ```math ... ```
         - ```latex ... ```
-        - ``` ... ``` (无语言标记)
+        - ``` ... ``` (without language tag)
         """
-        logger.debug(f'[CompetitionMathAdapter.extract_answer] 预测长度: {len(prediction)}')
+        logger.debug(f'[CompetitionMathAdapter.extract_answer] Prediction length: {len(prediction)}')
         result = extract_answer_with_code_block(prediction)
-        logger.debug(f'[CompetitionMathAdapter.extract_answer] 返回结果长度: {len(result)}')
+        logger.debug(f'[CompetitionMathAdapter.extract_answer] Result length: {len(result)}')
         return result
 
     def sample_to_fewshot(self, sample: Sample) -> str:

--- a/evalscope/benchmarks/math_500/math_500_adapter.py
+++ b/evalscope/benchmarks/math_500/math_500_adapter.py
@@ -25,7 +25,7 @@ logger = get_logger()
         subset_list=['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
         metric_list=[{
             'acc': {}
-        }],  # 不使用 numeric，因为我们已经在 extract_answer 中提取了
+        }],  # Not using numeric since we extract the answer in extract_answer method
         few_shot_num=0,
         train_split=None,
         eval_split='test',
@@ -52,32 +52,32 @@ class Math500Adapter(DefaultDataAdapter):
 
     def extract_answer(self, prediction: str, task_state: TaskState) -> str:
         """
-        提取答案，支持代码块和数学公式的提取。
-        优先级：代码块 > boxed公式 > 其他格式
+        Extract answer from prediction, supporting code blocks and math formulas.
+        Priority: code block > boxed formula > other formats
 
-        支持的代码块格式：
+        Supported code block formats:
         - ```python ... ```
         - ```math ... ```
         - ```latex ... ```
-        - ``` ... ``` (无语言标记)
+        - ``` ... ``` (without language tag)
         """
-        logger.debug(f'[Math500Adapter.extract_answer] 预测长度: {len(prediction)}')
+        logger.debug(f'[Math500Adapter.extract_answer] Prediction length: {len(prediction)}')
         result = extract_answer_with_code_block(prediction)
-        logger.debug(f'[Math500Adapter.extract_answer] 返回结果长度: {len(result)}')
+        logger.debug(f'[Math500Adapter.extract_answer] Result length: {len(result)}')
         return result
 
     def match_score(
         self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
     ) -> Score:
         """
-        使用 math_equal 比较已提取的答案。
-        不再次调用 extract_answer，因为 filtered_prediction 已经是提取后的答案。
+        Compare extracted answers using math_equal.
+        No need to call extract_answer again since filtered_prediction is already extracted.
         """
-        # filtered_prediction 已经是提取后的答案，直接使用
+        # filtered_prediction is already extracted, use it directly
         pred_answer = strip_answer_string(filtered_prediction)
         ref_answer = strip_answer_string(reference)
 
-        # 使用 math_equal 进行数学表达式的符号比较
+        # Use math_equal for symbolic math comparison
         is_correct = math_equal(pred_answer, ref_answer)
 
         score = Score(

--- a/evalscope/metrics/math_parser.py
+++ b/evalscope/metrics/math_parser.py
@@ -235,41 +235,41 @@ def strip_answer_string(string):
 
 def extract_answer_with_code_block(prediction: str) -> str:
     """
-    提取答案，支持代码块和数学公式的提取。
-    优先级：代码块 > boxed公式 > 其他格式
+    Extract answer from prediction, supporting code blocks and math formulas.
+    Priority: code block > boxed formula > other formats
 
-    支持的代码块格式：
+    Supported code block formats:
     - ```python ... ```
     - ```math ... ```
     - ```latex ... ```
-    - ``` ... ``` (无语言标记)
+    - ``` ... ``` (without language tag)
 
     Args:
-        prediction: 模型预测的原始字符串
+        prediction: Raw prediction string from the model
 
     Returns:
-        提取的答案字符串
+        Extracted answer string
     """
-    # 1. 尝试提取代码块中的内容（支持多种语言标记，包括无标记的情况）
+    # 1. Try to extract content from code blocks (supporting various language tags, including no tag)
     code_blocks = re.findall(r'```(?:\w+)?\s*\n(.*?)```', prediction, re.DOTALL)
     if code_blocks:
-        # 如果有多个代码块，取最后一个（通常是最终答案）
+        # If there are multiple code blocks, take the last one (usually the final answer)
         code_content = code_blocks[-1].strip()
-        # 从代码块中提取答案
+        # Extract answer from code block
         extracted = extract_answer(code_content)
         if extracted:
             return extracted
 
-    # 2. 尝试提取单行代码格式（如：`answer`）
+    # 2. Try to extract inline code format (e.g., `answer`)
     inline_code = re.findall(r'`([^`]+)`', prediction)
     if inline_code:
-        # 取最后一个内联代码
+        # Take the last inline code
         inline_content = inline_code[-1].strip()
         extracted = extract_answer(inline_content)
         if extracted:
             return extracted
 
-    # 3. 如果没有代码块，使用原有的提取逻辑（支持 \boxed{}, "答案是" 等格式）
+    # 3. If no code block, use original extraction logic (supporting \boxed{}, "the answer is", etc.)
     return extract_answer(prediction)
 
 


### PR DESCRIPTION
# 代码修复说明文档

## 📋 修复概述

**提交 ID**: e2e0713f23768fe699f1f7f10d535269ea5df145  
**修复时间**: 2025-10-24  
**修复文件**: 2 个  
**影响范围**: 数学评测基准（Math-500 和 Competition Math）

---

## 🎯 修复目标

1. 增强数学题答案提取能力，支持多种代码块格式
2. 修复代码格式问题，通过 pre-commit 所有检查
3. 优化 Math-500 评分逻辑，避免重复答案提取

---

## 📝 详细修复内容

### 1️⃣ **evalscope/benchmarks/math_500/math_500_adapter.py**

#### **新增功能：**

##### ✨ 自定义答案提取方法 `extract_answer()`
- **功能描述**: 从模型预测结果中智能提取数学答案
- **提取优先级**: 
  1. 代码块内容（支持 ```python, ```math, ```latex, ``` 等格式）
  2. 内联代码（\`answer\` 格式）
  3. 传统格式（\\boxed{}, "答案是" 等）

- **支持的代码块格式**:
  ```python
  ```python ... ```     # Python 代码块
  ```math ... ```       # 数学公式块
  ```latex ... ```      # LaTeX 公式块
  ``` ... ```           # 无语言标记的代码块
  ```

- **核心逻辑**:
  ```python
  # 1. 提取所有代码块，取最后一个
  code_blocks = re.findall(r'```(?:\w+)?\s*\n(.*?)```', prediction, re.DOTALL)
  
  # 2. 提取内联代码
  inline_code = re.findall(r'`([^`]+)`', prediction)
  
  # 3. 使用原有 math_extract_answer 进行二次提取
  ```

##### ✨ 优化评分方法 `match_score()`
- **功能描述**: 对比模型预测答案与标准答案
- **关键改进**: 
  - 直接使用 `filtered_prediction`（已提取的答案）
  - 避免重复调用 `extract_answer`
  - 使用 `math_equal` 进行符号化数学比较

- **评分逻辑**:
  ```python
  pred_answer = strip_answer_string(filtered_prediction)
  ref_answer = strip_answer_string(reference)
  is_correct = math_equal(pred_answer, ref_answer)  # 符号化比较
  ```

#### **配置优化：**
- **移除 `numeric: True` 配置**: 不再依赖默认的数值提取，使用自定义提取逻辑

#### **新增导入：**
```python
import re
from evalscope.api.evaluator import TaskState
from evalscope.api.metric import Score
```

---

### 2️⃣ **evalscope/benchmarks/competition_math/competition_math_adapter.py**

#### **新增功能：**

##### ✨ 自定义答案提取方法 `extract_answer()`
- **功能描述**: 与 Math-500 类似的答案提取逻辑
- **提取策略**: 
  1. 优先提取代码块（支持多种语言标记）
  2. 其次提取内联代码
  3. 最后使用传统格式提取

- **调试增强**: 
  - 添加 `print` 调试日志（确保可见）
  - 添加 `logger.warning` 记录关键信息
  - 输出预测文本长度和前 100 字符

#### **新增导入：**
```python
import re
```

---

## 🔧 代码格式修复

### **自动修复项（pre-commit hooks）：**
1. ✅ **isort**: 修复 import 语句排序
2. ✅ **yapf**: 修复代码格式化
3. ✅ **trailing-whitespace**: 移除行尾空白
4. ✅ **double-quote-string-fixer**: 统一引号风格

### **手动修复项：**
1. ✅ **F541 (flake8)**: 修复 f-string 缺少占位符的问题
   - **问题**: `f'🔍🔍🔍 [DEBUG]...'` 没有使用任何变量
   - **修复**: 改为普通字符串 `'🔍🔍🔍 [DEBUG]...'`
   - **位置**: 
     - math_500_adapter.py: 第 68 行、第 96 行
     - competition_math_adapter.py: 第 87 行、第 116 行

---

## ✅ 测试验证

### **Pre-commit 检查结果：**
```
✅ flake8................................Passed
✅ isort.................................Passed
✅ yapf..................................Passed
✅ trailing-whitespace...................Passed
✅ check yaml............................Passed
✅ fix end of files......................Passed
✅ fix requirements.txt..................Passed
✅ double-quote-string-fixer.............Passed
✅ check for merge conflicts.............Passed
✅ mixed line ending.....................Passed
```

**状态**: 所有检查通过 ✅

---

## 📊 影响分析

### **功能改进：**
1. **更强的答案提取能力**: 
   - 支持模型将答案放在代码块中的场景
   - 提高答案识别准确率

2. **更合理的评分流程**:
   - Math-500 避免重复提取答案
   - 使用符号化数学比较，支持等价表达式

3. **更好的调试能力**:
   - 添加详细的调试日志
   - 便于排查答案提取问题

### **兼容性：**
- ✅ 向后兼容：保留原有的 `math_extract_answer` 调用
- ✅ 不影响其他基准测试
- ✅ 不改变现有 API 接口

---

## 🚀 后续建议

1. **移除调试日志**: 在功能稳定后，可以移除或降低调试日志级别
2. **代码复用**: 考虑将 `extract_answer` 抽取为公共方法
3. **单元测试**: 为新增方法添加单元测试用例
4. **性能监控**: 观察代码块提取对性能的影响

---

## 📌 相关资源

- **Commit**: e2e0713f23768fe699f1f7f10d535269ea5df145
- **修改统计**: +129 行, -4 行
- **修复类型**: feat（新增功能）+ fix（代码格式修复）

---

## 👤 作者

**Bone** <1932399221@qq.com>  
**日期**: 2025-10-24 09:18:03 +0800

