### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -11,7 +11,6 @@ See https://docs.litellm.ai/docs/providers for the full list.
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from openai._types import NOT_GIVEN
 from openai.types.chat import ChatCompletion
 
 from evalscope.api.messages import ChatMessage
@@ -73,14 +72,15 @@ class LiteLLMAPI(ModelAPI):
         )
 
         request = dict(
-            messages=messages,
-            tools=openai_chat_tools(tools) if len(tools) > 0 else NOT_GIVEN,
-            tool_choice=openai_chat_tool_choice(tool_choice) if len(tools) > 0 else NOT_GIVEN,
             # drop_params silently drops provider-unsupported kwargs
             # to prevent cross-provider errors
             drop_params=True,
             **completion_params,
         )
+        request["messages"] = messages
+        if len(tools) > 0:
+            request["tools"] = openai_chat_tools(tools)
+            request["tool_choice"] = openai_chat_tool_choice(tool_choice)
         if self.api_key:
             request["api_key"] = self.api_key
         if self.base_url:

--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -9,9 +9,8 @@ See https://docs.litellm.ai/docs/providers for the full list.
 """
 
 import time
-from typing import Any, Dict, List, Optional, Tuple
-
 from openai.types.chat import ChatCompletion
+from typing import Any, Dict, List, Optional, Tuple
 
 from evalscope.api.messages import ChatMessage
 from evalscope.api.messages.perf_metrics import PerformanceMetrics
@@ -78,14 +77,14 @@ class LiteLLMAPI(ModelAPI):
             drop_params=True,
             **completion_params,
         )
-        request["messages"] = messages
+        request['messages'] = messages
         if len(tools) > 0:
-            request["tools"] = openai_chat_tools(tools)
-            request["tool_choice"] = openai_chat_tool_choice(tool_choice)
+            request['tools'] = openai_chat_tools(tools)
+            request['tool_choice'] = openai_chat_tool_choice(tool_choice)
         if self.api_key:
-            request["api_key"] = self.api_key
+            request['api_key'] = self.api_key
         if self.base_url:
-            request["api_base"] = self.base_url
+            request['api_base'] = self.base_url
 
         try:
             t_start = time.monotonic()

--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -1,0 +1,118 @@
+"""LiteLLM model API provider for EvalScope.
+
+Routes to 100+ LLM providers via litellm.completion().
+Provider API keys are read from environment variables automatically
+(OPENAI_API_KEY, ANTHROPIC_API_KEY, AWS_ACCESS_KEY_ID, GEMINI_API_KEY, etc.).
+
+Model names use LiteLLM format: "provider/model-name".
+See https://docs.litellm.ai/docs/providers for the full list.
+"""
+
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from openai._types import NOT_GIVEN
+from openai.types.chat import ChatCompletion
+
+from evalscope.api.messages import ChatMessage
+from evalscope.api.messages.perf_metrics import PerformanceMetrics
+from evalscope.api.model import ChatCompletionChoice, GenerateConfig, ModelAPI, ModelOutput
+from evalscope.api.tool import ToolChoice, ToolInfo
+from evalscope.utils import get_logger
+from evalscope.utils.function_utils import retry_call
+from .utils.openai import (
+    chat_choices_from_openai,
+    model_output_from_openai,
+    openai_chat_messages,
+    openai_chat_tool_choice,
+    openai_chat_tools,
+    openai_completion_params,
+    openai_handle_bad_request,
+)
+
+logger = get_logger()
+
+
+class LiteLLMAPI(ModelAPI):
+    """LiteLLM model API provider.
+
+    Uses litellm.completion() to route to any of 100+ LLM providers.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+        )
+
+    def generate(
+        self,
+        input: List[ChatMessage],
+        tools: List[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        import litellm
+
+        request: Dict[str, Any] = {}
+
+        messages = openai_chat_messages(input)
+        completion_params = openai_completion_params(
+            model=self.model_name,
+            config=config,
+            tools=len(tools) > 0,
+        )
+
+        request = dict(
+            messages=messages,
+            tools=openai_chat_tools(tools) if len(tools) > 0 else NOT_GIVEN,
+            tool_choice=openai_chat_tool_choice(tool_choice) if len(tools) > 0 else NOT_GIVEN,
+            # drop_params silently drops provider-unsupported kwargs
+            # to prevent cross-provider errors
+            drop_params=True,
+            **completion_params,
+        )
+        if self.api_key:
+            request["api_key"] = self.api_key
+        if self.base_url:
+            request["api_base"] = self.base_url
+
+        try:
+            t_start = time.monotonic()
+
+            response = retry_call(
+                litellm.completion,
+                retries=config.retries,
+                sleep_interval=config.retry_interval,
+                **request,
+            )
+
+            total_time = time.monotonic() - t_start
+
+            completion = ChatCompletion(**response.model_dump())
+
+            choices = chat_choices_from_openai(completion, tools)
+            output = model_output_from_openai(completion, choices)
+
+            output.time = total_time
+            usage = output.usage
+            output.message.perf_metrics = PerformanceMetrics(
+                latency=total_time,
+                ttft=None,
+                input_tokens=usage.input_tokens if usage else 0,
+                output_tokens=usage.output_tokens if usage else 0,
+            )
+            return output
+
+        except Exception as ex:
+            logger.error(f"LiteLLM [{self.model_name}] error: {ex}")
+            raise

--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -118,5 +118,5 @@ class LiteLLMAPI(ModelAPI):
             return output
 
         except Exception as ex:
-            logger.error(f"LiteLLM [{self.model_name}] error: {ex}")
+            logger.error(f'LiteLLM [{self.model_name}] error: {ex}')
             raise

--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -21,6 +21,7 @@ from evalscope.utils import get_logger
 from evalscope.utils.function_utils import retry_call
 from .utils.openai import (
     chat_choices_from_openai,
+    collect_stream_response,
     model_output_from_openai,
     openai_chat_messages,
     openai_chat_tool_choice,
@@ -97,8 +98,12 @@ class LiteLLMAPI(ModelAPI):
             )
 
             total_time = time.monotonic() - t_start
+            ttft: Optional[float] = None
 
-            completion = ChatCompletion(**response.model_dump())
+            if config.stream and not isinstance(response, ChatCompletion):
+                completion, ttft = collect_stream_response(response, request_start=t_start)
+            else:
+                completion = ChatCompletion(**response.model_dump())
 
             choices = chat_choices_from_openai(completion, tools)
             output = model_output_from_openai(completion, choices)
@@ -107,7 +112,7 @@ class LiteLLMAPI(ModelAPI):
             usage = output.usage
             output.message.perf_metrics = PerformanceMetrics(
                 latency=total_time,
-                ttft=None,
+                ttft=ttft,
                 input_tokens=usage.input_tokens if usage else 0,
                 output_tokens=usage.output_tokens if usage else 0,
             )

--- a/evalscope/models/model_apis.py
+++ b/evalscope/models/model_apis.py
@@ -27,6 +27,15 @@ def anthropic_api() -> type[ModelAPI]:
     return AnthropicCompatibleAPI
 
 
+@register_model_api(name='litellm')
+def litellm_api() -> type[ModelAPI]:
+    check_import('litellm', package='litellm', raise_error=True, feature_name='litellm')
+
+    from .litellm_compatible import LiteLLMAPI
+
+    return LiteLLMAPI
+
+
 @register_model_api(name='server')
 @deprecated(since='1.0.0', remove_in='1.1.0', alternative='openai_api')
 def server() -> type[ModelAPI]:

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -11,6 +11,7 @@ Markdown
 modelscope[datasets]>=1.34
 more_itertools
 nltk
+litellm>=1.55,<2.0
 openai
 overrides
 pandas

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -7,11 +7,11 @@ jinja2
 jsonlines
 jsonschema
 latex2sympy2_extended[antlr4_9_3]
+litellm>=1.55,<2.0
 Markdown
 modelscope[datasets]>=1.34
 more_itertools
 nltk
-litellm>=1.55,<2.0
 openai
 overrides
 pandas


### PR DESCRIPTION
                                                                                                                                                                                                                     
  ## Summary                                                                                                                                                                                                         
  - Adds [LiteLLM](https://github.com/BerriAI/litellm) as a native model API provider (`litellm`), routing to 100+ LLM providers through `litellm.completion()`                                                      
  - Follows the same `ModelAPI` + `@register_model_api` pattern as existing providers (openai_api, anthropic_api)                                                                                                    
  - Reuses OpenAI helper functions for message conversion and response parsing since litellm returns OpenAI-compatible responses.                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                         
  - `evalscope/models/litellm_compatible.py` - new `LiteLLMAPI(ModelAPI)` with `generate()` calling `litellm.completion()` directly. `drop_params=True` for cross-provider compatibility. Converts response to       
  `ChatCompletion` for reuse of existing OpenAI parsers.                                                                                                                                                             
  - `evalscope/models/model_apis.py` - registered `@register_model_api(name='litellm')` with lazy import and `check_import` guard                                                                                    
  - `requirements/framework.txt` - added `litellm>=1.55,<2.0`                                                                                                                                                        
                                                                                                                                                                                                                     
  ## Code usage                                                                                                                                                                                                      
                                                                                                                                                                                                                     
  **In task config:**
  ```yaml
  eval_type: litellm
  model: anthropic/claude-sonnet-4-20250514                                                                                                                                                                          
```   
  In Python:  
  ```python                                                                                                                                                                                                       
  from evalscope.api.registry import get_model_api
  from evalscope.api.model import GenerateConfig                                                                                                                                                                     
  from evalscope.api.messages import ChatMessageUser
                                                                                                                                                                                                                     
  # Get the LiteLLM provider class                                                                                                                                                                                   
  LiteLLMAPI = get_model_api('litellm')                                                                                                                                                                              
                                                                                                                                                                                                                     
  # Create an instance - provider API keys are read from env vars automatically
  # export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                              
  model = LiteLLMAPI(model_name='anthropic/claude-sonnet-4-20250514')
                                                                                                                                                                                                                     
  # Generate                                                                                                                                                                                                         
  output = model.generate(                                                                                                                                                                                           
      input=[ChatMessageUser(content='What is 2+2?')],                                                                                                                                                               
      tools=[],                                       
      tool_choice='none',
      config=GenerateConfig(max_tokens=100),                                                                                                                                                                         
  )                                         
  print(output.message.text)                                                                                                                                                                                         
  # Output: 4               
```                                                                                                                                                                                                                     
  Provider API keys are read from environment variables automatically. Full provider list: https://docs.litellm.ai/docs/providers
                                                                                                                                                                                                                     
  Testing         
 ```                                                                                                                                                                                                                    
  12 live E2E tests against Azure AI Foundry via litellm.completion():                                                                                                                                               
   
  Core completion:                                                                                                                                                                                                   
  - basic completion - calls litellm.completion(), verifies correct answer ("4"), response parsed through ChatCompletion and model_output_from_openai
  - ChatCompletion conversion - verifies ChatCompletion(**response.model_dump()) produces valid object with assistant role                                                                                           
  - usage stats - verifies prompt_tokens and completion_tokens are present and > 0                                        
  - finish_reason is stop - verifies completion finishes cleanly                                                                                                                                                     
                                                                                                                                                                                                                     
  Cross-provider compatibility:                                                                                                                                                                                      
  - system message - system + user messages forwarded correctly                                                                                                                                                      
  - multi-turn context - 3-message conversation, context retained ("Alice")                                                                                                                                          
  - drop_params works - unsupported kwargs (seed, frequency_penalty) silently dropped without error
  - temperature=0 - zero temperature works without error                                                                                                                                                             
                                                                                                                                                                                                                     
  Edge cases:                                                                                                                                                                                                        
  - max_tokens respected - short limit produces short response                                                                                                                                                       
  - invalid model raises - nonexistent model raises exception                                                                                                                                                        
  - JSON serializable - model_dump() output passes through json.dumps() without error
  - NOT_GIVEN tools handled - empty tools list does not pass OpenAI sentinel to litellm                                                                                                                              
                                                                                       
  PASS: basic completion                                                                                                                                                                                             
  PASS: ChatCompletion conversion                                                                                                                                                                                    
  PASS: usage stats                                                                                                                                                                                                  
  PASS: system message                                                                                                                                                                                               
  PASS: multi-turn context
  PASS: max_tokens respected
  PASS: drop_params works
  PASS: invalid model raises
  PASS: JSON serializable
  PASS: finish_reason is stop                                                                                                                                                                                        
  PASS: NOT_GIVEN tools handled
  PASS: temperature=0                                                                                                                                                                                                
                  
  Results: 12 passed, 0 failed
```
  Risk / Compatibility                                                                                                                                                                                               
   
  - Additive only. Existing providers untouched.                                                                                                                                                                     
  - litellm added to requirements/framework.txt with >=1.55,<2.0 pin.
  - Registration uses check_import('litellm', ...) guard so the app does not break if litellm is not installed.                                                                                                      
  - Reuses existing OpenAI helper functions (openai_chat_messages, model_output_from_openai, chat_choices_from_openai) since litellm returns OpenAI-compatible responses.                                            
  - drop_params=True silently drops provider-unsupported kwargs, preventing cross-provider errors.                                                                                                                   