### PR TITLE
feat: add configurable image compression for VLM benchmarks

### DIFF
--- a/evalscope/api/benchmark/adapters/vision_language_adapter.py
+++ b/evalscope/api/benchmark/adapters/vision_language_adapter.py
@@ -1,7 +1,8 @@
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from evalscope.api.messages.content import Content, ContentImage, ContentText, ContentVideo
+from evalscope.utils.io_utils import bytes_to_base64, compress_image_to_limit, parse_size
 from evalscope.utils.url_utils import guess_video_format
 from .default_data_adapter import DefaultDataAdapter
 
@@ -11,6 +12,50 @@ class VisionLanguageAdapter(DefaultDataAdapter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # Optional image size limit; None means no compression is applied.
+        # Can be configured via dataset_args: {'<benchmark_name>': {'max_image_bytes': <int|str>}}
+        # Accepts integers (bytes) or human-readable strings like '5mb', '500kb', '1.5gb'.
+        self._max_image_bytes: Optional[int] = parse_size(self._benchmark_meta.max_image_bytes)
+
+    def _process_image_bytes(self, image_bytes: bytes) -> Tuple[bytes, str]:
+        """Optionally compress image bytes to the configured size limit.
+
+        If ``max_image_bytes`` is set (non-None), the image will be re-encoded
+        via :func:`compress_image_to_limit` to ensure it does not exceed the
+        limit.  Otherwise the original bytes are returned unchanged with format
+        ``'png'``.
+
+        Args:
+            image_bytes (bytes): Raw image bytes to process.
+
+        Returns:
+            Tuple[bytes, str]: A 2-tuple of ``(processed_bytes, format_str)``
+            where *format_str* is ``'png'`` when no compression was applied and
+            ``'jpeg'`` otherwise.
+        """
+        if self._max_image_bytes is not None:
+            return compress_image_to_limit(image_bytes, self._max_image_bytes)
+        return image_bytes, 'png'
+
+    def _image_bytes_to_base64(self, image_bytes: bytes, default_format: str = 'png') -> str:
+        """Convert raw image bytes to a base64 data-URI, compressing first if needed.
+
+        This is the recommended helper for subclasses that obtain images as raw
+        bytes.  It applies the optional size-limit compression configured via
+        ``max_image_bytes`` before base64-encoding.
+
+        Args:
+            image_bytes (bytes): Raw image bytes.
+            default_format (str): Image format hint used when no compression is
+                applied.  Defaults to ``'png'``.
+
+        Returns:
+            str: Base64-encoded data-URI string with MIME header.
+        """
+        if self._max_image_bytes is not None:
+            processed_bytes, fmt = compress_image_to_limit(image_bytes, self._max_image_bytes)
+            return bytes_to_base64(processed_bytes, format=fmt, add_header=True)
+        return bytes_to_base64(image_bytes, format=default_format, add_header=True)
 
     def _parse_text_with_images(self, text: str, image_map: Dict[int, str]) -> List[Content]:
         """

--- a/evalscope/api/benchmark/adapters/vision_language_adapter.py
+++ b/evalscope/api/benchmark/adapters/vision_language_adapter.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 from evalscope.api.messages.content import Content, ContentImage, ContentText, ContentVideo
 from evalscope.utils.io_utils import bytes_to_base64, compress_image_to_limit, parse_size
@@ -17,26 +17,6 @@ class VisionLanguageAdapter(DefaultDataAdapter):
         # Accepts integers (bytes) or human-readable strings like '5mb', '500kb', '1.5gb'.
         self._max_image_bytes: Optional[int] = parse_size(self._benchmark_meta.max_image_bytes)
 
-    def _process_image_bytes(self, image_bytes: bytes) -> Tuple[bytes, str]:
-        """Optionally compress image bytes to the configured size limit.
-
-        If ``max_image_bytes`` is set (non-None), the image will be re-encoded
-        via :func:`compress_image_to_limit` to ensure it does not exceed the
-        limit.  Otherwise the original bytes are returned unchanged with format
-        ``'png'``.
-
-        Args:
-            image_bytes (bytes): Raw image bytes to process.
-
-        Returns:
-            Tuple[bytes, str]: A 2-tuple of ``(processed_bytes, format_str)``
-            where *format_str* is ``'png'`` when no compression was applied and
-            ``'jpeg'`` otherwise.
-        """
-        if self._max_image_bytes is not None:
-            return compress_image_to_limit(image_bytes, self._max_image_bytes)
-        return image_bytes, 'png'
-
     def _image_bytes_to_base64(self, image_bytes: bytes, default_format: str = 'png') -> str:
         """Convert raw image bytes to a base64 data-URI, compressing first if needed.
 
@@ -46,15 +26,20 @@ class VisionLanguageAdapter(DefaultDataAdapter):
 
         Args:
             image_bytes (bytes): Raw image bytes.
-            default_format (str): Image format hint used when no compression is
+            default_format (str): Image format used when no compression is
                 applied.  Defaults to ``'png'``.
 
         Returns:
             str: Base64-encoded data-URI string with MIME header.
         """
         if self._max_image_bytes is not None:
-            processed_bytes, fmt = compress_image_to_limit(image_bytes, self._max_image_bytes)
-            return bytes_to_base64(processed_bytes, format=fmt, add_header=True)
+            compressed_bytes, fmt = compress_image_to_limit(image_bytes, self._max_image_bytes)
+            # compress_image_to_limit returns fmt='png' when no compression was applied,
+            # which is a sentinel value — not the actual image format.  In that case,
+            # fall back to the caller's default_format for the correct MIME type.
+            if fmt == 'png':
+                fmt = default_format
+            return bytes_to_base64(compressed_bytes, format=fmt, add_header=True)
         return bytes_to_base64(image_bytes, format=default_format, add_header=True)
 
     def _parse_text_with_images(self, text: str, image_map: Dict[int, str]) -> List[Content]:

--- a/evalscope/api/benchmark/meta.py
+++ b/evalscope/api/benchmark/meta.py
@@ -114,6 +114,14 @@ class BenchmarkMeta:
     sandbox_config: Optional[Dict[str, Any]] = field(default_factory=dict)
     """Configuration for sandboxed code execution environments. """
 
+    max_image_bytes: Optional[Union[int, str]] = None
+    """Maximum image size for vision-language benchmarks.
+    When set, images exceeding this limit are re-encoded (JPEG compression + downscale)
+    via ``compress_image_to_limit`` before base64 encoding.  ``None`` disables compression.
+    Accepts an integer byte count or a human-readable string such as ``'5mb'``, ``'500kb'``,
+    ``'1.5gb'`` (parsed by ``parse_size``).
+    Useful for avoiding 413 errors when sending multi-image payloads to APIs."""
+
     def __post_init__(self):
         """Validate fields after initialization."""
         if self.few_shot_num < 0:

--- a/evalscope/benchmarks/mmmu_pro/mmmu_pro_adapter.py
+++ b/evalscope/benchmarks/mmmu_pro/mmmu_pro_adapter.py
@@ -6,7 +6,6 @@ from evalscope.api.dataset import Sample
 from evalscope.api.messages import ChatMessageUser, Content, ContentImage, ContentText
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.io_utils import bytes_to_base64
 from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import MultipleChoiceTemplate, answer_character, prompt
 
@@ -134,14 +133,14 @@ class MMMUPROAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
 
             image = record.get('image')
             if image:
-                content_list.append(ContentImage(image=bytes_to_base64(image['bytes'], format='png', add_header=True)))
+                content_list.append(ContentImage(image=self._image_bytes_to_base64(image['bytes'], 'png')))
         else:
             # Prepare image map
             image_map: Dict[int, str] = {}
             for i in range(MMMUPROAdapter.MAX_IMAGES):
                 image = record.get(f'image_{i+1}')
                 if image:
-                    image_base64 = bytes_to_base64(image['bytes'], format='png', add_header=True)
+                    image_base64 = self._image_bytes_to_base64(image['bytes'], 'png')
                     image_map[i + 1] = image_base64
 
             # Build prompt text

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -681,7 +681,10 @@ def parse_size(value: Optional[Union[int, float, str]]) -> Optional[int]:
     if value is None:
         return None
     if isinstance(value, (int, float)):
-        return int(value)
+        result = int(value)
+        if result <= 0:
+            raise ValueError(f'Size must be positive, got: {value}')
+        return result
 
     value = str(value).strip()
     if not value:
@@ -697,7 +700,10 @@ def parse_size(value: Optional[Union[int, float, str]]) -> Optional[int]:
 
     # Try plain numeric string first (no unit suffix)
     try:
-        return int(float(value))
+        result = int(float(value))
+        if result <= 0:
+            raise ValueError(f'Size must be positive, got: {value}')
+        return result
     except ValueError:
         pass
 
@@ -711,7 +717,10 @@ def parse_size(value: Optional[Union[int, float, str]]) -> Optional[int]:
     if multiplier is None:
         raise ValueError(f'Unknown size unit {unit_str!r} in {value!r}. Supported: {list(_UNITS.keys())}')
 
-    return int(float(number_str) * multiplier)
+    result = int(float(number_str) * multiplier)
+    if result <= 0:
+        raise ValueError(f'Size must be positive, got: {value}')
+    return result
 
 
 def compress_image_to_limit(

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -652,6 +652,68 @@ def convert_image_base64_format(image_base64: str) -> Tuple[str, str]:
         return image_base64, detected_format
 
 
+def parse_size(value: Optional[Union[int, float, str]]) -> Optional[int]:
+    """Parse a human-readable size string or numeric value to an integer byte count.
+
+    Accepts:
+    - ``None``: returns ``None``.
+    - ``int`` / ``float``: returned as ``int`` directly (interpreted as bytes).
+    - Numeric string (e.g., ``'5000000'``): converted to ``int``.
+    - Human-readable string with unit suffix (case-insensitive), e.g.::
+
+          '500b'   -> 500
+          '10kb'   -> 10_240
+          '5mb'    -> 5_242_880
+          '1.5gb'  -> 1_610_612_736
+          '2TB'    -> 2_199_023_255_552
+
+    Supported units: ``b``, ``kb``, ``mb``, ``gb``, ``tb``.
+
+    Args:
+        value: A ``None``, numeric value, or size string to parse.
+
+    Returns:
+        The size in bytes as an ``int``, or ``None`` if *value* is ``None``.
+
+    Raises:
+        ValueError: If *value* is a non-empty string that cannot be parsed.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    value = str(value).strip()
+    if not value:
+        return None
+
+    _UNITS: Dict[str, int] = {
+        'b': 1,
+        'kb': 1024,
+        'mb': 1024**2,
+        'gb': 1024**3,
+        'tb': 1024**4,
+    }
+
+    # Try plain numeric string first (no unit suffix)
+    try:
+        return int(float(value))
+    except ValueError:
+        pass
+
+    # Match optional float + unit suffix
+    match = re.fullmatch(r'([0-9]*\.?[0-9]+)\s*([a-zA-Z]+)', value)
+    if not match:
+        raise ValueError(f'Cannot parse size value: {value!r}')
+
+    number_str, unit_str = match.group(1), match.group(2).lower()
+    multiplier = _UNITS.get(unit_str)
+    if multiplier is None:
+        raise ValueError(f'Unknown size unit {unit_str!r} in {value!r}. Supported: {list(_UNITS.keys())}')
+
+    return int(float(number_str) * multiplier)
+
+
 def compress_image_to_limit(
     image_bytes: bytes,
     max_bytes: int = 10_000_000,

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -75,6 +75,7 @@ class TestVLMBenchmark(TestBenchmark):
                 'Accounting',
                 # 'Agriculture',
             ],
+            'max_image_bytes': '5mb',
             'extra_params': {
                 'dataset_format': 'standard (4 options)',  # 'standard (4 options)', 'standard (10 options)', 'vision'
             },


### PR DESCRIPTION
## Problem

When evaluating MMMU_PRO, large multi-image payloads exceed API server limits (nginx 413 Request Entity Too Large). MMMU_PRO images can be up to 2560x2545 PNG (~25MB per image).

## Solution

Add a unified, opt-in image compression mechanism at the `VisionLanguageAdapter` base class level:

- **`parse_size()`** utility in `io_utils.py`: accepts human-readable strings like `'5mb'`, `'10MB'`, `'500kb'` as well as raw integers
- **`_image_bytes_to_base64()`** helper in `VisionLanguageAdapter`: automatically compresses images when `max_image_bytes` is configured
- **`max_image_bytes`** field in `BenchmarkMeta`: configurable per-benchmark via `dataset_args`
- Updated `mmmu_pro_adapter.py` to use the new unified helper

## Usage

```python
TaskConfig(
    model='your-model',
    datasets=['mmmu_pro'],
    dataset_args={
        'mmmu_pro': {
            'max_image_bytes': '5mb'  # or 5_000_000
        }
    }
)
```

## Design

- Default: no compression (backward compatible)
- Uses existing `compress_image_to_limit()` under the hood (JPEG quality ladder + resolution scaling)
- All VLM benchmarks can benefit by simply setting `max_image_bytes` in dataset_args
- ZeroBench's existing inline compression is unaffected

Fixes #1347