### PR TITLE
fix: Output token throughput and Total token throughput on Concurrency 1

### DIFF
--- a/evalscope/perf/utils/benchmark_util.py
+++ b/evalscope/perf/utils/benchmark_util.py
@@ -114,8 +114,8 @@ class BenchmarkMetrics:
         else:
             self.n_failed_queries += 1
 
-        self.calculate_averages()
         self.update_total_time(benchmark_data)
+        self.calculate_averages()
 
     def update_total_time(self, benchmark_data: BenchmarkData):
         # Use the earliest start_time seen so far


### PR DESCRIPTION
I encountered the same issue as #1076.

Here is a simple fix.