### PR TITLE
Fix LiveCodeBench extraction: use last fenced code block

### DIFF
--- a/evalscope/benchmarks/live_code_bench/extract_utils.py
+++ b/evalscope/benchmarks/live_code_bench/extract_utils.py
@@ -17,7 +17,7 @@ def extract_code_generation(model_output: str, model_type: str = 'chat'):
 
     if len(indexlines) < 2:
         return ''
-    return '\n'.join(outputlines[indexlines[0] + 1:indexlines[1]])
+    return '\n'.join(outputlines[indexlines[-2] + 1:indexlines[-1]])
 
 
 def extract_code_execution(model_output: str, cot: bool = False):


### PR DESCRIPTION
## PR Description

This PR aligns EvalScope’s LiveCodeBench code extraction behavior with upstream LiveCodeBench.

-  Problem: EvalScope currently extracts the first fenced code block, which can evaluate intermediate/draft code for models that emit multiple code blocks.
- Fix: Switch extraction to use the last fenced code block by taking the final pair of ``` markers.

This improves correctness for outputs containing multiple fenced blocks and matches upstream behavior.

- close #1167 
