### PR TITLE
fix SWE-bench architecture selection

### DIFF
--- a/evalscope/benchmarks/swe_bench/build_images.py
+++ b/evalscope/benchmarks/swe_bench/build_images.py
@@ -36,6 +36,8 @@ def build_images(
     from swebench.harness.docker_build import build_instance_images  # type: ignore
     from swebench.harness.test_spec.test_spec import make_test_spec  # type: ignore
 
+    from .utils import resolve_swebench_arch
+
     extra_build_instance_images_kwargs = {'tag': LATEST, 'env_image_tag': LATEST}
 
     # Code copied from the swe_bench repository
@@ -50,15 +52,17 @@ def build_images(
 
     # We also keep a mapping from instance_ids to the name of the docker image
     id_to_docker_image: Dict[str, str] = {}
+    id_to_test_spec: Dict[str, TestSpec] = {}
 
     # Note that remote images are named eg "sphinx-doc_1776_sphinx-11502"
     namespace = (dockerhub_username or 'swebench') if use_remote_images else None
 
     for swebench_instance in samples_hf:
-        test_spec = make_test_spec(swebench_instance, namespace=namespace)
-        test_spec.arch = force_arch or test_spec.arch
+        arch = resolve_swebench_arch(swebench_instance['instance_id'], force_arch)
+        test_spec = make_test_spec(swebench_instance, namespace=namespace, arch=arch)
         docker_image_name = test_spec.instance_image_key
         id_to_docker_image[swebench_instance['instance_id']] = docker_image_name
+        id_to_test_spec[swebench_instance['instance_id']] = test_spec
 
     # Get list of locally available Docker images
     available_docker_images = _get_available_docker_images()
@@ -118,9 +122,10 @@ def build_images(
     # Build any remaining images locally
     if len(samples_to_build_images_for) > 0:
         logger.warning('BUILDING SWE-BENCH IMAGES. NOTE: This can take a long time.')
+        test_specs_to_build = [id_to_test_spec[s['instance_id']] for s in samples_to_build_images_for]
         build_instance_images(
             client=docker_client,
-            dataset=samples_hf,
+            dataset=test_specs_to_build,
             force_rebuild=force_rebuild,
             max_workers=max_workers,
             **extra_build_instance_images_kwargs,

--- a/evalscope/benchmarks/swe_bench/swe_bench_adapter.py
+++ b/evalscope/benchmarks/swe_bench/swe_bench_adapter.py
@@ -158,7 +158,11 @@ class SWEBenchVerifiedAdapter(DefaultDataAdapter):
             from functools import partial
 
             from .utils import get_remote_docker_image_from_id
-            docker_image_from_id = partial(get_remote_docker_image_from_id, dockerhub_username=self.dockerhub_username)
+            docker_image_from_id = partial(
+                get_remote_docker_image_from_id,
+                dockerhub_username=self.dockerhub_username,
+                force_arch=self.force_arch,
+            )
 
         # update metadata with docker image
         for sample in samples:
@@ -189,6 +193,7 @@ class SWEBenchVerifiedAdapter(DefaultDataAdapter):
             timeout=1800,
             log_dir=self._task_config.work_dir,
             dockerhub_username=self.dockerhub_username,
+            force_arch=self.force_arch,
         )
 
         score.value = {'acc': float(result.get('resolved', 0.0))}

--- a/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
@@ -288,7 +288,11 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
                 return id_to_docker_image_map.get(instance_id, '')
         else:
             from functools import partial
-            docker_image_from_id = partial(get_remote_docker_image_from_id, dockerhub_username=self.dockerhub_username)
+            docker_image_from_id = partial(
+                get_remote_docker_image_from_id,
+                dockerhub_username=self.dockerhub_username,
+                force_arch=self.force_arch,
+            )
 
         for sample in samples:
             sample.metadata['docker_image'] = docker_image_from_id(sample.metadata['instance_id'])
@@ -424,6 +428,8 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
             pred=filtered_prediction,
             timeout=1800,
             log_dir=self._task_config.work_dir,
+            dockerhub_username=self.dockerhub_username,
+            force_arch=self.force_arch,
         )
 
         score.value = {'acc': float(result.get('resolved', 0.0))}

--- a/evalscope/benchmarks/swe_bench/utils.py
+++ b/evalscope/benchmarks/swe_bench/utils.py
@@ -1,26 +1,48 @@
 import platform
 import traceback
 from pathlib import Path, PurePosixPath
+from typing import Literal
 
 from evalscope.utils import get_logger
 
 logger = get_logger()
 
 DEFAULT_DOCKERHUB_USERNAME = 'swebench'
+SwebenchArch = Literal['arm64', 'x86_64']
+SwebenchForceArch = Literal['', 'arm64', 'x86_64']
 
 
-def get_remote_docker_image_from_id(instance_id: str, dockerhub_username: str = DEFAULT_DOCKERHUB_USERNAME) -> str:
+def _is_arm_machine() -> bool:
+    return platform.machine().lower() in {'aarch64', 'arm64'}
+
+
+def _requires_x86(instance_id: str) -> bool:
+    from swebench.harness.constants import USE_X86  # type: ignore
+
+    return instance_id in USE_X86
+
+
+def resolve_swebench_arch(instance_id: str, force_arch: SwebenchForceArch = '') -> SwebenchArch:
+    """Resolve the SWE-bench Docker image architecture for an instance."""
+    if force_arch:
+        return force_arch
+
+    if _is_arm_machine() and not _requires_x86(instance_id):
+        return 'arm64'
+
+    return 'x86_64'
+
+
+def get_remote_docker_image_from_id(
+    instance_id: str,
+    dockerhub_username: str = DEFAULT_DOCKERHUB_USERNAME,
+    force_arch: SwebenchForceArch = '',
+) -> str:
     """Image name format as found on DockerHub since swebench v3.0"""
     # NOTE: The swebench library contains this logic within `make_test_spec`,
     # but this module would require significant refactoring to use it.
     updated_instance_id = instance_id.replace('__', '_1776_')
-    if platform.machine() in {'aarch64', 'arm64'}:
-        from swebench.harness.constants import USE_X86  # type: ignore
-
-        # use arm64 unless explicitly specified
-        arch = 'arm64' if instance_id not in USE_X86 else 'x86_64'
-    else:
-        arch = 'x86_64'
+    arch = resolve_swebench_arch(instance_id, force_arch)
     username = dockerhub_username or DEFAULT_DOCKERHUB_USERNAME
     return f'{username}/sweb.eval.{arch}.{updated_instance_id}:latest'
 
@@ -38,6 +60,7 @@ def eval_instance(
     timeout: int = 1800,
     log_dir: str = 'outputs',
     dockerhub_username: str = DEFAULT_DOCKERHUB_USERNAME,
+    force_arch: SwebenchForceArch = '',
 ) -> dict:
     from docker.client import DockerClient
     from swebench.harness.constants import (
@@ -63,7 +86,12 @@ def eval_instance(
     eval_completed = False
     report = {}
     try:
-        test_spec: TestSpec = make_test_spec(instance, namespace=dockerhub_username or DEFAULT_DOCKERHUB_USERNAME)
+        arch = resolve_swebench_arch(instance[KEY_INSTANCE_ID], force_arch)
+        test_spec: TestSpec = make_test_spec(
+            instance,
+            namespace=dockerhub_username or DEFAULT_DOCKERHUB_USERNAME,
+            arch=arch,
+        )
         instance_id = test_spec.instance_id
         pred = {
             KEY_PREDICTION: pred,


### PR DESCRIPTION
## Summary

- Resolve SWE-bench Docker image architecture from one shared helper.
- Pass the resolved architecture into `make_test_spec` for image preparation and evaluation.
- Build local fallback images from already-resolved `TestSpec` objects so the upstream default `x86_64` does not override EvalScope selection.

## Root cause

SWE-bench `make_test_spec` defaults `arch` to `x86_64`. EvalScope only changed `test_spec.arch` after creating the spec in one path, while other paths regenerated specs without passing `arch`, so ARM machines could still pull, build, or evaluate against x86 images.

## Validation

- `make lint`

Closes #1418
