### PR TITLE
fix(rageval): summarize custom mteb task results

### DIFF
--- a/evalscope/backend/rag_eval/__init__.py
+++ b/evalscope/backend/rag_eval/__init__.py
@@ -1,4 +1,41 @@
-from evalscope.backend.rag_eval.backend_manager import RAGEvalBackendManager, Tools
-from evalscope.backend.rag_eval.utils.clip import VisionModel
-from evalscope.backend.rag_eval.utils.embedding import EmbeddingModel
-from evalscope.backend.rag_eval.utils.llm import LLM, ChatOpenAI, LocalLLM
+from typing import TYPE_CHECKING
+
+from evalscope.utils.import_utils import _LazyModule
+
+if TYPE_CHECKING:
+    from evalscope.backend.rag_eval.backend_manager import RAGEvalBackendManager, Tools
+    from evalscope.backend.rag_eval.utils.clip import VisionModel
+    from evalscope.backend.rag_eval.utils.embedding import EmbeddingModel
+    from evalscope.backend.rag_eval.utils.llm import LLM, ChatOpenAI, LocalLLM
+
+else:
+    _import_structure = {
+        'backend_manager': [
+            'RAGEvalBackendManager',
+            'Tools',
+        ],
+        'utils.clip': [
+            'VisionModel',
+        ],
+        'utils.embedding': [
+            'EmbeddingModel',
+        ],
+        'utils.llm': [
+            'LLM',
+            'ChatOpenAI',
+            'LocalLLM',
+        ],
+        'cmteb': [],
+        'ragas': [],
+        'clip_benchmark': [],
+    }
+
+    import sys
+
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()['__file__'],
+        _import_structure,
+        module_spec=__spec__,
+        extra_objects={},
+    )

--- a/evalscope/backend/rag_eval/cmteb/__init__.py
+++ b/evalscope/backend/rag_eval/cmteb/__init__.py
@@ -1,4 +1,118 @@
-from evalscope.backend.rag_eval.cmteb.arguments import EvalArguments, ModelArguments
-from evalscope.backend.rag_eval.cmteb.base import *
-from evalscope.backend.rag_eval.cmteb.task_template import one_stage_eval, two_stage_eval
-from evalscope.backend.rag_eval.cmteb.tasks import *
+from typing import TYPE_CHECKING
+
+from evalscope.utils.import_utils import _LazyModule
+
+if TYPE_CHECKING:
+    from evalscope.backend.rag_eval.cmteb.arguments import EvalArguments, ModelArguments
+    from evalscope.backend.rag_eval.cmteb.base import TaskBase
+    from evalscope.backend.rag_eval.cmteb.task_template import one_stage_eval, two_stage_eval
+    from evalscope.backend.rag_eval.cmteb.tasks import (
+        AFQMC,
+        ATEC,
+        BQ,
+        CLS_CLASSIFICATION,
+        CLS_CLUSTERING,
+        CLS_CUSTOM,
+        CLS_DICT,
+        CLS_PAIR_CLASSIFICATION,
+        CLS_RERANKING,
+        CLS_RETRIEVAL,
+        CLS_STS,
+        LCQMC,
+        PAWSX,
+        QBQTC,
+        STSB,
+        CLSClusteringFastP2P,
+        CLSClusteringFastS2S,
+        CmedqaRetrieval,
+        CMedQAv1,
+        CMedQAv2,
+        Cmnli,
+        CovidRetrieval,
+        CustomRetrieval,
+        DuRetrieval,
+        EcomRetrieval,
+        IFlyTek,
+        JDReview,
+        MedicalRetrieval,
+        MMarcoReranking,
+        MMarcoRetrieval,
+        MultilingualSentiment,
+        Ocnli,
+        OnlineShopping,
+        T2Reranking,
+        T2Retrieval,
+        ThuNewsClusteringFastP2P,
+        ThuNewsClusteringFastS2S,
+        TNews,
+        VideoRetrieval,
+        Waimai,
+    )
+
+else:
+    _task_exports = [
+        'AFQMC',
+        'ATEC',
+        'BQ',
+        'CLS_CLASSIFICATION',
+        'CLS_CUSTOM',
+        'CLS_DICT',
+        'CLS_CLUSTERING',
+        'CLS_PAIR_CLASSIFICATION',
+        'CLS_RERANKING',
+        'CLS_RETRIEVAL',
+        'CLS_STS',
+        'CMedQAv1',
+        'CMedQAv2',
+        'CLSClusteringFastP2P',
+        'CLSClusteringFastS2S',
+        'CmedqaRetrieval',
+        'Cmnli',
+        'CovidRetrieval',
+        'CustomRetrieval',
+        'DuRetrieval',
+        'EcomRetrieval',
+        'IFlyTek',
+        'JDReview',
+        'LCQMC',
+        'MMarcoReranking',
+        'MMarcoRetrieval',
+        'MedicalRetrieval',
+        'MultilingualSentiment',
+        'Ocnli',
+        'OnlineShopping',
+        'PAWSX',
+        'QBQTC',
+        'STSB',
+        'T2Reranking',
+        'T2Retrieval',
+        'TNews',
+        'ThuNewsClusteringFastP2P',
+        'ThuNewsClusteringFastS2S',
+        'VideoRetrieval',
+        'Waimai',
+    ]
+    _import_structure = {
+        'arguments': [
+            'EvalArguments',
+            'ModelArguments',
+        ],
+        'base': [
+            'TaskBase',
+        ],
+        'task_template': [
+            'one_stage_eval',
+            'two_stage_eval',
+        ],
+        'tasks': _task_exports,
+    }
+
+    import sys
+
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()['__file__'],
+        _import_structure,
+        module_spec=__spec__,
+        extra_objects={},
+    )

--- a/evalscope/backend/rag_eval/cmteb/task_template.py
+++ b/evalscope/backend/rag_eval/cmteb/task_template.py
@@ -1,31 +1,63 @@
-import mteb
 import os
 from tabulate import tabulate
 
-from evalscope.backend.rag_eval import EmbeddingModel, cmteb
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
 
 
-def show_results(output_folder, model, results):
+def _build_task_type_by_name(tasks):
+    task_type_by_name = {}
+    for task in tasks:
+        metadata = getattr(task, 'metadata', None)
+        task_name = getattr(metadata, 'name', None)
+        task_type = getattr(metadata, 'type', None)
+        if task_name and task_type:
+            task_type_by_name[task_name] = task_type
+    return task_type_by_name
+
+
+def _resolve_task_type(task_result, task_type_by_name=None):
+    if not task_result:
+        return 'Unknown'
+
+    task_type_by_name = task_type_by_name or {}
+    task_name = getattr(task_result, 'task_name', None)
+    if task_name and task_name in task_type_by_name:
+        return task_type_by_name[task_name]
+
+    try:
+        return task_result.task_type
+    except (AttributeError, KeyError):
+        return 'Unknown'
+
+
+def _build_result_table(model, results, task_type_by_name=None):
     model_name = model.mteb_model_meta.model_name_as_path()
     revision = model.mteb_model_meta.revision
 
     data = []
     for model_res in results:
         main_res = model_res.only_main_score()
+        task_type = _resolve_task_type(main_res, task_type_by_name)
         for split, score in main_res.scores.items():
             for sub_score in score:
                 data.append({
                     'Model': model_name.replace('eval__', ''),
                     'Revision': revision,
-                    'Task Type': main_res.task_type,
+                    'Task Type': task_type,
                     'Task': main_res.task_name,
                     'Split': split,
                     'Subset': sub_score['hf_subset'],
                     'Main Score': sub_score['main_score'],
                 })
+    return data
+
+
+def show_results(output_folder, model, results, task_type_by_name=None):
+    model_name = model.mteb_model_meta.model_name_as_path()
+    revision = model.mteb_model_meta.revision
+    data = _build_result_table(model, results, task_type_by_name)
 
     save_path = os.path.join(
         output_folder,
@@ -40,6 +72,10 @@ def one_stage_eval(
     model_args,
     eval_args,
 ) -> None:
+    import mteb
+
+    from evalscope.backend.rag_eval import EmbeddingModel, cmteb
+
     # load model
     model = EmbeddingModel.load(**model_args)
     custom_dataset_path = eval_args.pop('dataset_path', None)
@@ -52,7 +88,7 @@ def one_stage_eval(
     results = evaluation.run(model, **eval_args)
 
     # save and log results
-    show_results(eval_args['output_folder'], model, results)
+    show_results(eval_args['output_folder'], model, results, _build_task_type_by_name(tasks))
 
 
 def two_stage_eval(
@@ -61,6 +97,11 @@ def two_stage_eval(
     eval_args,
 ) -> None:
     """a two-stage run with the second stage reading results saved from the first stage."""
+
+    import mteb
+
+    from evalscope.backend.rag_eval import EmbeddingModel, cmteb
+
     # load model
     dual_encoder = EmbeddingModel.load(**model1_args)
     cross_encoder = EmbeddingModel.load(**model2_args)
@@ -96,4 +137,4 @@ def two_stage_eval(
         )
 
         # save and log results
-        show_results(second_stage_path, cross_encoder, results)
+        show_results(second_stage_path, cross_encoder, results, _build_task_type_by_name([task]))

--- a/tests/rag/test_mteb_result_summary.py
+++ b/tests/rag/test_mteb_result_summary.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+from evalscope.backend.rag_eval.cmteb import task_template
+
+
+class FakeModelMeta:
+
+    revision = 'test-revision'
+
+    @staticmethod
+    def model_name_as_path():
+        return 'eval__test-model'
+
+
+class FakeModel:
+    mteb_model_meta = FakeModelMeta()
+
+
+class FakeMainResult:
+
+    task_name = 'CustomRetrieval'
+    scores = {
+        'test': [
+            {
+                'hf_subset': 'default',
+                'main_score': 0.75,
+            }
+        ]
+    }
+
+    @property
+    def task_type(self):
+        raise KeyError('CustomRetrieval')
+
+
+class FakeModelResult:
+
+    @staticmethod
+    def only_main_score():
+        return FakeMainResult()
+
+
+def test_build_result_table_uses_evaluated_task_metadata_for_custom_tasks():
+    tasks = [
+        SimpleNamespace(
+            metadata=SimpleNamespace(
+                name='CustomRetrieval',
+                type='Retrieval',
+            )
+        )
+    ]
+
+    data = task_template._build_result_table(
+        FakeModel(),
+        [FakeModelResult()],
+        task_template._build_task_type_by_name(tasks),
+    )
+
+    assert data == [
+        {
+            'Model': 'test-model',
+            'Revision': 'test-revision',
+            'Task Type': 'Retrieval',
+            'Task': 'CustomRetrieval',
+            'Split': 'test',
+            'Subset': 'default',
+            'Main Score': 0.75,
+        }
+    ]
+
+
+def test_resolve_task_type_falls_back_when_mteb_registry_lookup_fails():
+    assert task_template._resolve_task_type(FakeMainResult()) == 'Unknown'
+
+
+def test_resolve_task_type_handles_missing_result_shape():
+    assert task_template._resolve_task_type(None) == 'Unknown'
+    assert task_template._resolve_task_type(SimpleNamespace()) == 'Unknown'


### PR DESCRIPTION
## Summary
- Use the evaluated task objects' metadata when rendering RAGEval/MTEB result summaries, instead of relying on `TaskResult.task_type` to look the task up again from the upstream MTEB registry.
- Keep a defensive fallback for missing task metadata or unexpected result shapes, so custom tasks do not crash summary rendering.
- Make RAGEval/cmteb package exports lazy, following the existing project pattern, so `task_template` can be imported normally without eagerly loading optional MTEB/embedding dependencies.
- Add regression coverage for a custom task whose `TaskResult.task_type` lookup raises `KeyError`, matching the `CustomRetrieval` failure mode.

Fixes #915

## Validation
- Pre-commit hooks for the changed files pass.
- RAGEval/MTEB custom task result-summary regression tests pass.
- Standard package imports for `task_template` and public RAGEval/cmteb exports pass.
- Python compilation check for the changed summary/import code and new test passes.
- Whitespace diff check passes.
- Existing MTEB integration tests collect successfully with level-0 tests skipped.