### PR TITLE
fix(terminal_bench): check docker cli before trials

### DIFF
--- a/docs/en/third_party/terminal_bench.md
+++ b/docs/en/third_party/terminal_bench.md
@@ -18,7 +18,7 @@ Links:
 
 ```{important}
 - **Python Version**: Must use **Python >= 3.12**.
-- **Docker Environment**: Docker is used by default for evaluation. Please ensure Docker Engine and Docker Compose are installed and running locally.
+- **Docker Environment**: Docker is used by default for evaluation. Please ensure Docker Engine, Docker Compose, and the `docker` CLI are installed and available in the environment running EvalScope.
 - **Network Connection**:
   - The dataset is downloaded from Harbor Hub. Please ensure network connectivity.
   - Container building and runtime may require internet access to download dependencies. Ensure a stable network environment.
@@ -126,5 +126,6 @@ After evaluation completes, a result table similar to the following will be outp
 ## Troubleshooting
 
 1. **Docker Connection Failed**: Please check if Docker Desktop or Docker Engine is running and the current user has permission to access the Docker socket.
-2. **Dataset Download Failed**: The dataset is downloaded via GitHub. Please check network connectivity or configure a proxy.
-3. **Python Version Error**: If you encounter syntax errors or package compatibility issues, please confirm you are using Python 3.12+.
+2. **Docker CLI Not Found**: If EvalScope runs inside a container, mounting `/var/run/docker.sock` is not enough. The container also needs the `docker` command-line client installed.
+3. **Dataset Download Failed**: The dataset is downloaded via GitHub. Please check network connectivity or configure a proxy.
+4. **Python Version Error**: If you encounter syntax errors or package compatibility issues, please confirm you are using Python 3.12+.

--- a/docs/zh/third_party/terminal_bench.md
+++ b/docs/zh/third_party/terminal_bench.md
@@ -18,7 +18,7 @@ EvalScope 支持两个版本：
 
 ```{important}
 - **Python 版本**：必须使用 **Python >= 3.12**。
-- **Docker 环境**：默认使用 Docker 运行评测，请确保本地已安装并启动 Docker Engine 和 Docker Compose。
+- **Docker 环境**：默认使用 Docker 运行评测，请确保运行 EvalScope 的环境中已安装并启动 Docker Engine、Docker Compose 以及 `docker` 命令行工具。
 - **网络连接**：
   - 数据集从 Harbor Hub 下载，请确保网络通畅。
   - 容器构建和运行时可能需要联网下载依赖，需保证环境网络稳定。
@@ -126,5 +126,6 @@ run_task(task_cfg)
 ## 故障排除
 
 1. **Docker 连接失败**：请检查 Docker Desktop 或 Docker Engine 是否正在运行，且当前用户有权限访问 Docker socket。
-2. **数据集下载失败**：数据集通过 Harbor Hub 下载，请检查网络连接或配置代理。
-3. **Python 版本错误**：如果遇到语法错误或包兼容性问题，请确认使用的是 Python 3.12+。
+2. **Docker CLI 未找到**：如果 EvalScope 在容器内运行，仅挂载 `/var/run/docker.sock` 是不够的，容器内还需要安装 `docker` 命令行工具。
+3. **数据集下载失败**：数据集通过 Harbor Hub 下载，请检查网络连接或配置代理。
+4. **Python 版本错误**：如果遇到语法错误或包兼容性问题，请确认使用的是 Python 3.12+。

--- a/evalscope/benchmarks/terminal_bench/terminal_bench_adapter.py
+++ b/evalscope/benchmarks/terminal_bench/terminal_bench_adapter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -57,6 +58,20 @@ COMMON_EXTRA_PARAMS = {
 }
 
 
+def _validate_environment_requirements(environment_type: str):
+    environment_type = (environment_type or '').strip().lower()
+    if environment_type != 'docker':
+        return
+
+    if shutil.which('docker') is None:
+        raise RuntimeError(
+            'Terminal-Bench with environment_type=\'docker\' requires the Docker CLI to be installed in the '
+            'environment running EvalScope. Mounting /var/run/docker.sock only exposes the Docker daemon socket; '
+            'it does not provide the docker command. Install the Docker CLI in the container or switch '
+            'environment_type to \'daytona\', \'e2b\', or \'modal\'.'
+        )
+
+
 class _TerminalBenchBase(AgentAdapter):
     """Shared logic for Terminal-Bench adapters."""
 
@@ -73,6 +88,8 @@ class _TerminalBenchBase(AgentAdapter):
         self.environment_kwargs = self.extra_params.get('environment_kwargs', {})
 
     def load(self):
+        _validate_environment_requirements(self.environment_type)
+
         from harbor.models.job.config import DatasetConfig
 
         config = DatasetConfig(

--- a/tests/benchmark/test_terminal_bench_adapter.py
+++ b/tests/benchmark/test_terminal_bench_adapter.py
@@ -1,0 +1,31 @@
+import pytest
+
+from evalscope.benchmarks.terminal_bench.terminal_bench_adapter import _validate_environment_requirements
+
+
+def test_terminal_bench_docker_requires_cli(monkeypatch):
+    monkeypatch.setattr(
+        'evalscope.benchmarks.terminal_bench.terminal_bench_adapter.shutil.which',
+        lambda command: None,
+    )
+
+    with pytest.raises(RuntimeError, match='requires the Docker CLI'):
+        _validate_environment_requirements('docker')
+
+
+def test_terminal_bench_docker_allows_installed_cli(monkeypatch):
+    monkeypatch.setattr(
+        'evalscope.benchmarks.terminal_bench.terminal_bench_adapter.shutil.which',
+        lambda command: '/usr/bin/docker',
+    )
+
+    _validate_environment_requirements('docker')
+
+
+def test_terminal_bench_skips_docker_cli_check_for_remote_environments(monkeypatch):
+    monkeypatch.setattr(
+        'evalscope.benchmarks.terminal_bench.terminal_bench_adapter.shutil.which',
+        lambda command: None,
+    )
+
+    _validate_environment_requirements('e2b')


### PR DESCRIPTION
## Summary
- Fail early for Terminal-Bench Docker runs when the `docker` CLI is unavailable, with an error message that explains why mounting `/var/run/docker.sock` alone is not sufficient.
- Run the preflight check during dataset loading, before Harbor starts launching trials.
- Document the Docker CLI requirement and add regression coverage for Docker and non-Docker environments.

Fixes #1378

## Validation
- Pre-commit hooks for the changed files pass.
- Terminal-Bench adapter regression tests pass.
- Python compilation check for the changed adapter and new test passes.
- Whitespace diff check passes.