### PR TITLE
fix: handle max_position_embeddings AttributeError in tokenizer loading

### DIFF
--- a/evalscope/perf/plugin/api/custom_api.py
+++ b/evalscope/perf/plugin/api/custom_api.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncGenerator, Dict, List, Tuple, Union
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.multi_turn_args import _sample_int_or_range
 from evalscope.perf.plugin.api.base import ApiPluginBase
+from evalscope.perf.plugin.datasets.utils import load_tokenizer
 from evalscope.perf.plugin.registry import register_api
 from evalscope.perf.utils.benchmark_util import BenchmarkData
 from evalscope.utils.logger import get_logger
@@ -32,8 +33,7 @@ class CustomPlugin(ApiPluginBase):
         """
         super().__init__(param=param)
         if param.tokenizer_path is not None:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(param.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple, Union
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.multi_turn_args import _sample_int_or_range
 from evalscope.perf.plugin.api.default_api import DefaultApiPlugin
-from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
+from evalscope.perf.plugin.datasets.utils import load_tokenizer, tokenize_chat_messages
 from evalscope.perf.plugin.registry import register_api
 from evalscope.utils.io_utils import base64_to_PIL
 from evalscope.utils.logger import get_logger
@@ -29,8 +29,7 @@ class OpenaiPlugin(DefaultApiPlugin):
         """
         super().__init__(param=param)
         if param.tokenizer_path is not None:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(param.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/api/openai_embedding_api.py
+++ b/evalscope/perf/plugin/api/openai_embedding_api.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.api.base import ApiPluginBase
+from evalscope.perf.plugin.datasets.utils import load_tokenizer
 from evalscope.perf.plugin.registry import register_api
 from evalscope.perf.utils.benchmark_util import BenchmarkData
 from evalscope.utils.logger import get_logger
@@ -36,8 +37,7 @@ class OpenaiEmbeddingPlugin(ApiPluginBase):
         """
         super().__init__(param=param)
         if param.tokenizer_path is not None:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(param.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/api/openai_rerank_api.py
+++ b/evalscope/perf/plugin/api/openai_rerank_api.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.api.base import ApiPluginBase
+from evalscope.perf.plugin.datasets.utils import load_tokenizer
 from evalscope.perf.plugin.registry import register_api
 from evalscope.perf.utils.benchmark_util import BenchmarkData
 from evalscope.utils.logger import get_logger
@@ -37,8 +38,7 @@ class OpenaiRerankPlugin(ApiPluginBase):
         """
         super().__init__(param=param)
         if param.tokenizer_path is not None:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(param.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -11,6 +11,7 @@ from evalscope.models.utils.openai_responses import (
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.multi_turn_args import _sample_int_or_range
 from evalscope.perf.plugin.api.default_api import DefaultApiPlugin, StreamedResponseHandler
+from evalscope.perf.plugin.datasets.utils import load_tokenizer
 from evalscope.perf.plugin.registry import register_api
 from evalscope.perf.utils.benchmark_util import BenchmarkData
 from evalscope.utils.logger import get_logger
@@ -25,8 +26,7 @@ class OpenAIResponsesPlugin(DefaultApiPlugin):
     def __init__(self, param: Arguments):
         super().__init__(param=param)
         if param.tokenizer_path is not None:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(param.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(param.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
-from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
+from evalscope.perf.plugin.datasets.utils import load_tokenizer, tokenize_chat_messages
 
 Message = Dict[str, Any]  # single OpenAI message: {"role": ..., "content": ...}
 Messages = List[Message]  # delta messages for one turn
@@ -19,8 +19,7 @@ class DatasetPluginBase:
         """
         self.query_parameters = query_parameters
         if query_parameters.tokenizer_path:
-            from modelscope import AutoTokenizer
-            self.tokenizer = AutoTokenizer.from_pretrained(query_parameters.tokenizer_path, trust_remote_code=True)
+            self.tokenizer = load_tokenizer(query_parameters.tokenizer_path)
         else:
             self.tokenizer = None
 

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -1,5 +1,40 @@
+import logging
 import numpy as np
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def load_tokenizer(tokenizer_path: str) -> Optional[object]:
+    """Load a tokenizer from the given path, with a fallback for models that lack ``max_position_embeddings``.
+
+    Some model configs (e.g. DeepSeek-V3) do not define ``max_position_embeddings``, which causes
+    ``transformers >= 5.x`` to raise an ``AttributeError`` inside ``standardize_rope_params()`` when
+    ``trust_remote_code=True`` is used.  This helper retries with ``trust_remote_code=False`` in that
+    case so evaluation can continue without manual intervention.
+
+    Args:
+        tokenizer_path (str): Local path or ModelScope/HuggingFace model ID for the tokenizer.
+
+    Returns:
+        The loaded tokenizer instance.
+
+    Raises:
+        AttributeError: Re-raised if the error is unrelated to ``max_position_embeddings``.
+        Exception: Any other exception from ``AutoTokenizer.from_pretrained`` is propagated as-is.
+    """
+    from modelscope import AutoTokenizer
+
+    try:
+        return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+    except AttributeError as e:
+        if 'max_position_embeddings' in str(e):
+            logger.warning(
+                f'Tokenizer loading with trust_remote_code=True failed: {e}. '
+                'Retrying with trust_remote_code=False.'
+            )
+            return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=False)
+        raise
 
 
 def tokenize_chat_messages(tokenizer, messages: List[Dict], add_generation_prompt: bool = True) -> List[int]:

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -1,11 +1,12 @@
-import logging
 import numpy as np
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
-logger = logging.getLogger(__name__)
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
 
 
-def load_tokenizer(tokenizer_path: str) -> Optional[object]:
+def load_tokenizer(tokenizer_path: str) -> object:
     """Load a tokenizer from the given path, with a fallback for models that lack ``max_position_embeddings``.
 
     Some model configs (e.g. DeepSeek-V3) do not define ``max_position_embeddings``, which causes


### PR DESCRIPTION
## Problem

When using `evalscope perf` with DeepSeek-V3 model on Transformers 5.x, loading the tokenizer fails with:
```
AttributeError: 'PreTrainedConfig' object has no attribute 'max_position_embeddings'
```

This is caused by Transformers 5.x calling `standardize_rope_params()` which accesses `config.max_position_embeddings`, but DeepSeek-V3's config lacks this attribute when loaded with generic PretrainedConfig.

## Solution

- Add a shared `load_tokenizer()` helper in `evalscope/perf/plugin/datasets/utils.py`
- The helper catches `AttributeError` containing `max_position_embeddings` and retries with `trust_remote_code=False`
- All 6 tokenizer loading sites in perf plugin now use this unified helper

## Compatibility

- ✅ Transformers 4.x: first attempt succeeds, no fallback needed
- ✅ Transformers 5.x: catches error, fallback succeeds
- ✅ Other models (Qwen, LLaMA, etc.): unaffected

Fixes #1333