### PR TITLE
fix(agent): preserve stdout whitespace in bash tool to prevent patch corruption

### DIFF
--- a/evalscope/agent/strategies/swe_bench/swe_bench_backticks.py
+++ b/evalscope/agent/strategies/swe_bench/swe_bench_backticks.py
@@ -170,7 +170,7 @@ class SweBenchBackticksStrategy(AgentStrategy):
                 continue
             if stripped.startswith('Tool call error'):
                 continue
-            return content.strip()
+            return content
         return ''
 
 

--- a/evalscope/agent/strategies/swe_bench/swe_bench_toolcall.py
+++ b/evalscope/agent/strategies/swe_bench/swe_bench_toolcall.py
@@ -160,7 +160,7 @@ class SweBenchToolcallStrategy(AgentStrategy):
                 continue
             if stripped.startswith('Tool call error'):
                 continue
-            return content.strip()
+            return content
         return ''
 
 

--- a/evalscope/agent/tools/bash.py
+++ b/evalscope/agent/tools/bash.py
@@ -44,7 +44,7 @@ async def run_bash(call: ToolCall, env: Optional[AgentEnvironment]) -> str:
 def _format_exec_result(result: ExecResult) -> str:
     parts = []
     if result.stdout:
-        parts.append(result.stdout.rstrip())
+        parts.append(result.stdout)
     if result.stderr:
         parts.append(f'[stderr]\n{result.stderr.rstrip()}')
     if result.timed_out:


### PR DESCRIPTION
## Summary

- Remove `rstrip()` from `_format_exec_result` stdout path — it strips trailing context lines (single-space lines) from git patches, causing hunk header line counts to mismatch and `git apply` to reject valid patches as corrupted
- Remove `.strip()` from `extract_final_answer` in both swe_bench strategies — same class of bug on the submission recovery path

## Root Cause

1. `evalscope/agent/tools/bash.py:47` called `result.stdout.rstrip()` which removes trailing whitespace including lines that contain only a single space. In unified diff format these are valid context lines — stripping them makes the `@@` hunk header's line count wrong, so `git apply` rejects the patch.

2. `extract_final_answer` in both `swe_bench_toolcall.py` and `swe_bench_backticks.py` called `.strip()` on the recovered submission content. This has the same effect when a patch ends with a context line containing only a space character.

The downstream `format_exec_observation` (used to render observations to the model) already calls `rstrip()` on its own, and the upstream `check_sentinel` already returns a clean payload — so both strips are unnecessary.

Closes #1408

## Test plan

- [x] Verify `format_exec_observation` in `_observation.py:189` already rstrips for model display
- [x] Verify `check_sentinel` returns clean payload without extraneous whitespace
- [x] Run SWE-bench agentic eval on an instance known to produce trailing-whitespace patches (e.g. `ansible-0ea40e09`)