### PR TITLE
Add LoCoMo QA benchmark

### DIFF
--- a/docs/en/benchmarks/locomo.md
+++ b/docs/en/benchmarks/locomo.md
@@ -1,0 +1,126 @@
+# LoCoMo
+
+
+## Overview
+
+LoCoMo evaluates very long-term conversational memory in two-person multi-session dialogues. This adapter supports the
+official question-answering task from `locomo10.json`.
+
+## Task Description
+
+- **Task Type**: Long-context question answering
+- **Input**: Multi-session conversation history with session dates and a question
+- **Output**: Short free-form answer
+- **Subsets**: `qa`
+
+## Key Features
+
+- Uses the official LoCoMo QA data file hosted on ModelScope
+- Supports full-history long-context prompts and evidence-only oracle prompts
+- Includes image captions from the released data when present, but does not download image files
+- Uses LoCoMo's rule-based F1 / adversarial refusal scoring instead of an LLM judge
+
+## Evaluation Notes
+
+- Default subset is `qa` with `eval_mode=long_context`
+- Use `extra_params.eval_mode='oracle_context'` for evidence-only upper-bound evaluation
+- Event summarization, multimodal dialog generation, and RAG retrieval are not included in this QA adapter
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `locomo` |
+| **Dataset ID** | [evalscope/locomo](https://modelscope.cn/datasets/evalscope/locomo/summary) |
+| **Paper** | N/A |
+| **Tags** | `LongContext`, `MultiTurn`, `QA` |
+| **Metrics** | `f1` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 1,986 |
+| Prompt Length (Mean) | 94097.72 chars |
+| Prompt Length (Min/Max) | 55178 / 111026 chars |
+
+## Sample Example
+
+**Subset**: `qa`
+
+```json
+{
+  "input": [
+    {
+      "id": "b585f7b0",
+      "content": "Below is a conversation between two people: Caroline and Melanie. The conversation takes place over multiple days and the date of each conversation is wriiten at the beginning of the conversation.\n\nDATE: 1:56 pm on 8 May, 2023\nCONVERSATION:\nC ... [TRUNCATED 74397 chars] ... m of a short phrase for the following question. Answer with exact words from the context whenever possible.\n\nQuestion: When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date. Short answer:"
+    }
+  ],
+  "target": "7 May 2023",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "sample_id": "conv-26",
+    "qa_index": 0,
+    "category": 2,
+    "category_name": "temporal",
+    "raw_question": "When did Caroline go to the LGBTQ support group?",
+    "answer": "7 May 2023",
+    "adversarial_answer": null,
+    "eval_mode": "long_context",
+    "question": "When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date.",
+    "evidence": [
+      "D1:3"
+    ]
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `eval_mode` | `str` | `long_context` | Evaluation mode: long_context or oracle_context. Choices: ['long_context', 'oracle_context'] |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets locomo \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['locomo'],
+    dataset_args={
+        'locomo': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/llm.md
+++ b/docs/en/get_started/supported_dataset/llm.md
@@ -63,6 +63,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 | `jnlpba` | [JNLPBA](../../benchmarks/jnlpba.md) | `Knowledge`, `NER` |
 | `jnlpba_rare` | [JNLPBA-Rare](../../benchmarks/jnlpba_rare.md) | `Knowledge`, `NER` |
 | `live_code_bench` | [Live-Code-Bench](../../benchmarks/live_code_bench.md) | `Coding` |
+| `locomo` | [LoCoMo](../../benchmarks/locomo.md) | `LongContext`, `MultiTurn`, `QA` |
 | `logi_qa` | [LogiQA](../../benchmarks/logi_qa.md) | `MCQ`, `Reasoning` |
 | `longbench_v2` | [LongBench-v2](../../benchmarks/longbench_v2.md) | `LongContext`, `MCQ`, `ReadingComprehension` |
 | `longmemeval` | [LongMemEval](../../benchmarks/longmemeval.md) | `LongContext`, `MultiTurn`, `QA`, `Retrieval` |
@@ -180,6 +181,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/jnlpba.md
 ../../benchmarks/jnlpba_rare.md
 ../../benchmarks/live_code_bench.md
+../../benchmarks/locomo.md
 ../../benchmarks/logi_qa.md
 ../../benchmarks/longbench_v2.md
 ../../benchmarks/longmemeval.md

--- a/docs/zh/benchmarks/locomo.md
+++ b/docs/zh/benchmarks/locomo.md
@@ -1,0 +1,123 @@
+# LoCoMo
+
+
+## 概述
+
+LoCoMo 用于评估两人在多轮会话对话中的超长期对话记忆能力。该适配器支持来自 `locomo10.json` 的官方问答任务。
+
+## 任务描述
+
+- **任务类型**：长上下文问答
+- **输入**：包含会话日期的多轮对话历史和一个问题
+- **输出**：简短的自由格式答案
+- **子集**：`qa`
+
+## 主要特性
+
+- 使用托管在 ModelScope 上的官方 LoCoMo QA 数据文件
+- 支持完整历史的长上下文提示和仅含证据的 oracle 提示
+- 在数据中存在时包含图像说明，但不会下载图像文件
+- 使用 LoCoMo 基于规则的 F1 / 对抗性拒绝评分机制，而非基于大语言模型（LLM）的评判器
+
+## 评估说明
+
+- 默认子集为 `qa`，且 `eval_mode=long_context`
+- 使用 `extra_params.eval_mode='oracle_context'` 进行仅含证据的上限评估
+- 此 QA 适配器不包含事件摘要、多模态对话生成和 RAG 检索任务
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `locomo` |
+| **数据集ID** | [evalscope/locomo](https://modelscope.cn/datasets/evalscope/locomo/summary) |
+| **论文** | N/A |
+| **标签** | `LongContext`, `MultiTurn`, `QA` |
+| **指标** | `f1` |
+| **默认示例数** | 0-shot |
+| **评估分割** | `test` |
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 1,986 |
+| 提示词长度（平均） | 94097.72 字符 |
+| 提示词长度（最小/最大） | 55178 / 111026 字符 |
+
+## 样例示例
+
+**子集**: `qa`
+
+```json
+{
+  "input": [
+    {
+      "id": "b585f7b0",
+      "content": "Below is a conversation between two people: Caroline and Melanie. The conversation takes place over multiple days and the date of each conversation is wriiten at the beginning of the conversation.\n\nDATE: 1:56 pm on 8 May, 2023\nCONVERSATION:\nC ... [TRUNCATED 74397 chars] ... m of a short phrase for the following question. Answer with exact words from the context whenever possible.\n\nQuestion: When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date. Short answer:"
+    }
+  ],
+  "target": "7 May 2023",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "sample_id": "conv-26",
+    "qa_index": 0,
+    "category": 2,
+    "category_name": "temporal",
+    "raw_question": "When did Caroline go to the LGBTQ support group?",
+    "answer": "7 May 2023",
+    "adversarial_answer": null,
+    "eval_mode": "long_context",
+    "question": "When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date.",
+    "evidence": [
+      "D1:3"
+    ]
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `eval_mode` | `str` | `long_context` | 评估模式：long_context 或 oracle_context。可选值：['long_context', 'oracle_context'] |
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets locomo \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['locomo'],
+    dataset_args={
+        'locomo': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/llm.md
+++ b/docs/zh/get_started/supported_dataset/llm.md
@@ -63,6 +63,7 @@
 | `jnlpba` | [JNLPBA](../../benchmarks/jnlpba.md) | `Knowledge`, `NER` |
 | `jnlpba_rare` | [JNLPBA-Rare](../../benchmarks/jnlpba_rare.md) | `Knowledge`, `NER` |
 | `live_code_bench` | [Live-Code-Bench](../../benchmarks/live_code_bench.md) | `Coding` |
+| `locomo` | [LoCoMo](../../benchmarks/locomo.md) | `LongContext`, `MultiTurn`, `QA` |
 | `logi_qa` | [LogiQA](../../benchmarks/logi_qa.md) | `MCQ`, `Reasoning` |
 | `longbench_v2` | [LongBench-v2](../../benchmarks/longbench_v2.md) | `LongContext`, `MCQ`, `ReadingComprehension` |
 | `longmemeval` | [LongMemEval](../../benchmarks/longmemeval.md) | `LongContext`, `MultiTurn`, `QA`, `Retrieval` |
@@ -180,6 +181,7 @@
 ../../benchmarks/jnlpba.md
 ../../benchmarks/jnlpba_rare.md
 ../../benchmarks/live_code_bench.md
+../../benchmarks/locomo.md
 ../../benchmarks/logi_qa.md
 ../../benchmarks/longbench_v2.md
 ../../benchmarks/longmemeval.md

--- a/evalscope/benchmarks/_meta/locomo.json
+++ b/evalscope/benchmarks/_meta/locomo.json
@@ -1,0 +1,98 @@
+{
+  "meta": {
+    "pretty_name": "LoCoMo",
+    "dataset_id": "evalscope/locomo",
+    "paper_url": null,
+    "tags": [
+      "QA",
+      "LongContext",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "f1"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "qa"
+    ],
+    "description": "\n## Overview\n\nLoCoMo evaluates very long-term conversational memory in two-person multi-session dialogues. This adapter supports the\nofficial question-answering task from `locomo10.json`.\n\n## Task Description\n\n- **Task Type**: Long-context question answering\n- **Input**: Multi-session conversation history with session dates and a question\n- **Output**: Short free-form answer\n- **Subsets**: `qa`\n\n## Key Features\n\n- Uses the official LoCoMo QA data file hosted on ModelScope\n- Supports full-history long-context prompts and evidence-only oracle prompts\n- Includes image captions from the released data when present, but does not download image files\n- Uses LoCoMo's rule-based F1 / adversarial refusal scoring instead of an LLM judge\n\n## Evaluation Notes\n\n- Default subset is `qa` with `eval_mode=long_context`\n- Use `extra_params.eval_mode='oracle_context'` for evidence-only upper-bound evaluation\n- Event summarization, multimodal dialog generation, and RAG retrieval are not included in this QA adapter\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "eval_mode": {
+        "type": "str",
+        "description": "Evaluation mode: long_context or oracle_context.",
+        "value": "long_context",
+        "choices": [
+          "long_context",
+          "oracle_context"
+        ]
+      }
+    },
+    "sandbox_config": {},
+    "category": "llm"
+  },
+  "statistics": {
+    "total_samples": 1986,
+    "subset_stats": [
+      {
+        "name": "qa",
+        "sample_count": 1986,
+        "prompt_length_mean": 94097.72,
+        "prompt_length_min": 55178,
+        "prompt_length_max": 111026,
+        "prompt_length_std": 14752.53,
+        "target_length_mean": 28.32
+      }
+    ],
+    "prompt_length": {
+      "mean": 94097.72,
+      "min": 55178,
+      "max": 111026,
+      "std": 14752.53
+    },
+    "target_length_mean": 28.32,
+    "computed_at": "2026-06-17T16:13:38.793650"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "b585f7b0",
+          "content": "Below is a conversation between two people: Caroline and Melanie. The conversation takes place over multiple days and the date of each conversation is wriiten at the beginning of the conversation.\n\nDATE: 1:56 pm on 8 May, 2023\nCONVERSATION:\nC ... [TRUNCATED 74397 chars] ... m of a short phrase for the following question. Answer with exact words from the context whenever possible.\n\nQuestion: When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date. Short answer:"
+        }
+      ],
+      "target": "7 May 2023",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "sample_id": "conv-26",
+        "qa_index": 0,
+        "category": 2,
+        "category_name": "temporal",
+        "raw_question": "When did Caroline go to the LGBTQ support group?",
+        "answer": "7 May 2023",
+        "adversarial_answer": null,
+        "eval_mode": "long_context",
+        "question": "When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date.",
+        "evidence": [
+          "D1:3"
+        ]
+      }
+    },
+    "subset": "qa",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# LoCoMo\n\n\n## Overview\n\nLoCoMo evaluates very long-term conversational memory in two-person multi-session dialogues. This adapter supports the\nofficial question-answering task from `locomo10.json`.\n\n## Task Description\n\n- **Task Type**: Long-context question answering\n- **Input**: Multi-session conversation history with session dates and a question\n- **Output**: Short free-form answer\n- **Subsets**: `qa`\n\n## Key Features\n\n- Uses the official LoCoMo QA data file hosted on ModelScope\n- Supports full-history long-context prompts and evidence-only oracle prompts\n- Includes image captions from the released data when present, but does not download image files\n- Uses LoCoMo's rule-based F1 / adversarial refusal scoring instead of an LLM judge\n\n## Evaluation Notes\n\n- Default subset is `qa` with `eval_mode=long_context`\n- Use `extra_params.eval_mode='oracle_context'` for evidence-only upper-bound evaluation\n- Event summarization, multimodal dialog generation, and RAG retrieval are not included in this QA adapter\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `locomo` |\n| **Dataset ID** | [evalscope/locomo](https://modelscope.cn/datasets/evalscope/locomo/summary) |\n| **Paper** | N/A |\n| **Tags** | `LongContext`, `MultiTurn`, `QA` |\n| **Metrics** | `f1` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 1,986 |\n| Prompt Length (Mean) | 94097.72 chars |\n| Prompt Length (Min/Max) | 55178 / 111026 chars |\n\n## Sample Example\n\n**Subset**: `qa`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"b585f7b0\",\n      \"content\": \"Below is a conversation between two people: Caroline and Melanie. The conversation takes place over multiple days and the date of each conversation is wriiten at the beginning of the conversation.\\n\\nDATE: 1:56 pm on 8 May, 2023\\nCONVERSATION:\\nC ... [TRUNCATED 74397 chars] ... m of a short phrase for the following question. Answer with exact words from the context whenever possible.\\n\\nQuestion: When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date. Short answer:\"\n    }\n  ],\n  \"target\": \"7 May 2023\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"sample_id\": \"conv-26\",\n    \"qa_index\": 0,\n    \"category\": 2,\n    \"category_name\": \"temporal\",\n    \"raw_question\": \"When did Caroline go to the LGBTQ support group?\",\n    \"answer\": \"7 May 2023\",\n    \"adversarial_answer\": null,\n    \"eval_mode\": \"long_context\",\n    \"question\": \"When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date.\",\n    \"evidence\": [\n      \"D1:3\"\n    ]\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `eval_mode` | `str` | `long_context` | Evaluation mode: long_context or oracle_context. Choices: ['long_context', 'oracle_context'] |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets locomo \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['locomo'],\n    dataset_args={\n        'locomo': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# LoCoMo\n\n\n## 概述\n\nLoCoMo 用于评估两人在多轮会话对话中的超长期对话记忆能力。该适配器支持来自 `locomo10.json` 的官方问答任务。\n\n## 任务描述\n\n- **任务类型**：长上下文问答\n- **输入**：包含会话日期的多轮对话历史和一个问题\n- **输出**：简短的自由格式答案\n- **子集**：`qa`\n\n## 主要特性\n\n- 使用托管在 ModelScope 上的官方 LoCoMo QA 数据文件\n- 支持完整历史的长上下文提示和仅含证据的 oracle 提示\n- 在数据中存在时包含图像说明，但不会下载图像文件\n- 使用 LoCoMo 基于规则的 F1 / 对抗性拒绝评分机制，而非基于大语言模型（LLM）的评判器\n\n## 评估说明\n\n- 默认子集为 `qa`，且 `eval_mode=long_context`\n- 使用 `extra_params.eval_mode='oracle_context'` 进行仅含证据的上限评估\n- 此 QA 适配器不包含事件摘要、多模态对话生成和 RAG 检索任务\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `locomo` |\n| **数据集ID** | [evalscope/locomo](https://modelscope.cn/datasets/evalscope/locomo/summary) |\n| **论文** | N/A |\n| **标签** | `LongContext`, `MultiTurn`, `QA` |\n| **指标** | `f1` |\n| **默认示例数** | 0-shot |\n| **评估分割** | `test` |\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 1,986 |\n| 提示词长度（平均） | 94097.72 字符 |\n| 提示词长度（最小/最大） | 55178 / 111026 字符 |\n\n## 样例示例\n\n**子集**: `qa`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"b585f7b0\",\n      \"content\": \"Below is a conversation between two people: Caroline and Melanie. The conversation takes place over multiple days and the date of each conversation is wriiten at the beginning of the conversation.\\n\\nDATE: 1:56 pm on 8 May, 2023\\nCONVERSATION:\\nC ... [TRUNCATED 74397 chars] ... m of a short phrase for the following question. Answer with exact words from the context whenever possible.\\n\\nQuestion: When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date. Short answer:\"\n    }\n  ],\n  \"target\": \"7 May 2023\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"sample_id\": \"conv-26\",\n    \"qa_index\": 0,\n    \"category\": 2,\n    \"category_name\": \"temporal\",\n    \"raw_question\": \"When did Caroline go to the LGBTQ support group?\",\n    \"answer\": \"7 May 2023\",\n    \"adversarial_answer\": null,\n    \"eval_mode\": \"long_context\",\n    \"question\": \"When did Caroline go to the LGBTQ support group? Use DATE of CONVERSATION to answer with an approximate date.\",\n    \"evidence\": [\n      \"D1:3\"\n    ]\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `eval_mode` | `str` | `long_context` | 评估模式：long_context 或 oracle_context。可选值：['long_context', 'oracle_context'] |\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets locomo \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['locomo'],\n    dataset_args={\n        'locomo': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "1641590bc672a607ea9905cfae78f57c",
+    "needs_translation": false
+  },
+  "updated_at": "2026-06-17T16:13:40.132287",
+  "translation_updated_at": "2026-06-17T16:13:44"
+}

--- a/evalscope/benchmarks/locomo/__init__.py
+++ b/evalscope/benchmarks/locomo/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.

--- a/evalscope/benchmarks/locomo/locomo_adapter.py
+++ b/evalscope/benchmarks/locomo/locomo_adapter.py
@@ -1,0 +1,201 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from evalscope.api.benchmark import BenchmarkMeta, DefaultDataAdapter
+from evalscope.api.dataset import DatasetDict, DictDataLoader, Sample
+from evalscope.api.dataset.hub import download_dataset_file
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageUser
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from .utils import CATEGORY_IDS, CATEGORY_NAMES, DATA_FILE, build_qa_prompt, get_target_answer, locomo_f1_score
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='locomo',
+        pretty_name='LoCoMo',
+        tags=[Tags.QA, Tags.LONG_CONTEXT, Tags.MULTI_TURN],
+        description="""
+## Overview
+
+LoCoMo evaluates very long-term conversational memory in two-person multi-session dialogues. This adapter supports the
+official question-answering task from `locomo10.json`.
+
+## Task Description
+
+- **Task Type**: Long-context question answering
+- **Input**: Multi-session conversation history with session dates and a question
+- **Output**: Short free-form answer
+- **Subsets**: `qa`
+
+## Key Features
+
+- Uses the official LoCoMo QA data file hosted on ModelScope
+- Supports full-history long-context prompts and evidence-only oracle prompts
+- Includes image captions from the released data when present, but does not download image files
+- Uses LoCoMo's rule-based F1 / adversarial refusal scoring instead of an LLM judge
+
+## Evaluation Notes
+
+- Default subset is `qa` with `eval_mode=long_context`
+- Use `extra_params.eval_mode='oracle_context'` for evidence-only upper-bound evaluation
+- Event summarization, multimodal dialog generation, and RAG retrieval are not included in this QA adapter
+""",
+        dataset_id='evalscope/locomo',
+        metric_list=['f1'],
+        few_shot_num=0,
+        train_split=None,
+        eval_split='test',
+        subset_list=['qa'],
+        default_subset='qa',
+        extra_params={
+            'eval_mode': {
+                'type': 'str',
+                'description': 'Evaluation mode: long_context or oracle_context.',
+                'value': 'long_context',
+                'choices': ['long_context', 'oracle_context'],
+            },
+        },
+    )
+)
+class LoCoMoAdapter(DefaultDataAdapter):
+    """Adapter for the LoCoMo QA task."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.eval_mode = self.extra_params.get('eval_mode', 'long_context')
+
+    def load(self) -> Tuple[DatasetDict, None]:
+        self._validate_params()
+        records = self._load_records()
+        dataset = DictDataLoader(
+            dict_list=records,
+            sample_fields=self.record_to_sample,
+            subset='qa',
+            limit=self.limit,
+            repeats=self.repeats,
+            shuffle=self.shuffle,
+            seed=self.seed,
+        ).load()
+        return DatasetDict({'qa': dataset}), None
+
+    def _validate_params(self) -> None:
+        if self.subset_list != ['qa']:
+            raise ValueError('LoCoMo currently supports subset_list=["qa"] only.')
+        if self.eval_mode not in ['long_context', 'oracle_context']:
+            raise ValueError(f'Unsupported eval_mode: {self.eval_mode}')
+
+    def _load_records(self) -> List[Dict[str, Any]]:
+        file_path = self._resolve_dataset_file()
+        conversations = json.loads(Path(file_path).read_text(encoding='utf-8'))
+        records = []
+        for conversation_record in conversations:
+            conversation = conversation_record['conversation']
+            sample_id = conversation_record['sample_id']
+            for qa_index, qa in enumerate(conversation_record['qa']):
+                records.append({
+                    'sample_id': sample_id,
+                    'qa_index': qa_index,
+                    'conversation': conversation,
+                    'qa': qa,
+                })
+        return records
+
+    def _resolve_dataset_file(self) -> str:
+        dataset_path = Path(self.dataset_id)
+        if dataset_path.is_file():
+            return str(dataset_path)
+        if dataset_path.exists():
+            file_path = dataset_path / DATA_FILE
+            if not file_path.exists():
+                raise FileNotFoundError(f'LoCoMo data file not found: {file_path}')
+            return str(file_path)
+        return download_dataset_file(
+            data_id_or_path=self.dataset_id,
+            file_path=DATA_FILE,
+            data_source=self.dataset_hub,
+            force_redownload=self.force_redownload,
+            cache_dir=self.dataset_dir,
+        )
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        qa = record['qa']
+        prompt, prompt_metadata = build_qa_prompt(
+            conversation=record['conversation'],
+            qa=qa,
+            eval_mode=self.eval_mode,
+        )
+        target = get_target_answer(qa)
+        metadata = {
+            'sample_id': record['sample_id'],
+            'qa_index': record['qa_index'],
+            'category': qa['category'],
+            'category_name': CATEGORY_NAMES.get(qa['category'], f'category_{qa["category"]}'),
+            'raw_question': qa['question'],
+            'answer': target,
+            'adversarial_answer': qa.get('adversarial_answer'),
+            'eval_mode': self.eval_mode,
+            **prompt_metadata,
+        }
+        return Sample(input=[ChatMessageUser(content=prompt)], target=target, metadata=metadata)
+
+    def match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        category = int(task_state.metadata['category'])
+        value = locomo_f1_score(filtered_prediction, reference, category)
+        score = Score(extracted_prediction=filtered_prediction, prediction=original_prediction)
+        score.value = {'f1': value}
+        score.metadata = {
+            'category': category,
+            'category_name': task_state.metadata.get('category_name'),
+        }
+        score.main_score_name = 'f1'
+        return score
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        valid_scores = [s for s in sample_scores if s.score and 'f1' in s.score.value]
+        if not valid_scores:
+            return []
+
+        agg_scores = [
+            self._make_agg_score(metric_name='f1', aggregation_name='overall', scores=valid_scores),
+        ]
+
+        category_means = []
+        for category in CATEGORY_IDS:
+            category_scores = [s for s in valid_scores if (s.sample_metadata or {}).get('category') == category]
+            if not category_scores:
+                continue
+            category_name = CATEGORY_NAMES.get(category, f'category_{category}')
+            agg = self._make_agg_score(metric_name='f1', aggregation_name=category_name, scores=category_scores)
+            agg_scores.append(agg)
+            category_means.append(agg.score)
+
+        if category_means:
+            agg_scores.append(
+                AggScore(
+                    metric_name='f1',
+                    aggregation_name='task_averaged',
+                    score=sum(category_means) / len(category_means),
+                    num=len(category_means),
+                )
+            )
+
+        return agg_scores
+
+    @staticmethod
+    def _make_agg_score(metric_name: str, aggregation_name: str, scores: List[SampleScore]) -> AggScore:
+        values = [float(s.score.value[metric_name]) for s in scores]
+        ids = [s.sample_id for s in scores]
+        return AggScore(
+            metric_name=metric_name,
+            aggregation_name=aggregation_name,
+            score=sum(values) / len(values),
+            num=len(values),
+            ids=ids,
+        )

--- a/evalscope/benchmarks/locomo/utils.py
+++ b/evalscope/benchmarks/locomo/utils.py
@@ -1,0 +1,156 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import re
+import string
+import unicodedata
+from collections import Counter
+from nltk.stem import PorterStemmer
+from typing import Any, Dict, List, Tuple
+
+DATA_FILE = 'locomo10.json'
+CATEGORY_IDS = [4, 1, 2, 3, 5]
+CATEGORY_NAMES = {
+    1: 'multi_hop',
+    2: 'temporal',
+    3: 'commonsense',
+    4: 'single_hop',
+    5: 'adversarial',
+}
+PUNCTUATION_TABLE = str.maketrans('', '', string.punctuation)
+STEMMER = PorterStemmer()
+
+CONV_START_PROMPT = (
+    'Below is a conversation between two people: {} and {}. The conversation takes place over multiple days and '
+    'the date of each conversation is wriiten at the beginning of the conversation.\n\n'
+)
+
+QA_PROMPT = (
+    '\nBased on the above context, write an answer in the form of a short phrase for the following question. '
+    'Answer with exact words from the context whenever possible.\n\nQuestion: {} Short answer:'
+)
+
+QA_PROMPT_CAT_5 = '\nBased on the above context, answer the following question.\n\nQuestion: {} Short answer:'
+
+
+def build_qa_prompt(conversation: Dict[str, Any], qa: Dict[str, Any], eval_mode: str) -> Tuple[str, Dict[str, Any]]:
+    """Build the LoCoMo QA prompt and return prompt metadata."""
+    question = _build_question(qa)
+    history = _build_history(conversation, evidence=qa.get('evidence', []), eval_mode=eval_mode)
+    speaker_a = conversation.get('speaker_a') or _infer_speakers(conversation)[0]
+    speaker_b = conversation.get('speaker_b') or _infer_speakers(conversation)[1]
+    prompt = CONV_START_PROMPT.format(speaker_a, speaker_b) + history
+    if qa.get('category') == 5:
+        prompt += QA_PROMPT_CAT_5.format(question)
+    else:
+        prompt += QA_PROMPT.format(question)
+    return prompt, {'question': question, 'evidence': qa.get('evidence', [])}
+
+
+def get_target_answer(qa: Dict[str, Any]) -> str:
+    """Return the scoring target for a LoCoMo QA item."""
+    if qa.get('category') == 5 and 'answer' not in qa:
+        return 'No information available'
+    return str(qa.get('answer', ''))
+
+
+def locomo_f1_score(prediction: str, reference: str, category: int) -> float:
+    """Compute LoCoMo's QA score for one prediction."""
+    if category == 5:
+        lowered = prediction.lower()
+        if 'no information available' in lowered or 'not mentioned' in lowered:
+            return 1.0
+        return 0.0
+    if category == 1:
+        return _multi_answer_f1(prediction, reference)
+    if category == 3:
+        reference = reference.split(';')[0].strip()
+    return _token_f1(prediction, reference)
+
+
+def _build_question(qa: Dict[str, Any]) -> str:
+    question = str(qa['question'])
+    if qa.get('category') == 2:
+        return question + ' Use DATE of CONVERSATION to answer with an approximate date.'
+    if qa.get('category') == 5:
+        return question + " If the answer is not mentioned in the conversation, answer 'No information available'."
+    return question
+
+
+def _build_history(conversation: Dict[str, Any], evidence: List[str], eval_mode: str) -> str:
+    session_nums = _session_numbers(conversation)
+    evidence_set = set(evidence or [])
+    history = ''
+    for session_num in session_nums:
+        session_key = f'session_{session_num}'
+        turns = conversation.get(session_key) or []
+        if eval_mode == 'oracle_context':
+            turns = [turn for turn in turns if turn and turn.get('dia_id') in evidence_set]
+            if not turns:
+                continue
+        date_time = conversation.get(f'{session_key}_date_time') or ''
+        history += f'DATE: {date_time}\nCONVERSATION:\n'
+        for turn in turns:
+            history += _format_turn(turn)
+        history += '\n'
+    return history
+
+
+def _format_turn(turn: Dict[str, Any]) -> str:
+    text = f'{turn.get("speaker", "")} said, "{turn.get("text", "")}"'
+    if turn.get('blip_caption'):
+        text += f' and shared {turn["blip_caption"]}.'
+    return text + '\n\n'
+
+
+def _session_numbers(conversation: Dict[str, Any]) -> List[int]:
+    nums = []
+    for key in conversation:
+        if key.startswith('session_') and not key.endswith('_date_time'):
+            suffix = key.split('_')[-1]
+            if suffix.isdigit():
+                nums.append(int(suffix))
+    return sorted(nums)
+
+
+def _infer_speakers(conversation: Dict[str, Any]) -> Tuple[str, str]:
+    speakers = []
+    for session_num in _session_numbers(conversation):
+        for turn in conversation.get(f'session_{session_num}') or []:
+            speaker = turn.get('speaker')
+            if speaker and speaker not in speakers:
+                speakers.append(speaker)
+            if len(speakers) == 2:
+                return speakers[0], speakers[1]
+    return '', ''
+
+
+def _normalize_answer(text: str) -> str:
+    text = unicodedata.normalize('NFD', str(text)).lower().replace(',', '')
+    text = text.translate(PUNCTUATION_TABLE)
+    text = re.sub(r'\b(a|an|the|and)\b', ' ', text)
+    return ' '.join(text.split())
+
+
+def _stem(word: str) -> str:
+    return STEMMER.stem(word)
+
+
+def _token_f1(prediction: str, reference: str) -> float:
+    prediction_tokens = [_stem(token) for token in _normalize_answer(prediction).split()]
+    reference_tokens = [_stem(token) for token in _normalize_answer(reference).split()]
+    common = Counter(prediction_tokens) & Counter(reference_tokens)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0.0
+    precision = num_same / len(prediction_tokens) if prediction_tokens else 0.0
+    recall = num_same / len(reference_tokens) if reference_tokens else 0.0
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _multi_answer_f1(prediction: str, reference: str) -> float:
+    predictions = [p.strip() for p in prediction.split(',')]
+    references = [r.strip() for r in reference.split(',')]
+    if not references:
+        return 0.0
+    return sum(max(_token_f1(pred, ref) for pred in predictions) for ref in references) / len(references)

--- a/tests/benchmark/test_eval.py
+++ b/tests/benchmark/test_eval.py
@@ -830,6 +830,24 @@ class TestNativeBenchmark(TestBenchmark):
             },
         )
 
+    def test_locomo(self):
+        """Test LoCoMo dataset."""
+        dataset_args = {
+            'subset_list': ['qa'],
+        }
+        self._run_dataset_test(
+            'locomo',
+            dataset_args,
+            use_mock=True,
+            limit=1,
+            eval_batch_size=1,
+            judge_strategy=JudgeStrategy.RULE,
+            generation_config={
+                'max_tokens': 128,
+                'temperature': 0.0,
+            },
+        )
+
 
 if __name__ == '__main__':
     # Run specific test: python -m unittest test_eval.TestBenchmark.test_gsm8k


### PR DESCRIPTION
## Summary

- Add a native LoCoMo QA benchmark adapter backed by the ModelScope `evalscope/locomo` dataset.
- Support `long_context` and `oracle_context` prompt modes with LoCoMo rule-based F1/refusal scoring.
- Generate benchmark docs/meta and add a minimal native benchmark test.

## Validation

- `PATH=/Users/yunlin/miniconda3/bin:$PATH make docs-pipeline BENCHMARK=locomo FORCE=1`
- `/Users/yunlin/miniconda3/bin/python -m unittest tests.benchmark.test_eval.TestNativeBenchmark.test_locomo`
- `/Users/yunlin/miniconda3/bin/pre-commit run flake8 --files evalscope/benchmarks/locomo/__init__.py evalscope/benchmarks/locomo/utils.py evalscope/benchmarks/locomo/locomo_adapter.py tests/benchmark/test_eval.py`
- `/Users/yunlin/miniconda3/bin/pre-commit run isort --files evalscope/benchmarks/locomo/__init__.py evalscope/benchmarks/locomo/utils.py evalscope/benchmarks/locomo/locomo_adapter.py tests/benchmark/test_eval.py`
- `/Users/yunlin/miniconda3/bin/pre-commit run yapf --files evalscope/benchmarks/locomo/__init__.py evalscope/benchmarks/locomo/utils.py evalscope/benchmarks/locomo/locomo_adapter.py tests/benchmark/test_eval.py`
- Real API e2e: `qwen-plus`, `limit=10`, `judge_strategy=rule` -> `overall_f1=0.5125`
