### PR TITLE
fix(perf): round int fields after sla multi-run averaging

### DIFF
--- a/evalscope/perf/utils/perf_models.py
+++ b/evalscope/perf/utils/perf_models.py
@@ -16,7 +16,7 @@ Public classes
 from __future__ import annotations
 
 import json
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from tabulate import tabulate
 from typing import Any, Dict, List, Optional
 
@@ -67,6 +67,14 @@ class BenchmarkSummary(BaseModel):
     # --- Speculative decoding (optional) ---
     avg_decoded_tokens_per_iter: Optional[float] = Field(None, alias=Metrics.AVERAGE_DECODED_TOKENS_PER_ITER)
     approx_spec_acceptance_rate: Optional[float] = Field(None, alias=Metrics.APPROX_SPECULATIVE_ACCEPTANCE_RATE)
+
+    # Multi-run averaging produces fractional ints; round before validation.
+    @field_validator('concurrency', 'total_requests', 'succeed_requests', 'failed_requests', mode='before')
+    @classmethod
+    def _round_to_int(cls, v):
+        if isinstance(v, float):
+            return round(v)
+        return v
 
     # -----------------------------------------------------------------------
     # Derived properties


### PR DESCRIPTION
## Problem

When `--sla-num-runs >= 2`, `db_util.average_results` computes arithmetic means over all numeric fields. 

Int-typed count fields (`concurrency`, `total_requests`, `succeed_requests`, `failed_requests`) can produce fractional values (e.g. `(390+391+391)/3 = 390.67`) that Pydantic strict-int validation rejects with a `ValidationError`, crashing the SLA tuner.

## Solution

Add `@field_validator(mode='before')` on the four int fields of `BenchmarkSummary` that rounds float inputs back to int. The rounding happens at the schema layer where the int contract is declared, keeping `db_util.average_results` schema-agnostic.
