### PR TITLE
Save model reasoning content in evaluation cache to avoid redundant computation

### DIFF
--- a/evalscope/api/evaluator/cache.py
+++ b/evalscope/api/evaluator/cache.py
@@ -196,11 +196,11 @@ class CacheManager:
             The saved review result object
         """
         cache_file = self.get_review_cache_path(subset)
-        output = getattr(task_state, "output", None)
+        output = task_state.output
         # Convert score and state to serializable review result
         review_result = ReviewResult.from_score_state(sample_score, task_state, save_metadata)
         # Save reasoning content into review result
-        review_result.reasoning = (output.metadata or {}).get("reason", "") if output else ""
+        review_result.reasoning = (output.metadata or {}).get("reason", "")
         # Serialize to dictionary
         review_result_dict = review_result.model_dump()
         # Append to JSONL cache file

--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -110,10 +110,10 @@ class OpenAICompatibleAPI(ModelAPI):
             # save reasoning content into review result
             if completion.choices:
                 message = completion.choices[0].message
-                reasoning_content = getattr(message, "reasoning", None) or getattr(message, "reasoning_content", None) or ""
+                reasoning = getattr(message, "reasoning_content", None) or getattr(message, "reasoning", None) or ""
                 if model_output.metadata is None:
                     model_output.metadata = {}
-                model_output.metadata["reason"] = reasoning_content
+                model_output.metadata["reason"] = reasoning
 
             return model_output
 


### PR DESCRIPTION
Reason
Evaluating reasoning-intensive models is computationally expensive and time-consuming.However, the original pipeline does not persist the model's internal reasoninging process during evaluation. As a result, valuable reasoning content is discarded after each inference, leading to wasted computation when re-analyzing or reviewing results.
Changes
Add reasoning field to the ReviewResult Pydantic model
Extract and store model reasoning content from both reasoning and reasoning_content response fields
Safely handle empty responses and metadata to avoid index errors
Persist reasoning content in the review cache to avoid redundant model inference
This improvement preserves useful reasoning logs without re-computing evaluations, improving efficiency in result analysis and debugging.