### PR TITLE
fix: include perf deps in `service` optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ perf             = {file = ["requirements/perf.txt"]}
 app              = {file = ["requirements/app.txt"]}
 aigc             = {file = ["requirements/aigc.txt"]}
 sandbox          = {file = ["requirements/sandbox.txt"]}
-service          = {file = ["requirements/service.txt"]}
+service          = {file = ["requirements/service.txt", "requirements/perf.txt"]}
 mcp              = {file = ["requirements/mcp.txt"]}
 dev              = {file = ["requirements/dev.txt"]}
 docs             = {file = ["requirements/docs.txt"]}


### PR DESCRIPTION
Fixes #1399

## Problem

`pip install "evalscope[service]"` followed by `evalscope service` (or simply `import evalscope.service`) fails with:

```
ModuleNotFoundError: No module named 'uvicorn'
```

(and similarly `fastapi` / `sse_starlette` / `aiohttp` once `uvicorn` is present).

## Root cause

The `service` extra only declares `requirements/service.txt`, which contains just `flask` and `plotly`. But the `service` module imports the **perf** stack at import time:

```
evalscope.service.app
  -> evalscope/service/utils/process.py:
       from evalscope.perf.main import run_perf_benchmark
    -> evalscope/perf/main.py:
         from .utils.local_server import start_app
      -> evalscope/perf/utils/local_server.py:
           import uvicorn
           from fastapi import FastAPI
           from sse_starlette.sse import EventSourceResponse
```

`uvicorn`, `fastapi`, `sse_starlette` (and `aiohttp`) are declared only in `requirements/perf.txt`, which `[service]` never pulls in. So the `service` extra is under-specified for its own import graph.

## Reproduce

```bash
python -m venv /tmp/svc && /tmp/svc/bin/pip install "evalscope[service]"
/tmp/svc/bin/python -c "import evalscope.service"
# ModuleNotFoundError: No module named 'uvicorn'
```

## Fix

Read `requirements/perf.txt` into the `service` extra as well, mirroring how the `all` extra already concatenates multiple requirement files. After this change, a clean `pip install "evalscope[service]"` pulls in `aiohttp`, `fastapi`, `sse_starlette`, `uvicorn`, etc., and `import evalscope.service` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)