### PR TITLE
print request id

### DIFF
--- a/evalscope/api/model/model_output.py
+++ b/evalscope/api/model/model_output.py
@@ -129,6 +129,9 @@ class ChatCompletionChoice(BaseModel):
 class ModelOutput(BaseModel):
     """Output from model generation."""
 
+    id: Optional[str] = Field(default=None)
+    """Completion ID."""
+
     model: str = Field(default_factory=str)
     """Model used for generation."""
 

--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -99,9 +99,7 @@ class OpenAICompatibleAPI(ModelAPI):
             # handle streaming response
             if not isinstance(completion, ChatCompletion):
                 completion = collect_stream_response(completion)
-            request_id = getattr(completion, 'id', None)
-            if request_id:
-                logger.info(f'Request ID: {request_id}')
+
             response = completion.model_dump()
             self.on_response(response)
 

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -376,6 +376,7 @@ def model_output_from_anthropic(
     )
 
     return ModelOutput(
+        id=message.id,
         model=message.model,
         choices=choices,
         usage=ModelUsage(

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -511,6 +511,7 @@ def model_output_from_openai(
     choices: list[ChatCompletionChoice],
 ) -> ModelOutput:
     return ModelOutput(
+        id=completion.id,
         model=completion.model,
         choices=choices,
         usage=(


### PR DESCRIPTION
In order to facilitate the identification of backend issues, such as sglang, the request_id should be printed.