### PR TITLE
fix(rag): truncate texts exceeding max_seq_length in API encoder/reranker

### DIFF
--- a/docs/en/user_guides/backend/rageval_backend/mteb.md
+++ b/docs/en/user_guides/backend/rageval_backend/mteb.md
@@ -350,6 +350,7 @@ For retrieval tasks, a sample of 100,000 candidates (including the ground truth)
 | `api_base` | `str` | - | API base URL; rerankers call the rerank endpoint — if the URL does not end with `/rerank` or `/reranks`, `/rerank` is appended by default (`/reranks` for DashScope domains) |
 | `api_key` | `str` | - | API key |
 | `dimensions` | `Optional[int]` | `None` | Model output dimensions |
+| `max_seq_length` | `int` | `512` | Maximum sequence length; texts exceeding this limit are automatically truncated before sending to the API |
 | `encode_kwargs` | `dict` | `{"batch_size": 10}` | Encoding arguments |
 
 ### Evaluation Configuration (eval)

--- a/docs/zh/user_guides/backend/rageval_backend/mteb.md
+++ b/docs/zh/user_guides/backend/rageval_backend/mteb.md
@@ -350,6 +350,7 @@ run_task(task_cfg=task_cfg)
 | `api_base` | `str` | - | API 服务地址；reranker 会调用 rerank 端点，地址未以 `/rerank` 或 `/reranks` 结尾时默认追加 `/rerank`（DashScope 域名自动追加 `/reranks`） |
 | `api_key` | `str` | - | API 密钥 |
 | `dimensions` | `Optional[int]` | `None` | 模型输出维度 |
+| `max_seq_length` | `int` | `512` | 最大序列长度；超过此长度的文本将被自动截断后再发送到 API |
 | `encode_kwargs` | `dict` | `{"batch_size": 10}` | 编码参数 |
 
 ### 评测配置参数（eval）

--- a/evalscope/backend/rag_eval/models/__init__.py
+++ b/evalscope/backend/rag_eval/models/__init__.py
@@ -54,6 +54,7 @@ def load_model(config):
                 prompts=getattr(config, 'prompts', None),
                 revision=getattr(config, 'revision', 'master'),
                 batch_size=kwargs.get('encode_kwargs', {}).get('batch_size', 10),
+                max_seq_length=getattr(config, 'max_seq_length', 512),
             )
         return APIEncoder(
             model_name=config.model_name,

--- a/evalscope/backend/rag_eval/models/encoder.py
+++ b/evalscope/backend/rag_eval/models/encoder.py
@@ -186,7 +186,7 @@ class APIEncoder(BaseEncoder):
             api_base: Base URL for the OpenAI-compatible API.
             api_key: API key for authentication.
             dimensions: Embedding dimensions (if supported by API).
-            max_seq_length: Maximum sequence length (informational).
+            max_seq_length: Maximum sequence length; texts exceeding this (in estimated tokens) are truncated.
             prompt: A single prompt to prepend to queries.
             prompts: Dict mapping task names to prompts.
             revision: Model revision (metadata only for API models).
@@ -204,6 +204,9 @@ class APIEncoder(BaseEncoder):
         self.batch_size = batch_size
         self.max_seq_length = max_seq_length
 
+        # Conservative estimate: 1 token ≈ 3 characters (reasonable for mixed CJK/Latin text).
+        self._max_chars = self.max_seq_length * 3
+
         self._client = OpenAIEmbeddings(
             model=model_name,
             base_url=api_base,
@@ -212,6 +215,21 @@ class APIEncoder(BaseEncoder):
             check_embedding_ctx_length=check_embedding_ctx_length,
         )
         self._supported_encode_params = get_supported_params(self._client.embed_documents)
+
+    def _truncate_texts(self, texts: List[str]) -> List[str]:
+        """Truncate texts that exceed max_seq_length (estimated by character count)."""
+        if self.max_seq_length <= 0:
+            return texts
+        truncated = []
+        for text in texts:
+            if len(text) > self._max_chars:
+                logger.warning(
+                    f'Text length ({len(text)} chars) exceeds estimated max ({self._max_chars} chars '
+                    f'for max_seq_length={self.max_seq_length}), truncating.'
+                )
+                text = text[:self._max_chars]
+            truncated.append(text)
+        return truncated
 
     def encode(self, inputs, **kwargs: Any) -> Array:
         """Encode texts into embeddings using API.
@@ -259,6 +277,7 @@ class APIEncoder(BaseEncoder):
             batch_texts = texts[i:i + self.batch_size]
             if prompt is not None:
                 batch_texts = [prompt + text for text in batch_texts]
+            batch_texts = self._truncate_texts(batch_texts)
             response = self._client.embed_documents(batch_texts, chunk_size=self.batch_size, **encode_kwargs)
             embeddings.extend(response)
         return torch.tensor(embeddings)

--- a/evalscope/backend/rag_eval/models/encoder.py
+++ b/evalscope/backend/rag_eval/models/encoder.py
@@ -221,14 +221,17 @@ class APIEncoder(BaseEncoder):
         if self.max_seq_length <= 0:
             return texts
         truncated = []
+        truncated_count = 0
         for text in texts:
             if len(text) > self._max_chars:
-                logger.warning(
-                    f'Text length ({len(text)} chars) exceeds estimated max ({self._max_chars} chars '
-                    f'for max_seq_length={self.max_seq_length}), truncating.'
-                )
+                truncated_count += 1
                 text = text[:self._max_chars]
             truncated.append(text)
+        if truncated_count:
+            logger.warning(
+                f'Truncated {truncated_count}/{len(texts)} texts to {self._max_chars} chars '
+                f'(max_seq_length={self.max_seq_length}).'
+            )
         return truncated
 
     def encode(self, inputs, **kwargs: Any) -> Array:

--- a/evalscope/backend/rag_eval/models/reranker.py
+++ b/evalscope/backend/rag_eval/models/reranker.py
@@ -201,10 +201,7 @@ class APIReranker(BaseReranker):
     def _truncate_text(self, text: str) -> str:
         """Truncate text that exceeds max_seq_length (estimated by character count)."""
         if self.max_seq_length > 0 and len(text) > self._max_chars:
-            logger.warning(
-                f'Text length ({len(text)} chars) exceeds estimated max ({self._max_chars} chars '
-                f'for max_seq_length={self.max_seq_length}), truncating.'
-            )
+            self._truncated_count += 1
             return text[:self._max_chars]
         return text
 
@@ -250,6 +247,7 @@ class APIReranker(BaseReranker):
         scores: List[float] = [0.0] * len(sentences)
         grouped_sentences: Dict[str, List] = {}
         prompt = self.prompt
+        self._truncated_count = 0
 
         # Group by query
         for idx, sentence in enumerate(sentences):
@@ -264,6 +262,12 @@ class APIReranker(BaseReranker):
             query = self._truncate_text(prompt + query)
             document = self._truncate_text(document)
             grouped_sentences.setdefault(query, []).append((idx, document))
+
+        if self._truncated_count:
+            logger.warning(
+                f'Truncated {self._truncated_count} texts to {self._max_chars} chars '
+                f'(max_seq_length={self.max_seq_length}).'
+            )
 
         # Process each query group in batches
         max_retries = 3

--- a/evalscope/backend/rag_eval/models/reranker.py
+++ b/evalscope/backend/rag_eval/models/reranker.py
@@ -149,6 +149,7 @@ class APIReranker(BaseReranker):
         revision: Optional[str] = 'master',
         batch_size: int = 10,
         timeout: int = 60,
+        max_seq_length: int = 512,
         **kwargs: Any,
     ) -> None:
         """Initialize APIReranker.
@@ -162,6 +163,7 @@ class APIReranker(BaseReranker):
             revision: Model revision (metadata only for API models).
             batch_size: Number of documents per API request.
             timeout: Request timeout in seconds.
+            max_seq_length: Maximum sequence length; texts exceeding this (in estimated tokens) are truncated.
             **kwargs: Extra keyword arguments (ignored).
         """
         if not api_base:
@@ -175,6 +177,8 @@ class APIReranker(BaseReranker):
         self.framework = ['API']
         self.batch_size = batch_size
         self.timeout = timeout
+        self.max_seq_length = max_seq_length
+        self._max_chars = max_seq_length * 3
 
         # Build the rerank URL (default /rerank, DashScope uses /reranks)
         self.rerank_url = api_base.rstrip('/')
@@ -193,6 +197,16 @@ class APIReranker(BaseReranker):
             self.headers['Authorization'] = f'Bearer {resolved_api_key}'
 
         self.session = requests.Session()
+
+    def _truncate_text(self, text: str) -> str:
+        """Truncate text that exceeds max_seq_length (estimated by character count)."""
+        if self.max_seq_length > 0 and len(text) > self._max_chars:
+            logger.warning(
+                f'Text length ({len(text)} chars) exceeds estimated max ({self._max_chars} chars '
+                f'for max_seq_length={self.max_seq_length}), truncating.'
+            )
+            return text[:self._max_chars]
+        return text
 
     def predict(self, inputs1, inputs2=None, **kwargs: Any) -> Array:
         """Predict relevance scores via the rerank API.
@@ -247,7 +261,9 @@ class APIReranker(BaseReranker):
                     query = f'{query} {instruction}'.strip()
             else:
                 raise ValueError('API reranker expects query-document pairs (2 or 3 elements).')
-            grouped_sentences.setdefault(prompt + query, []).append((idx, document))
+            query = self._truncate_text(prompt + query)
+            document = self._truncate_text(document)
+            grouped_sentences.setdefault(query, []).append((idx, document))
 
         # Process each query group in batches
         max_retries = 3

--- a/tests/rag/test_api_encoder.py
+++ b/tests/rag/test_api_encoder.py
@@ -1,0 +1,132 @@
+import pytest
+
+torch = pytest.importorskip('torch')
+pytest.importorskip('langchain_openai')
+pytest.importorskip('mteb')
+
+import langchain_openai.embeddings
+
+from evalscope.backend.rag_eval.models import load_model
+from evalscope.backend.rag_eval.models.encoder import APIEncoder
+
+
+class MockOpenAIEmbeddings:
+    """Mock for langchain_openai.OpenAIEmbeddings that records calls."""
+
+    def __init__(self, *, model, base_url, api_key, dimensions, check_embedding_ctx_length):
+        self.model = model
+        self.base_url = base_url
+        self.api_key = api_key
+        self.dimensions = dimensions
+        self.check_embedding_ctx_length = check_embedding_ctx_length
+
+    def embed_documents(self, texts, chunk_size=None, **kwargs):
+        self._last_texts = texts
+        return [[0.1, 0.2, 0.3]] * len(texts)
+
+
+def _make_encoder(monkeypatch, **overrides):
+    """Create an APIEncoder with mocked OpenAIEmbeddings."""
+    monkeypatch.setattr(langchain_openai.embeddings, 'OpenAIEmbeddings', MockOpenAIEmbeddings)
+
+    defaults = dict(
+        model_name='test-model',
+        api_base='http://localhost:8000/v1',
+        api_key='test-key',
+        dimensions=1024,
+        max_seq_length=10,
+        batch_size=100,
+    )
+    defaults.update(overrides)
+    return APIEncoder(**defaults)
+
+
+def test_encode_basic(monkeypatch):
+    encoder = _make_encoder(monkeypatch, max_seq_length=512)
+    result = encoder.encode(['hello', 'world'])
+    assert result.shape == (2, 3)
+
+
+def test_encode_truncates_long_texts(monkeypatch):
+    encoder = _make_encoder(monkeypatch, max_seq_length=10)
+    long_text = 'x' * 100
+    short_text = 'hi'
+    encoder.encode([long_text, short_text])
+
+    last_texts = encoder._client._last_texts
+    assert len(last_texts[0]) == 10 * 3
+    assert last_texts[1] == short_text
+
+
+def test_encode_truncates_after_prompt(monkeypatch):
+    encoder = _make_encoder(monkeypatch, max_seq_length=10, prompt='prefix: ')
+    long_text = 'y' * 100
+
+    try:
+        from mteb.types import PromptType
+        prompt_type = PromptType.query
+    except ImportError:
+        prompt_type = 'query'
+
+    encoder.encode([long_text], prompt_type=prompt_type)
+
+    last_texts = encoder._client._last_texts
+    assert last_texts[0].startswith('prefix: ')
+    assert len(last_texts[0]) == 10 * 3
+
+
+def test_encode_no_truncation_when_within_limit(monkeypatch):
+    encoder = _make_encoder(monkeypatch, max_seq_length=512)
+    text = 'short text'
+    encoder.encode([text])
+    assert encoder._client._last_texts == [text]
+
+
+def test_all_init_params_stored(monkeypatch):
+    encoder = _make_encoder(
+        monkeypatch,
+        model_name='my-model',
+        api_base='http://example.com/v1',
+        api_key='key-123',
+        dimensions=768,
+        max_seq_length=256,
+        batch_size=32,
+        prompt='query: ',
+        prompts={'task1': 'prompt1'},
+    )
+
+    assert encoder.model_name_or_path == 'my-model'
+    assert encoder.max_seq_length == 256
+    assert encoder._max_chars == 256 * 3
+    assert encoder.batch_size == 32
+    assert encoder.prompt == 'query: '
+    assert encoder.prompts == {'task1': 'prompt1'}
+    assert encoder._client.model == 'my-model'
+    assert encoder._client.base_url == 'http://example.com/v1'
+    assert encoder._client.api_key == 'key-123'
+    assert encoder._client.dimensions == 768
+
+
+def test_load_model_creates_api_encoder(monkeypatch):
+    monkeypatch.setattr(langchain_openai.embeddings, 'OpenAIEmbeddings', MockOpenAIEmbeddings)
+
+    model = load_model({
+        'model_name': 'embed-model',
+        'api_base': 'http://localhost/v1',
+        'api_key': 'test',
+        'dimensions': 512,
+        'max_seq_length': 1024,
+        'encode_kwargs': {'batch_size': 64},
+    })
+
+    assert isinstance(model, APIEncoder)
+    assert model.max_seq_length == 1024
+    assert model._max_chars == 1024 * 3
+    assert model.batch_size == 64
+
+
+def test_batch_size_from_encode_kwargs(monkeypatch):
+    encoder = _make_encoder(monkeypatch, batch_size=2)
+    texts = ['a', 'b', 'c', 'd', 'e']
+    encoder.encode(texts)
+    assert encoder._client._last_texts is not None

--- a/tests/rag/test_api_reranker.py
+++ b/tests/rag/test_api_reranker.py
@@ -147,3 +147,65 @@ def test_load_api_cross_encoder():
     })
 
     assert isinstance(model, APIReranker)
+
+
+def test_load_api_cross_encoder_passes_max_seq_length():
+    model = load_model({
+        'model_name': 'reranker',
+        'api_base': 'https://example.com/v1',
+        'api_key': 'test',
+        'is_cross_encoder': True,
+        'max_seq_length': 1024,
+    })
+
+    assert isinstance(model, APIReranker)
+    assert model.max_seq_length == 1024
+    assert model._max_chars == 1024 * 3
+
+
+def test_api_reranker_truncates_long_texts(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    calls = []
+
+    def mock_post(self, url, headers, json, timeout):
+        calls.append(json)
+        return MockResponse({'results': [{'index': 0, 'relevance_score': 0.5}]})
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.models.reranker.requests.Session.post', mock_post)
+
+    model = APIReranker(
+        model_name='reranker',
+        api_base='https://example.com/v1',
+        batch_size=10,
+        max_seq_length=10,
+    )
+
+    long_query = 'q' * 100
+    long_doc = 'd' * 100
+    model.predict([[long_query, long_doc]])
+
+    assert len(calls[0]['query']) == 10 * 3
+    assert len(calls[0]['documents'][0]) == 10 * 3
+
+
+def test_api_reranker_no_truncation_short_texts(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    calls = []
+
+    def mock_post(self, url, headers, json, timeout):
+        calls.append(json)
+        return MockResponse({'results': [{'index': 0, 'score': 0.9}]})
+
+    monkeypatch.setattr('evalscope.backend.rag_eval.models.reranker.requests.Session.post', mock_post)
+
+    model = APIReranker(
+        model_name='reranker',
+        api_base='https://example.com/v1',
+        batch_size=10,
+        max_seq_length=512,
+    )
+
+    model.predict([['short query', 'short doc']])
+
+    assert calls[0]['query'] == 'short query'
+    assert calls[0]['documents'] == ['short doc']


### PR DESCRIPTION
## Summary

Fixes #1406

- **`APIEncoder.encode()`**: truncate input texts to `max_seq_length * 3` characters before sending to the embedding API, preventing 400 errors when corpus texts exceed the model's context window
- **`APIReranker`**: add `max_seq_length` parameter and truncate query/document texts in `predict()` before calling the rerank API
- **`load_model()`**: pass `max_seq_length` from config to `APIReranker`

Truncation uses a conservative character estimate (1 token ≈ 3 chars) and logs a warning when triggered.

## Test plan

- [x] New unit tests for `APIEncoder` (encode, truncation, prompt+truncation, param wiring, load_model) — 7 tests
- [x] New unit tests for `APIReranker` truncation and `max_seq_length` passthrough — 3 tests
- [x] All 16 tests pass in both base and eval conda envs
- [x] E2E verified with DashScope `text-embedding-v3`: long text (1150 chars) truncated to 192 chars, API returns correct embeddings without 400 error
- [x] `make lint` passes