### PR TITLE
Replace eval() with ast.literal_eval() in ParseStrArgsAction

### DIFF
--- a/evalscope/arguments.py
+++ b/evalscope/arguments.py
@@ -1,5 +1,6 @@
 # flake8: noqa: E501
 import argparse
+import ast
 import json
 
 from evalscope.constants import EvalBackend, JudgeStrategy, ModelTask
@@ -23,10 +24,10 @@ class ParseStrArgsAction(argparse.Action):
         for arg in values.strip().split(','):
             key, value = map(str.strip, arg.split('=', 1))  # Use maxsplit=1 to handle multiple '='
             try:
-                # Safely evaluate the value using eval
-                arg_dict[key] = eval(value)
-            except Exception:
-                # If eval fails, check if it's a boolean value
+                # Safely evaluate the value using ast.literal_eval
+                arg_dict[key] = ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                # If ast.literal_eval fails, check if it's a boolean value
                 value_lower = value.lower()
                 if value_lower == 'true':
                     arg_dict[key] = True


### PR DESCRIPTION
## What

Switch from `eval()` to `ast.literal_eval()` in `ParseStrArgsAction` within `evalscope/arguments.py`. 

## Why

The current implementation uses `eval()` to parse CLI arguments, which introduces a potential code injection vulnerability. Since `model-args` are often complex structures (dicts, lists), switching to `ast.literal_eval()` provides a secure way to evaluate these Python literals without the risk of arbitrary code execution. 

## Type

- [x] Bug fix / Security hardening
- [ ] Refactor

## Testing

Verified that `ast.literal_eval()` correctly parses integers, booleans, lists, and dictionaries while preventing any function calls or malicious payloads.