### PR TITLE
perf: support swanlab_host for self-hosted SwanLab deployments

### DIFF
--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -182,6 +182,9 @@ class Arguments(BaseArgument):
     swanlab_api_key: Optional[str] = None
     """Will be deprecated in the future."""
 
+    swanlab_host: Optional[str] = None
+    """SwanLab host URL for self-hosted deployments. Falls back to SWANLAB_HOST env var."""
+
     name: Optional[str] = None
     """Name for the run."""
 
@@ -575,6 +578,11 @@ def add_argument(parser: argparse.ArgumentParser):
                         choices=[VisualizerType.WANDB, VisualizerType.SWANLAB, VisualizerType.CLEARML, None], help='The visualizer to use, default None')  # noqa: E501
     parser.add_argument('--wandb-api-key', type=str, default=None, help='The wandb API key')
     parser.add_argument('--swanlab-api-key', type=str, default=None, help='The swanlab API key')
+    parser.add_argument(
+        '--swanlab-host',
+        type=str,
+        default=None,
+        help='SwanLab host URL for self-hosted deployments (also reads SWANLAB_HOST env var)')
     parser.add_argument('--name', type=str, help='The wandb/swanlab/clearml result name and result db name')
     parser.add_argument('--enable-progress-tracker', action='store_true', default=False, help='Enable progress tracker')
 

--- a/evalscope/perf/utils/log_utils.py
+++ b/evalscope/perf/utils/log_utils.py
@@ -115,8 +115,11 @@ def init_swanlab(args: Arguments) -> None:
         init_kwargs['workspace'] = workspace
 
     swanlab_host = args.swanlab_host or os.getenv('SWANLAB_HOST')
-    if isinstance(args.swanlab_api_key, str) and not args.swanlab_api_key == 'local':
-        login_kwargs = {'api_key': args.swanlab_api_key}
+    is_local = args.swanlab_api_key == 'local'
+    if not is_local and (isinstance(args.swanlab_api_key, str) or swanlab_host):
+        login_kwargs = {}
+        if isinstance(args.swanlab_api_key, str):
+            login_kwargs['api_key'] = args.swanlab_api_key
         if swanlab_host:
             login_kwargs['host'] = swanlab_host
         swanlab.login(**login_kwargs)

--- a/evalscope/perf/utils/log_utils.py
+++ b/evalscope/perf/utils/log_utils.py
@@ -114,8 +114,12 @@ def init_swanlab(args: Arguments) -> None:
     if workspace:
         init_kwargs['workspace'] = workspace
 
+    swanlab_host = args.swanlab_host or os.getenv('SWANLAB_HOST')
     if isinstance(args.swanlab_api_key, str) and not args.swanlab_api_key == 'local':
-        swanlab.login(api_key=args.swanlab_api_key)
+        login_kwargs = {'api_key': args.swanlab_api_key}
+        if swanlab_host:
+            login_kwargs['host'] = swanlab_host
+        swanlab.login(**login_kwargs)
     swanlab.init(**init_kwargs)
 
 


### PR DESCRIPTION
## Summary
- Add `swanlab_host` argument (also reads `SWANLAB_HOST` env var) to perf Arguments
- Pass `host` to `swanlab.login()` when configured, enabling private SwanLab deployments

## Test plan
- [ ] Run perf with `--visualizer swanlab --swanlab-api-key <key> --swanlab-host https://swanlab.example.com` against a self-hosted SwanLab instance
- [ ] Verify env-var fallback via `SWANLAB_HOST=...`

Fixes #648