### PR TITLE
fix --analysis-report=true bug

### DIFF
--- a/evalscope/report/report.py
+++ b/evalscope/report/report.py
@@ -229,7 +229,7 @@ class Report:
 
             prompt = ANALYSIS_PROMPT.format(language=language, report_str=self.to_json_str())
             judge_llm = LLMJudge(**judge_llm_config)
-            response = judge_llm(prompt)
+            response = judge_llm.judge(prompt)
         except Exception as e:
             logger.error(f'Error generating analysis: {e}')
             response = 'N/A'


### PR DESCRIPTION
# Reason
'LLMJudge' object is not callable, there is no __call__() method

# Before
2025-12-04 17:34:29 - evalscope - ERROR: Error generating analysis: 'LLMJudge' object is not callable
2025-12-04 17:34:29 - evalscope - INFO: Report analysis:
N/A
![image](https://github.com/user-attachments/assets/6b936993-87f6-424c-96db-53c360010626)

# After
2025-12-04 17:50:16 - evalscope - INFO: Report analysis:
\#Model Evaluation Report

\##Overall Performance
![image](https://github.com/user-attachments/assets/c7dc3479-39c4-45b3-a3b0-8e91ea62d9e7)
