### PR TITLE
fix(rag): resolve custom MTEB task type without registry lookup, fix …

### DIFF
--- a/evalscope/backend/rag_eval/cmteb/task_template.py
+++ b/evalscope/backend/rag_eval/cmteb/task_template.py
@@ -8,19 +8,28 @@ from evalscope.utils.logger import get_logger
 logger = get_logger()
 
 
-def show_results(output_folder, model, results):
+def show_results(output_folder, model, results, task_type_map=None):
     model_name = model.mteb_model_meta.model_name_as_path()
     revision = model.mteb_model_meta.revision
+    task_type_map = task_type_map or {}
 
     data = []
     for model_res in results:
         main_res = model_res.only_main_score()
+        # Resolve task type from local task instances first; custom tasks (e.g. CustomRetrieval)
+        # are not registered in mteb's TASKS_REGISTRY, so main_res.task_type would raise KeyError.
+        task_type = task_type_map.get(main_res.task_name)
+        if task_type is None:
+            try:
+                task_type = main_res.task_type
+            except KeyError:
+                task_type = 'Custom'
         for split, score in main_res.scores.items():
             for sub_score in score:
                 data.append({
                     'Model': model_name.replace('eval__', ''),
                     'Revision': revision,
-                    'Task Type': main_res.task_type,
+                    'Task Type': task_type,
                     'Task': main_res.task_name,
                     'Split': split,
                     'Subset': sub_score['hf_subset'],
@@ -34,6 +43,7 @@ def show_results(output_folder, model, results):
     )
     logger.info(f'Evaluation results:\n{tabulate(data, headers="keys", tablefmt="grid")}')
     logger.info(f'Evaluation results saved in {os.path.abspath(save_path)}')
+    return data
 
 
 def one_stage_eval(
@@ -52,7 +62,8 @@ def one_stage_eval(
     results = evaluation.run(model, **eval_args)
 
     # save and log results
-    show_results(eval_args['output_folder'], model, results)
+    task_type_map = {task.metadata.name: task.metadata.type for task in tasks}
+    show_results(eval_args['output_folder'], model, results, task_type_map)
 
 
 def two_stage_eval(
@@ -70,6 +81,7 @@ def two_stage_eval(
 
     tasks = cmteb.TaskBase.get_tasks(task_names=eval_args['tasks'])
     for task in tasks:
+        task_type_map = {task.metadata.name: task.metadata.type}
         evaluation = mteb.MTEB(tasks=[task])
 
         # stage 1: run dual encoder
@@ -96,4 +108,4 @@ def two_stage_eval(
         )
 
         # save and log results
-        show_results(second_stage_path, cross_encoder, results)
+        show_results(second_stage_path, cross_encoder, results, task_type_map)

--- a/tests/rag/test_cmteb_show_results.py
+++ b/tests/rag/test_cmteb_show_results.py
@@ -1,0 +1,60 @@
+import pytest
+
+pytest.importorskip('mteb')
+
+from evalscope.backend.rag_eval.cmteb.task_template import show_results
+
+
+class MockModelMeta:
+
+    revision = 'v1'
+
+    def model_name_as_path(self):
+        return 'eval__test-model'
+
+
+class MockModel:
+
+    mteb_model_meta = MockModelMeta()
+
+
+class MockMainScore:
+
+    def __init__(self, task_name, raise_key_error=False):
+        self.task_name = task_name
+        self.scores = {'test': [{'hf_subset': 'default', 'main_score': 0.5}]}
+        self._raise_key_error = raise_key_error
+
+    @property
+    def task_type(self):
+        if self._raise_key_error:
+            raise KeyError(f"KeyError: '{self.task_name}' not found. Did you mean: EcomRetrieval?")
+        return 'Retrieval'
+
+
+class MockModelResult:
+
+    def __init__(self, main_score):
+        self._main_score = main_score
+
+    def only_main_score(self):
+        return self._main_score
+
+
+def test_show_results_prefers_local_task_type_map(tmp_path):
+    # Custom task resolves via the local map, even though mteb lookup would raise KeyError.
+    results = [MockModelResult(MockMainScore('CustomRetrieval', raise_key_error=True))]
+
+    data = show_results(str(tmp_path), MockModel(), results, {'CustomRetrieval': 'Retrieval'})
+
+    assert data[0]['Task Type'] == 'Retrieval'
+    assert data[0]['Task'] == 'CustomRetrieval'
+
+
+def test_show_results_falls_back_to_custom_on_keyerror(tmp_path):
+    # Regression for issue #915: not in local map and mteb lookup raises KeyError.
+    results = [MockModelResult(MockMainScore('CustomRetrieval', raise_key_error=True))]
+
+    data = show_results(str(tmp_path), MockModel(), results, task_type_map=None)
+
+    assert data[0]['Task Type'] == 'Custom'


### PR DESCRIPTION
## Summary

Fixes #915.

Running a custom embedding evaluation (`tasks: ["CustomRetrieval"]`) via the
RAGEval / MTEB backend crashes right after evaluation finishes with:

KeyError: 'CustomRetrieval' not found. Did you mean: EcomRetrieval?


## Root cause

Custom tasks such as `CustomRetrieval` are registered only in evalscope's
local `CLS_CUSTOM` map (`cmteb/tasks/__init__.py`), not in mteb's global
`TASKS_REGISTRY`. They evaluate fine, but `show_results()` reads the task type
via mteb's `main_res.task_type`, which internally calls `get_task(task_name)`
against `TASKS_REGISTRY`. Since the custom task isn't there, mteb raises
`KeyError` — the failure is purely in result display, after the run succeeded.

## Fix

`show_results()` now resolves the task type from the local task instances
(already held during the run) via a `{name: type}` map, and falls back to
`'Custom'` when mteb cannot resolve it. Built-in tasks are unaffected (they
resolve through the local map or, failing that, mteb's registry).

Changes are limited to `evalscope/backend/rag_eval/cmteb/task_template.py`.

## Tests

Added `tests/rag/test_cmteb_show_results.py`:
- task type resolved from the local map (custom task path)
- fallback to `'Custom'` when the mteb lookup raises `KeyError` (the #915 regression)