### PR TITLE
Add OpenAI Responses API support, solve #1192

### DIFF
--- a/docs/en/get_started/basic_usage.md
+++ b/docs/en/get_started/basic_usage.md
@@ -180,6 +180,18 @@ evalscope eval \
  --limit 10
 ```
 
+For OpenAI's official Responses API, use `--eval-type openai_responses_api` and point `--api-url` at the API root:
+```shell
+evalscope eval \
+ --model gpt-4.1-mini \
+ --api-url https://api.openai.com/v1 \
+ --api-key $OPENAI_API_KEY \
+ --eval-type openai_responses_api \
+ --datasets gsm8k \
+ --limit 10 \
+ --generation-config '{"stream": true, "max_tokens": 512}'
+```
+
 ### Using Judge Models for Assessment
 
 For certain subjective or open-ended tasks (such as `simple_qa`), you can specify a powerful "judge model" to evaluate the target model's output.

--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -19,7 +19,7 @@ The following environment variables can be set before launch to control global d
 |-----------|------|-------------|---------|
 | `--model` | `str` | Name of the model to be evaluated<br>• ModelScope model ID (e.g., `Qwen/Qwen2.5-0.5B-Instruct`)<br>• Local model path (e.g., `/path/to/model`)<br>• Model ID for API service (e.g., `Qwen2.5-0.5B-Instruct`) | - |
 | `--model-id` | `str` | Alias for the evaluated model, used in reports | Last part of `model` |
-| `--api-url` | `str` | Model API endpoint, supports OpenAI-compatible format<br>Example: `http://127.0.0.1:8000/v1` | `None` |
+| `--api-url` | `str` | Model API endpoint, supports OpenAI-compatible and OpenAI Responses API roots<br>Example: `http://127.0.0.1:8000/v1` or `https://api.openai.com/v1` | `None` |
 | `--api-key` | `str` | Model API endpoint key | `EMPTY` |
 | `--model-args` | `str` | Model loading parameters, comma-separated `key=value` or JSON string<br>• `revision`: Model revision<br>• `precision`: Model precision<br>• `device_map`: Device allocation | `revision=master`<br>`precision=torch.float16`<br>`device_map=auto` |
 | `--model-task` | `str` | Model task type | `text_generation`<br>(Options: `image_generation`) |
@@ -144,7 +144,7 @@ The `--generation-config` parameter supports the following options (comma-separa
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `--eval-type` | `str` | Evaluation type<br>• `llm_ckpt`: Local model inference (transformers)<br>• `openai_api`: OpenAI-compatible API service<br>• `anthropic_api`: Anthropic Claude API service<br>• `litellm`: LiteLLM multi-provider routing (supports 100+ LLM providers)<br>• `text2image`: Text-to-image model (diffusers)<br>• `image_editing`: Image editing model<br>• `mock_llm`: Simulated inference (for verification)<br>• `custom`: Custom evaluation type | `None` (auto-detect) |
+| `--eval-type` | `str` | Evaluation type<br>• `llm_ckpt`: Local model inference (transformers)<br>• `openai_api`: OpenAI-compatible Chat Completions API service<br>• `openai_responses_api`: OpenAI official Responses API service<br>• `anthropic_api`: Anthropic Claude API service<br>• `litellm`: LiteLLM multi-provider routing (supports 100+ LLM providers)<br>• `text2image`: Text-to-image model (diffusers)<br>• `image_editing`: Image editing model<br>• `mock_llm`: Simulated inference (for verification)<br>• `custom`: Custom evaluation type | `None` (auto-detect) |
 | `--eval-batch-size` | `int` | Evaluation batch size, applies to the following stages:<br>• Inference: concurrent requests (service mode) or batch size (checkpoint mode)<br>• LLM-judge review: number of concurrent threads<br>• `batch_calculate_metrics`: number of samples per batch window | `1` (service mode: `8`) |
 | `--eval-backend` | `str` | Evaluation backend<br>• `Native`: Default backend<br>• `OpenCompass`: LLM evaluation<br>• `VLMEvalKit`: Multimodal model evaluation<br>• `RAGEval`: RAG/Embedding/Reranker/CLIP evaluation<br>• `ThirdParty`: Special task evaluation | `Native` |
 | `--eval-config` | `str` | Configuration file path for non-Native backends | - |

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -7,9 +7,9 @@ Execute `evalscope perf --help` to get a full parameter description.
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `--model` | `str` | Name or path of the test model | - |
-| `--url` | `str` | API address, supporting `/chat/completion` and `/completion` endpoints | - |
+| `--url` | `str` | API address, supporting `/chat/completions`, `/completions`, and `/responses` endpoints | - |
 | `--name` | `str` | Name for wandb/swanlab database result and result database | `{model_name}_{current_time}` |
-| `--api` | `str` | Service API type<br>• `openai`: OpenAI-compatible API (requires `--url`)<br>• `openai_embedding`: OpenAI-compatible Embedding API<br>• `openai_rerank`: OpenAI/Cohere-compatible Rerank API<br>• `local`: Start local transformers inference<br>• `local_vllm`: Start local vLLM inference service<br>• Custom: See [Custom API Guide](./custom.md#custom-api-requests) | - |
+| `--api` | `str` | Service API type<br>• `openai`: OpenAI-compatible Chat Completions API (requires `--url`)<br>• `openai_responses`: OpenAI official Responses API<br>• `openai_embedding`: OpenAI-compatible Embedding API<br>• `openai_rerank`: OpenAI/Cohere-compatible Rerank API<br>• `local`: Start local transformers inference<br>• `local_vllm`: Start local vLLM inference service<br>• Custom: See [Custom API Guide](./custom.md#custom-api-requests) | - |
 | `--port` | `int` | Port for local inference service<br>Only applicable to `local` and `local_vllm` | `8877` |
 | `--attn-implementation` | `str` | Attention implementation method<br>Only effective when `api=local` | `None`<br>(Optional: `flash_attention_2`, `eager`, `sdpa`) |
 | `--api-key` | `str` | API key | `None` |

--- a/docs/zh/get_started/basic_usage.md
+++ b/docs/zh/get_started/basic_usage.md
@@ -158,6 +158,18 @@ evalscope eval \
  --limit 10
 ```
 
+如需评测 OpenAI 官方 Responses API，请设置 `--eval-type openai_responses_api`，并将 `--api-url` 指向 API 根路径：
+```shell
+evalscope eval \
+ --model gpt-4.1-mini \
+ --api-url https://api.openai.com/v1 \
+ --api-key $OPENAI_API_KEY \
+ --eval-type openai_responses_api \
+ --datasets gsm8k \
+ --limit 10 \
+ --generation-config '{"stream": true, "max_tokens": 512}'
+```
+
 ### 自定义评测参数
 
 **示例1. 调整模型加载和推理生成参数** 

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -19,7 +19,7 @@
 |------|------|------|--------|
 | `--model` | `str` | 被评测的模型名称<br>• ModelScope模型ID（如`Qwen/Qwen2.5-0.5B-Instruct`）<br>• 本地模型路径（如`/path/to/model`）<br>• API服务的模型ID（如`Qwen2.5-0.5B-Instruct`） | - |
 | `--model-id` | `str` | 模型别名，用于报告展示 | `model`的最后一部分 |
-| `--api-url` | `str` | 模型API端点，支持OpenAI兼容格式<br>示例：`http://127.0.0.1:8000/v1` | `None` |
+| `--api-url` | `str` | 模型API端点，支持OpenAI兼容格式和OpenAI Responses API根路径<br>示例：`http://127.0.0.1:8000/v1` 或 `https://api.openai.com/v1` | `None` |
 | `--api-key` | `str` | 模型API端点密钥 | `EMPTY` |
 | `--model-args` | `str` | 模型加载参数，逗号分隔的`key=value`或JSON字符串<br>• `revision`: 模型版本<br>• `precision`: 模型精度<br>• `device_map`: 设备分配 | `revision=master`<br>`precision=torch.float16`<br>`device_map=auto` |
 | `--model-task` | `str` | 模型任务类型 | `text_generation`<br>（可选：`image_generation`） |
@@ -144,7 +144,7 @@
 
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
-| `--eval-type` | `str` | 评测类型<br>• `llm_ckpt`: 本地模型推理（transformers）<br>• `openai_api`: OpenAI兼容API服务<br>• `anthropic_api`: Anthropic Claude API服务<br>• `litellm`: LiteLLM多厂商路由（支持100+ LLM提供商）<br>• `text2image`: 文本转图像模型（diffusers）<br>• `image_editing`: 图像编辑模型<br>• `mock_llm`: 模拟推理（功能验证）<br>• `custom`: 自定义评测类型 | `None`（自动判断） |
+| `--eval-type` | `str` | 评测类型<br>• `llm_ckpt`: 本地模型推理（transformers）<br>• `openai_api`: OpenAI兼容Chat Completions API服务<br>• `openai_responses_api`: OpenAI官方Responses API服务<br>• `anthropic_api`: Anthropic Claude API服务<br>• `litellm`: LiteLLM多厂商路由（支持100+ LLM服务商）<br>• `text2image`: 文本转图像模型（diffusers）<br>• `image_editing`: 图像编辑模型<br>• `mock_llm`: 模拟推理（功能验证）<br>• `custom`: 自定义评测类型 | `None`（自动判断） |
 | `--eval-batch-size` | `int` | 评测批量大小，作用于以下阶段：<br>• 推理阶段：并发请求数（service模式）或批量大小（checkpoint模式）<br>• LLM-judge 评审阶段：并发线程数<br>• batch_calculate_metrics 阶段：每批次处理的样本数 | `1`（service模式为`8`） |
 | `--eval-backend` | `str` | 评测后端<br>• `Native`: 默认后端<br>• `OpenCompass`: 大语言模型评测<br>• `VLMEvalKit`: 多模态模型评测<br>• `RAGEval`: RAG/Embedding/Reranker/CLIP评测<br>• `ThirdParty`: 特殊任务评测 | `Native` |
 | `--eval-config` | `str` | 非Native后端的配置文件路径 | - |

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -7,9 +7,9 @@
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
 | `--model` | `str` | 测试模型名称，或模型路径 | - |
-| `--url` | `str` | API地址，支持`/chat/completion`和`/completion`端点 | - |
+| `--url` | `str` | API地址，支持`/chat/completions`、`/completions`和`/responses`端点 | - |
 | `--name` | `str` | wandb/swanlab数据库结果名称和结果数据库名称 | `{model_name}_{current_time}` |
-| `--api` | `str` | 服务API类型<br>• `openai`: OpenAI兼容API（需提供`--url`）<br>• `openai_embedding`: OpenAI兼容Embedding API<br>• `openai_rerank`: OpenAI/Cohere兼容Rerank API<br>• `local`: 启动本地transformers推理<br>• `local_vllm`: 启动本地vLLM推理服务<br>• 自定义：参考[自定义API指南](./custom.md/#自定义请求-api) | - |
+| `--api` | `str` | 服务API类型<br>• `openai`: OpenAI兼容Chat Completions API（需提供`--url`）<br>• `openai_responses`: OpenAI官方Responses API<br>• `openai_embedding`: OpenAI兼容Embedding API<br>• `openai_rerank`: OpenAI/Cohere兼容Rerank API<br>• `local`: 启动本地transformers推理<br>• `local_vllm`: 启动本地vLLM推理服务<br>• 自定义：参考[自定义API指南](./custom.md/#自定义请求-api) | - |
 | `--port` | `int` | 本地推理服务端口<br>仅对`local`和`local_vllm`有效 | `8877` |
 | `--attn-implementation` | `str` | Attention实现方式<br>仅在`api=local`时有效 | `None`<br>（可选：`flash_attention_2`、`eager`、`sdpa`） |
 | `--api-key` | `str` | API密钥 | `None` |

--- a/evalscope/arguments.py
+++ b/evalscope/arguments.py
@@ -62,7 +62,17 @@ def add_argument(parser: argparse.ArgumentParser):
 
     # Evaluation-related arguments
     parser.add_argument('--eval-type', type=str,
-                        choices=[EvalType.CHECKPOINT, EvalType.OPENAI_API, EvalType.ANTHROPIC_API, EvalType.LITELLM, EvalType.MOCK_LLM, EvalType.TEXT2IMAGE, EvalType.IMAGE_EDITING, EvalType.CUSTOM],
+                        choices=[
+                            EvalType.CHECKPOINT,
+                            EvalType.OPENAI_API,
+                            EvalType.OPENAI_RESPONSES_API,
+                            EvalType.ANTHROPIC_API,
+                            EvalType.LITELLM,
+                            EvalType.MOCK_LLM,
+                            EvalType.TEXT2IMAGE,
+                            EvalType.IMAGE_EDITING,
+                            EvalType.CUSTOM,
+                        ],
                         help='Evaluation backend type. Auto-inferred from --api-url / --model when omitted.')  # noqa: E501
     parser.add_argument('--eval-backend', type=str, help='The evaluation backend to use.',
                         choices=[EvalBackend.NATIVE, EvalBackend.OPEN_COMPASS, EvalBackend.VLM_EVAL_KIT, EvalBackend.RAG_EVAL])  # noqa: E501

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -366,7 +366,7 @@ class TaskConfig(BaseArgument):
         elif self.model_task == ModelTask.TEXT_GENERATION:
             if self.eval_type == EvalType.CHECKPOINT:
                 return DEFAULT_TEXT_GEN_CHECKPOINT_CONFIG.copy()
-            elif self.eval_type == EvalType.OPENAI_API:
+            elif self.eval_type in (EvalType.OPENAI_API, EvalType.OPENAI_RESPONSES_API):
                 return DEFAULT_TEXT_GEN_SERVICE_CONFIG.copy()
 
         return {}

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -128,8 +128,9 @@ class TaskConfig(BaseArgument):
     # Evaluation-related arguments
     eval_type: Optional[str] = None
     """Evaluation backend type. One of: 'llm_ckpt' (local checkpoint), 'openai_api',
-    'anthropic_api', 'litellm', 'mock_llm', 'text2image', 'image_editing', 'custom'.
-    Deprecated aliases: 'checkpoint' -> 'llm_ckpt', 'server' -> 'openai_api'."""
+    'openai_responses_api', 'anthropic_api', 'litellm', 'mock_llm', 'text2image',
+    'image_editing', 'custom'. Deprecated aliases: 'checkpoint' -> 'llm_ckpt',
+    'server' -> 'openai_api'."""
 
     eval_backend: str = EvalBackend.NATIVE
     """Backend framework to use for evaluation."""

--- a/evalscope/constants.py
+++ b/evalscope/constants.py
@@ -77,6 +77,7 @@ class EvalType:
     TEXT2IMAGE = 'text2image'  # image generation service
     IMAGE_EDITING = 'image_editing'  # image editing service
     OPENAI_API = 'openai_api'
+    OPENAI_RESPONSES_API = 'openai_responses_api'
     ANTHROPIC_API = 'anthropic_api'
     LITELLM = 'litellm'
 

--- a/evalscope/models/model_apis.py
+++ b/evalscope/models/model_apis.py
@@ -18,6 +18,13 @@ def openai_api() -> type[ModelAPI]:
     return OpenAICompatibleAPI
 
 
+@register_model_api(name='openai_responses_api')
+def openai_responses_api() -> type[ModelAPI]:
+    from .openai_responses import OpenAIResponsesAPI
+
+    return OpenAIResponsesAPI
+
+
 @register_model_api(name='anthropic_api')
 def anthropic_api() -> type[ModelAPI]:
     check_import('anthropic', package='anthropic', raise_error=True, feature_name='anthropic_api')

--- a/evalscope/models/openai_responses.py
+++ b/evalscope/models/openai_responses.py
@@ -1,0 +1,194 @@
+import os
+import time
+from openai import APIStatusError, BadRequestError, PermissionDeniedError, UnprocessableEntityError
+from openai._types import NOT_GIVEN
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from evalscope.api.messages import ChatMessage
+from evalscope.api.messages.perf_metrics import PerformanceMetrics
+from evalscope.api.model import ChatCompletionChoice, GenerateConfig, ModelOutput
+from evalscope.api.tool import ToolChoice, ToolInfo
+from evalscope.utils import get_logger
+from evalscope.utils.argument_utils import get_supported_params
+from evalscope.utils.function_utils import async_retry_call, retry_call
+from .openai_compatible import OpenAICompatibleAPI
+from .utils.openai import openai_handle_bad_request
+from .utils.openai_responses import (
+    async_collect_response_stream,
+    chat_choices_from_openai_response,
+    collect_response_stream,
+    model_output_from_openai_response,
+    openai_response_messages,
+    openai_response_params,
+    openai_response_tool_choice,
+    openai_response_tools,
+)
+
+try:
+    from openai.types.responses import Response
+except ImportError as ex:
+    Response = None
+    _OPENAI_RESPONSES_IMPORT_ERROR: Optional[ImportError] = ex
+else:
+    _OPENAI_RESPONSES_IMPORT_ERROR = None
+
+logger = get_logger()
+
+
+class OpenAIResponsesAPI(OpenAICompatibleAPI):
+    """OpenAI official Responses API provider."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        resolved_base_url = base_url or os.environ.get('EVALSCOPE_BASE_URL', None)
+        if resolved_base_url is not None:
+            resolved_base_url = resolved_base_url.rstrip('/').removesuffix('/responses')
+        super().__init__(
+            model_name=model_name,
+            base_url=resolved_base_url,
+            api_key=api_key,
+            config=config,
+            **model_args,
+        )
+        self._validate_responses_client()
+
+    def _validate_responses_client(self) -> None:
+        if _OPENAI_RESPONSES_IMPORT_ERROR is not None or not hasattr(self.client, 'responses'):
+            raise RuntimeError(
+                'The installed version of the "openai" library does not support the Responses API. '
+                'Please upgrade to openai>=1.56.0.'
+            )
+
+    def generate(
+        self,
+        input: List[ChatMessage],
+        tools: List[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        request, tools, config = self._build_request(input, tools, tool_choice, config)
+
+        try:
+            t_start = time.monotonic()
+            ttft: Optional[float] = None
+
+            response = retry_call(
+                self.client.responses.create,
+                retries=config.retries,
+                sleep_interval=config.retry_interval,
+                **request,
+            )
+            if not self._is_response_object(response):
+                response, ttft = collect_response_stream(response, request_start=t_start)
+
+            total_time = time.monotonic() - t_start
+            return self._build_output(response, tools, total_time, ttft)
+
+        except (BadRequestError, UnprocessableEntityError, PermissionDeniedError) as ex:
+            return self.handle_bad_request(ex)
+        except ValueError as ex:
+            logger.error(f'Model [{self.model_name}] returned an invalid response: {ex}')
+            raise
+
+    async def generate_async(
+        self,
+        input: List[ChatMessage],
+        tools: List[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        request, tools, config = self._build_request(input, tools, tool_choice, config)
+
+        try:
+            t_start = time.monotonic()
+            ttft: Optional[float] = None
+
+            response = await async_retry_call(
+                self.async_client.responses.create,
+                retries=config.retries,
+                sleep_interval=config.retry_interval,
+                **request,
+            )
+            if not self._is_response_object(response):
+                response, ttft = await async_collect_response_stream(response, request_start=t_start)
+
+            total_time = time.monotonic() - t_start
+            return self._build_output(response, tools, total_time, ttft)
+
+        except (BadRequestError, UnprocessableEntityError, PermissionDeniedError) as ex:
+            return self.handle_bad_request(ex)
+        except ValueError as ex:
+            logger.error(f'Model [{self.model_name}] returned an invalid response: {ex}')
+            raise
+
+    def _build_request(
+        self,
+        input: List[ChatMessage],
+        tools: List[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> Tuple[Dict[str, Any], List[ToolInfo], GenerateConfig]:
+        tools, tool_choice, config = self.resolve_tools(tools, tool_choice, config)
+        request = dict(
+            input=openai_response_messages(input),
+            tools=openai_response_tools(tools) if len(tools) > 0 else NOT_GIVEN,
+            tool_choice=openai_response_tool_choice(tool_choice) if len(tools) > 0 else NOT_GIVEN,
+            **self.response_params(config=config, tools=len(tools) > 0),
+        )
+        self.validate_request_params(request)
+        return request, tools, config
+
+    @staticmethod
+    def _is_response_object(response: Any) -> bool:
+        return Response is not None and isinstance(response, Response)
+
+    def _build_output(
+        self,
+        response: Any,
+        tools: List[ToolInfo],
+        total_time: float,
+        ttft: Optional[float],
+    ) -> ModelOutput:
+        self.on_response(response.model_dump())
+        choices = self.chat_choices_from_response(response, tools)
+        output = model_output_from_openai_response(response, choices)
+        output.time = total_time
+        usage = output.usage
+        output.message.perf_metrics = PerformanceMetrics(
+            latency=total_time,
+            ttft=ttft,
+            input_tokens=usage.input_tokens if usage else 0,
+            output_tokens=usage.output_tokens if usage else 0,
+        )
+        return output
+
+    def response_params(self, config: GenerateConfig, tools: bool) -> Dict[str, Any]:
+        return openai_response_params(
+            model=self.model_name,
+            config=config,
+            tools=tools,
+        )
+
+    def validate_request_params(self, params: Dict[str, Any]) -> None:
+        if not hasattr(self, '_valid_params'):
+            self._valid_params = get_supported_params(self.client.responses.create)
+
+        extra_body = params.get('extra_body', {})
+        for key in list(params.keys()):
+            if key not in self._valid_params:
+                extra_body[key] = params.pop(key)
+
+        if extra_body:
+            params['extra_body'] = extra_body
+
+    def chat_choices_from_response(self, response: Response, tools: List[ToolInfo]) -> List[ChatCompletionChoice]:
+        return chat_choices_from_openai_response(response, tools)
+
+    def handle_bad_request(self, ex: APIStatusError) -> Union[ModelOutput, Exception]:
+        return openai_handle_bad_request(self.model_name, ex)

--- a/evalscope/models/utils/openai_responses.py
+++ b/evalscope/models/utils/openai_responses.py
@@ -1,0 +1,377 @@
+import json
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from evalscope.api.messages import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageTool,
+    Content,
+    ContentReasoning,
+    ContentText,
+)
+from evalscope.api.model import ChatCompletionChoice, GenerateConfig, ModelOutput, ModelUsage, StopReason
+from evalscope.api.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo, parse_tool_call
+from evalscope.utils.url_utils import file_as_data_uri, is_data_uri, is_http_url
+from .openai import openai_assistant_content
+
+try:
+    from openai.types.responses import Response
+except ImportError:
+    Response = Any
+
+
+def openai_response_input_part(content: Content) -> Dict[str, Any]:
+    if content.type == 'text':
+        return {'type': 'input_text', 'text': content.text}
+    if content.type == 'image':
+        image_url = content.image
+        if not is_http_url(image_url) and not is_data_uri(image_url):
+            image_url = file_as_data_uri(image_url)
+        return {'type': 'input_image', 'image_url': image_url, 'detail': content.detail}
+    if content.type == 'audio':
+        raise RuntimeError('Audio content is not currently supported by OpenAI Responses API input messages.')
+    if content.type == 'video':
+        raise RuntimeError('Video content is not currently supported by OpenAI Responses API input messages.')
+    raise RuntimeError(f'Content type {content.type} is not currently supported by OpenAI Responses API.')
+
+
+def openai_response_message(message: ChatMessage) -> List[Dict[str, Any]]:
+    if message.role == 'system':
+        return [{'role': 'system', 'content': message.text}]
+    if message.role == 'user':
+        return [{
+            'role': 'user',
+            'content': (
+                message.content if isinstance(message.content, str) else
+                [openai_response_input_part(content) for content in message.content]
+            ),
+        }]
+    if message.role == 'assistant':
+        return openai_response_assistant_message(message)
+    if message.role == 'tool':
+        return [openai_response_tool_message(message)]
+    raise ValueError(f'Unexpected message role {message.role}')
+
+
+def openai_response_messages(messages: List[ChatMessage]) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for message in messages:
+        items.extend(openai_response_message(message))
+    return items
+
+
+def openai_response_assistant_message(message: ChatMessageAssistant) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    content = openai_assistant_content(message)
+    if content:
+        items.append({'role': 'assistant', 'content': content})
+    for call in message.tool_calls or []:
+        items.append(openai_response_function_call(call))
+    return items
+
+
+def openai_response_tool_message(message: ChatMessageTool) -> Dict[str, Any]:
+    return {
+        'type': 'function_call_output',
+        'call_id': str(message.tool_call_id),
+        'output': f'Error: {message.error.message}' if message.error else message.text,
+    }
+
+
+def openai_response_function_call(tool_call: ToolCall) -> Dict[str, Any]:
+    return {
+        'type': 'function_call',
+        'call_id': tool_call.id,
+        'name': tool_call.function.name,
+        'arguments': json.dumps(tool_call.function.arguments),
+    }
+
+
+def openai_response_tool_param(tool: ToolInfo) -> Dict[str, Any]:
+    return {
+        'type': 'function',
+        'name': tool.name,
+        'description': tool.description,
+        'parameters': tool.parameters.model_dump(exclude_none=True),
+        'strict': False,
+    }
+
+
+def openai_response_tools(tools: List[ToolInfo]) -> List[Dict[str, Any]]:
+    return [openai_response_tool_param(tool) for tool in tools]
+
+
+def openai_response_tool_choice(tool_choice: ToolChoice) -> Union[str, Dict[str, Any]]:
+    if isinstance(tool_choice, ToolFunction):
+        return {'type': 'function', 'name': tool_choice.name}
+    if tool_choice == 'any':
+        return 'required'
+    return tool_choice
+
+
+def openai_response_params(model: str, config: GenerateConfig, tools: bool) -> Dict[str, Any]:
+    params: Dict[str, Any] = {'model': model}
+    if config.stream is not None:
+        params['stream'] = config.stream
+    if config.timeout is not None:
+        params['timeout'] = config.timeout
+    if config.max_tokens is not None:
+        params['max_output_tokens'] = config.max_tokens
+    if config.temperature is not None:
+        params['temperature'] = config.temperature
+    if config.top_p is not None:
+        params['top_p'] = config.top_p
+    if config.top_logprobs is not None:
+        params['top_logprobs'] = config.top_logprobs
+    if tools and config.parallel_tool_calls is not None:
+        params['parallel_tool_calls'] = config.parallel_tool_calls
+    if config.reasoning_effort is not None or config.reasoning_summary is not None:
+        reasoning: Dict[str, Any] = {}
+        if config.reasoning_effort is not None:
+            reasoning['effort'] = config.reasoning_effort
+        if config.reasoning_summary is not None:
+            reasoning['summary'] = config.reasoning_summary
+        params['reasoning'] = reasoning
+    if config.response_schema is not None:
+        text_format = {
+            'type': 'json_schema',
+            'name': config.response_schema.name,
+            'schema': config.response_schema.json_schema.model_dump(exclude_none=True),
+        }
+        if config.response_schema.description is not None:
+            text_format['description'] = config.response_schema.description
+        if config.response_schema.strict is not None:
+            text_format['strict'] = config.response_schema.strict
+        params['text'] = {'format': text_format}
+    if config.extra_body:
+        params['extra_body'] = config.extra_body
+    if config.extra_query:
+        params['extra_query'] = config.extra_query
+    if config.extra_headers:
+        params['extra_headers'] = config.extra_headers
+    return params
+
+
+def collect_response_stream(
+    response_stream: Iterable[Any],
+    request_start: Optional[float] = None,
+) -> Tuple[Response, Optional[float]]:
+    response: Optional[Response] = None
+    t_start = request_start if request_start is not None else time.monotonic()
+    ttft: Optional[float] = None
+
+    for event in response_stream:
+        event_type = getattr(event, 'type', None)
+        delta = getattr(event, 'delta', None)
+        if ttft is None and event_type in _FIRST_TOKEN_EVENT_TYPES and delta:
+            ttft = time.monotonic() - t_start
+        if event_type in ('response.completed', 'response.incomplete', 'response.failed'):
+            response = event.response
+
+    if response is None:
+        raise ValueError('OpenAI Responses stream ended without a terminal response event.')
+    return response, ttft
+
+
+async def async_collect_response_stream(
+    response_stream: Any,
+    request_start: Optional[float] = None,
+) -> Tuple[Response, Optional[float]]:
+    response: Optional[Response] = None
+    t_start = request_start if request_start is not None else time.monotonic()
+    ttft: Optional[float] = None
+
+    async for event in response_stream:
+        event_type = getattr(event, 'type', None)
+        delta = getattr(event, 'delta', None)
+        if ttft is None and event_type in _FIRST_TOKEN_EVENT_TYPES and delta:
+            ttft = time.monotonic() - t_start
+        if event_type in ('response.completed', 'response.incomplete', 'response.failed'):
+            response = event.response
+
+    if response is None:
+        raise ValueError('OpenAI Responses stream ended without a terminal response event.')
+    return response, ttft
+
+
+def model_output_from_openai_response(
+    response: Response,
+    choices: List[ChatCompletionChoice],
+) -> ModelOutput:
+    return ModelOutput(
+        id=response.id,
+        model=response.model,
+        choices=choices,
+        usage=model_usage_from_openai_response(response),
+    )
+
+
+def model_usage_from_openai_response(response: Response) -> Optional[ModelUsage]:
+    usage = response.usage
+    if usage is None:
+        return None
+    return ModelUsage(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        input_tokens_cache_read=(
+            usage.input_tokens_details.cached_tokens if usage.input_tokens_details is not None else None
+        ),
+        reasoning_tokens=(
+            usage.output_tokens_details.reasoning_tokens if usage.output_tokens_details is not None else None
+        ),
+        total_tokens=usage.total_tokens,
+    )
+
+
+def chat_choices_from_openai_response(response: Response, tools: List[ToolInfo]) -> List[ChatCompletionChoice]:
+    text = response_output_text(response)
+    reasoning = response_reasoning_text(response)
+    tool_calls = response_tool_calls(response, tools)
+    content: Union[str, List[Content]]
+    if reasoning:
+        content = [ContentReasoning(reasoning=reasoning), ContentText(text=text)]
+    else:
+        content = text
+    return [
+        ChatCompletionChoice(
+            message=ChatMessageAssistant(
+                content=content,
+                model=response.model,
+                source='generate',
+                tool_calls=tool_calls or None,
+            ),
+            stop_reason=response_stop_reason(response, has_tool_calls=bool(tool_calls)),
+        )
+    ]
+
+
+def response_output_text(response: Response) -> str:
+    output_text = getattr(response, 'output_text', None)
+    if isinstance(output_text, str) and output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in response.output or []:
+        if getattr(item, 'type', None) != 'message':
+            continue
+        for content in getattr(item, 'content', []) or []:
+            content_type = getattr(content, 'type', None)
+            if content_type == 'output_text':
+                parts.append(getattr(content, 'text', '') or '')
+            elif content_type == 'refusal':
+                parts.append(getattr(content, 'refusal', '') or '')
+    return ''.join(parts)
+
+
+def response_reasoning_text(response: Response) -> str:
+    parts: List[str] = []
+    for item in response.output or []:
+        if getattr(item, 'type', None) != 'reasoning':
+            continue
+        for summary in getattr(item, 'summary', []) or []:
+            text = getattr(summary, 'text', None)
+            if text:
+                parts.append(text)
+        for content in getattr(item, 'content', []) or []:
+            text = getattr(content, 'text', None)
+            if text:
+                parts.append(text)
+    return ''.join(parts)
+
+
+def response_tool_calls(response: Response, tools: List[ToolInfo]) -> List[ToolCall]:
+    calls: List[ToolCall] = []
+    for item in response.output or []:
+        if getattr(item, 'type', None) != 'function_call':
+            continue
+        calls.append(
+            parse_tool_call(
+                getattr(item, 'call_id', '') or getattr(item, 'id', ''),
+                getattr(item, 'name', ''),
+                getattr(item, 'arguments', '') or '{}',
+                tools,
+            )
+        )
+    return calls
+
+
+def response_stop_reason(response: Response, has_tool_calls: bool = False) -> StopReason:
+    if has_tool_calls:
+        return 'tool_calls'
+    if response.status == 'incomplete' and response.incomplete_details is not None:
+        reason = response.incomplete_details.reason
+        if reason == 'max_output_tokens':
+            return 'max_tokens'
+        if reason == 'content_filter':
+            return 'content_filter'
+    if response.status == 'failed':
+        return 'unknown'
+    return 'stop'
+
+
+def response_usage_from_dict(payload: Dict[str, Any]) -> Optional[Tuple[int, int]]:
+    usage = payload.get('usage')
+    if not usage:
+        return None
+    if 'input_tokens' in usage or 'output_tokens' in usage:
+        return usage.get('input_tokens', 0), usage.get('output_tokens', 0)
+    if 'prompt_tokens' in usage or 'completion_tokens' in usage:
+        return usage.get('prompt_tokens', 0), usage.get('completion_tokens', 0)
+    return None
+
+
+def response_text_from_dict(payload: Dict[str, Any]) -> str:
+    if isinstance(payload.get('output_text'), str):
+        return payload['output_text']
+    parts: List[str] = []
+    for item in payload.get('output', []) or []:
+        if item.get('type') != 'message':
+            continue
+        for content in item.get('content', []) or []:
+            content_type = content.get('type')
+            if content_type == 'output_text':
+                parts.append(content.get('text', '') or '')
+            elif content_type == 'refusal':
+                parts.append(content.get('refusal', '') or '')
+    return ''.join(parts)
+
+
+def normalize_responses_input(value: Any) -> Any:
+    if isinstance(value, list):
+        return [normalize_responses_message(message) if isinstance(message, dict) else message for message in value]
+    return value
+
+
+def normalize_responses_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    content = message.get('content')
+    if not isinstance(content, list):
+        return message
+    normalized = dict(message)
+    normalized['content'] = [normalize_responses_content_part(part) for part in content]
+    return normalized
+
+
+def normalize_responses_content_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    part_type = part.get('type')
+    if part_type == 'text':
+        return {'type': 'input_text', 'text': part.get('text', '')}
+    if part_type == 'image_url':
+        image_url = part.get('image_url', {})
+        if isinstance(image_url, str):
+            return {'type': 'input_image', 'image_url': image_url, 'detail': 'auto'}
+        return {
+            'type': 'input_image',
+            'image_url': image_url.get('url'),
+            'detail': image_url.get('detail', 'auto'),
+        }
+    return part
+
+
+_FIRST_TOKEN_EVENT_TYPES = {
+    'response.output_text.delta',
+    'response.refusal.delta',
+    'response.reasoning_text.delta',
+    'response.reasoning_summary_text.delta',
+    'response.function_call_arguments.delta',
+}

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -14,6 +14,9 @@ logger = get_logger()
 
 _OPENAI_API_ENDPOINT_MAP = {
     'openai': 'chat/completions',
+    'openai_responses': 'responses',
+    'openai_response': 'responses',
+    'responses': 'responses',
     'openai_embedding': 'embeddings',
     'embedding': 'embeddings',
     'openai_rerank': 'reranks',
@@ -33,9 +36,10 @@ class Arguments(BaseArgument):
     """Attention implementation, only for local inference."""
 
     api: str = 'openai'
-    """Service API protocol. One of: 'openai' (chat/completions), 'openai_embedding'/'embedding'
-    (embeddings), 'openai_rerank'/'rerank' (reranks), or 'local'/'local_vllm' for in-process
-    inference. The endpoint path is auto-appended onto `--url` based on this value."""
+    """Service API protocol. One of: 'openai' (chat/completions), 'openai_responses'
+    (Responses API), 'openai_embedding'/'embedding' (embeddings), 'openai_rerank'/'rerank'
+    (reranks), or 'local'/'local_vllm' for in-process inference. The endpoint path is
+    auto-appended onto `--url` based on this value."""
 
     tokenizer_path: Optional[str] = None
     """Path to the tokenizer."""
@@ -445,8 +449,12 @@ class Arguments(BaseArgument):
         if self.api in _OPENAI_API_ENDPOINT_MAP:
             _stripped = self.url.rstrip('/')
             _expected_suffix = _OPENAI_API_ENDPOINT_MAP[self.api]
-            _known_endpoints = ('chat/completions', 'completions', 'embeddings', 'reranks')
-            if not any(_stripped.endswith('/' + ep) for ep in _known_endpoints):
+            _known_endpoints = ('chat/completions', 'completions', 'responses', 'embeddings', 'reranks')
+            if self.api in ('openai_responses', 'openai_response',
+                            'responses') and _stripped.endswith('/chat/completions'):
+                self.url = _stripped[:-len('chat/completions')] + 'responses'
+                logger.warning(f'OpenAI Responses API selected: URL auto-adjusted to responses endpoint: {self.url}')
+            elif not any(_stripped.endswith('/' + ep) for ep in _known_endpoints):
                 self.url = _stripped + '/' + _expected_suffix
                 logger.warning(
                     f'URL "{_stripped}" has no endpoint path, auto-appended "/{_expected_suffix}". '
@@ -455,6 +463,8 @@ class Arguments(BaseArgument):
 
         # When tokenize_prompt is enabled, redirect to the completions endpoint.
         if self.tokenize_prompt:
+            if self.api in ('openai_responses', 'openai_response', 'responses'):
+                raise ValueError('--tokenize-prompt is not supported with the OpenAI Responses API.')
             if not self.tokenizer_path:
                 raise ValueError('--tokenizer-path is required when --tokenize-prompt is set.')
             _stripped = self.url.rstrip('/')
@@ -532,7 +542,7 @@ def add_argument(parser: argparse.ArgumentParser):
     # Model and API
     parser.add_argument('--model', type=str, required=True, help='The test model name.')
     parser.add_argument('--attn-implementation', required=False, default=None, help='Attention implementaion')
-    parser.add_argument('--api', type=str, default='openai', help='Service API protocol: openai | openai_embedding/embedding | openai_rerank/rerank | local/local_vllm. Determines the auto-appended endpoint path on --url.')  # noqa: E501
+    parser.add_argument('--api', type=str, default='openai', help='Service API protocol: openai | openai_responses/responses | openai_embedding/embedding | openai_rerank/rerank | local/local_vllm. Determines the auto-appended endpoint path on --url.')  # noqa: E501
     parser.add_argument(
         '--tokenizer-path', type=str, required=False, default=None, help='Specify the tokenizer weight path')
 

--- a/evalscope/perf/plugin/api/__init__.py
+++ b/evalscope/perf/plugin/api/__init__.py
@@ -4,3 +4,4 @@ from .dashscope_api import DashScopeApiPlugin
 from .openai_api import OpenaiPlugin
 from .openai_embedding_api import OpenaiEmbeddingPlugin
 from .openai_rerank_api import OpenaiRerankPlugin
+from .openai_responses_api import OpenAIResponsesPlugin

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -1,0 +1,261 @@
+import json
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple, Union
+
+from evalscope.models.utils.openai_responses import (
+    normalize_responses_input,
+    response_text_from_dict,
+    response_usage_from_dict,
+)
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.multi_turn_args import _sample_int_or_range
+from evalscope.perf.plugin.api.default_api import DefaultApiPlugin, StreamedResponseHandler
+from evalscope.perf.plugin.registry import register_api
+from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+
+@register_api(['openai_responses', 'openai_response', 'responses'])
+class OpenAIResponsesPlugin(DefaultApiPlugin):
+    """OpenAI official Responses API plugin."""
+
+    def __init__(self, param: Arguments):
+        super().__init__(param=param)
+        if param.tokenizer_path is not None:
+            from modelscope import AutoTokenizer
+            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+        else:
+            self.tokenizer = None
+
+    def build_request(self, messages: Union[List[Dict], str, Dict], param: Arguments = None) -> Dict:
+        param = param or self.param
+        try:
+            if param.query_template is not None:
+                query = self._load_query_template(param.query_template)
+                query['input'] = normalize_responses_input(messages)
+            elif isinstance(messages, dict):
+                query = dict(messages)
+                if 'messages' in query and 'input' not in query:
+                    query['input'] = normalize_responses_input(query.pop('messages'))
+            else:
+                query = {'input': normalize_responses_input(messages)}
+            return self._compose_query_from_parameter(query, param)
+        except Exception as e:
+            logger.exception(e)
+            return None
+
+    def parse_responses(self, responses: List[Dict], request: str = None, **kwargs) -> Tuple[int, int]:
+        if not responses:
+            logger.error('Received empty response list (responses=[]) from OpenAI Responses API.')
+            return 0, 0
+
+        for response in reversed(responses):
+            payload = response.get('response', response)
+            usage = response_usage_from_dict(payload)
+            if usage is not None:
+                return usage
+
+        if self.tokenizer is None:
+            raise ValueError(
+                'Error: Unable to retrieve usage information from OpenAI Responses API response and no tokenizer was '
+                'specified. Please ensure the API returns usage or set --tokenizer-path.'
+            )
+
+        input_tokens = self._count_input_tokens(request)
+        output_tokens = 0
+        for idx, choice_contents in self._collect_output_text(responses).items():
+            output_tokens += len(self.tokenizer.encode(''.join(choice_contents), add_special_tokens=False))
+        return input_tokens, output_tokens
+
+    async def process_request(self, client_session, url: str, headers: Dict, body: Dict) -> BenchmarkData:
+        headers = {'Content-Type': 'application/json', **headers}
+        data = json.dumps(body, ensure_ascii=False)
+
+        output = BenchmarkData()
+        ttft = 0.0
+        generated_text = ''
+        st = time.perf_counter()
+        output.start_time = st
+        output.request = data
+        most_recent_timestamp = st
+        try:
+            async with client_session.post(url=url, data=data, headers=headers) as response:
+                content_type = response.headers.get('Content-Type', '')
+                if response.status != 200:
+                    output.status_code = response.status
+                    try:
+                        err_payload = await response.json()
+                        output.error = json.dumps(err_payload, ensure_ascii=False)
+                    except Exception:
+                        output.error = await response.text()
+                    output.success = False
+                    return output
+
+                if 'text/event-stream' in content_type:
+                    handler = StreamedResponseHandler()
+                    stream_failed = False
+                    async for chunk_bytes in response.content.iter_any():
+                        if not chunk_bytes:
+                            continue
+                        messages = handler.add_chunk(chunk_bytes)
+                        for message in messages:
+                            if message.startswith(':'):
+                                continue
+                            chunk = _extract_sse_data(message)
+                            if not chunk:
+                                continue
+                            if chunk == '[DONE]':
+                                continue
+
+                            timestamp = time.perf_counter()
+                            payload = json.loads(chunk)
+                            event_type = payload.get('type')
+                            delta = payload.get('delta') or ''
+                            if event_type in _DELTA_EVENT_TYPES and delta:
+                                if ttft == 0.0:
+                                    ttft = timestamp - st
+                                    output.first_chunk_latency = ttft
+                                else:
+                                    output.inter_chunk_latency.append(timestamp - most_recent_timestamp)
+                                generated_text += delta
+                            elif event_type == 'response.completed':
+                                response_payload = payload.get('response', {})
+                                usage = response_usage_from_dict(response_payload)
+                                if usage is not None:
+                                    output.prompt_tokens, output.completion_tokens = usage
+                                    self._set_cached_tokens(output, response_payload.get('usage', {}))
+                                if not generated_text:
+                                    generated_text = response_text_from_dict(response_payload)
+                            elif event_type == 'response.failed':
+                                stream_failed = True
+                                output.error = json.dumps(payload.get('response', payload), ensure_ascii=False)
+
+                            output.response_messages.append(payload)
+                            most_recent_timestamp = timestamp
+
+                    output.generated_text = generated_text
+                    output.success = not stream_failed
+                    output.completed_time = most_recent_timestamp
+                    output.query_latency = most_recent_timestamp - st
+                    return output
+
+                payload: Any
+                try:
+                    payload = await response.json()
+                except Exception:
+                    payload = await response.text()
+
+                timestamp = time.perf_counter()
+                output.completed_time = timestamp
+                output.query_latency = timestamp - st
+                output.first_chunk_latency = output.query_latency
+
+                if isinstance(payload, dict):
+                    output.generated_text = response_text_from_dict(payload)
+                    usage = response_usage_from_dict(payload)
+                    if usage is not None:
+                        output.prompt_tokens, output.completion_tokens = usage
+                        self._set_cached_tokens(output, payload.get('usage', {}))
+                    output.response_messages.append(payload)
+                else:
+                    output.generated_text = str(payload)
+                    output.response_messages.append(payload)
+                output.success = True
+                return output
+        except Exception:
+            import sys
+            import traceback
+
+            output.success = False
+            output.error = ''.join(traceback.format_exception(*sys.exc_info()))
+            logger.error(output.error)
+            return output
+
+    @staticmethod
+    def _load_query_template(query_template: str) -> Dict:
+        if query_template.startswith('@'):
+            file_path = query_template[1:]
+            with open(file_path, 'r') as file:
+                return json.load(file)
+        return json.loads(query_template)
+
+    @staticmethod
+    def _set_cached_tokens(output: Any, usage: Dict[str, Any]) -> None:
+        details = usage.get('input_tokens_details') or usage.get('prompt_tokens_details')
+        if details and isinstance(details, dict):
+            cached = details.get('cached_tokens')
+            if cached is not None:
+                output.real_cached_tokens = cached
+
+    def _compose_query_from_parameter(self, payload: Dict, param: Arguments) -> Dict:
+        payload['model'] = param.model
+        if param.max_tokens is not None:
+            payload['max_output_tokens'] = _sample_int_or_range(param.max_tokens)
+        if param.stream is not None:
+            payload['stream'] = param.stream
+        if param.temperature is not None:
+            payload['temperature'] = param.temperature
+        if param.top_p is not None:
+            payload['top_p'] = param.top_p
+        if param.n_choices is not None and param.n_choices > 1:
+            logger.warning('OpenAI Responses API does not support n_choices > 1; ignoring --n-choices.')
+        if param.extra_args is not None:
+            payload.update(param.extra_args)
+        return payload
+
+    def _count_input_tokens(self, request_str: str) -> int:
+        request = json.loads(request_str)
+        input_value = request.get('input', '')
+        return self._count_input_value(input_value)
+
+    def _count_input_value(self, value: Any) -> int:
+        if isinstance(value, str):
+            return len(self.tokenizer.encode(value, add_special_tokens=False))
+        if isinstance(value, list):
+            return sum(self._count_input_value(item) for item in value)
+        if not isinstance(value, dict):
+            return 0
+        if isinstance(value.get('content'), str):
+            return self._count_input_value(value['content'])
+        if isinstance(value.get('content'), list):
+            return self._count_input_value(value['content'])
+        if value.get('type') in ('input_text', 'output_text'):
+            return len(self.tokenizer.encode(value.get('text', ''), add_special_tokens=False))
+        return 0
+
+    @staticmethod
+    def _collect_output_text(responses: List[Dict]) -> Dict[int, List[str]]:
+        contents = defaultdict(list)
+        has_delta = any(response.get('type') in _DELTA_EVENT_TYPES for response in responses)
+        for response in responses:
+            if response.get('type') in _DELTA_EVENT_TYPES:
+                contents[0].append(response.get('delta') or '')
+            elif not has_delta:
+                text = response_text_from_dict(response.get('response', response))
+                if text:
+                    contents[0].append(text)
+        return contents
+
+
+_DELTA_EVENT_TYPES = {
+    'response.output_text.delta',
+    'response.refusal.delta',
+    'response.reasoning_text.delta',
+    'response.reasoning_summary_text.delta',
+}
+
+
+def _extract_sse_data(message: str) -> str:
+    data_lines = []
+    for line in message.splitlines():
+        line = line.strip()
+        if not line or line.startswith(':'):
+            continue
+        if line.startswith('data:'):
+            data_lines.append(line.removeprefix('data:').strip())
+    if data_lines:
+        return '\n'.join(data_lines).strip()
+    return message.removeprefix('data:').strip()

--- a/examples/example_eval_perf.py
+++ b/examples/example_eval_perf.py
@@ -1,4 +1,6 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+import os
+
 from evalscope.perf.main import run_perf_benchmark
 
 
@@ -25,6 +27,21 @@ def run_perf_stream():
         'dataset': 'openqa',
         'stream': True,
         'debug': True,
+    }
+    run_perf_benchmark(task_cfg)
+
+
+def run_perf_openai_responses():
+    task_cfg = {
+        'url': 'https://api.openai.com/v1',
+        'parallel': 1,
+        'model': 'gpt-4.1-mini',
+        'number': 5,
+        'api': 'openai_responses',
+        'api_key': os.getenv('OPENAI_API_KEY'),
+        'dataset': 'openqa',
+        'stream': True,
+        'max_tokens': 128,
     }
     run_perf_benchmark(task_cfg)
 

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,0 +1,265 @@
+import pytest
+from openai.types.responses import Response
+from types import SimpleNamespace
+
+from evalscope.api.messages import ChatMessageUser, ContentImage, ContentText
+from evalscope.api.model import GenerateConfig
+from evalscope.models.openai_responses import OpenAIResponsesAPI
+from evalscope.models.utils.openai_responses import (
+    chat_choices_from_openai_response,
+    openai_response_messages,
+    response_text_from_dict,
+    response_usage_from_dict,
+)
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.api.openai_responses_api import OpenAIResponsesPlugin, _extract_sse_data
+
+
+def test_openai_response_messages_normalize_multimodal_content():
+    messages = openai_response_messages([
+        ChatMessageUser(
+            content=[
+                ContentText(text='Describe the image.'),
+                ContentImage(image='https://example.com/cat.png', detail='low'),
+            ]
+        )
+    ])
+
+    assert messages == [{
+        'role': 'user',
+        'content': [
+            {
+                'type': 'input_text',
+                'text': 'Describe the image.'
+            },
+            {
+                'type': 'input_image',
+                'image_url': 'https://example.com/cat.png',
+                'detail': 'low'
+            },
+        ],
+    }]
+
+
+def test_openai_responses_provider_builds_native_request():
+    api = OpenAIResponsesAPI(
+        model_name='gpt-4.1-mini',
+        base_url='https://api.openai.com/v1/responses',
+        api_key='dummy',
+    )
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return Response(
+            id='resp_test',
+            created_at=0,
+            error=None,
+            incomplete_details=None,
+            instructions=None,
+            metadata={},
+            model='gpt-4.1-mini',
+            object='response',
+            output=[],
+            parallel_tool_calls=True,
+            temperature=0,
+            tool_choice='auto',
+            tools=[],
+            top_p=1,
+            status='completed',
+        )
+
+    api.client.responses.create = fake_create
+    api._valid_params = {
+        'input',
+        'max_output_tokens',
+        'model',
+        'stream',
+        'temperature',
+        'tool_choice',
+        'tools',
+    }
+
+    output = api.generate(
+        input=[ChatMessageUser(content='hello')],
+        tools=[],
+        tool_choice='none',
+        config=GenerateConfig(stream=True, max_tokens=16, temperature=0, retries=1),
+    )
+
+    assert api.base_url == 'https://api.openai.com/v1'
+    assert captured['model'] == 'gpt-4.1-mini'
+    assert captured['input'] == [{
+        'role': 'user',
+        'content': 'hello',
+    }]
+    assert captured['stream'] is True
+    assert captured['max_output_tokens'] == 16
+    assert 'messages' not in captured
+    assert output.model == 'gpt-4.1-mini'
+
+
+def test_openai_responses_provider_requires_responses_client():
+    api = SimpleNamespace(client=SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match='openai>=1.56.0'):
+        OpenAIResponsesAPI._validate_responses_client(api)
+
+
+def test_openai_responses_perf_build_request_and_endpoint_resolution():
+    args = Arguments(
+        model='gpt-4.1-mini',
+        api='openai_responses',
+        url='https://api.openai.com/v1',
+        number=1,
+        parallel=1,
+        stream=True,
+        max_tokens=64,
+    )
+    plugin = OpenAIResponsesPlugin(args)
+
+    request = plugin.build_request([{'role': 'user', 'content': [{'type': 'text', 'text': 'hello'}]}])
+
+    assert args.url == 'https://api.openai.com/v1/responses'
+    assert request['model'] == 'gpt-4.1-mini'
+    assert request['stream'] is True
+    assert request['max_output_tokens'] == 64
+    assert request['input'] == [{
+        'role': 'user',
+        'content': [{
+            'type': 'input_text',
+            'text': 'hello'
+        }],
+    }]
+
+
+def test_openai_responses_perf_warns_only_for_multiple_choices(monkeypatch):
+    warnings = []
+    monkeypatch.setattr(
+        'evalscope.perf.plugin.api.openai_responses_api.logger.warning',
+        lambda msg: warnings.append(msg),
+    )
+
+    args = Arguments(
+        model='gpt-4.1-mini',
+        api='openai_responses',
+        url='https://api.openai.com/v1/responses',
+        number=1,
+        parallel=1,
+        n_choices=1,
+    )
+    OpenAIResponsesPlugin(args).build_request('hello')
+    assert warnings == []
+
+    args = Arguments(
+        model='gpt-4.1-mini',
+        api='openai_responses',
+        url='https://api.openai.com/v1/responses',
+        number=1,
+        parallel=1,
+        n_choices=2,
+    )
+    OpenAIResponsesPlugin(args).build_request('hello')
+    assert warnings == ['OpenAI Responses API does not support n_choices > 1; ignoring --n-choices.']
+
+
+def test_openai_responses_perf_defaults_to_responses_endpoint_and_rejects_tokenized_prompt():
+    args = Arguments(
+        model='gpt-4.1-mini',
+        api='openai_responses',
+        number=1,
+        parallel=1,
+    )
+
+    assert args.url == 'http://127.0.0.1:8877/v1/responses'
+
+    with pytest.raises(ValueError, match='--tokenize-prompt is not supported'):
+        Arguments(
+            model='gpt-4.1-mini',
+            api='openai_responses',
+            number=1,
+            parallel=1,
+            tokenize_prompt=True,
+            tokenizer_path='dummy',
+        )
+
+
+def test_openai_responses_perf_parse_stream_events():
+    args = Arguments(
+        model='gpt-4.1-mini',
+        api='openai_responses',
+        url='https://api.openai.com/v1/responses',
+        number=1,
+        parallel=1,
+    )
+    plugin = OpenAIResponsesPlugin(args)
+
+    responses = [
+        {
+            'type': 'response.output_text.delta',
+            'delta': 'hel',
+        },
+        {
+            'type': 'response.output_text.delta',
+            'delta': 'lo',
+        },
+        {
+            'type': 'response.completed',
+            'response': {
+                'usage': {
+                    'input_tokens': 3,
+                    'output_tokens': 2,
+                }
+            },
+        },
+    ]
+
+    assert plugin.parse_responses(responses, request='{}') == (3, 2)
+    assert plugin._collect_output_text(responses)[0] == ['hel', 'lo']
+
+
+def test_openai_responses_extracts_semantic_sse_data():
+    message = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}'
+
+    assert _extract_sse_data(message) == '{"type":"response.output_text.delta","delta":"hi"}'
+
+
+def test_response_dict_text_and_usage_parsing():
+    payload = {
+        'output': [{
+            'type': 'message',
+            'content': [{
+                'type': 'output_text',
+                'text': 'hello'
+            }],
+        }],
+        'usage': {
+            'input_tokens': 3,
+            'output_tokens': 1,
+            'total_tokens': 4,
+        },
+    }
+
+    assert response_text_from_dict(payload) == 'hello'
+    assert response_usage_from_dict(payload) == (3, 1)
+
+
+def test_chat_choices_from_openai_response_object():
+    response = SimpleNamespace(
+        id='resp_1',
+        model='gpt-4.1-mini',
+        status='completed',
+        incomplete_details=None,
+        output=[SimpleNamespace(
+            type='message',
+            content=[
+                SimpleNamespace(type='output_text', text='hello'),
+            ],
+        )],
+    )
+
+    choices = chat_choices_from_openai_response(response, tools=[])
+
+    assert len(choices) == 1
+    assert choices[0].message.text == 'hello'
+    assert choices[0].stop_reason == 'stop'


### PR DESCRIPTION
Add OpenAI Responses API support, solve #1192

# Changes

- Add a new `openai_responses_api` eval type.
- Route requests through the official OpenAI SDK `client.responses.create(...)`.
- Support Responses API request fields such as:
  - `input`
  - `max_output_tokens`
  - `stream`
  - `reasoning`
  - structured output via `text.format`
  - function tools / tool choice

Have tested it on my own openai api key