### PR TITLE
Fix --dataset-dir parameter to work correctly

### DIFF
--- a/evalscope/api/benchmark/adapters/default_data_adapter.py
+++ b/evalscope/api/benchmark/adapters/default_data_adapter.py
@@ -257,6 +257,7 @@ class DefaultDataAdapter(DataAdapter):
             shuffle_choices=self.shuffle_choices,  # Shuffle choices if requested
             data_source=self.dataset_hub,  # Data source configuration
             force_redownload=self.force_redownload,  # Force redownload if enabled
+            dataset_dir=self.dataset_dir,  # Dataset directory
         )
         dataset = loader.load()
         return dataset
@@ -289,6 +290,7 @@ class DefaultDataAdapter(DataAdapter):
             shuffle_choices=self.shuffle_choices,  # Shuffle choices if requested
             data_source=self.dataset_hub,  # Data source configuration
             force_redownload=self.force_redownload,  # Force redownload if enabled
+            dataset_dir=self.dataset_dir,  # Dataset directory
         )
         dataset = loader.load()
         return dataset

--- a/evalscope/api/benchmark/benchmark.py
+++ b/evalscope/api/benchmark/benchmark.py
@@ -349,6 +349,13 @@ class DataAdapter(LLMJudgeMixin, SandboxMixin, ABC):
         return self._task_config.seed
 
     @property
+    def dataset_dir(self) -> str:
+        """
+        Return the dataset directory for the benchmark.
+        """
+        return self._task_config.dataset_dir
+
+    @property
     def shuffle(self) -> bool:
         """
         Return whether to shuffle the dataset before evaluation.

--- a/evalscope/api/dataset/loader.py
+++ b/evalscope/api/dataset/loader.py
@@ -38,6 +38,7 @@ class DataLoader(ABC):
         repeats: int = 1,
         trust_remote: bool = True,
         force_redownload: bool = False,
+        dataset_dir: Optional[str] = None,
         **kwargs
     ):
         self.data_id_or_path = data_id_or_path
@@ -55,6 +56,7 @@ class DataLoader(ABC):
         self.repeats = repeats
         self.trust_remote = trust_remote
         self.force_redownload = force_redownload
+        self.dataset_dir = dataset_dir
         self.kwargs = kwargs
 
     @abstractmethod
@@ -81,7 +83,10 @@ class RemoteDataLoader(DataLoader):
         data_to_sample = record_to_sample_fn(self.sample_fields)
         # generate a unique cache dir for this dataset
         dataset_hash = gen_hash(f'{path}{self.split}{self.subset}{self.version}{self.kwargs}')
-        datasets_cache_dir = os.path.join(DEFAULT_EVALSCOPE_CACHE_DIR, 'datasets')
+        if self.dataset_dir:
+            datasets_cache_dir = os.path.join(self.dataset_dir, 'datasets')
+        else:
+            datasets_cache_dir = os.path.join(DEFAULT_EVALSCOPE_CACHE_DIR, 'datasets')
         dataset_cache_dir = os.path.join(datasets_cache_dir, f'{safe_filename(path)}-{dataset_hash}')
         # force re-download: remove local cache if requested
         if self.force_redownload and os.path.exists(dataset_cache_dir):


### PR DESCRIPTION
- Add dataset_dir parameter to DataLoader base class
- Modify RemoteDataLoader to use custom dataset_dir for caching
- Add dataset_dir property to DataAdapter class
- Update DefaultDataAdapter to pass dataset_dir to DataLoader

This fixes the issue where --dataset-dir command line parameter was not being used to change the dataset cache location, causing datasets to always be cached in the default location ~/.cache/evalscope/datasets instead of the user-specified directory.

Now users can specify --dataset-dir /path/to/datasets and datasets will be cached in /path/to/datasets/datasets/ as expected.