### PR TITLE
UI dashboard supports HTTP params parameters

### DIFF
--- a/evalscope/app/ui/app_ui.py
+++ b/evalscope/app/ui/app_ui.py
@@ -18,13 +18,13 @@ def create_app_ui(args: argparse.Namespace):
     lang = args.lang
     locale_dict = get_app_locale(lang)
 
-    with gr.Blocks(title="Evalscope Dashboard") as demo:
-        gr.HTML("<h1 style=\"text-align: left;\">%s (v%s)</h1>" % (locale_dict["title"], __version__))
+    with gr.Blocks(title='Evalscope Dashboard') as demo:
+        gr.HTML(f'<h1 style="text-align: left;">{locale_dict["title"]} (v{__version__})</h1>')
         with gr.Row():
             with gr.Column(scale=0, min_width=35):
-                toggle_btn = gr.Button("<")
+                toggle_btn = gr.Button('<')
             with gr.Column(scale=1):
-                gr.HTML(f"<h3 style=\"text-align: left;\">%s</h3>" % (locale_dict["star_beggar"]))
+                gr.HTML(f'<h3 style="text-align: left;">{locale_dict["star_beggar"]}</h3>')
 
         with gr.Row():
             with gr.Column(scale=1) as sidebar_column:
@@ -48,29 +48,29 @@ def create_app_ui(args: argparse.Namespace):
             URL format: ?reports=report1;report2;report3
             """
             if request:
-                query_params = getattr(request, "query_params", {})
-                reports_param = query_params.get("reports", "")
-                logger.debug(f"reports_param from url: {reports_param}")
+                query_params = getattr(request, 'query_params', {})
+                reports_param = query_params.get('reports', '')
+                logger.debug(f'reports_param from url: {reports_param}')
 
                 if reports_param:
                     # Parse comma-separated report names
-                    selected_reports = [r.strip() for r in reports_param.split(";") if r.strip()]
-                    logger.debug(f"selected_reports: {selected_reports}")
+                    selected_reports = [r.strip() for r in reports_param.split(';') if r.strip()]
+                    logger.debug(f'selected_reports: {selected_reports}')
 
                     # Get available reports from the outputs directory
                     available_folders = scan_for_report_folders(args.outputs)
-                    logger.debug(f"available_folders: {available_folders}")
+                    logger.debug(f'available_folders: {available_folders}')
 
                     # Filter to only include valid reports by pre-building a prefix map for efficiency.
                     available_folders_set = set(available_folders)
                     prefix_map = {}
                     for folder in available_folders:
-                        prefix = folder.split("::")[0]
+                        prefix = folder.split('::')[0]
                         prefix_map.setdefault(prefix, []).append(folder)
 
                     valid_reports = []
                     for selected in selected_reports:
-                        if "::" in selected:
+                        if '::' in selected:
                             # Exact match
                             if selected in available_folders_set:
                                 valid_reports.append(selected)
@@ -79,7 +79,7 @@ def create_app_ui(args: argparse.Namespace):
                             valid_reports.extend(prefix_map.get(selected, []))
                     # Remove duplicates and maintain the original order
                     valid_reports = list(dict.fromkeys(valid_reports))
-                    logger.debug(f"valid_reports: {valid_reports}")
+                    logger.debug(f'valid_reports: {valid_reports}')
 
                     if valid_reports:
                         return (
@@ -97,7 +97,7 @@ def create_app_ui(args: argparse.Namespace):
         )
         def update_displays(reports_dropdown):
             if not reports_dropdown:
-                gr.Warning(locale_dict["note"], duration=3)
+                gr.Warning(locale_dict['note'], duration=3)
                 return gr.skip()
 
             return (
@@ -108,7 +108,7 @@ def create_app_ui(args: argparse.Namespace):
         @toggle_btn.click(inputs=[sidebar_visible], outputs=[sidebar_column, sidebar_visible, toggle_btn])
         def toggle_sidebar(visible):
             new_visible = not visible
-            text = "<" if new_visible else ">"
+            text = '<' if new_visible else '>'
             return gr.update(visible=new_visible), new_visible, gr.update(value=text)
 
     return demo


### PR DESCRIPTION
# Feature
1、Automatically trigger a 'load and view' after passing in HTTP parameters
2、Parameters can be prefixed with fields before '::'. In this case, there may be multiple matching results.
`http://localhost:7860/?reports=20251208@@deepseek_r1`
3、The parameters can also be perfectly matched, in which case the result of such matching can only be one.
`http://localhost:7860/?reports=20251208@@deepseek_r1::live_code_bench`
4、Multiple reports should be separated by semicolons, while the above rules still apply and support mixing.
`http://localhost:7860/?reports=20251207@@deepseek_r1;20251208@@deepseek_r1::live_code_bench`
