### PR TITLE
support line_by_line_oai custom dataset mode

### DIFF
--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -53,7 +53,7 @@ class OpenaiPlugin(DefaultApiPlugin):
         try:
             # --tokenize-prompt path: convert messages/text/token-IDs to a token-ID list
             # and send as a /v1/completions request with `prompt=[int, ...]`.
-            if param.tokenize_prompt and not isinstance(messages, Dict):
+            if param.tokenize_prompt and not isinstance(messages, dict):
                 token_ids = self._messages_to_token_ids(messages, param)
                 query = {'prompt': token_ids}
                 return self.__compose_query_from_parameter(query, param)

--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -34,11 +34,11 @@ class OpenaiPlugin(DefaultApiPlugin):
         else:
             self.tokenizer = None
 
-    def build_request(self, messages: Union[List[Dict], str, List[int]], param: Arguments = None) -> Dict:
+    def build_request(self, messages: Union[List[Dict], str, List[int], Dict], param: Arguments = None) -> Dict:
         """Build the openai format request based on prompt, dataset
 
         Args:
-            messages (List[Dict] | str | List[int]): The basic message to generator query.
+            messages (List[Dict] | str | List[int] | Dict): The basic message to generator query.
                 When param.tokenize_prompt is True, this may also be a list of token IDs
                 (List[int]) produced by the random dataset plugin.
             param (QueryParameters): The query parameters.
@@ -53,7 +53,7 @@ class OpenaiPlugin(DefaultApiPlugin):
         try:
             # --tokenize-prompt path: convert messages/text/token-IDs to a token-ID list
             # and send as a /v1/completions request with `prompt=[int, ...]`.
-            if param.tokenize_prompt:
+            if param.tokenize_prompt and not isinstance(messages, Dict):
                 token_ids = self._messages_to_token_ids(messages, param)
                 query = {'prompt': token_ids}
                 return self.__compose_query_from_parameter(query, param)
@@ -71,6 +71,8 @@ class OpenaiPlugin(DefaultApiPlugin):
 
                 # replace template messages with input messages.
                 query['messages'] = messages
+            elif isinstance(messages, dict):
+                query = messages
             elif isinstance(messages, str):
                 query = {'prompt': messages}
             else:

--- a/evalscope/perf/plugin/datasets/line_by_line.py
+++ b/evalscope/perf/plugin/datasets/line_by_line.py
@@ -1,5 +1,6 @@
+import json
 import sys
-from typing import Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
@@ -8,19 +9,68 @@ from evalscope.perf.plugin.registry import register_dataset
 
 @register_dataset('line_by_line')
 class LineByLineDatasetPlugin(DatasetPluginBase):
-    """Read dataset and return prompt.
+    """Read dataset line by line and return prompt.
+
+    Each line in the file can be one of the following formats:
+
+    1. **Plain text** (original format)::
+
+        example: 今天天气怎么样？
+
+       Treated as a raw prompt string. ``__compose_query_from_parameter`` is
+       called to merge CLI-level generation parameters (e.g. ``temperature``).
+
+    2. **OpenAI messages** (JSON array)::
+
+        example: [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}]
+
+       Treated as a list of message dicts. ``__compose_query_from_parameter`` is
+       called to merge CLI-level generation parameters.
+
+    3. **Complete request body** (JSON object)::
+        # note max_tokens will be overridden by CLI-level generation parameters
+        example: {"messages": [...], "temperature": 0.6, "max_tokens": 128}
+
+       Treated as a complete request body. The parameters inside the JSON object
+       (e.g. ``temperature``) take precedence and ``__compose_query_from_parameter``
+       is **NOT** called, so CLI-level generation parameters are ignored.
     """
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
 
-    def build_messages(self) -> Iterator[List[Dict]]:
+    def _try_parse_json(self, line: str) -> Union[str, List[Dict], Dict[str, Any]]:
+        """Try to parse the line as JSON.
+
+        Returns:
+            - The original string if JSON parsing fails.
+            - List[Dict] if the line is a JSON array (messages format).
+            - Dict if the line is a JSON object (complete request body).
+        """
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            return line  # Not valid JSON, treat as plain text
+        return parsed  # List[Dict] or Dict
+
+    def build_messages(self) -> Iterator[Union[str, List[Dict], Dict[str, Any]]]:
         for item in self.dataset_line_by_line(self.query_parameters.dataset_path):
-            prompt = item.strip()
-            is_valid, _ = self.check_prompt_length(prompt)
-            if is_valid:
+            line = item.strip()
+            if not line:
+                continue
+
+            parsed = self._try_parse_json(line)
+
+            if isinstance(parsed, str):
+                prompt = parsed
+                is_valid, _ = self.check_prompt_length(prompt)
+                if not is_valid:
+                    continue
                 if self.query_parameters.apply_chat_template:
                     message = self.create_message(prompt)
-                    yield [message]
+                    result = [message]
                 else:
-                    yield prompt
+                    result = prompt
+            else:
+                result = parsed
+            yield result


### PR DESCRIPTION
针对这个问题：https://github.com/modelscope/evalscope/issues/1340
支持了line_by_line读取jsonl包含3种请求格式：
- 字符串：例如 "今天天气怎么样？"
- Dict的openai格式的请求，例如{"messages": [{"role": "system", "content": "你是一个乐于助人的助手。"}, {"role": "user", "content": "今天天气怎么样？"}, {"role": "assistant", "content": "我无法获取实时天气信息，建议您查看天气预报应用。"}, {"role": "user", "content": "那明天呢？"}], "temperature": 0.6}
- List[Dict]的openai格式的请求，例如 [{"role": "system", "content": "你是一个乐于助人的助手。"}, {"role": "user", "content": "今天天气怎么样？"}, {"role": "assistant", "content": "我无法获取实时天气信息，建议您查看天气预报应用。"}, {"role": "user", "content": "那明天呢？"}]
注意及时是Dict的openai格式，请求内部可能包含了max_token设置，仍然被benchmark工具设置的参数覆盖。因为有的可能不包含这些参数，另外便于使用同一个数据集评测不同输出场景。

使用方法：
```
evalscope perf \
  --dataset line_by_line \
  --dataset-path line_by_line_oai_example.jsonl \
  --url http://localhost:30000/v1/chat/completions \
  --model deepseek_v3 \
  --max-tokens 10 \
  --min-tokens 10 \
  --number 10 \
  --parallel 10
```

一个jsonl数据集内容样例：
```
Summarize all of this in a concise sheet
{"messages": [{"role": "system", "content": "你是一个乐于助人的助手。"}, {"role": "user", "content": "今天天气怎么样？"}, {"role": "assistant", "content": "我无法获取实时天气信息，建议您查看天气预报应用。"}, {"role": "user", "content": "那明天呢？"}], "temperature": 0.6, "max_tokens": 30}
{"messages": [{"role": "user", "content": "用中文写一首关于春天的短诗。"}], "temperature": 1.0, "max_tokens": 20}
[{"role": "system", "content": "你是一个乐于助人的助手。"}, {"role": "user", "content": "今天天气怎么样？"}, {"role": "assistant", "content": "我无法获取实时天气信息，建议您查看天气预报应用。"}, {"role": "user", "content": "那明天呢？"}]
```