### PR TITLE
fix(streaming): Robust parsing of SSE chunks with multiple events and \r\n normalization

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -35,7 +35,7 @@ class StreamedResponseHandler:
             chunk_str = chunk_bytes.decode('utf-8', errors='ignore')
         # Normalize CRLF (common in SSE implementations) to LF so downstream
         # splitting on "\n\n" works consistently.
-        self.buffer += chunk_str.replace("\r\n", "\n")
+        self.buffer += chunk_str.replace('\r\n', '\n')
 
         messages = []
 


### PR DESCRIPTION
### What problem does this PR solve? / Problem Description

Under high parallelism or poor network conditions, OpenAI-compatible streaming APIs (text/event-stream) are prone to **TCP packet coalescence**, causing a single `chunk` to contain multiple complete SSE events (e.g., `data: {...}\n\n data: {...}\n\n`).

The original `StreamedResponseHandler` parsing logic implicitly assumes:
- Each chunk contains at most one event.
- It directly attempts `json.loads(buffer[6:])`.

When a chunk contains multiple events, JSON parsing fails, and the handler mistakenly treats it as "incomplete JSON", continuing to buffer until the stream ends. As a result:
- No delta tokens are parsed during the entire response.
- `most_recent_timestamp` remains unupdated, leading to final latency calculated as 0, while success=1.

This issue is not noticeable in low-parallelism short responses, but it almost always reproduces in high parallelism (e.g., 50+) with long output tasks.

### Why this solution? / Solution Rationale

1. **Normalize CRLF → LF**: Many servers use `\r\n\r\n` as the separator(like Xinference). First uniformly replace it with `\n`, then split consistently on `\n\n` to avoid missing events.

### Key changes / Main Changes

- After converting `chunk_bytes` to `str`, uniformly replace `"\r\n"` with `"\n"`.
- Add a small amount of comments for better maintainability.