### PR TITLE
Fix tokenize-prompt length semantics

### DIFF
--- a/evalscope/perf/plugin/datasets/random_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_dataset.py
@@ -48,18 +48,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
         token-ID lists that bypass the decode/re-encode round-trip entirely."""
         tokenize_prompt = self.query_parameters.tokenize_prompt
 
-        if tokenize_prompt:
-            # Subtract prefix_length so that the final prompt
-            # (prefix_ids + inner_seq) stays within [min, max]_prompt_length.
-            min_prompt_length = self.query_parameters.min_prompt_length - self.prefix_length
-            max_prompt_length = self.query_parameters.max_prompt_length - self.prefix_length + 1
-            if min_prompt_length < 0:
-                logger.warning(
-                    f'min_prompt_length is less than prefix_length {self.prefix_length}, '
-                    'setting min_prompt_length to 0.'
-                )
-                min_prompt_length = 0
-        elif self.query_parameters.apply_chat_template:
+        if self.query_parameters.apply_chat_template and not tokenize_prompt:
             template_len = self.get_template_len()
             min_prompt_length = self.query_parameters.min_prompt_length - template_len
             max_prompt_length = self.query_parameters.max_prompt_length - template_len + 1
@@ -120,7 +109,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
         offset: int,
         index: int,
     ) -> List[int]:
-        """Return a raw token-ID list of exactly `input_len` tokens (+ prefix).
+        """Return a raw token-ID list of exactly `prefix_length + input_len` tokens.
 
         Unlike `generate_token_sequence`, this method never decodes tokens to text
         and therefore avoids any token ID → text → token ID round-trip inflation.


### PR DESCRIPTION
## Summary

Fix the `random` dataset behavior when `--tokenize-prompt` is enabled so that `--min-prompt-length` and `--max-prompt-length` keep the same meaning as before.

Before this change, enabling `--tokenize-prompt` subtracted `prefix_length` during sampling, which changed the effective input-length semantics. As a result, the final server-side input length range became inconsistent with the behavior when `--tokenize-prompt` was disabled.

This PR restores the original behavior:
- `min-prompt-length` / `max-prompt-length` continue to describe the sampled prompt body length
- final total input length remains `prefix_length + sampled_length`
- `--tokenize-prompt` only changes how prompts are sent, not the meaning of length-related arguments

## Changes

- remove the extra `prefix_length` subtraction in `random_dataset.py` for the `--tokenize-prompt` path
- keep the direct token-ID fast path unchanged apart from restoring the historical length semantics
- update the token-ID helper docstring to match the actual output length behavior

## Why

This keeps argument behavior backward-compatible and avoids surprising differences between:
- `--tokenize-prompt=false`
- `--tokenize-prompt=true`

## Validation

- ran targeted regression validation for the `random` dataset behavior
- ran style checks for the changed file

## Notes

- this commit intentionally includes only `evalscope/perf/plugin/datasets/random_dataset.py`
