### PR TITLE
fix(agent/sandbox): fail-fast in EnclaveAgentEnvironment when ms_enclave is missing

### DIFF
--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -34,6 +34,7 @@ from evalscope.api.sandbox import (
     merge_sandbox_config_dicts,
     resolve_engine,
 )
+from evalscope.utils.import_utils import check_import
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -76,6 +77,11 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         timeout: float = 60.0,
         **_: Any,
     ) -> None:
+        # ms_enclave is mandatory for this environment. Fail fast at construction
+        # time so missing-dependency errors don't surface as opaque tool errors
+        # inside the agent loop (which the model interprets as a broken sandbox).
+        check_import('ms_enclave', extra='sandbox', raise_error=True, feature_name='EnclaveAgentEnvironment')
+
         self._engine: SandboxEngine = resolve_engine(engine)
         self._timeout = float(timeout)
         self._manager_config: Dict[str, Any] = dict(manager_config or {})

--- a/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
@@ -27,7 +27,7 @@ from evalscope.api.metric import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.api.sandbox import merge_sandbox_config_dicts
 from evalscope.constants import Tags
-from evalscope.utils.import_utils import check_import, is_build_doc
+from evalscope.utils.import_utils import is_build_doc
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -222,8 +222,6 @@ class SWEBenchProAgenticAdapter(AgentLoopAdapter):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-
-        check_import('docker', extra='sandbox', raise_error=True, feature_name=self.pretty_name)
 
         self.action_protocol: str = self.extra_params.get('action_protocol', 'toolcall')
         if self.action_protocol not in {'toolcall', 'backticks'}:


### PR DESCRIPTION
## Summary

Fail-fast in `EnclaveAgentEnvironment.__init__` when `ms_enclave` is not installed, instead of letting missing-dependency errors surface as opaque per-tool-call failures inside the agent loop.

## Problem (refs #1362)

`EnclaveAgentEnvironment` hardcodes `ms_enclave` for all sandbox engines (docker / volcengine / enclave). Previously the dependency was only checked when `TaskConfig.sandbox.enabled=True`, so users running agentic benchmarks (e.g. `swe_bench_*_agentic`, `swe_bench_pro_agentic`) without `evalscope[sandbox]` silently got `acc=0.0`:

1. Every bash tool call raised `ImportError: No module named 'ms_enclave'`
2. The agent loop returned that as a tool error to the model
3. The model spent ~250 steps complaining about a broken environment
4. The adapter fallback wrote reasoning text into `patch.diff`
5. `git apply` rejected the malformed content

User had to upload full output bundles for us to diagnose.

## Fix

Move `check_import('ms_enclave', extra='sandbox', raise_error=True)` into `EnclaveAgentEnvironment.__init__`. Single fail-fast covers every current and future caller of this environment — no per-adapter duplication.

Also drop the now-redundant `check_import('docker', ...)` in `swe_bench_pro_agentic_adapter` since `evalscope[sandbox]` / `ms-enclave[docker]` already covers the docker package.

## Files

- `evalscope/agent/environments/enclave.py` (+6)
- `evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py` (-3)

## Validation

- `make lint` passes