### PR TITLE
feat: support API reranker evaluation, fix #1029

### DIFF
--- a/docs/en/user_guides/backend/rageval_backend/mteb.md
+++ b/docs/en/user_guides/backend/rageval_backend/mteb.md
@@ -199,7 +199,8 @@ two_stage_task_cfg = {
 
       - **For remote API model service support**:
         - `model_name`: `str`: Model name.
-        - `api_base`: `str`: Model API service address.
+        - `is_cross_encoder`: `bool`: Whether the remote API model is a reranker, default is False. Set it to `True` for API rerankers; otherwise the embedding API is used.
+        - `api_base`: `str`: Model API base URL. API rerankers call the rerank endpoint; if the URL does not end with `/rerank` or `/reranks`, `/rerank` is appended automatically.
         - `api_key`: `str`: Model API key.
         - `dimension`: `int`: Model output dimension.
         - `encode_kwargs`: `dict`: Encoding keyword arguments, default is:

--- a/docs/zh/user_guides/backend/rageval_backend/mteb.md
+++ b/docs/zh/user_guides/backend/rageval_backend/mteb.md
@@ -198,7 +198,8 @@ two_stage_task_cfg = {
             - `hub`: `str` 模型来源，可以是 "modelscope" 或 "huggingface"。
         - **对于远程API模型服务支持**：
             - `model_name`: `str` 模型名称。
-            - `api_base`: `str` 模型API服务地址。
+            - `is_cross_encoder`: `bool` 远程API模型是否为reranker，默认为 False；API reranker需设置为 `True`，否则使用embedding API。
+            - `api_base`: `str` 模型API服务地址；API reranker会调用rerank端点，如果地址未以 `/rerank` 或 `/reranks` 结尾，会自动追加 `/rerank`。
             - `api_key`: `str` 模型API密钥。
             - `dimension`: `int` 模型输出维度。
             - `encode_kwargs`: `dict` 编码的关键字参数，默认值为：  

--- a/evalscope/backend/rag_eval/utils/embedding.py
+++ b/evalscope/backend/rag_eval/utils/embedding.py
@@ -247,10 +247,10 @@ class APIEmbeddingModel(BaseModel):
 class APIRerankerModel(BaseModel):
     """Reranker adapter for OpenAI-compatible rerank APIs."""
 
-    def __init__(self, **kwargs):
-        self.model_name = kwargs.get('model_name')
-        self.api_base = kwargs.get('api_base')
-        self.api_key = kwargs.get('api_key') or os.getenv('OPENAI_API_KEY')
+    def __init__(self, **kwargs) -> None:
+        self.model_name: str = kwargs.get('model_name')
+        self.api_base: str = kwargs.get('api_base')
+        self.api_key: Optional[str] = kwargs.get('api_key') or os.getenv('OPENAI_API_KEY')
 
         if not self.api_base:
             raise ValueError('api_base is required for API reranker model.')
@@ -258,13 +258,13 @@ class APIRerankerModel(BaseModel):
         super().__init__(model_name_or_path=self.model_name, **kwargs)
 
         self.framework = ['API']
-        self.batch_size = self.encode_kwargs.get('batch_size', 10)
-        self.timeout = kwargs.get('timeout', 60)
-        self.rerank_url = self.api_base.rstrip('/')
+        self.batch_size: int = self.encode_kwargs.get('batch_size', 10)
+        self.timeout: int = kwargs.get('timeout', 60)
+        self.rerank_url: str = self.api_base.rstrip('/')
         if not self.rerank_url.endswith(('/rerank', '/reranks')):
             self.rerank_url = f'{self.rerank_url}/rerank'
 
-        self.headers = {'Content-Type': 'application/json'}
+        self.headers: Dict[str, str] = {'Content-Type': 'application/json'}
         if self.api_key:
             self.headers['Authorization'] = f'Bearer {self.api_key}'
         self.session = requests.Session()
@@ -275,8 +275,8 @@ class APIRerankerModel(BaseModel):
         if not sentences:
             return torch.tensor([])
 
-        scores = [0.0] * len(sentences)
-        grouped_sentences = {}
+        scores: List[float] = [0.0] * len(sentences)
+        grouped_sentences: Dict[str, List] = {}
         prompt = self.prompt or ''
 
         for idx, sentence in enumerate(sentences):
@@ -299,7 +299,7 @@ class APIRerankerModel(BaseModel):
                     'query': query,
                     'documents': documents,
                     'top_n': len(documents),
-                    'return_documents': True,
+                    'return_documents': False,
                 }
                 response = self.session.post(self.rerank_url, headers=self.headers, json=payload, timeout=self.timeout)
                 response.raise_for_status()
@@ -316,8 +316,10 @@ class APIRerankerModel(BaseModel):
                         try:
                             doc_idx = int(doc_idx)
                         except (TypeError, ValueError):
+                            logger.warning(f'Rerank result has non-integer index: {result.get("index")}, skipping.')
                             continue
                     if doc_idx < 0 or doc_idx >= len(batch_pairs):
+                        logger.warning(f'Rerank result index {doc_idx} out of range [0, {len(batch_pairs)}), skipping.')
                         continue
                     score = result.get('relevance_score', result.get('score', 0.0))
                     scores[batch_pairs[doc_idx][0]] = score

--- a/evalscope/backend/rag_eval/utils/embedding.py
+++ b/evalscope/backend/rag_eval/utils/embedding.py
@@ -1,4 +1,5 @@
 import os
+import requests
 import torch
 from langchain_core.embeddings import Embeddings
 from langchain_openai.embeddings import OpenAIEmbeddings
@@ -243,6 +244,87 @@ class APIEmbeddingModel(BaseModel):
         return torch.tensor(embeddings)
 
 
+class APIRerankerModel(BaseModel):
+    """Reranker adapter for OpenAI-compatible rerank APIs."""
+
+    def __init__(self, **kwargs):
+        self.model_name = kwargs.get('model_name')
+        self.api_base = kwargs.get('api_base')
+        self.api_key = kwargs.get('api_key') or os.getenv('OPENAI_API_KEY')
+
+        if not self.api_base:
+            raise ValueError('api_base is required for API reranker model.')
+
+        super().__init__(model_name_or_path=self.model_name, **kwargs)
+
+        self.framework = ['API']
+        self.batch_size = self.encode_kwargs.get('batch_size', 10)
+        self.timeout = kwargs.get('timeout', 60)
+        self.rerank_url = self.api_base.rstrip('/')
+        if not self.rerank_url.endswith(('/rerank', '/reranks')):
+            self.rerank_url = f'{self.rerank_url}/rerank'
+
+        self.headers = {'Content-Type': 'application/json'}
+        if self.api_key:
+            self.headers['Authorization'] = f'Bearer {self.api_key}'
+        self.session = requests.Session()
+
+    def predict(self, sentences: List[List[str]], **kwargs) -> Tensor:
+        self.encode_kwargs.update(kwargs)
+        self.batch_size = self.encode_kwargs.get('batch_size', self.batch_size)
+        if not sentences:
+            return torch.tensor([])
+
+        scores = [0.0] * len(sentences)
+        grouped_sentences = {}
+        prompt = self.prompt or ''
+
+        for idx, sentence in enumerate(sentences):
+            if len(sentence) == 2:
+                query, document = sentence
+            elif len(sentence) == 3:
+                query, document, instruction = sentence
+                if instruction is not None:
+                    query = f'{query} {instruction}'.strip()
+            else:
+                raise ValueError('API reranker expects query-document pairs.')
+            grouped_sentences.setdefault(prompt + query, []).append((idx, document))
+
+        for query, pairs in grouped_sentences.items():
+            for i in range(0, len(pairs), self.batch_size):
+                batch_pairs = pairs[i:i + self.batch_size]
+                documents = [doc for _, doc in batch_pairs]
+                payload = {
+                    'model': self.model_name,
+                    'query': query,
+                    'documents': documents,
+                    'top_n': len(documents),
+                    'return_documents': True,
+                }
+                response = self.session.post(self.rerank_url, headers=self.headers, json=payload, timeout=self.timeout)
+                response.raise_for_status()
+                data = response.json()
+                results = data.get('results')
+                if results is None:
+                    raise ValueError(f'Invalid rerank response: {data}')
+
+                for result_idx, result in enumerate(results):
+                    doc_idx = result.get('index')
+                    if doc_idx is None:
+                        doc_idx = result_idx
+                    else:
+                        try:
+                            doc_idx = int(doc_idx)
+                        except (TypeError, ValueError):
+                            continue
+                    if doc_idx < 0 or doc_idx >= len(batch_pairs):
+                        continue
+                    score = result.get('relevance_score', result.get('score', 0.0))
+                    scores[batch_pairs[doc_idx][0]] = score
+
+        return torch.tensor(scores)
+
+
 class EmbeddingModel:
     """Custom embeddings"""
 
@@ -255,7 +337,9 @@ class EmbeddingModel:
         **kwargs,
     ):
         if kwargs.get('model_name'):
-            # If model_name is provided, use OpenAIEmbeddings
+            if is_cross_encoder:
+                return APIRerankerModel(**kwargs)
+            # API embedding models use the OpenAI-compatible embeddings client.
             return APIEmbeddingModel(**kwargs)
 
         # If model path does not exist and hub is 'modelscope', download the model

--- a/tests/rag/test_api_reranker.py
+++ b/tests/rag/test_api_reranker.py
@@ -1,0 +1,146 @@
+import pytest
+
+torch = pytest.importorskip('torch')
+pytest.importorskip('langchain_openai')
+pytest.importorskip('mteb')
+pytest.importorskip('sentence_transformers')
+
+from evalscope.backend.rag_eval.utils.embedding import APIRerankerModel, EmbeddingModel
+
+
+class MockResponse:
+
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.data
+
+
+def test_api_reranker_predict(monkeypatch):
+    calls = []
+
+    def mock_post(self, url, headers, json, timeout):
+        calls.append({'url': url, 'headers': headers, 'json': json, 'timeout': timeout})
+        return MockResponse({
+            'results': [
+                {
+                    'index': 1,
+                    'relevance_score': 0.2,
+                },
+                {
+                    'index': 0,
+                    'relevance_score': 0.9,
+                },
+            ]
+        })
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.utils.embedding.requests.Session.post', mock_post)
+
+    model = APIRerankerModel(
+        model_name='Qwen3-Reranker-8B',
+        api_base='https://aiping.cn/api/v1',
+        api_key='test-key',
+        encode_kwargs={'batch_size': 10},
+    )
+    scores = model.predict([['query', 'document 0', None], ['query', 'document 1', None]])
+
+    assert torch.equal(scores, torch.tensor([0.9, 0.2]))
+    assert calls == [{
+        'url': 'https://aiping.cn/api/v1/rerank',
+        'headers': {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-key',
+        },
+        'json': {
+            'model': 'Qwen3-Reranker-8B',
+            'query': 'query',
+            'documents': ['document 0', 'document 1'],
+            'top_n': 2,
+            'return_documents': True,
+        },
+        'timeout': 60,
+    }]
+
+
+def test_api_reranker_keeps_explicit_endpoint(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+
+    def mock_post(self, url, headers, json, timeout):
+        return MockResponse({'results': [{'index': 0, 'score': 0.8}]})
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.utils.embedding.requests.Session.post', mock_post)
+
+    model = APIRerankerModel(
+        model_name='reranker',
+        api_base='https://example.com/v1/reranks',
+        encode_kwargs={'batch_size': 1},
+    )
+
+    assert model.rerank_url == 'https://example.com/v1/reranks'
+    assert torch.equal(model.predict([['query', 'document']]), torch.tensor([0.8]))
+
+
+def test_api_reranker_applies_instruction(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    calls = []
+
+    def mock_post(self, url, headers, json, timeout):
+        calls.append(json)
+        return MockResponse({'results': [{'index': 0, 'score': 0.8}]})
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.utils.embedding.requests.Session.post', mock_post)
+
+    model = APIRerankerModel(
+        model_name='reranker',
+        api_base='https://example.com/v1',
+        encode_kwargs={'batch_size': 1},
+    )
+
+    scores = model.predict([['query', 'document', 'instruction']])
+
+    assert torch.equal(scores, torch.tensor([0.8]))
+    assert calls[0]['query'] == 'query instruction'
+
+
+def test_api_reranker_defaults_none_index(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+
+    def mock_post(self, url, headers, json, timeout):
+        return MockResponse({'results': [{'index': None, 'score': 0.8}]})
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.utils.embedding.requests.Session.post', mock_post)
+
+    model = APIRerankerModel(
+        model_name='reranker',
+        api_base='https://example.com/v1',
+        encode_kwargs={'batch_size': 1},
+    )
+
+    assert torch.equal(model.predict([['query', 'document']]), torch.tensor([0.8]))
+
+
+def test_api_reranker_uses_openai_api_key_env(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'env-key')
+
+    model = APIRerankerModel(
+        model_name='reranker',
+        api_base='https://example.com/v1',
+        encode_kwargs={'batch_size': 1},
+    )
+
+    assert model.headers['Authorization'] == 'Bearer env-key'
+
+
+def test_load_api_cross_encoder():
+    model = EmbeddingModel.load(
+        model_name='Qwen3-Reranker-8B',
+        api_base='https://aiping.cn/api/v1',
+        api_key='test-key',
+        is_cross_encoder=True,
+    )
+
+    assert isinstance(model, APIRerankerModel)

--- a/tests/rag/test_api_reranker.py
+++ b/tests/rag/test_api_reranker.py
@@ -60,7 +60,7 @@ def test_api_reranker_predict(monkeypatch):
             'query': 'query',
             'documents': ['document 0', 'document 1'],
             'top_n': 2,
-            'return_documents': True,
+            'return_documents': False,
         },
         'timeout': 60,
     }]


### PR DESCRIPTION
 - Add `APIRerankerModel`, the API counterpart of the existing `CrossEncoderModel`.
  - Route remote API models with `model_name` and `is_cross_encoder=True` to rerank endpoints instead of the embeddings endpoint.
  - Support both MTEB cross-encoder input formats: `(query, doc)` and `(query, doc, instruction)`.
  - Preserve rerank response indices when mapping API scores back to MTEB document order.

  This implementation keeps `APIRerankerModel` in `evalscope/backend/rag_eval/utils/embedding.py` because that module already contains both embedding  adapters and the existing local reranker adapter logic. **And a cleaner long-term refactor could split the module into embedding and reranker adapters.**  Perhaps we could do a follow-up refactor that splits the current `embedding.py` module into separate  embedding and reranker adapter modules. 

