### PR TITLE
fix(rageval): report custom retrieval results

### DIFF
--- a/evalscope/backend/rag_eval/cmteb/task_template.py
+++ b/evalscope/backend/rag_eval/cmteb/task_template.py
@@ -8,9 +8,17 @@ from evalscope.utils.logger import get_logger
 logger = get_logger()
 
 
-def show_results(output_folder, model, results):
+def _get_task_type(main_res, task_types):
+    try:
+        return main_res.task_type
+    except KeyError:
+        return task_types.get(main_res.task_name, 'Unknown')
+
+
+def show_results(output_folder, model, results, tasks=None):
     model_name = model.mteb_model_meta.model_name_as_path()
     revision = model.mteb_model_meta.revision
+    task_types = {task.metadata.name: task.metadata.type for task in tasks or []}
 
     data = []
     for model_res in results:
@@ -20,7 +28,7 @@ def show_results(output_folder, model, results):
                 data.append({
                     'Model': model_name.replace('eval__', ''),
                     'Revision': revision,
-                    'Task Type': main_res.task_type,
+                    'Task Type': _get_task_type(main_res, task_types),
                     'Task': main_res.task_name,
                     'Split': split,
                     'Subset': sub_score['hf_subset'],
@@ -52,7 +60,7 @@ def one_stage_eval(
     results = evaluation.run(model, **eval_args)
 
     # save and log results
-    show_results(eval_args['output_folder'], model, results)
+    show_results(eval_args['output_folder'], model, results, tasks=tasks)
 
 
 def two_stage_eval(
@@ -96,4 +104,4 @@ def two_stage_eval(
         )
 
         # save and log results
-        show_results(second_stage_path, cross_encoder, results)
+        show_results(second_stage_path, cross_encoder, results, tasks=[task])

--- a/tests/rag/test_mteb_summary.py
+++ b/tests/rag/test_mteb_summary.py
@@ -1,0 +1,61 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_task_template():
+    module_path = (
+        Path(__file__).parents[2]
+        / 'evalscope'
+        / 'backend'
+        / 'rag_eval'
+        / 'cmteb'
+        / 'task_template.py'
+    )
+    stubs = {
+        'mteb': types.SimpleNamespace(MTEB=object),
+        'tabulate': types.SimpleNamespace(tabulate=lambda *args, **kwargs: ''),
+        'evalscope': types.ModuleType('evalscope'),
+        'evalscope.backend': types.ModuleType('evalscope.backend'),
+        'evalscope.backend.rag_eval': types.SimpleNamespace(
+            EmbeddingModel=object, cmteb=object
+        ),
+        'evalscope.utils': types.ModuleType('evalscope.utils'),
+        'evalscope.utils.logger': types.SimpleNamespace(
+            get_logger=lambda: types.SimpleNamespace(info=lambda *args, **kwargs: None)
+        ),
+    }
+    old_modules = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'task_template_under_test', module_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, old_module in old_modules.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+
+class _CustomMainResult:
+    task_name = 'CustomRetrieval'
+
+    @property
+    def task_type(self):
+        raise KeyError("'CustomRetrieval' not found")
+
+
+def test_custom_task_type_uses_runtime_metadata():
+    task_template = _load_task_template()
+    task = types.SimpleNamespace(
+        metadata=types.SimpleNamespace(name='CustomRetrieval', type='Retrieval')
+    )
+    task_types = {task.metadata.name: task.metadata.type}
+
+    assert task_template._get_task_type(_CustomMainResult(), task_types) == 'Retrieval'


### PR DESCRIPTION
## Summary
- use the runtime task metadata when displaying MTEB results
- avoid crashing on custom tasks such as CustomRetrieval that are not registered in MTEB's global task registry
- add a focused regression test for the custom-task fallback

Fixes #915

## To verify
- python -m pytest tests\rag\test_mteb_summary.py -q
- python -m ruff check evalscope\backend\rag_eval\cmteb\task_template.py tests\rag\test_mteb_summary.py
- python -m ruff format --check tests\rag\test_mteb_summary.py
- python -m py_compile evalscope\backend\rag_eval\cmteb\task_template.py tests\rag\test_mteb_summary.py
- git diff --check