### PR TITLE
fix: add retry mechanism for jsonl file writing

### DIFF
--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -10,6 +10,8 @@ import re
 import string
 import unicodedata
 import yaml
+import time
+import random
 from datetime import datetime
 from io import BytesIO
 from PIL import Image
@@ -208,6 +210,7 @@ def dump_jsonl_data(
 
     Raises:
         ValueError: When *jsonl_file* is empty or ``None``.
+        PermissionError: When file is locked.
     """
     if not jsonl_file:
         raise ValueError('output file must be provided.')
@@ -222,7 +225,17 @@ def dump_jsonl_data(
 
     mode = 'w' if dump_mode == DumpMode.OVERWRITE else 'a'
     with jsonl.open(jsonl_file, mode=mode) as writer:
-        writer.write_all(data_list)
+        max_retries = 50
+        for attempt in range(max_retries):
+            try:
+                with jsonl.open(jsonl_file, mode=mode) as writer:
+                    writer.write_all(data_list)
+                break
+            except PermissionError as e:
+                if attempt == max_retries - 1:
+                    logger.error(f'Failed to write to "{jsonl_file}" after "{max_retries}" attempts due to file locking: {e}')
+                    raise
+                time.sleep(0.1 + random.uniform(0.01, 0.1) * attempt)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement retry logic for writing to jsonl file in case of PermissionError.

when writing large batch write requests to filesystem in windows, it raises permission error due to file locking due to this eval freezes and stops listening responses from the server

multiple log like below is generated in the terminal
026-06-09 09:09:15,253 - openai._base_client - INFO: Retrying request to /chat/completions in 0.912047 seconds.00s/it] 
2026-06-09 09:09:15,269 - openai._base_client - INFO: Retrying request to /chat/completions in 0.886564 seconds
2026-06-09 09:09:15,285 - openai._base_client - INFO: Retrying request to /chat/completions in 0.923344 seconds
2026-06-09 09:09:15,286 - openai._base_client - INFO: Retrying request to /chat/completions in 0.942365 seconds        
2026-06-09 09:09:15,286 - openai._base_client - INFO: Retrying request to /chat/completions in 0.819679 seconds 

the below log is generated in outputs logs file
2026-06-09 08:36:49 - evalscope - ERROR: Processing item in subset='default' failed: [Errno 13] Permission denied: './outputs\\20260609_082713\\reviews\\Qwen3.6-27B\\gpqa_diamond_default.jsonl'
Traceback:
Traceback (most recent call last):
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\evalscope\utils\function_utils.py", line 425, in run_in_threads_with_progress
    on_result(items[item_index], result)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\evalscope\evaluator\evaluator.py", line 295, in on_result
    self._persist_result(item, *result)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\evalscope\evaluator\evaluator.py", line 366, in _persist_result
    review_result = self.cache_manager.save_review_cache(
        subset=item.subset,
    ...<2 lines>...
        save_metadata=self.benchmark.save_metadata,
    )
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\evalscope\api\evaluator\cache.py", line 205, in save_review_cache
    dump_jsonl_data(data_list=review_result_dict, jsonl_file=cache_file, dump_mode=DumpMode.APPEND)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\evalscope\utils\io_utils.py", line 224, in dump_jsonl_data
    with jsonl.open(jsonl_file, mode=mode) as writer:
         ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shahid\AppData\Roaming\Python\Python314\site-packages\jsonlines\jsonlines.py", line 643, in open
    fp = builtins.open(file, mode=mode + "t", encoding=encoding)
PermissionError: [Errno 13] Permission denied: './outputs\\20260609_082713\\reviews\\Qwen3.6-27B\\gpqa_diamond_default.jsonl'

after rewriting the json dumps its no longer a problem, the error is still raised but it gets fixed on the go by the code, randomness is added to prevent thundering herd problem