### PR TITLE
fix(models): forward reasoning_content as top-level field in multi-turn

### DIFF
--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -40,23 +40,29 @@ The `--generation-config` parameter supports the following options (comma-separa
 
 | Parameter | Type | Description | Supported Backends |
 |-----------|------|-------------|--------------------|
-| `timeout` | `int` | Request timeout (seconds) | All |
+| `timeout` | `int`/`float` | Request timeout (seconds) | All |
 | `retries` | `int` | Number of retries, default is 5. | OpenAI-compatible |
 | `retry_interval` | `int` | Retry interval (seconds), default is 10. | OpenAI-compatible |
 | `stream` | `bool` | Whether to return responses in streaming mode | All |
 | `max_tokens` | `int` | Maximum number of tokens generated | All |
 | `top_p` | `float` | Nucleus sampling; only considers tokens accounting for top_p probability mass | All |
 | `temperature` | `float` | Sampling temperature, range 0~2; higher means more randomness | All |
+| `stop_seqs` | `list[str]` | Sequences that trigger stop generation; the returned text does not include the stop sequence | All |
 | `frequency_penalty` | `float` | Range -2.0~2.0; positive values penalize repeated tokens | OpenAI-compatible |
 | `presence_penalty` | `float` | Range -2.0~2.0; positive values penalize already appeared tokens | OpenAI-compatible |
-| `logit_bias` | `dict` | Mapping of token IDs to bias values (-100~100)<br>Example: `"42=10,43=-10"` | OpenAI, Grok, vLLM |
-| `seed` | `int` | Random seed | OpenAI, Google, Mistral, Groq, HuggingFace, vLLM |
+| `repetition_penalty` | `float` | Exponential penalty applied to existing tokens. 1.0 means no penalty | OpenAI-compatible, HuggingFace, vLLM |
+| `logit_bias` | `dict` | Mapping of token IDs to bias values (-100~100)<br>Example: `"42=10,43=-10"` | OpenAI-compatible |
+| `seed` | `int` | Random seed | OpenAI-compatible |
 | `do_sample` | `bool` | Whether to use sampling strategy (otherwise greedy decoding) | Transformers |
 | `top_k` | `int` | Sample next token from the top_k most likely candidates | Anthropic, Google, HuggingFace, vLLM, SGLang |
-| `logprobs` | `bool` | Whether to return log probabilities for output tokens | OpenAI, Grok, TogetherAI, HuggingFace, llama-cpp-python, vLLM, SGLang |
-| `top_logprobs` | `int` | Return the top N tokens and their probabilities (range 0~20) | OpenAI, Grok, HuggingFace, vLLM, SGLang |
+| `logprobs` | `bool` | Whether to return log probabilities for output tokens | OpenAI-compatible, HuggingFace, llama-cpp-python |
+| `top_logprobs` | `int` | Return the top N tokens and their probabilities (range 0~20) | OpenAI-compatible, HuggingFace |
 | `parallel_tool_calls` | `bool` | Whether to support parallel tool calls | OpenAI, Groq |
-| `max_tool_output` | `int` | Maximum bytes for tool output | All (default 16*1024) |
+| `response_schema` | `dict` | Request structured output (JSON Schema); the output still needs to be validated | OpenAI, Google, Mistral |
+| `reasoning_effort` | `str` | Reasoning effort level. One of `low` / `medium` (default) / `high` | OpenAI o1 series |
+| `reasoning_tokens` | `int` | Maximum tokens budget for reasoning (thinking budget) | Anthropic Claude |
+| `reasoning_summary` | `str` | Reasoning summary verbosity. One of `concise` / `detailed` / `auto` | OpenAI reasoning series |
+| `reasoning_history` | `str` | How to encode prior-turn assistant `reasoning_content` in multi-turn requests. One of `reasoning_field` (default; pass as independent top-level field, works for DeepSeek V4 thinking, Qwen3 thinking), `think_tag` (embed as `<think>...</think>` in content string, legacy Together/Groq compatible), `none` (strip entirely; **required for DeepSeek R1 legacy** which forbids `reasoning_content` in requests) | OpenAI-compatible |
 | `extra_body` | `dict` | Extra request body for OpenAI-compatible services | OpenAI-compatible services |
 | `extra_query` | `dict` | Extra query parameters for OpenAI-compatible services | OpenAI-compatible services |
 | `extra_headers` | `dict` | Extra headers for OpenAI-compatible services | OpenAI-compatible services |

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -40,23 +40,29 @@
 
 | 参数 | 类型 | 说明 | 支持的后端 |
 |------|------|------|------------|
-| `timeout` | `int` | 请求超时时间（秒） | 所有 |
+| `timeout` | `int`/`float` | 请求超时时间（秒） | 所有 |
 | `retries` | `int` | 重试次数，默认为5 | OpenAI兼容 |
 | `retry_interval` | `int` | 重试间隔时间（秒），默认10 | OpenAI兼容 |
 | `stream` | `bool` | 是否流式返回响应 | 所有 |
 | `max_tokens` | `int` | 最大生成token数量 | 所有 |
 | `top_p` | `float` | Nucleus采样，考虑概率质量为top_p的token | 所有 |
 | `temperature` | `float` | 采样温度，范围0~2，越高越随机 | 所有 |
+| `stop_seqs` | `list[str]` | 触发停止生成的序列列表，返回文本不包含该序列 | 所有 |
 | `frequency_penalty` | `float` | 范围-2.0~2.0，正值惩罚重复token | OpenAI兼容 |
 | `presence_penalty` | `float` | 范围-2.0~2.0，正值惩罚已出现token | OpenAI兼容 |
+| `repetition_penalty` | `float` | 对已生成token施加指数惩罚，1.0 表示不惩罚 | OpenAI兼容、HuggingFace、vLLM |
 | `logit_bias` | `dict` | token id到偏置值的映射（-100~100）<br>示例：`"42=10,43=-10"` | OpenAI兼容 |
 | `seed` | `int` | 随机种子 | OpenAI兼容 |
 | `do_sample` | `bool` | 是否采用采样策略（否则贪婪解码） | Transformers |
-| `top_k` | `int` | 从top_k最可能的词中采样 | Anthropic, Google, HuggingFace, vLLM, SGLang |
-| `logprobs` | `bool` | 是否返回输出token的对数概率 | OpenAI, Grok, TogetherAI, HuggingFace, llama-cpp-python, vLLM, SGLang |
-| `top_logprobs` | `int` | 返回概率最高的前N个token（范围0~20） | OpenAI, Grok, HuggingFace, vLLM, SGLang |
-| `parallel_tool_calls` | `bool` | 工具调用是否支持并行 | OpenAI, Groq |
-| `max_tool_output` | `int` | 工具输出的最大字节数 | 所有（默认16*1024） |
+| `top_k` | `int` | 从top_k最可能的词中采样 | Anthropic、Google、HuggingFace、vLLM、SGLang |
+| `logprobs` | `bool` | 是否返回输出token的对数概率 | OpenAI兼容、HuggingFace、llama-cpp-python |
+| `top_logprobs` | `int` | 返回概率最高的前N个token（范围0~20） | OpenAI兼容、HuggingFace |
+| `parallel_tool_calls` | `bool` | 工具调用是否支持并行 | OpenAI、Groq |
+| `response_schema` | `dict` | 请求结构化输出（JSON Schema），仍需对输出做校验 | OpenAI、Google、Mistral |
+| `reasoning_effort` | `str` | reasoning 努力程度，可选 `low` / `medium`（默认）/ `high` | OpenAI o1 系列 |
+| `reasoning_tokens` | `int` | reasoning 最大 token 预算（thinking budget） | Anthropic Claude |
+| `reasoning_summary` | `str` | reasoning 摘要级别，可选 `concise` / `detailed` / `auto` | OpenAI reasoning 系列 |
+| `reasoning_history` | `str` | 多轮对话中如何编码上一轮 assistant 的 `reasoning_content`。可选值：`reasoning_field`（默认，作为独立顶层字段透传，适配 DeepSeek V4 thinking、Qwen3 thinking 等）、`think_tag`（编码为 `<think>...</think>` 塞进 content 字符串，兼容旧版 Together / Groq 等部署）、`none`（完全剥离，DeepSeek R1 等禁止回传 `reasoning_content` 的 legacy 模型必须显式设此值） | OpenAI兼容 |
 | `extra_body` | `dict` | 向OpenAI兼容服务发送的额外请求体 | OpenAI兼容服务 |
 | `extra_query` | `dict` | 向OpenAI兼容服务发送的额外查询参数 | OpenAI兼容服务 |
 | `extra_headers` | `dict` | 向OpenAI兼容服务发送的额外请求头 | OpenAI兼容服务 |

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -1,7 +1,7 @@
 # flake8: noqa: E501
 from copy import deepcopy
-from pydantic import BaseModel, Field, model_validator
-from typing import Any, Dict, List, Literal, Optional, Union
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Literal, Optional
 
 from evalscope.utils.json_schema import JSONSchema
 
@@ -37,7 +37,13 @@ class GenerateConfig(BaseModel):
     """Retry interval between retries (in seconds). Only supported by OpenAI compatible models."""
 
     batch_size: Optional[int] = Field(default=None)
-    """Maximum number of concurrent connections to Model API (default is model specific) or batch size for generation."""
+    """Maximum number of concurrent connections to the Model API, or batch size for generation.
+
+    Internal field — synced from :class:`TaskConfig.eval_batch_size` during task
+    initialization. Setting it directly in ``generation_config`` has no effect
+    because :meth:`TaskConfig._post_init_generation_config` overwrites it with
+    ``eval_batch_size``. Use ``--eval-batch-size`` instead.
+    """
 
     stream: Optional[bool] = Field(default=None)
     """Whether to stream the response (default is model specific)."""
@@ -53,9 +59,6 @@ class GenerateConfig(BaseModel):
 
     stop_seqs: Optional[List[str]] = Field(default=None)
     """Sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence."""
-
-    best_of: Optional[int] = Field(default=None)
-    """Generates best_of completions server-side and returns the 'best' (the one with the highest log probability per token). vLLM only."""
 
     frequency_penalty: Optional[float] = Field(default=None)
     """Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. OpenAI, Google, Grok, Groq, vLLM, and SGLang only."""
@@ -90,15 +93,6 @@ class GenerateConfig(BaseModel):
     parallel_tool_calls: Optional[bool] = Field(default=None)
     """Whether to enable parallel function calling during tool use (defaults to True). OpenAI and Groq only."""
 
-    internal_tools: Optional[bool] = Field(default=None)
-    """Whether to automatically map tools to model internal implementations (e.g. 'computer' for anthropic)."""
-
-    max_tool_output: Optional[int] = Field(default=None)
-    """Maximum tool output (in bytes). Defaults to 16 * 1024."""
-
-    cache_prompt: Union[Literal['auto'], bool, None] = Field(default=None)
-    """Whether to cache the prompt prefix. Defaults to "auto", which will enable caching for requests with tools. Anthropic only."""
-
     reasoning_effort: Optional[Literal['low', 'medium', 'high']] = Field(default=None)
     """Constrains effort on reasoning for reasoning models (defaults to `medium`). Open AI o1 models only."""
 
@@ -108,8 +102,23 @@ class GenerateConfig(BaseModel):
     reasoning_summary: Optional[Literal['concise', 'detailed', 'auto']] = Field(default=None)
     """Provide summary of reasoning steps (defaults to no summary). Use 'auto' to access the most detailed summarizer available for the current model. OpenAI reasoning models only."""
 
-    reasoning_history: Optional[Literal['none', 'all', 'last', 'auto']] = Field(default=None)
-    """Include reasoning in chat message history sent to generate."""
+    reasoning_history: Optional[Literal['none', 'think_tag', 'reasoning_field']] = Field(default=None)
+    """How to encode prior-turn ``reasoning_content`` in multi-turn requests sent to OpenAI-compatible servers.
+
+    When ``None`` (default), treated as ``'reasoning_field'`` at consumption time.
+
+    - ``'none'``: strip reasoning entirely from multi-turn history. Required for
+      DeepSeek R1 (legacy ``deepseek-reasoner``), which forbids ``reasoning_content``
+      in request messages. Safest cross-provider choice when reasoning continuity
+      is not needed.
+    - ``'think_tag'``: embed reasoning as ``<think>...</think>`` in the content
+      string. Pre-fix behavior; use for providers that consume ``<think>`` tags
+      inline (e.g., legacy Together/Groq deployments).
+    - ``'reasoning_field'``: pass ``reasoning_content`` as a top-level field on
+      each assistant message, with content kept clean (no ``<think>`` tag).
+      Required for DeepSeek V4 thinking mode; recommended for Qwen3 thinking and
+      any provider following the modern OpenAI-compatible reasoning protocol.
+    """
 
     response_schema: Optional[ResponseSchema] = Field(default=None)
     """Request a response format as JSONSchema (output should still be validated). OpenAI, Google, and Mistral only."""
@@ -134,19 +143,6 @@ class GenerateConfig(BaseModel):
 
     guidance_scale: Optional[float] = Field(default=None)
     """Guidance scale for image generation model only"""
-
-    # migrate reasoning_history as a bool
-    @model_validator(mode='before')
-    @classmethod
-    def migrate_reasoning(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            reasoning_history = data.get('reasoning_history', None)
-            if reasoning_history is True:
-                data['reasoning_history'] = 'all'
-            elif reasoning_history is False:
-                data['reasoning_history'] = 'none'
-
-        return data
 
     def merge(self, other: 'GenerateConfig') -> 'GenerateConfig':
         """Merge another model configuration into this one.

--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -131,7 +131,7 @@ class OpenAICompatibleAPI(ModelAPI):
         )
 
         request = dict(
-            messages=openai_chat_messages(input),
+            messages=openai_chat_messages(input, reasoning_format=(config.reasoning_history or 'reasoning_field')),
             tools=openai_chat_tools(tools) if len(tools) > 0 else NOT_GIVEN,
             tool_choice=openai_chat_tool_choice(tool_choice) if len(tools) > 0 else NOT_GIVEN,
             **completion_params,
@@ -203,7 +203,7 @@ class OpenAICompatibleAPI(ModelAPI):
         )
 
         request = dict(
-            messages=openai_chat_messages(input),
+            messages=openai_chat_messages(input, reasoning_format=(config.reasoning_history or 'reasoning_field')),
             tools=openai_chat_tools(tools) if len(tools) > 0 else NOT_GIVEN,
             tool_choice=openai_chat_tool_choice(tool_choice) if len(tools) > 0 else NOT_GIVEN,
             **completion_params,

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -31,7 +31,7 @@ from openai.types.chat.chat_completion_message_tool_call import Function
 from openai.types.completion_usage import CompletionUsage
 from openai.types.shared_params.function_definition import FunctionDefinition
 from pydantic import JsonValue
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from evalscope.api.messages import (
     ChatMessage,
@@ -57,6 +57,7 @@ from evalscope.api.model import (
     as_stop_reason,
 )
 from evalscope.api.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo, parse_tool_call
+from evalscope.utils import get_logger
 from evalscope.utils.url_utils import (
     data_uri_to_base64,
     file_as_data_uri,
@@ -65,6 +66,10 @@ from evalscope.utils.url_utils import (
     is_http_url,
     video_as_data_uri,
 )
+
+logger = get_logger()
+
+ReasoningFormat = Literal['think_tag', 'reasoning_field', 'none']
 
 BASE_64_DATA_REMOVED = '<base64-data-removed>'
 
@@ -128,8 +133,19 @@ def openai_chat_completion_part(content: Content) -> Union[ChatCompletionContent
 
 
 def openai_chat_message(
-    message: ChatMessage, system_role: Literal['user', 'system', 'developer'] = 'system'
+    message: ChatMessage,
+    system_role: Literal['user', 'system', 'developer'] = 'system',
+    reasoning_format: ReasoningFormat = 'think_tag',
 ) -> ChatCompletionMessageParam:
+    """Serialize a :class:`ChatMessage` into an OpenAI chat-completions message param.
+
+    ``reasoning_format`` controls how prior-turn ``ContentReasoning`` parts on
+    assistant messages are encoded for the wire — see
+    :func:`openai_assistant_content` for the per-mode behavior. When
+    ``'reasoning_field'`` is selected, the last ``ContentReasoning`` is also
+    promoted to a top-level ``reasoning_content`` key on the assistant dict
+    (required by DeepSeek V4 thinking and recommended for Qwen3 thinking).
+    """
     if message.role == 'system':
         if system_role == 'user':
             return ChatCompletionUserMessageParam(role='user', content=message.text)
@@ -146,14 +162,7 @@ def openai_chat_message(
             ),
         )
     elif message.role == 'assistant':
-        if message.tool_calls:
-            return ChatCompletionAssistantMessageParam(
-                role=message.role,
-                content=openai_assistant_content(message),
-                tool_calls=[openai_chat_tool_call_param(call) for call in message.tool_calls],
-            )
-        else:
-            return ChatCompletionAssistantMessageParam(role=message.role, content=openai_assistant_content(message))
+        return _openai_assistant_message_param(message, reasoning_format)
     elif message.role == 'tool':
         return ChatCompletionToolMessageParam(
             role=message.role,
@@ -164,11 +173,60 @@ def openai_chat_message(
         raise ValueError(f'Unexpected message role {message.role}')
 
 
+def _openai_assistant_message_param(
+    message: ChatMessageAssistant,
+    reasoning_format: ReasoningFormat,
+) -> ChatCompletionAssistantMessageParam:
+    """Build the assistant-role message dict, optionally with a top-level
+    ``reasoning_content`` field when ``reasoning_format='reasoning_field'``.
+
+    The OpenAI Python SDK's ``ChatCompletionAssistantMessageParam`` is a
+    ``TypedDict(total=False)``; extra keys are not stripped at runtime and the
+    SDK forwards them verbatim to the server. We build a plain dict so the
+    extra ``reasoning_content`` key survives, then cast it back to the
+    TypedDict for the caller's signature.
+    """
+    payload: Dict[str, Any] = {'role': message.role, 'content': openai_assistant_content(message, reasoning_format)}
+    if message.tool_calls:
+        payload['tool_calls'] = [openai_chat_tool_call_param(call) for call in message.tool_calls]
+    if reasoning_format == 'reasoning_field':
+        reasoning_text = _extract_last_reasoning(message)
+        if reasoning_text is not None:
+            if not reasoning_text.strip():
+                logger.debug(
+                    'reasoning_field mode: extracted reasoning is blank; '
+                    'injecting single-space placeholder to satisfy strict server validation '
+                    '(e.g. DeepSeek V4 thinking mode rejects empty reasoning_content).'
+                )
+                reasoning_text = ' '
+            payload['reasoning_content'] = reasoning_text
+    return cast(ChatCompletionAssistantMessageParam, payload)
+
+
+def _extract_last_reasoning(message: ChatMessageAssistant) -> Optional[str]:
+    """Return the last ``ContentReasoning.reasoning`` from a multi-part assistant
+    message, or ``None`` if the message has no reasoning parts (e.g. content is
+    a plain string, or all parts are text/other).
+
+    Multiple ``ContentReasoning`` parts are deduplicated to the last one to
+    match litellm's behavior in
+    ``litellm/llms/deepseek/chat/transformation.py``.
+    """
+    if isinstance(message.content, str):
+        return None
+    last_reasoning: Optional[str] = None
+    for c in message.content:
+        if c.type == 'reasoning':
+            last_reasoning = c.reasoning
+    return last_reasoning
+
+
 def openai_chat_messages(
     messages: List[ChatMessage],
     system_role: Literal['user', 'system', 'developer'] = 'system',
+    reasoning_format: ReasoningFormat = 'think_tag',
 ) -> List[ChatCompletionMessageParam]:
-    return [openai_chat_message(message, system_role) for message in messages]
+    return [openai_chat_message(message, system_role, reasoning_format) for message in messages]
 
 
 def openai_completion_params(model: str, config: GenerateConfig, tools: bool) -> Dict[str, Any]:
@@ -230,24 +288,44 @@ def openai_completion_params(model: str, config: GenerateConfig, tools: bool) ->
     return params
 
 
-def openai_assistant_content(message: ChatMessageAssistant, include_reasoning=True) -> str:
-    # In agent bridge scenarios, we could encounter concepts such as reasoning and
-    # .internal use in the ChatMessageAssistant that are not supported by the OpenAI
-    # choices API. This code smuggles that data into the plain text so that it
-    # survives multi-turn round trips.
+def openai_assistant_content(
+    message: ChatMessageAssistant,
+    reasoning_format: ReasoningFormat = 'think_tag',
+) -> str:
+    """Render the assistant message's ``content`` field for an OpenAI-compatible payload.
 
+    In agent bridge scenarios, ``ChatMessageAssistant`` can carry concepts
+    (``ContentReasoning``, ``.internal``) that are not part of the OpenAI
+    choices API. ``reasoning_format`` controls how ``ContentReasoning`` parts
+    are handled:
+
+    - ``'think_tag'`` (default): smuggle reasoning into the plain text as
+      ``<think>...</think>`` so it survives multi-turn round-trips on
+      providers that accept inline <think> blocks (e.g. OpenAI, Together, Groq).
+    - ``'reasoning_field'``: drop reasoning from the content string; the
+      caller is expected to write it as a top-level ``reasoning_content``
+      field on the assistant message dict.
+    - ``'none'``: drop reasoning entirely; the wire payload carries no trace
+      of the prior-turn CoT. Required for DeepSeek R1 (legacy), which
+      forbids ``reasoning_content`` in request messages.
+
+    ``.internal`` smuggling via ``<internal>...</internal>`` is preserved
+    across all modes (agent-bridge invariant).
+    """
     if isinstance(message.content, str):
         content = message.content
     else:
         content = ''
         for c in message.content:
-            if c.type == 'reasoning' and include_reasoning:
-                attribs = ''
-                if c.signature is not None:
-                    attribs = f'{attribs} signature="{c.signature}"'
-                if c.redacted:
-                    attribs = f'{attribs} redacted="true"'
-                content = f'{content}\n<think{attribs}>\n{c.reasoning}\n</think>\n'
+            if c.type == 'reasoning':
+                if reasoning_format == 'think_tag':
+                    attribs = ''
+                    if c.signature is not None:
+                        attribs = f'{attribs} signature="{c.signature}"'
+                    if c.redacted:
+                        attribs = f'{attribs} redacted="true"'
+                    content = f'{content}\n<think{attribs}>\n{c.reasoning}\n</think>\n'
+                # 'reasoning_field' and 'none' both drop reasoning from content
             elif c.type == 'text':
                 content = f'{content}\n{c.text}'
 
@@ -262,10 +340,16 @@ def openai_assistant_content(message: ChatMessageAssistant, include_reasoning=Tr
 
 def openai_chat_choices(choices: List[ChatCompletionChoice], include_reasoning: bool = True) -> List[Choice]:
     oai_choices: List[Choice] = []
+    # Translate the legacy ``include_reasoning`` toggle into the new
+    # ``reasoning_format`` axis. ``False`` historically meant "strip reasoning
+    # from the assistant content before handing it back to tau/terminal_bench",
+    # which is exactly the ``'none'`` mode; ``True`` preserves the prior
+    # ``<think>``-tag inlining.
+    reasoning_format: ReasoningFormat = 'think_tag' if include_reasoning else 'none'
 
     for index, choice in enumerate(choices):
         # Handle content
-        content = openai_assistant_content(choice.message, include_reasoning=include_reasoning)
+        content = openai_assistant_content(choice.message, reasoning_format=reasoning_format)
 
         # Handle tool calls
         if choice.message.tool_calls:

--- a/tests/models/test_openai_reasoning.py
+++ b/tests/models/test_openai_reasoning.py
@@ -10,11 +10,7 @@ parts, blank reasoning).
 import pytest
 from pydantic import ValidationError
 
-from evalscope.api.messages import (
-    ChatMessageAssistant,
-    ContentReasoning,
-    ContentText,
-)
+from evalscope.api.messages import ChatMessageAssistant, ContentReasoning, ContentText
 from evalscope.api.model import GenerateConfig
 from evalscope.api.tool import ToolCall, ToolFunction
 from evalscope.models.utils.openai import openai_chat_message

--- a/tests/models/test_openai_reasoning.py
+++ b/tests/models/test_openai_reasoning.py
@@ -1,0 +1,151 @@
+"""Unit tests for the three reasoning_format modes in openai_chat_message.
+
+Each test pins the outgoing assistant-message dict shape so the breakage of
+DeepSeek V4 thinking (issue #1392) cannot regress silently. The matrix covers
+the three modes against representative ChatMessageAssistant shapes
+(reasoning + text, tool_calls + reasoning, plain text, multiple reasoning
+parts, blank reasoning).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from evalscope.api.messages import (
+    ChatMessageAssistant,
+    ContentReasoning,
+    ContentText,
+)
+from evalscope.api.model import GenerateConfig
+from evalscope.api.tool import ToolCall, ToolFunction
+from evalscope.models.utils.openai import openai_chat_message
+
+
+def _asst_reasoning_and_text(reasoning: str, text: str) -> ChatMessageAssistant:
+    return ChatMessageAssistant(
+        content=[ContentReasoning(reasoning=reasoning), ContentText(text=text)],
+    )
+
+
+def _asst_tool_call_with_reasoning(reasoning: str) -> ChatMessageAssistant:
+    tc = ToolCall(
+        id='call-1',
+        function=ToolFunction(name='lookup', arguments={'q': 'paris'}),
+        type='function',
+    )
+    return ChatMessageAssistant(
+        content=[ContentReasoning(reasoning=reasoning)],
+        tool_calls=[tc],
+    )
+
+
+# ---------------------------------------------------------------------------
+# think_tag (default / pre-fix behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_think_tag_embeds_reasoning_in_content():
+    msg = _asst_reasoning_and_text('user wants paris weather', 'It is sunny.')
+    out = openai_chat_message(msg, reasoning_format='think_tag')
+    assert out['role'] == 'assistant'
+    assert '<think>' in out['content']
+    assert 'user wants paris weather' in out['content']
+    assert 'It is sunny.' in out['content']
+    assert 'reasoning_content' not in out
+
+
+def test_think_tag_is_the_default():
+    msg = _asst_reasoning_and_text('cot', 'reply')
+    out = openai_chat_message(msg)
+    assert '<think>' in out['content']
+    assert 'reasoning_content' not in out
+
+
+# ---------------------------------------------------------------------------
+# reasoning_field (the fix)
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_field_promotes_to_top_level():
+    msg = _asst_reasoning_and_text('user wants paris weather', 'It is sunny.')
+    out = openai_chat_message(msg, reasoning_format='reasoning_field')
+    assert '<think>' not in out['content']
+    assert 'It is sunny.' in out['content']
+    assert out['reasoning_content'] == 'user wants paris weather'
+
+
+def test_reasoning_field_with_tool_calls():
+    msg = _asst_tool_call_with_reasoning('need to call lookup')
+    out = openai_chat_message(msg, reasoning_format='reasoning_field')
+    assert out['reasoning_content'] == 'need to call lookup'
+    assert '<think>' not in out['content']
+    assert len(out['tool_calls']) == 1
+    assert out['tool_calls'][0]['function']['name'] == 'lookup'
+
+
+def test_reasoning_field_picks_last_when_multiple():
+    msg = ChatMessageAssistant(
+        content=[
+            ContentReasoning(reasoning='first thought'),
+            ContentText(text='intermediate'),
+            ContentReasoning(reasoning='final thought'),
+            ContentText(text='reply'),
+        ],
+    )
+    out = openai_chat_message(msg, reasoning_format='reasoning_field')
+    assert out['reasoning_content'] == 'final thought'
+
+
+def test_reasoning_field_blank_falls_back_to_single_space():
+    msg = _asst_reasoning_and_text('   ', 'reply')
+    out = openai_chat_message(msg, reasoning_format='reasoning_field')
+    assert out['reasoning_content'] == ' '
+
+
+def test_reasoning_field_no_reasoning_omits_key():
+    msg = ChatMessageAssistant(content='plain reply, no reasoning')
+    out = openai_chat_message(msg, reasoning_format='reasoning_field')
+    assert 'reasoning_content' not in out
+    assert out['content'] == 'plain reply, no reasoning'
+
+
+# ---------------------------------------------------------------------------
+# none (drop reasoning entirely, for DeepSeek R1 etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_none_drops_reasoning_entirely():
+    msg = _asst_reasoning_and_text('cot text', 'reply text')
+    out = openai_chat_message(msg, reasoning_format='none')
+    assert '<think>' not in out['content']
+    assert 'cot text' not in out['content']
+    assert 'reply text' in out['content']
+    assert 'reasoning_content' not in out
+
+
+def test_none_keeps_tool_calls():
+    msg = _asst_tool_call_with_reasoning('cot')
+    out = openai_chat_message(msg, reasoning_format='none')
+    assert 'reasoning_content' not in out
+    assert '<think>' not in out['content']
+    assert len(out['tool_calls']) == 1
+
+
+# ---------------------------------------------------------------------------
+# GenerateConfig schema invariants (breaking change verification)
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_history_accepts_new_literal_values():
+    for v in ('none', 'think_tag', 'reasoning_field'):
+        cfg = GenerateConfig(reasoning_history=v)
+        assert cfg.reasoning_history == v
+
+
+def test_reasoning_history_rejects_legacy_literal_values():
+    for v in ('all', 'last', 'auto'):
+        with pytest.raises(ValidationError):
+            GenerateConfig(reasoning_history=v)
+
+
+def test_reasoning_history_default_is_none():
+    assert GenerateConfig().reasoning_history is None


### PR DESCRIPTION
## Summary

Fixes [#1392](https://github.com/modelscope/evalscope/issues/1392) — DeepSeek V4 thinking mode rejects evalscope's multi-turn requests with `HTTP 400 "The reasoning_content in the thinking mode must be passed back to the API."`, and Qwen3 thinking silently pollutes context by parsing `<think>...</think>` as plain text.

**Root cause**: `openai_assistant_content` encodes `ContentReasoning` as `<think>...</think>` inside the `content` string and never writes a top-level `reasoning_content` field. This worked for OpenAI/Together/Groq but breaks modern OpenAI-compatible providers that expect `reasoning_content` as an independent field.

**Fix**: redefine `GenerateConfig.reasoning_history` literal from inspect_ai-style filter values (`'none'|'all'|'last'|'auto'`) to wire-format values (`'none'|'think_tag'|'reasoning_field'`), and consume it in `OpenAICompatibleAPI.generate` / `generate_async` to control the per-request wire shape.

### ⚠ Breaking Change

| Provider | Old default (`think_tag`) | New default (`reasoning_field`) |
|---|---|---|
| OpenAI / vLLM / SGLang / Together / Groq | ✓ | ✓ (extra field ignored) |
| DeepSeek V4 thinking | ✗ 400 | ✓ **auto-fixed** |
| Qwen3 thinking (DashScope) | ⚠ context pollution | ✓ **auto-fixed** |
| **DeepSeek R1** (legacy `deepseek-reasoner`) | ✓ | ✗ **400 — opt-out required** |

R1 users must explicitly set `--generation-config '{\"reasoning_history\":\"none\"}'` because R1's protocol forbids `reasoning_content` echo-back. Documented in `docs/{zh,en}/get_started/parameters.md`.

### Affected benchmarks before the fix

- `bfcl_v3` (the one reported in #1392), `gaia`, `swe_bench_*_agentic`, `swe_bench_pro_agentic` — all route prior-turn assistant messages through `openai_chat_messages` and hit the bug
- `tau_bench` / `tau2` / `tau3` / `terminal_bench` already workaround via response-side `openai_chat_choices(include_reasoning=False)`; their behavior is unchanged

### Drive-by cleanups in `GenerateConfig`

- Remove the cargo-culted `migrate_reasoning` bool→literal validator (zero consumers since v1.0)
- Remove 4 zombie fields with zero repo-wide consumers: `best_of`, `cache_prompt`, `internal_tools`, `max_tool_output`
- Document `batch_size` as an internal field (synced from `TaskConfig.eval_batch_size`, not user-facing)
- Document 6 previously-undocumented but actively-consumed fields: `stop_seqs`, `repetition_penalty`, `response_schema`, `reasoning_effort`, `reasoning_tokens`, `reasoning_summary`. Fix `timeout` type (`int` → `int/float`)

### Design notes

- Last `ContentReasoning` wins when multiple are present on an assistant message (matches litellm's behavior; see `_extract_last_reasoning`).
- Blank/whitespace reasoning falls back to a single-space `\" \"` placeholder with a debug log (DeepSeek V4 rejects empty `reasoning_content`).
- No capability flag / model-name sniffing; users opt in/out explicitly via `reasoning_history`.
- `litellm_compatible.py` path is intentionally out of scope (litellm has its own schema validation that may strip extra top-level keys — deferred to a follow-up PR).

**Prior art**: [BerriAI/litellm#28080](https://github.com/BerriAI/litellm/pull/28080) — the same fix for the DeepSeek path in litellm, including the single-space fallback design.

## Test plan

- [x] `make lint` passes
- [x] `pytest tests/models/test_openai_reasoning.py -v` — 12 new unit tests covering 3 modes × 5 message shapes + schema invariants (legacy literal rejection, new literal acceptance, default behavior)
- [x] `pytest tests/agent/external/test_openai_chat_round_trip.py -v` — 6 round-trip tests still green (regression check)
- [x] `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings` — CI smoke green (no regression on the happy-path benchmark run)
- [x] End-to-end against `qwen3-max` (DashScope, thinking enabled): all 3 modes produce the expected wire shape (`<think>` in content / top-level `reasoning_content` / clean drop) and all 3 are accepted by the server
- [ ] Reviewer: verify against DeepSeek V4 (`deepseek-v4-pro` + `extra_body={\"thinking\":{\"type\":\"enabled\"}}`) returns 200 instead of 400
- [ ] Reviewer: verify DeepSeek R1 (`deepseek-reasoner`) regression — default config should now 400; `reasoning_history='none'` should return 200