### PR TITLE
[Fix] Fix ineffective repeats in DatasetDict.from_dataset

### DIFF
--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -342,9 +342,9 @@ class DatasetDict:
                 if isinstance(limit, float):
                     limit = int(len(samples) * limit)
                 samples = samples[:limit]
-            # Repeat k times
-            if repeats > 1:
-                samples = [copy.deepcopy(sample) for sample in samples for _ in range(repeats)]
+            # Repeat k times; always deepcopy to avoid mutating the original dataset
+            # (repeats=0 yields empty list; repeats=1 yields one isolated copy per sample)
+            samples = [copy.deepcopy(sample) for sample in samples for _ in range(repeats)]
             cur_dataset = MemoryDataset(samples, name=dataset.name)
             # Reindex the dataset to ensure consistent IDs and group IDs
             cur_dataset.reindex(group_size=repeats)

--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 import random
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -340,8 +341,10 @@ class DatasetDict:
             if limit is not None:
                 if isinstance(limit, float):
                     limit = int(len(samples) * limit)
-                total_limit = limit * repeats
-                samples = samples[:total_limit]
+                samples = samples[:limit]
+            # Repeat k times
+            if repeats > 1:
+                samples = [copy.deepcopy(sample) for sample in samples for _ in range(repeats)]
             cur_dataset = MemoryDataset(samples, name=dataset.name)
             # Reindex the dataset to ensure consistent IDs and group IDs
             cur_dataset.reindex(group_size=repeats)

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -143,6 +143,37 @@ class TestDatasetDictFromDatasetRepeats(unittest.TestCase):
             self.assertEqual(samples[i * 3 + 1].input, base)
             self.assertEqual(samples[i * 3 + 2].input, base)
 
+    # ------------------------------------------------------------------
+    # regression: repeats=0 must not raise ZeroDivisionError
+    # ------------------------------------------------------------------
+
+    def test_repeats_zero_returns_empty(self):
+        """repeats=0 must produce an empty dataset without raising ZeroDivisionError."""
+        dataset = _make_dataset(5)
+        # Should not raise, and should return empty samples
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=3, repeats=0)
+        samples = self._get_samples(result)
+        self.assertEqual(len(samples), 0, 'repeats=0 must yield zero samples')
+
+    # ------------------------------------------------------------------
+    # regression: repeats=1 must not mutate original dataset samples
+    # ------------------------------------------------------------------
+
+    def test_repeats_one_does_not_mutate_original(self):
+        """repeats=1 must not mutate the id/group_id fields of the original input samples."""
+        dataset = _make_dataset(5)
+        original_ids = [s.id for s in dataset.samples]  # all None before call
+
+        DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=3, repeats=1)
+
+        # Original dataset samples must remain unmodified
+        for original, sample in zip(original_ids, dataset.samples):
+            self.assertEqual(
+                sample.id,
+                original,
+                f'Original sample.id was mutated from {original} to {sample.id} (deepcopy required for repeats=1)',
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -1,0 +1,148 @@
+import unittest
+
+from evalscope.api.dataset.dataset import DatasetDict, MemoryDataset, Sample
+
+SUBSET = 'default'
+
+
+def _make_dataset(n: int, name: str = 'test') -> MemoryDataset:
+    """Create a MemoryDataset with *n* distinct samples (input = 'question_i')."""
+    samples = [
+        Sample(input=f'question_{i}', target=f'answer_{i}', subset_key=SUBSET)
+        for i in range(n)
+    ]
+    return MemoryDataset(samples, name=name)
+
+
+class TestDatasetDictFromDatasetRepeats(unittest.TestCase):
+    """Unit tests for DatasetDict.from_dataset — repeats parameter."""
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _get_samples(self, dataset_dict: DatasetDict):
+        """Return the flat sample list for the single subset."""
+        return list(dataset_dict[SUBSET])
+
+    # ------------------------------------------------------------------
+    # core regression test (PR #1363)
+    # ------------------------------------------------------------------
+
+    def test_repeats_produces_copies_not_distinct_samples(self):
+        """limit=5, repeats=3 must yield [s0,s0,s0, s1,s1,s1, …], not 15 distinct samples."""
+        dataset = _make_dataset(20)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=5, repeats=3)
+        samples = self._get_samples(result)
+
+        # Total count: 5 * 3 = 15
+        self.assertEqual(len(samples), 15, 'Expected 5 original samples × 3 repeats = 15 total')
+
+        # Each trio should share the same original input (not 15 distinct inputs)
+        for i in range(5):
+            base_input = samples[i * 3].input
+            self.assertEqual(samples[i * 3 + 1].input, base_input,
+                             f'group {i}: copy 1 input differs from copy 0')
+            self.assertEqual(samples[i * 3 + 2].input, base_input,
+                             f'group {i}: copy 2 input differs from copy 0')
+
+        # Verify the first 5 original inputs are used (not inputs 5-19)
+        expected_inputs = [f'question_{i}' for i in range(5)]
+        actual_inputs = [samples[i * 3].input for i in range(5)]
+        self.assertEqual(actual_inputs, expected_inputs,
+                         'The first `limit` samples should be used as the source, not samples beyond limit')
+
+    # ------------------------------------------------------------------
+    # group_id correctness
+    # ------------------------------------------------------------------
+
+    def test_group_id_assigned_correctly(self):
+        """Each group of k copies must share the same group_id."""
+        dataset = _make_dataset(10)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=4, repeats=3)
+        samples = self._get_samples(result)
+
+        # 4 groups × 3 copies = 12 samples
+        self.assertEqual(len(samples), 12)
+
+        for i in range(4):
+            expected_group_id = i
+            for j in range(3):
+                idx = i * 3 + j
+                self.assertEqual(
+                    samples[idx].group_id, expected_group_id,
+                    f'sample index {idx}: expected group_id={expected_group_id}, got {samples[idx].group_id}'
+                )
+
+    def test_id_is_globally_unique(self):
+        """After reindex every sample must have a unique id."""
+        dataset = _make_dataset(10)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=4, repeats=3)
+        samples = self._get_samples(result)
+        ids = [s.id for s in samples]
+        self.assertEqual(len(ids), len(set(ids)), 'Sample ids must be unique after reindex')
+
+    # ------------------------------------------------------------------
+    # deep-copy isolation
+    # ------------------------------------------------------------------
+
+    def test_copies_are_independent_objects(self):
+        """The k copies within each group must be distinct objects (deepcopy)."""
+        dataset = _make_dataset(5)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=3, repeats=2)
+        samples = self._get_samples(result)
+
+        for i in range(3):
+            copy_a = samples[i * 2]
+            copy_b = samples[i * 2 + 1]
+            self.assertIsNot(copy_a, copy_b,
+                             f'group {i}: the two copies must be different objects (deepcopy required)')
+
+    # ------------------------------------------------------------------
+    # boundary: repeats=1 (no duplication)
+    # ------------------------------------------------------------------
+
+    def test_repeats_one_returns_original_samples(self):
+        """repeats=1 must return exactly `limit` samples with no duplication."""
+        dataset = _make_dataset(10)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=5, repeats=1)
+        samples = self._get_samples(result)
+
+        self.assertEqual(len(samples), 5)
+        for i, s in enumerate(samples):
+            self.assertEqual(s.input, f'question_{i}')
+
+    # ------------------------------------------------------------------
+    # boundary: limit=None with repeats > 1
+    # ------------------------------------------------------------------
+
+    def test_repeats_without_limit(self):
+        """limit=None with repeats=2 must repeat every sample in the full dataset."""
+        dataset = _make_dataset(4)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=None, repeats=2)
+        samples = self._get_samples(result)
+
+        self.assertEqual(len(samples), 8, 'All 4 samples × 2 repeats = 8')
+        for i in range(4):
+            self.assertEqual(samples[i * 2].input, f'question_{i}')
+            self.assertEqual(samples[i * 2 + 1].input, f'question_{i}')
+
+    # ------------------------------------------------------------------
+    # boundary: float limit
+    # ------------------------------------------------------------------
+
+    def test_float_limit_with_repeats(self):
+        """float limit=0.5 on a 10-sample dataset → 5 samples, then repeated k times."""
+        dataset = _make_dataset(10)
+        result = DatasetDict.from_dataset(dataset, subset_list=[SUBSET], limit=0.5, repeats=3)
+        samples = self._get_samples(result)
+
+        self.assertEqual(len(samples), 15, 'float limit 0.5 × 10 = 5 samples × 3 repeats = 15')
+        for i in range(5):
+            base = samples[i * 3].input
+            self.assertEqual(samples[i * 3 + 1].input, base)
+            self.assertEqual(samples[i * 3 + 2].input, base)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix `DatasetDict.from_dataset` to actually repeat samples instead of just taking more distinct samples.

https://github.com/modelscope/evalscope/blob/05649760fafd71d27fabc0c5e58559aedfd89202/evalscope/api/dataset/dataset.py#L336-L348

Previously, `repeats` was applied as `total_limit = limit * repeats`, which simply sliced more distinct samples from the dataset. This violates the semantics of `repeats`.