### PR TITLE
fix(scicode): read assistant text blocks

### DIFF
--- a/evalscope/benchmarks/scicode/util.py
+++ b/evalscope/benchmarks/scicode/util.py
@@ -41,11 +41,7 @@ def get_generated_code(state: TaskState) -> list[str]:
         If the number of assistant messages does not match the number of subproblems in the task metadata.
 
     """
-    assistant_messages = [
-        extract_code(message.text)
-        for message in state.messages
-        if message.role == "assistant"
-    ]
+    assistant_messages = [extract_code(message.text) for message in state.messages if message.role == "assistant"]
     assert len(assistant_messages) == len(state.metadata["sub_steps"])
     return assistant_messages
 

--- a/evalscope/benchmarks/scicode/util.py
+++ b/evalscope/benchmarks/scicode/util.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from evalscope.api.evaluator import TaskState
 
 
@@ -21,7 +19,7 @@ def extract_code(block: str) -> str:
         The extracted code with the code fences and surrounding whitespace removed.
 
     """
-    return block.replace('```python', '').replace('```', '').strip()
+    return block.replace("```python", "").replace("```", "").strip()
 
 
 def get_generated_code(state: TaskState) -> list[str]:
@@ -44,9 +42,11 @@ def get_generated_code(state: TaskState) -> list[str]:
 
     """
     assistant_messages = [
-        extract_code(cast(str, message.content)) for message in state.messages if message.role == 'assistant'
+        extract_code(message.text)
+        for message in state.messages
+        if message.role == "assistant"
     ]
-    assert len(assistant_messages) == len(state.metadata['sub_steps'])
+    assert len(assistant_messages) == len(state.metadata["sub_steps"])
     return assistant_messages
 
 
@@ -73,4 +73,4 @@ def subproblem_str_to_int(num: str) -> int:
     1
 
     """
-    return int(num.split('.')[1])
+    return int(num.split(".")[1])

--- a/tests/benchmark/test_scicode_util.py
+++ b/tests/benchmark/test_scicode_util.py
@@ -9,11 +9,9 @@ def test_get_generated_code_accepts_text_content_blocks():
         model="test",
         sample=Sample(input="77", metadata={"sub_steps": [{}]}),
         messages=[
-            ChatMessageAssistant(
-                content=[
-                    ContentText(text="```python\ndef answer():\n    return 1\n```"),
-                ],
-            ),
+            ChatMessageAssistant(content=[
+                ContentText(text="```python\ndef answer():\n    return 1\n```"),
+            ], ),
         ],
     )
 

--- a/tests/benchmark/test_scicode_util.py
+++ b/tests/benchmark/test_scicode_util.py
@@ -1,0 +1,20 @@
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageAssistant, ContentText
+from evalscope.benchmarks.scicode.util import get_generated_code
+
+
+def test_get_generated_code_accepts_text_content_blocks():
+    state = TaskState(
+        model="test",
+        sample=Sample(input="77", metadata={"sub_steps": [{}]}),
+        messages=[
+            ChatMessageAssistant(
+                content=[
+                    ContentText(text="```python\ndef answer():\n    return 1\n```"),
+                ],
+            ),
+        ],
+    )
+
+    assert get_generated_code(state) == ["def answer():\n    return 1"]


### PR DESCRIPTION
## Summary

SciCode generated-code extraction now reads assistant text blocks through `message.text` instead of casting `message.content` to `str`.

`ChatMessageAssistant.content` can be a list of typed content blocks. Casting that list to `str` leaves Python object/list syntax in the extracted code, which breaks downstream SciCode execution. The existing message abstraction already exposes the flattened text, so the fix uses that path directly.

## Validation

- `python -m pytest tests\benchmark\test_scicode_util.py -q`
- `python -m py_compile evalscope\benchmarks\scicode\util.py tests\benchmark\test_scicode_util.py`
- `git diff --check upstream/main...HEAD`
