### PR TITLE
feat: add BigCodeBench and BigCodeBench-Hard benchmark support

### DIFF
--- a/docs/en/benchmarks/bigcodebench.md
+++ b/docs/en/benchmarks/bigcodebench.md
@@ -1,0 +1,142 @@
+# BigCodeBench
+
+
+## Overview
+
+BigCodeBench is an easy-to-use benchmark for solving practical and challenging tasks via code. It evaluates the true programming capabilities of large language models (LLMs) in a more realistic setting with diverse function calls from 139 popular libraries covering 723 API calls.
+
+## Task Description
+
+- **Task Type**: Code Generation (Python)
+- **Input**: Programming task description (docstring or natural language instruction)
+- **Output**: Complete Python function implementation
+- **Libraries**: 139 popular Python libraries (numpy, pandas, sklearn, etc.)
+
+## Key Features
+
+- 1,140 rich-context programming tasks in Python
+- Two evaluation modes: Complete (docstring) and Instruct (natural language)
+- Covers diverse function calls from 139 popular libraries
+- Uses unittest.TestCase for thorough correctness verification
+- Supports pass@k metric calculation
+
+## Evaluation Notes
+
+- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed
+- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)
+- Default timeout is 240 seconds per problem
+- `calibrate` option prepends code_prompt to align function signatures
+- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `bigcodebench` |
+| **Dataset ID** | [evalscope/bigcodebench](https://modelscope.cn/datasets/evalscope/bigcodebench/summary) |
+| **Paper** | N/A |
+| **Tags** | `Coding` |
+| **Metrics** | `acc` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `v0.1.4` |
+| **Aggregation** | `mean_and_pass_at_k` |
+
+
+## Data Statistics
+
+*Statistics not available.*
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "657d2473",
+      "content": "Calculates the average of the sums of absolute differences between each pair of consecutive numbers for all permutations of a given list. Each permutation is shuffled before calculating the differences. Args: - numbers (list): A list of numbe ... [TRUNCATED 75 chars] ... loat: The average of the sums of absolute differences for each shuffled permutation of the list.\nYou should write self-contained code starting with:\n```\nimport itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n```"
+    }
+  ],
+  "target": "    permutations = list(itertools.permutations(numbers))\n    sum_diffs = 0\n\n    for perm in permutations:\n        perm = list(perm)\n        shuffle(perm)\n        diffs = [abs(perm[i] - perm[i+1]) for i in range(len(perm)-1)]\n        sum_diffs += sum(diffs)\n\n    avg_sum_diffs = sum_diffs / len(permutations)\n    \n    return avg_sum_diffs",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task_id": "BigCodeBench/0",
+    "entry_point": "task_func",
+    "complete_prompt": "import itertools\nfrom random import shuffle\n\ndef task_func(numbers=list(range(1, 3))):\n    \"\"\"\n    Calculates the average of the sums of absolute differences between each pair of consecutive numbers \n    for all permutations of a given list.  ... [TRUNCATED 187 chars] ... age of the sums of absolute differences for each shuffled permutation of the list.\n\n    Requirements:\n    - itertools\n    - random.shuffle\n\n    Example:\n    >>> result = task_func([1, 2, 3])\n    >>> isinstance(result, float)\n    True\n    \"\"\"\n",
+    "code_prompt": "import itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n",
+    "test": "import unittest\nfrom unittest.mock import patch\nfrom random import seed, shuffle\nimport itertools\nclass TestCases(unittest.TestCase):\n    def test_default_numbers(self):\n        # Test with default number range (1 to 10) to check that the res ... [TRUNCATED 2578 chars] ...  x: seed(1) or shuffle(x)):\n            result1 = task_func([1, 2, 3])\n        with patch('random.shuffle', side_effect=lambda x: seed(1) or shuffle(x)):\n            result2 = task_func([1, 2, 4])\n        self.assertNotEqual(result1, result2)"
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{prompt}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `split` | `str` | `instruct` | Evaluation mode: "complete" (docstring completion) or "instruct" (NL instruction). Choices: ['complete', 'instruct'] |
+| `version` | `str` | `default` | Dataset version. Use "default" for the latest available version. |
+| `calibrate` | `bool` | `True` | Whether to prepend code_prompt to the solution for function signature alignment. |
+
+## Sandbox Configuration
+
+This benchmark requires a sandbox environment for code execution.
+
+```json
+{
+  "image": "bigcodebench/bigcodebench-evaluate:latest",
+  "tools_config": {
+    "shell_executor": {},
+    "python_executor": {}
+  },
+  "memory_limit": "4g"
+}
+```
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets bigcodebench \
+    --sandbox '{"enabled": true}' \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['bigcodebench'],
+    sandbox={'enabled': True},
+    dataset_args={
+        'bigcodebench': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```
+
+

--- a/docs/en/benchmarks/bigcodebench_hard.md
+++ b/docs/en/benchmarks/bigcodebench_hard.md
@@ -1,0 +1,146 @@
+# BigCodeBench-Hard
+
+
+## Overview
+
+BigCodeBench-Hard is a curated subset of BigCodeBench containing 148 tasks that are more aligned with real-world programming tasks. These tasks require more complex reasoning and multi-step problem solving.
+
+## Task Description
+
+- **Task Type**: Code Generation (Python)
+- **Input**: Programming task description (docstring or natural language instruction)
+- **Output**: Complete Python function implementation
+- **Difficulty**: Higher than BigCodeBench-Full, closer to real-world complexity
+
+## Key Features
+
+- 148 challenging tasks selected from BigCodeBench
+- Requires complex reasoning and multi-tool usage
+- Two evaluation modes: Complete (docstring) and Instruct (natural language)
+- Uses unittest.TestCase for thorough correctness verification
+- Supports pass@k metric calculation
+
+## Evaluation Notes
+
+- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed
+- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)
+- Default timeout is 240 seconds per problem
+- `calibrate` option prepends code_prompt to align function signatures
+- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `bigcodebench_hard` |
+| **Dataset ID** | [evalscope/bigcodebench-hard](https://modelscope.cn/datasets/evalscope/bigcodebench-hard/summary) |
+| **Paper** | N/A |
+| **Tags** | `Coding` |
+| **Metrics** | `acc` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `v0.1.4` |
+| **Aggregation** | `mean_and_pass_at_k` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 148 |
+| Prompt Length (Mean) | 777.94 chars |
+| Prompt Length (Min/Max) | 274 / 1816 chars |
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "207adc46",
+      "content": "Download all files from a specific directory on an FTP server using wget in a subprocess. Args: ftp_server (str): The FTP server address. Default is 'ftp.dlptest.com'. ftp_user (str): The FTP server username. Default is 'dlpuser'. ftp_passwor ... [TRUNCATED 798 chars] ...  FTP server.\nYou should write self-contained code starting with:\n```\nimport subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n```"
+    }
+  ],
+  "target": "    # Attempt to connect to the FTP server\n    try:\n        ftp_obj = ftplib.FTP(ftp_server)\n    except Exception as e:\n        raise Exception(f'Failed to connect to FTP server {ftp_server}: {str(e)}')\n\n    # Attempt to login to the FTP serv ... [TRUNCATED 625 chars] ...        command = f'wget ftp://{ftp_user}:{ftp_password}@{ftp_server}{ftp_dir}/{filename} -P {download_dir}'\n        subprocess.call(command, shell=True)\n        downloaded_files.append(filename)\n\n    ftp_obj.quit()\n    return downloaded_files",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task_id": "BigCodeBench/13",
+    "entry_point": "task_func",
+    "complete_prompt": "import subprocess\nimport ftplib\nimport os\n\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n    \"\"\"\n    Download all files from a specific directory on an FTP serv ... [TRUNCATED 909 chars] ... ctory. Outputs the message \"Failed to change to directory {ftp_dir} on server {ftp_server}: {str(e)}\"\n    \n    Requirements:\n    - subprocess\n    - ftplib\n    - os\n\n    Example:\n    >>> task_func()\n    ['file1.txt', 'file2.jpg', ...]\n    \"\"\"\n",
+    "code_prompt": "import subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n",
+    "test": "import unittest\nfrom unittest.mock import patch\nimport os\nclass TestCases(unittest.TestCase):\n    def setUp(self):\n        \"\"\"Setup a clean test environment before each test.\"\"\"\n        if not os.path.exists(\"downloaded_files\"):\n            o ... [TRUNCATED 2565 chars] ... with self.assertRaises(Exception) as context:\n            task_func(ftp_dir=\"/invalid_directory\")\n        self.assertEqual(str(context.exception), f'Failed to change to directory /invalid_directory on server ftp.dlptest.com: {error_message}')"
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{prompt}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `split` | `str` | `instruct` | Evaluation mode: "complete" (docstring completion) or "instruct" (NL instruction). Choices: ['complete', 'instruct'] |
+| `version` | `str` | `default` | Dataset version. Use "default" for the latest available version. |
+| `calibrate` | `bool` | `True` | Whether to prepend code_prompt to the solution for function signature alignment. |
+
+## Sandbox Configuration
+
+This benchmark requires a sandbox environment for code execution.
+
+```json
+{
+  "image": "bigcodebench/bigcodebench-evaluate:latest",
+  "tools_config": {
+    "shell_executor": {},
+    "python_executor": {}
+  },
+  "memory_limit": "4g"
+}
+```
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets bigcodebench_hard \
+    --sandbox '{"enabled": true}' \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['bigcodebench_hard'],
+    sandbox={'enabled': True},
+    dataset_args={
+        'bigcodebench_hard': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```
+
+

--- a/docs/en/get_started/supported_dataset/llm.md
+++ b/docs/en/get_started/supported_dataset/llm.md
@@ -20,6 +20,8 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 | `bc2gm` | [BC2GM](../../benchmarks/bc2gm.md) | `Knowledge`, `NER` |
 | `bc4chemd` | [BC4CHEMD](../../benchmarks/bc4chemd.md) | `Knowledge`, `NER` |
 | `bc5cdr` | [BC5CDR](../../benchmarks/bc5cdr.md) | `Knowledge`, `NER` |
+| `bigcodebench` | [BigCodeBench](../../benchmarks/bigcodebench.md) | `Coding` |
+| `bigcodebench_hard` | [BigCodeBench-Hard](../../benchmarks/bigcodebench_hard.md) | `Coding` |
 | `biomix_qa` | [BioMixQA](../../benchmarks/biomix_qa.md) | `Knowledge`, `MCQ`, `Medical` |
 | `broad_twitter_corpus` | [BroadTwitterCorpus](../../benchmarks/broad_twitter_corpus.md) | `Knowledge`, `NER` |
 | `ceval` | [C-Eval](../../benchmarks/ceval.md) | `Chinese`, `Knowledge`, `MCQ` |
@@ -138,6 +140,8 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/bc2gm.md
 ../../benchmarks/bc4chemd.md
 ../../benchmarks/bc5cdr.md
+../../benchmarks/bigcodebench.md
+../../benchmarks/bigcodebench_hard.md
 ../../benchmarks/biomix_qa.md
 ../../benchmarks/broad_twitter_corpus.md
 ../../benchmarks/ceval.md

--- a/docs/zh/benchmarks/bigcodebench.md
+++ b/docs/zh/benchmarks/bigcodebench.md
@@ -1,0 +1,139 @@
+# BigCodeBench
+
+
+## 概述
+
+BigCodeBench 是一个易于使用的基准测试，用于通过代码解决实际且具有挑战性的任务。它在更贴近现实的场景中评估大语言模型（LLMs）的真实编程能力，涵盖来自 139 个流行库的 723 个 API 调用。
+
+## 任务描述
+
+- **任务类型**：代码生成（Python）
+- **输入**：编程任务描述（文档字符串或自然语言指令）
+- **输出**：完整的 Python 函数实现
+- **涉及库**：139 个流行的 Python 库（如 numpy、pandas、sklearn 等）
+
+## 主要特性
+
+- 包含 1,140 个上下文丰富的 Python 编程任务
+- 提供两种评估模式：Complete（基于文档字符串）和 Instruct（基于自然语言指令）
+- 覆盖来自 139 个流行库的多样化函数调用
+- 使用 `unittest.TestCase` 进行全面的正确性验证
+- 支持 pass@k 指标计算
+
+## 评估说明
+
+- **需要沙箱环境**：要求预装 70+ 个 Python 库的沙箱环境
+- 通过 `split` 参数选择两种模式：`complete`（文档字符串补全）或 `instruct`（自然语言指令）
+- 每个问题默认超时时间为 240 秒
+- 启用 `calibrate` 选项会在生成代码前添加 `code_prompt`，以对齐函数签名
+- 沙箱环境设置详见 [沙箱文档](https://evalscope.readthedocs.io/zh-cn/latest/user_guides/sandbox.html)
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `bigcodebench` |
+| **数据集ID** | [evalscope/bigcodebench](https://modelscope.cn/datasets/evalscope/bigcodebench/summary) |
+| **论文** | N/A |
+| **标签** | `Coding` |
+| **指标** | `acc` |
+| **默认示例数** | 0-shot |
+| **评估划分版本** | `v0.1.4` |
+| **聚合方式** | `mean_and_pass_at_k` |
+
+
+## 数据统计
+
+*统计数据暂不可用。*
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "657d2473",
+      "content": "Calculates the average of the sums of absolute differences between each pair of consecutive numbers for all permutations of a given list. Each permutation is shuffled before calculating the differences. Args: - numbers (list): A list of numbe ... [TRUNCATED 75 chars] ... loat: The average of the sums of absolute differences for each shuffled permutation of the list.\nYou should write self-contained code starting with:\n```\nimport itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n```"
+    }
+  ],
+  "target": "    permutations = list(itertools.permutations(numbers))\n    sum_diffs = 0\n\n    for perm in permutations:\n        perm = list(perm)\n        shuffle(perm)\n        diffs = [abs(perm[i] - perm[i+1]) for i in range(len(perm)-1)]\n        sum_diffs += sum(diffs)\n\n    avg_sum_diffs = sum_diffs / len(permutations)\n    \n    return avg_sum_diffs",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task_id": "BigCodeBench/0",
+    "entry_point": "task_func",
+    "complete_prompt": "import itertools\nfrom random import shuffle\n\ndef task_func(numbers=list(range(1, 3))):\n    \"\"\"\n    Calculates the average of the sums of absolute differences between each pair of consecutive numbers \n    for all permutations of a given list.  ... [TRUNCATED 187 chars] ... age of the sums of absolute differences for each shuffled permutation of the list.\n\n    Requirements:\n    - itertools\n    - random.shuffle\n\n    Example:\n    >>> result = task_func([1, 2, 3])\n    >>> isinstance(result, float)\n    True\n    \"\"\"\n",
+    "code_prompt": "import itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n",
+    "test": "import unittest\nfrom unittest.mock import patch\nfrom random import seed, shuffle\nimport itertools\nclass TestCases(unittest.TestCase):\n    def test_default_numbers(self):\n        # Test with default number range (1 to 10) to check that the res ... [TRUNCATED 2578 chars] ...  x: seed(1) or shuffle(x)):\n            result1 = task_func([1, 2, 3])\n        with patch('random.shuffle', side_effect=lambda x: seed(1) or shuffle(x)):\n            result2 = task_func([1, 2, 4])\n        self.assertNotEqual(result1, result2)"
+  }
+}
+```
+
+## 提示模板
+
+**提示模板：**
+```text
+{prompt}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `split` | `str` | `instruct` | 评估模式："complete"（文档字符串补全）或 "instruct"（自然语言指令）。可选值：['complete', 'instruct'] |
+| `version` | `str` | `default` | 数据集版本。使用 "default" 表示最新可用版本。 |
+| `calibrate` | `bool` | `True` | 是否在解决方案前添加 `code_prompt` 以对齐函数签名。 |
+
+## 沙箱配置
+
+此基准测试需要沙箱环境来执行代码。
+
+```json
+{
+  "image": "bigcodebench/bigcodebench-evaluate:latest",
+  "tools_config": {
+    "shell_executor": {},
+    "python_executor": {}
+  },
+  "memory_limit": "4g"
+}
+```
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets bigcodebench \
+    --sandbox '{"enabled": true}' \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['bigcodebench'],
+    sandbox={'enabled': True},
+    dataset_args={
+        'bigcodebench': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/benchmarks/bigcodebench_hard.md
+++ b/docs/zh/benchmarks/bigcodebench_hard.md
@@ -1,0 +1,143 @@
+# BigCodeBench-Hard
+
+
+## 概述
+
+BigCodeBench-Hard 是 BigCodeBench 的一个精选子集，包含 148 个更贴近真实编程场景的任务。这些任务需要更复杂的推理能力和多步骤的问题解决能力。
+
+## 任务描述
+
+- **任务类型**：代码生成（Python）
+- **输入**：编程任务描述（文档字符串或自然语言指令）
+- **输出**：完整的 Python 函数实现
+- **难度**：高于 BigCodeBench-Full，更接近真实世界的复杂度
+
+## 主要特性
+
+- 从 BigCodeBench 中精选出的 148 个具有挑战性的任务
+- 要求复杂的推理能力和多工具协同使用
+- 提供两种评估模式：Complete（基于文档字符串）和 Instruct（基于自然语言指令）
+- 使用 `unittest.TestCase` 进行全面的正确性验证
+- 支持 pass@k 指标计算
+
+## 评估说明
+
+- **需要沙箱环境**：要求预装 70 多个 Python 库的沙箱环境
+- 通过 `split` 参数选择两种模式：`complete`（文档字符串补全）或 `instruct`（自然语言指令）
+- 每个问题默认超时时间为 240 秒
+- 启用 `calibrate` 选项会将 `code_prompt` 添加到生成代码前，以对齐函数签名
+- 沙箱环境设置请参阅 [沙箱文档](https://evalscope.readthedocs.io/zh-cn/latest/user_guides/sandbox.html)
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `bigcodebench_hard` |
+| **数据集ID** | [evalscope/bigcodebench-hard](https://modelscope.cn/datasets/evalscope/bigcodebench-hard/summary) |
+| **论文** | N/A |
+| **标签** | `Coding` |
+| **指标** | `acc` |
+| **默认示例数** | 0-shot |
+| **评估划分版本** | `v0.1.4` |
+| **聚合方式** | `mean_and_pass_at_k` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 148 |
+| 提示词长度（平均） | 777.94 字符 |
+| 提示词长度（最小/最大） | 274 / 1816 字符 |
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "207adc46",
+      "content": "Download all files from a specific directory on an FTP server using wget in a subprocess. Args: ftp_server (str): The FTP server address. Default is 'ftp.dlptest.com'. ftp_user (str): The FTP server username. Default is 'dlpuser'. ftp_passwor ... [TRUNCATED 798 chars] ...  FTP server.\nYou should write self-contained code starting with:\n```\nimport subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n```"
+    }
+  ],
+  "target": "    # Attempt to connect to the FTP server\n    try:\n        ftp_obj = ftplib.FTP(ftp_server)\n    except Exception as e:\n        raise Exception(f'Failed to connect to FTP server {ftp_server}: {str(e)}')\n\n    # Attempt to login to the FTP serv ... [TRUNCATED 625 chars] ...        command = f'wget ftp://{ftp_user}:{ftp_password}@{ftp_server}{ftp_dir}/{filename} -P {download_dir}'\n        subprocess.call(command, shell=True)\n        downloaded_files.append(filename)\n\n    ftp_obj.quit()\n    return downloaded_files",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task_id": "BigCodeBench/13",
+    "entry_point": "task_func",
+    "complete_prompt": "import subprocess\nimport ftplib\nimport os\n\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n    \"\"\"\n    Download all files from a specific directory on an FTP serv ... [TRUNCATED 909 chars] ... ctory. Outputs the message \"Failed to change to directory {ftp_dir} on server {ftp_server}: {str(e)}\"\n    \n    Requirements:\n    - subprocess\n    - ftplib\n    - os\n\n    Example:\n    >>> task_func()\n    ['file1.txt', 'file2.jpg', ...]\n    \"\"\"\n",
+    "code_prompt": "import subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n",
+    "test": "import unittest\nfrom unittest.mock import patch\nimport os\nclass TestCases(unittest.TestCase):\n    def setUp(self):\n        \"\"\"Setup a clean test environment before each test.\"\"\"\n        if not os.path.exists(\"downloaded_files\"):\n            o ... [TRUNCATED 2565 chars] ... with self.assertRaises(Exception) as context:\n            task_func(ftp_dir=\"/invalid_directory\")\n        self.assertEqual(str(context.exception), f'Failed to change to directory /invalid_directory on server ftp.dlptest.com: {error_message}')"
+  }
+}
+```
+
+## 提示模板
+
+**提示模板**：
+```text
+{prompt}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `split` | `str` | `instruct` | 评估模式："complete"（文档字符串补全）或 "instruct"（自然语言指令）。可选值：['complete', 'instruct'] |
+| `version` | `str` | `default` | 数据集版本。使用 "default" 表示最新可用版本。 |
+| `calibrate` | `bool` | `True` | 是否在生成代码前添加 `code_prompt` 以对齐函数签名。 |
+
+## 沙箱配置
+
+此基准测试需要沙箱环境来执行代码。
+
+```json
+{
+  "image": "bigcodebench/bigcodebench-evaluate:latest",
+  "tools_config": {
+    "shell_executor": {},
+    "python_executor": {}
+  },
+  "memory_limit": "4g"
+}
+```
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets bigcodebench_hard \
+    --sandbox '{"enabled": true}' \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['bigcodebench_hard'],
+    sandbox={'enabled': True},
+    dataset_args={
+        'bigcodebench_hard': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/llm.md
+++ b/docs/zh/get_started/supported_dataset/llm.md
@@ -20,6 +20,8 @@
 | `bc2gm` | [BC2GM](../../benchmarks/bc2gm.md) | `Knowledge`, `NER` |
 | `bc4chemd` | [BC4CHEMD](../../benchmarks/bc4chemd.md) | `Knowledge`, `NER` |
 | `bc5cdr` | [BC5CDR](../../benchmarks/bc5cdr.md) | `Knowledge`, `NER` |
+| `bigcodebench` | [BigCodeBench](../../benchmarks/bigcodebench.md) | `Coding` |
+| `bigcodebench_hard` | [BigCodeBench-Hard](../../benchmarks/bigcodebench_hard.md) | `Coding` |
 | `biomix_qa` | [BioMixQA](../../benchmarks/biomix_qa.md) | `Knowledge`, `MCQ`, `Medical` |
 | `broad_twitter_corpus` | [BroadTwitterCorpus](../../benchmarks/broad_twitter_corpus.md) | `Knowledge`, `NER` |
 | `ceval` | [C-Eval](../../benchmarks/ceval.md) | `Chinese`, `Knowledge`, `MCQ` |
@@ -138,6 +140,8 @@
 ../../benchmarks/bc2gm.md
 ../../benchmarks/bc4chemd.md
 ../../benchmarks/bc5cdr.md
+../../benchmarks/bigcodebench.md
+../../benchmarks/bigcodebench_hard.md
 ../../benchmarks/biomix_qa.md
 ../../benchmarks/broad_twitter_corpus.md
 ../../benchmarks/ceval.md

--- a/evalscope/api/sandbox/__init__.py
+++ b/evalscope/api/sandbox/__init__.py
@@ -20,7 +20,14 @@ from .config_builder import (
     should_build_docker_image,
 )
 from .engine import SandboxEngine, get_enclave_types, resolve_engine
-from .service import PoolHandle, SandboxHandle, SandboxService, build_and_acquire_pool_sync, get_sandbox_service
+from .service import (
+    PoolHandle,
+    SandboxHandle,
+    SandboxService,
+    build_and_acquire_pool_sync,
+    get_sandbox_service,
+    shutdown_sandbox_service,
+)
 
 __all__ = [
     'PoolHandle',
@@ -35,5 +42,6 @@ __all__ = [
     'get_sandbox_service',
     'merge_sandbox_config_dicts',
     'resolve_engine',
+    'shutdown_sandbox_service',
     'should_build_docker_image',
 ]

--- a/evalscope/api/sandbox/service.py
+++ b/evalscope/api/sandbox/service.py
@@ -271,6 +271,19 @@ def get_sandbox_service() -> SandboxService:
     return _SERVICE
 
 
+def shutdown_sandbox_service() -> None:
+    """Shut down the existing sandbox service without creating one.
+
+    This is safe to call from normal evaluation teardown.  If no sandbox was
+    ever used, the singleton is still ``None`` and the function is a no-op.
+    The atexit hook remains a last-resort fallback for callers that do not
+    perform explicit teardown.
+    """
+    if _SERVICE is None:
+        return
+    _SERVICE.shutdown_all()
+
+
 # ---------------------------------------------------------------------------
 # Convenience helpers used by SandboxMixin / EnclaveAgentEnvironment
 # ---------------------------------------------------------------------------
@@ -302,4 +315,5 @@ __all__ = [
     'SandboxService',
     'build_and_acquire_pool_sync',
     'get_sandbox_service',
+    'shutdown_sandbox_service',
 ]

--- a/evalscope/benchmarks/_meta/bigcodebench.json
+++ b/evalscope/benchmarks/_meta/bigcodebench.json
@@ -1,0 +1,96 @@
+{
+  "meta": {
+    "pretty_name": "BigCodeBench",
+    "dataset_id": "evalscope/bigcodebench",
+    "paper_url": null,
+    "tags": [
+      "Coding"
+    ],
+    "metrics": [
+      "acc"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "v0.1.4",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nBigCodeBench is an easy-to-use benchmark for solving practical and challenging tasks via code. It evaluates the true programming capabilities of large language models (LLMs) in a more realistic setting with diverse function calls from 139 popular libraries covering 723 API calls.\n\n## Task Description\n\n- **Task Type**: Code Generation (Python)\n- **Input**: Programming task description (docstring or natural language instruction)\n- **Output**: Complete Python function implementation\n- **Libraries**: 139 popular Python libraries (numpy, pandas, sklearn, etc.)\n\n## Key Features\n\n- 1,140 rich-context programming tasks in Python\n- Two evaluation modes: Complete (docstring) and Instruct (natural language)\n- Covers diverse function calls from 139 popular libraries\n- Uses unittest.TestCase for thorough correctness verification\n- Supports pass@k metric calculation\n\n## Evaluation Notes\n\n- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed\n- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)\n- Default timeout is 240 seconds per problem\n- `calibrate` option prepends code_prompt to align function signatures\n- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup\n",
+    "prompt_template": "{prompt}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean_and_pass_at_k",
+    "extra_params": {
+      "split": {
+        "type": "str",
+        "description": "Evaluation mode: \"complete\" (docstring completion) or \"instruct\" (NL instruction).",
+        "value": "instruct",
+        "choices": [
+          "complete",
+          "instruct"
+        ]
+      },
+      "version": {
+        "type": "str",
+        "description": "Dataset version. Use \"default\" for the latest available version.",
+        "value": "default"
+      },
+      "calibrate": {
+        "type": "bool",
+        "description": "Whether to prepend code_prompt to the solution for function signature alignment.",
+        "value": true
+      }
+    },
+    "sandbox_config": {
+      "image": "bigcodebench/bigcodebench-evaluate:latest",
+      "tools_config": {
+        "shell_executor": {},
+        "python_executor": {}
+      },
+      "memory_limit": "4g"
+    },
+    "category": "llm"
+  },
+  "statistics": {
+    "total_samples": 0,
+    "subset_stats": [],
+    "prompt_length": {
+      "mean": 0,
+      "min": 0,
+      "max": 0,
+      "std": null
+    },
+    "target_length_mean": null,
+    "computed_at": "2026-06-22T17:16:20.257001"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "657d2473",
+          "content": "Calculates the average of the sums of absolute differences between each pair of consecutive numbers for all permutations of a given list. Each permutation is shuffled before calculating the differences. Args: - numbers (list): A list of numbe ... [TRUNCATED 75 chars] ... loat: The average of the sums of absolute differences for each shuffled permutation of the list.\nYou should write self-contained code starting with:\n```\nimport itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n```"
+        }
+      ],
+      "target": "    permutations = list(itertools.permutations(numbers))\n    sum_diffs = 0\n\n    for perm in permutations:\n        perm = list(perm)\n        shuffle(perm)\n        diffs = [abs(perm[i] - perm[i+1]) for i in range(len(perm)-1)]\n        sum_diffs += sum(diffs)\n\n    avg_sum_diffs = sum_diffs / len(permutations)\n    \n    return avg_sum_diffs",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "task_id": "BigCodeBench/0",
+        "entry_point": "task_func",
+        "complete_prompt": "import itertools\nfrom random import shuffle\n\ndef task_func(numbers=list(range(1, 3))):\n    \"\"\"\n    Calculates the average of the sums of absolute differences between each pair of consecutive numbers \n    for all permutations of a given list.  ... [TRUNCATED 187 chars] ... age of the sums of absolute differences for each shuffled permutation of the list.\n\n    Requirements:\n    - itertools\n    - random.shuffle\n\n    Example:\n    >>> result = task_func([1, 2, 3])\n    >>> isinstance(result, float)\n    True\n    \"\"\"\n",
+        "code_prompt": "import itertools\nfrom random import shuffle\ndef task_func(numbers=list(range(1, 3))):\n",
+        "test": "import unittest\nfrom unittest.mock import patch\nfrom random import seed, shuffle\nimport itertools\nclass TestCases(unittest.TestCase):\n    def test_default_numbers(self):\n        # Test with default number range (1 to 10) to check that the res ... [TRUNCATED 2578 chars] ...  x: seed(1) or shuffle(x)):\n            result1 = task_func([1, 2, 3])\n        with patch('random.shuffle', side_effect=lambda x: seed(1) or shuffle(x)):\n            result2 = task_func([1, 2, 4])\n        self.assertNotEqual(result1, result2)"
+      }
+    },
+    "subset": "default",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# BigCodeBench\n\n\n## Overview\n\nBigCodeBench is an easy-to-use benchmark for solving practical and challenging tasks via code. It evaluates the true programming capabilities of large language models (LLMs) in a more realistic setting with diverse function calls from 139 popular libraries covering 723 API calls.\n\n## Task Description\n\n- **Task Type**: Code Generation (Python)\n- **Input**: Programming task description (docstring or natural language instruction)\n- **Output**: Complete Python function implementation\n- **Libraries**: 139 popular Python libraries (numpy, pandas, sklearn, etc.)\n\n## Key Features\n\n- 1,140 rich-context programming tasks in Python\n- Two evaluation modes: Complete (docstring) and Instruct (natural language)\n- Covers diverse function calls from 139 popular libraries\n- Uses unittest.TestCase for thorough correctness verification\n- Supports pass@k metric calculation\n\n## Evaluation Notes\n\n- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed\n- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)\n- Default timeout is 240 seconds per problem\n- `calibrate` option prepends code_prompt to align function signatures\n- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `bigcodebench` |\n| **Dataset ID** | [evalscope/bigcodebench](https://modelscope.cn/datasets/evalscope/bigcodebench/summary) |\n| **Paper** | N/A |\n| **Tags** | `Coding` |\n| **Metrics** | `acc` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `v0.1.4` |\n| **Aggregation** | `mean_and_pass_at_k` |\n\n\n## Data Statistics\n\n*Statistics not available.*\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"657d2473\",\n      \"content\": \"Calculates the average of the sums of absolute differences between each pair of consecutive numbers for all permutations of a given list. Each permutation is shuffled before calculating the differences. Args: - numbers (list): A list of numbe ... [TRUNCATED 75 chars] ... loat: The average of the sums of absolute differences for each shuffled permutation of the list.\\nYou should write self-contained code starting with:\\n```\\nimport itertools\\nfrom random import shuffle\\ndef task_func(numbers=list(range(1, 3))):\\n```\"\n    }\n  ],\n  \"target\": \"    permutations = list(itertools.permutations(numbers))\\n    sum_diffs = 0\\n\\n    for perm in permutations:\\n        perm = list(perm)\\n        shuffle(perm)\\n        diffs = [abs(perm[i] - perm[i+1]) for i in range(len(perm)-1)]\\n        sum_diffs += sum(diffs)\\n\\n    avg_sum_diffs = sum_diffs / len(permutations)\\n    \\n    return avg_sum_diffs\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task_id\": \"BigCodeBench/0\",\n    \"entry_point\": \"task_func\",\n    \"complete_prompt\": \"import itertools\\nfrom random import shuffle\\n\\ndef task_func(numbers=list(range(1, 3))):\\n    \\\"\\\"\\\"\\n    Calculates the average of the sums of absolute differences between each pair of consecutive numbers \\n    for all permutations of a given list.  ... [TRUNCATED 187 chars] ... age of the sums of absolute differences for each shuffled permutation of the list.\\n\\n    Requirements:\\n    - itertools\\n    - random.shuffle\\n\\n    Example:\\n    >>> result = task_func([1, 2, 3])\\n    >>> isinstance(result, float)\\n    True\\n    \\\"\\\"\\\"\\n\",\n    \"code_prompt\": \"import itertools\\nfrom random import shuffle\\ndef task_func(numbers=list(range(1, 3))):\\n\",\n    \"test\": \"import unittest\\nfrom unittest.mock import patch\\nfrom random import seed, shuffle\\nimport itertools\\nclass TestCases(unittest.TestCase):\\n    def test_default_numbers(self):\\n        # Test with default number range (1 to 10) to check that the res ... [TRUNCATED 2578 chars] ...  x: seed(1) or shuffle(x)):\\n            result1 = task_func([1, 2, 3])\\n        with patch('random.shuffle', side_effect=lambda x: seed(1) or shuffle(x)):\\n            result2 = task_func([1, 2, 4])\\n        self.assertNotEqual(result1, result2)\"\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{prompt}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `split` | `str` | `instruct` | Evaluation mode: \"complete\" (docstring completion) or \"instruct\" (NL instruction). Choices: ['complete', 'instruct'] |\n| `version` | `str` | `default` | Dataset version. Use \"default\" for the latest available version. |\n| `calibrate` | `bool` | `True` | Whether to prepend code_prompt to the solution for function signature alignment. |\n\n## Sandbox Configuration\n\nThis benchmark requires a sandbox environment for code execution.\n\n```json\n{\n  \"image\": \"bigcodebench/bigcodebench-evaluate:latest\",\n  \"tools_config\": {\n    \"shell_executor\": {},\n    \"python_executor\": {}\n  },\n  \"memory_limit\": \"4g\"\n}\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets bigcodebench \\\n    --sandbox '{\"enabled\": true}' \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['bigcodebench'],\n    sandbox={'enabled': True},\n    dataset_args={\n        'bigcodebench': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# BigCodeBench\n\n\n## 概述\n\nBigCodeBench 是一个易于使用的基准测试，用于通过代码解决实际且具有挑战性的任务。它在更贴近现实的场景中评估大语言模型（LLMs）的真实编程能力，涵盖来自 139 个流行库的 723 个 API 调用。\n\n## 任务描述\n\n- **任务类型**：代码生成（Python）\n- **输入**：编程任务描述（文档字符串或自然语言指令）\n- **输出**：完整的 Python 函数实现\n- **涉及库**：139 个流行的 Python 库（如 numpy、pandas、sklearn 等）\n\n## 主要特性\n\n- 包含 1,140 个上下文丰富的 Python 编程任务\n- 提供两种评估模式：Complete（基于文档字符串）和 Instruct（基于自然语言指令）\n- 覆盖来自 139 个流行库的多样化函数调用\n- 使用 `unittest.TestCase` 进行全面的正确性验证\n- 支持 pass@k 指标计算\n\n## 评估说明\n\n- **需要沙箱环境**：要求预装 70+ 个 Python 库的沙箱环境\n- 通过 `split` 参数选择两种模式：`complete`（文档字符串补全）或 `instruct`（自然语言指令）\n- 每个问题默认超时时间为 240 秒\n- 启用 `calibrate` 选项会在生成代码前添加 `code_prompt`，以对齐函数签名\n- 沙箱环境设置详见 [沙箱文档](https://evalscope.readthedocs.io/zh-cn/latest/user_guides/sandbox.html)\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `bigcodebench` |\n| **数据集ID** | [evalscope/bigcodebench](https://modelscope.cn/datasets/evalscope/bigcodebench/summary) |\n| **论文** | N/A |\n| **标签** | `Coding` |\n| **指标** | `acc` |\n| **默认示例数** | 0-shot |\n| **评估划分版本** | `v0.1.4` |\n| **聚合方式** | `mean_and_pass_at_k` |\n\n\n## 数据统计\n\n*统计数据暂不可用。*\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"657d2473\",\n      \"content\": \"Calculates the average of the sums of absolute differences between each pair of consecutive numbers for all permutations of a given list. Each permutation is shuffled before calculating the differences. Args: - numbers (list): A list of numbe ... [TRUNCATED 75 chars] ... loat: The average of the sums of absolute differences for each shuffled permutation of the list.\\nYou should write self-contained code starting with:\\n```\\nimport itertools\\nfrom random import shuffle\\ndef task_func(numbers=list(range(1, 3))):\\n```\"\n    }\n  ],\n  \"target\": \"    permutations = list(itertools.permutations(numbers))\\n    sum_diffs = 0\\n\\n    for perm in permutations:\\n        perm = list(perm)\\n        shuffle(perm)\\n        diffs = [abs(perm[i] - perm[i+1]) for i in range(len(perm)-1)]\\n        sum_diffs += sum(diffs)\\n\\n    avg_sum_diffs = sum_diffs / len(permutations)\\n    \\n    return avg_sum_diffs\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task_id\": \"BigCodeBench/0\",\n    \"entry_point\": \"task_func\",\n    \"complete_prompt\": \"import itertools\\nfrom random import shuffle\\n\\ndef task_func(numbers=list(range(1, 3))):\\n    \\\"\\\"\\\"\\n    Calculates the average of the sums of absolute differences between each pair of consecutive numbers \\n    for all permutations of a given list.  ... [TRUNCATED 187 chars] ... age of the sums of absolute differences for each shuffled permutation of the list.\\n\\n    Requirements:\\n    - itertools\\n    - random.shuffle\\n\\n    Example:\\n    >>> result = task_func([1, 2, 3])\\n    >>> isinstance(result, float)\\n    True\\n    \\\"\\\"\\\"\\n\",\n    \"code_prompt\": \"import itertools\\nfrom random import shuffle\\ndef task_func(numbers=list(range(1, 3))):\\n\",\n    \"test\": \"import unittest\\nfrom unittest.mock import patch\\nfrom random import seed, shuffle\\nimport itertools\\nclass TestCases(unittest.TestCase):\\n    def test_default_numbers(self):\\n        # Test with default number range (1 to 10) to check that the res ... [TRUNCATED 2578 chars] ...  x: seed(1) or shuffle(x)):\\n            result1 = task_func([1, 2, 3])\\n        with patch('random.shuffle', side_effect=lambda x: seed(1) or shuffle(x)):\\n            result2 = task_func([1, 2, 4])\\n        self.assertNotEqual(result1, result2)\"\n  }\n}\n```\n\n## 提示模板\n\n**提示模板：**\n```text\n{prompt}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `split` | `str` | `instruct` | 评估模式：\"complete\"（文档字符串补全）或 \"instruct\"（自然语言指令）。可选值：['complete', 'instruct'] |\n| `version` | `str` | `default` | 数据集版本。使用 \"default\" 表示最新可用版本。 |\n| `calibrate` | `bool` | `True` | 是否在解决方案前添加 `code_prompt` 以对齐函数签名。 |\n\n## 沙箱配置\n\n此基准测试需要沙箱环境来执行代码。\n\n```json\n{\n  \"image\": \"bigcodebench/bigcodebench-evaluate:latest\",\n  \"tools_config\": {\n    \"shell_executor\": {},\n    \"python_executor\": {}\n  },\n  \"memory_limit\": \"4g\"\n}\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets bigcodebench \\\n    --sandbox '{\"enabled\": true}' \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['bigcodebench'],\n    sandbox={'enabled': True},\n    dataset_args={\n        'bigcodebench': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "86a2b4701845ac156c978de01a8aa00d",
+    "needs_translation": false
+  },
+  "updated_at": "2026-06-22T17:16:23.830036",
+  "translation_updated_at": "2026-06-22T17:16:34"
+}

--- a/evalscope/benchmarks/_meta/bigcodebench_hard.json
+++ b/evalscope/benchmarks/_meta/bigcodebench_hard.json
@@ -1,0 +1,106 @@
+{
+  "meta": {
+    "pretty_name": "BigCodeBench-Hard",
+    "dataset_id": "evalscope/bigcodebench-hard",
+    "paper_url": null,
+    "tags": [
+      "Coding"
+    ],
+    "metrics": [
+      "acc"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "v0.1.4",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nBigCodeBench-Hard is a curated subset of BigCodeBench containing 148 tasks that are more aligned with real-world programming tasks. These tasks require more complex reasoning and multi-step problem solving.\n\n## Task Description\n\n- **Task Type**: Code Generation (Python)\n- **Input**: Programming task description (docstring or natural language instruction)\n- **Output**: Complete Python function implementation\n- **Difficulty**: Higher than BigCodeBench-Full, closer to real-world complexity\n\n## Key Features\n\n- 148 challenging tasks selected from BigCodeBench\n- Requires complex reasoning and multi-tool usage\n- Two evaluation modes: Complete (docstring) and Instruct (natural language)\n- Uses unittest.TestCase for thorough correctness verification\n- Supports pass@k metric calculation\n\n## Evaluation Notes\n\n- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed\n- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)\n- Default timeout is 240 seconds per problem\n- `calibrate` option prepends code_prompt to align function signatures\n- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup\n",
+    "prompt_template": "{prompt}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean_and_pass_at_k",
+    "extra_params": {
+      "split": {
+        "type": "str",
+        "description": "Evaluation mode: \"complete\" (docstring completion) or \"instruct\" (NL instruction).",
+        "value": "instruct",
+        "choices": [
+          "complete",
+          "instruct"
+        ]
+      },
+      "version": {
+        "type": "str",
+        "description": "Dataset version. Use \"default\" for the latest available version.",
+        "value": "default"
+      },
+      "calibrate": {
+        "type": "bool",
+        "description": "Whether to prepend code_prompt to the solution for function signature alignment.",
+        "value": true
+      }
+    },
+    "sandbox_config": {
+      "image": "bigcodebench/bigcodebench-evaluate:latest",
+      "tools_config": {
+        "shell_executor": {},
+        "python_executor": {}
+      },
+      "memory_limit": "4g"
+    },
+    "category": "llm"
+  },
+  "statistics": {
+    "total_samples": 148,
+    "subset_stats": [
+      {
+        "name": "default",
+        "sample_count": 148,
+        "prompt_length_mean": 777.94,
+        "prompt_length_min": 274,
+        "prompt_length_max": 1816,
+        "prompt_length_std": 308.48,
+        "target_length_mean": 705.7
+      }
+    ],
+    "prompt_length": {
+      "mean": 777.94,
+      "min": 274,
+      "max": 1816,
+      "std": 308.48
+    },
+    "target_length_mean": 705.7,
+    "computed_at": "2026-06-22T17:16:20.196844"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "207adc46",
+          "content": "Download all files from a specific directory on an FTP server using wget in a subprocess. Args: ftp_server (str): The FTP server address. Default is 'ftp.dlptest.com'. ftp_user (str): The FTP server username. Default is 'dlpuser'. ftp_passwor ... [TRUNCATED 798 chars] ...  FTP server.\nYou should write self-contained code starting with:\n```\nimport subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n```"
+        }
+      ],
+      "target": "    # Attempt to connect to the FTP server\n    try:\n        ftp_obj = ftplib.FTP(ftp_server)\n    except Exception as e:\n        raise Exception(f'Failed to connect to FTP server {ftp_server}: {str(e)}')\n\n    # Attempt to login to the FTP serv ... [TRUNCATED 625 chars] ...        command = f'wget ftp://{ftp_user}:{ftp_password}@{ftp_server}{ftp_dir}/{filename} -P {download_dir}'\n        subprocess.call(command, shell=True)\n        downloaded_files.append(filename)\n\n    ftp_obj.quit()\n    return downloaded_files",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "task_id": "BigCodeBench/13",
+        "entry_point": "task_func",
+        "complete_prompt": "import subprocess\nimport ftplib\nimport os\n\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n    \"\"\"\n    Download all files from a specific directory on an FTP serv ... [TRUNCATED 909 chars] ... ctory. Outputs the message \"Failed to change to directory {ftp_dir} on server {ftp_server}: {str(e)}\"\n    \n    Requirements:\n    - subprocess\n    - ftplib\n    - os\n\n    Example:\n    >>> task_func()\n    ['file1.txt', 'file2.jpg', ...]\n    \"\"\"\n",
+        "code_prompt": "import subprocess\nimport ftplib\nimport os\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\n",
+        "test": "import unittest\nfrom unittest.mock import patch\nimport os\nclass TestCases(unittest.TestCase):\n    def setUp(self):\n        \"\"\"Setup a clean test environment before each test.\"\"\"\n        if not os.path.exists(\"downloaded_files\"):\n            o ... [TRUNCATED 2565 chars] ... with self.assertRaises(Exception) as context:\n            task_func(ftp_dir=\"/invalid_directory\")\n        self.assertEqual(str(context.exception), f'Failed to change to directory /invalid_directory on server ftp.dlptest.com: {error_message}')"
+      }
+    },
+    "subset": "default",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# BigCodeBench-Hard\n\n\n## Overview\n\nBigCodeBench-Hard is a curated subset of BigCodeBench containing 148 tasks that are more aligned with real-world programming tasks. These tasks require more complex reasoning and multi-step problem solving.\n\n## Task Description\n\n- **Task Type**: Code Generation (Python)\n- **Input**: Programming task description (docstring or natural language instruction)\n- **Output**: Complete Python function implementation\n- **Difficulty**: Higher than BigCodeBench-Full, closer to real-world complexity\n\n## Key Features\n\n- 148 challenging tasks selected from BigCodeBench\n- Requires complex reasoning and multi-tool usage\n- Two evaluation modes: Complete (docstring) and Instruct (natural language)\n- Uses unittest.TestCase for thorough correctness verification\n- Supports pass@k metric calculation\n\n## Evaluation Notes\n\n- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed\n- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)\n- Default timeout is 240 seconds per problem\n- `calibrate` option prepends code_prompt to align function signatures\n- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `bigcodebench_hard` |\n| **Dataset ID** | [evalscope/bigcodebench-hard](https://modelscope.cn/datasets/evalscope/bigcodebench-hard/summary) |\n| **Paper** | N/A |\n| **Tags** | `Coding` |\n| **Metrics** | `acc` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `v0.1.4` |\n| **Aggregation** | `mean_and_pass_at_k` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 148 |\n| Prompt Length (Mean) | 777.94 chars |\n| Prompt Length (Min/Max) | 274 / 1816 chars |\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"207adc46\",\n      \"content\": \"Download all files from a specific directory on an FTP server using wget in a subprocess. Args: ftp_server (str): The FTP server address. Default is 'ftp.dlptest.com'. ftp_user (str): The FTP server username. Default is 'dlpuser'. ftp_passwor ... [TRUNCATED 798 chars] ...  FTP server.\\nYou should write self-contained code starting with:\\n```\\nimport subprocess\\nimport ftplib\\nimport os\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n```\"\n    }\n  ],\n  \"target\": \"    # Attempt to connect to the FTP server\\n    try:\\n        ftp_obj = ftplib.FTP(ftp_server)\\n    except Exception as e:\\n        raise Exception(f'Failed to connect to FTP server {ftp_server}: {str(e)}')\\n\\n    # Attempt to login to the FTP serv ... [TRUNCATED 625 chars] ...        command = f'wget ftp://{ftp_user}:{ftp_password}@{ftp_server}{ftp_dir}/{filename} -P {download_dir}'\\n        subprocess.call(command, shell=True)\\n        downloaded_files.append(filename)\\n\\n    ftp_obj.quit()\\n    return downloaded_files\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task_id\": \"BigCodeBench/13\",\n    \"entry_point\": \"task_func\",\n    \"complete_prompt\": \"import subprocess\\nimport ftplib\\nimport os\\n\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n    \\\"\\\"\\\"\\n    Download all files from a specific directory on an FTP serv ... [TRUNCATED 909 chars] ... ctory. Outputs the message \\\"Failed to change to directory {ftp_dir} on server {ftp_server}: {str(e)}\\\"\\n    \\n    Requirements:\\n    - subprocess\\n    - ftplib\\n    - os\\n\\n    Example:\\n    >>> task_func()\\n    ['file1.txt', 'file2.jpg', ...]\\n    \\\"\\\"\\\"\\n\",\n    \"code_prompt\": \"import subprocess\\nimport ftplib\\nimport os\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n\",\n    \"test\": \"import unittest\\nfrom unittest.mock import patch\\nimport os\\nclass TestCases(unittest.TestCase):\\n    def setUp(self):\\n        \\\"\\\"\\\"Setup a clean test environment before each test.\\\"\\\"\\\"\\n        if not os.path.exists(\\\"downloaded_files\\\"):\\n            o ... [TRUNCATED 2565 chars] ... with self.assertRaises(Exception) as context:\\n            task_func(ftp_dir=\\\"/invalid_directory\\\")\\n        self.assertEqual(str(context.exception), f'Failed to change to directory /invalid_directory on server ftp.dlptest.com: {error_message}')\"\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{prompt}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `split` | `str` | `instruct` | Evaluation mode: \"complete\" (docstring completion) or \"instruct\" (NL instruction). Choices: ['complete', 'instruct'] |\n| `version` | `str` | `default` | Dataset version. Use \"default\" for the latest available version. |\n| `calibrate` | `bool` | `True` | Whether to prepend code_prompt to the solution for function signature alignment. |\n\n## Sandbox Configuration\n\nThis benchmark requires a sandbox environment for code execution.\n\n```json\n{\n  \"image\": \"bigcodebench/bigcodebench-evaluate:latest\",\n  \"tools_config\": {\n    \"shell_executor\": {},\n    \"python_executor\": {}\n  },\n  \"memory_limit\": \"4g\"\n}\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets bigcodebench_hard \\\n    --sandbox '{\"enabled\": true}' \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['bigcodebench_hard'],\n    sandbox={'enabled': True},\n    dataset_args={\n        'bigcodebench_hard': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# BigCodeBench-Hard\n\n\n## 概述\n\nBigCodeBench-Hard 是 BigCodeBench 的一个精选子集，包含 148 个更贴近真实编程场景的任务。这些任务需要更复杂的推理能力和多步骤的问题解决能力。\n\n## 任务描述\n\n- **任务类型**：代码生成（Python）\n- **输入**：编程任务描述（文档字符串或自然语言指令）\n- **输出**：完整的 Python 函数实现\n- **难度**：高于 BigCodeBench-Full，更接近真实世界的复杂度\n\n## 主要特性\n\n- 从 BigCodeBench 中精选出的 148 个具有挑战性的任务\n- 要求复杂的推理能力和多工具协同使用\n- 提供两种评估模式：Complete（基于文档字符串）和 Instruct（基于自然语言指令）\n- 使用 `unittest.TestCase` 进行全面的正确性验证\n- 支持 pass@k 指标计算\n\n## 评估说明\n\n- **需要沙箱环境**：要求预装 70 多个 Python 库的沙箱环境\n- 通过 `split` 参数选择两种模式：`complete`（文档字符串补全）或 `instruct`（自然语言指令）\n- 每个问题默认超时时间为 240 秒\n- 启用 `calibrate` 选项会将 `code_prompt` 添加到生成代码前，以对齐函数签名\n- 沙箱环境设置请参阅 [沙箱文档](https://evalscope.readthedocs.io/zh-cn/latest/user_guides/sandbox.html)\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `bigcodebench_hard` |\n| **数据集ID** | [evalscope/bigcodebench-hard](https://modelscope.cn/datasets/evalscope/bigcodebench-hard/summary) |\n| **论文** | N/A |\n| **标签** | `Coding` |\n| **指标** | `acc` |\n| **默认示例数** | 0-shot |\n| **评估划分版本** | `v0.1.4` |\n| **聚合方式** | `mean_and_pass_at_k` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 148 |\n| 提示词长度（平均） | 777.94 字符 |\n| 提示词长度（最小/最大） | 274 / 1816 字符 |\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"207adc46\",\n      \"content\": \"Download all files from a specific directory on an FTP server using wget in a subprocess. Args: ftp_server (str): The FTP server address. Default is 'ftp.dlptest.com'. ftp_user (str): The FTP server username. Default is 'dlpuser'. ftp_passwor ... [TRUNCATED 798 chars] ...  FTP server.\\nYou should write self-contained code starting with:\\n```\\nimport subprocess\\nimport ftplib\\nimport os\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n```\"\n    }\n  ],\n  \"target\": \"    # Attempt to connect to the FTP server\\n    try:\\n        ftp_obj = ftplib.FTP(ftp_server)\\n    except Exception as e:\\n        raise Exception(f'Failed to connect to FTP server {ftp_server}: {str(e)}')\\n\\n    # Attempt to login to the FTP serv ... [TRUNCATED 625 chars] ...        command = f'wget ftp://{ftp_user}:{ftp_password}@{ftp_server}{ftp_dir}/{filename} -P {download_dir}'\\n        subprocess.call(command, shell=True)\\n        downloaded_files.append(filename)\\n\\n    ftp_obj.quit()\\n    return downloaded_files\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task_id\": \"BigCodeBench/13\",\n    \"entry_point\": \"task_func\",\n    \"complete_prompt\": \"import subprocess\\nimport ftplib\\nimport os\\n\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n    \\\"\\\"\\\"\\n    Download all files from a specific directory on an FTP serv ... [TRUNCATED 909 chars] ... ctory. Outputs the message \\\"Failed to change to directory {ftp_dir} on server {ftp_server}: {str(e)}\\\"\\n    \\n    Requirements:\\n    - subprocess\\n    - ftplib\\n    - os\\n\\n    Example:\\n    >>> task_func()\\n    ['file1.txt', 'file2.jpg', ...]\\n    \\\"\\\"\\\"\\n\",\n    \"code_prompt\": \"import subprocess\\nimport ftplib\\nimport os\\ndef task_func(ftp_server='ftp.dlptest.com', ftp_user='dlpuser', ftp_password='rNrKYTX9g7z3RgJRmxWuGHbeu', ftp_dir='/ftp/test'):\\n\",\n    \"test\": \"import unittest\\nfrom unittest.mock import patch\\nimport os\\nclass TestCases(unittest.TestCase):\\n    def setUp(self):\\n        \\\"\\\"\\\"Setup a clean test environment before each test.\\\"\\\"\\\"\\n        if not os.path.exists(\\\"downloaded_files\\\"):\\n            o ... [TRUNCATED 2565 chars] ... with self.assertRaises(Exception) as context:\\n            task_func(ftp_dir=\\\"/invalid_directory\\\")\\n        self.assertEqual(str(context.exception), f'Failed to change to directory /invalid_directory on server ftp.dlptest.com: {error_message}')\"\n  }\n}\n```\n\n## 提示模板\n\n**提示模板**：\n```text\n{prompt}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `split` | `str` | `instruct` | 评估模式：\"complete\"（文档字符串补全）或 \"instruct\"（自然语言指令）。可选值：['complete', 'instruct'] |\n| `version` | `str` | `default` | 数据集版本。使用 \"default\" 表示最新可用版本。 |\n| `calibrate` | `bool` | `True` | 是否在生成代码前添加 `code_prompt` 以对齐函数签名。 |\n\n## 沙箱配置\n\n此基准测试需要沙箱环境来执行代码。\n\n```json\n{\n  \"image\": \"bigcodebench/bigcodebench-evaluate:latest\",\n  \"tools_config\": {\n    \"shell_executor\": {},\n    \"python_executor\": {}\n  },\n  \"memory_limit\": \"4g\"\n}\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets bigcodebench_hard \\\n    --sandbox '{\"enabled\": true}' \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['bigcodebench_hard'],\n    sandbox={'enabled': True},\n    dataset_args={\n        'bigcodebench_hard': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "0414373dbf4c8fc19458129725e06ad8",
+    "needs_translation": false
+  },
+  "updated_at": "2026-06-22T17:16:20.214818",
+  "translation_updated_at": "2026-06-22T17:16:34"
+}

--- a/evalscope/benchmarks/bigcodebench/__init__.py
+++ b/evalscope/benchmarks/bigcodebench/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.

--- a/evalscope/benchmarks/bigcodebench/bigcodebench_adapter.py
+++ b/evalscope/benchmarks/bigcodebench/bigcodebench_adapter.py
@@ -1,0 +1,223 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from typing import Any, Dict
+
+from evalscope.api.benchmark import BenchmarkMeta, DefaultDataAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages.chat_message import ChatMessageUser
+from evalscope.api.metric import Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+DESCRIPTION = """
+## Overview
+
+BigCodeBench is an easy-to-use benchmark for solving practical and challenging tasks via code. It evaluates the true programming capabilities of large language models (LLMs) in a more realistic setting with diverse function calls from 139 popular libraries covering 723 API calls.
+
+## Task Description
+
+- **Task Type**: Code Generation (Python)
+- **Input**: Programming task description (docstring or natural language instruction)
+- **Output**: Complete Python function implementation
+- **Libraries**: 139 popular Python libraries (numpy, pandas, sklearn, etc.)
+
+## Key Features
+
+- 1,140 rich-context programming tasks in Python
+- Two evaluation modes: Complete (docstring) and Instruct (natural language)
+- Covers diverse function calls from 139 popular libraries
+- Uses unittest.TestCase for thorough correctness verification
+- Supports pass@k metric calculation
+
+## Evaluation Notes
+
+- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed
+- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)
+- Default timeout is 240 seconds per problem
+- `calibrate` option prepends code_prompt to align function signatures
+- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup
+"""  # noqa: E501
+
+HARD_DESCRIPTION = """
+## Overview
+
+BigCodeBench-Hard is a curated subset of BigCodeBench containing 148 tasks that are more aligned with real-world programming tasks. These tasks require more complex reasoning and multi-step problem solving.
+
+## Task Description
+
+- **Task Type**: Code Generation (Python)
+- **Input**: Programming task description (docstring or natural language instruction)
+- **Output**: Complete Python function implementation
+- **Difficulty**: Higher than BigCodeBench-Full, closer to real-world complexity
+
+## Key Features
+
+- 148 challenging tasks selected from BigCodeBench
+- Requires complex reasoning and multi-tool usage
+- Two evaluation modes: Complete (docstring) and Instruct (natural language)
+- Uses unittest.TestCase for thorough correctness verification
+- Supports pass@k metric calculation
+
+## Evaluation Notes
+
+- **Sandbox Required**: Requires sandbox environment with 70+ Python libraries pre-installed
+- Two modes available via `split` parameter: `complete` (docstring completion) or `instruct` (NL instruction)
+- Default timeout is 240 seconds per problem
+- `calibrate` option prepends code_prompt to align function signatures
+- See [sandbox documentation](https://evalscope.readthedocs.io/en/latest/user_guides/sandbox.html) for setup
+"""  # noqa: E501
+
+_EXTRA_PARAMS = {
+    'split': {
+        'type': 'str',
+        'description': 'Evaluation mode: "complete" (docstring completion) or "instruct" (NL instruction).',
+        'value': 'instruct',
+        'choices': ['complete', 'instruct']
+    },
+    'version': {
+        'type': 'str',
+        'description': 'Dataset version. Use "default" for the latest available version.',
+        'value': 'default'
+    },
+    'calibrate': {
+        'type': 'bool',
+        'description': 'Whether to prepend code_prompt to the solution for function signature alignment.',
+        'value': True
+    }
+}
+
+_SANDBOX_CONFIG = {
+    'image': 'bigcodebench/bigcodebench-evaluate:latest',
+    'tools_config': {
+        'shell_executor': {},
+        'python_executor': {}
+    },
+    'memory_limit': '4g',
+}
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='bigcodebench',
+        pretty_name='BigCodeBench',
+        tags=[Tags.CODING],
+        description=DESCRIPTION,
+        dataset_id='evalscope/bigcodebench',
+        subset_list=['default'],
+        metric_list=['acc'],
+        aggregation='mean_and_pass_at_k',
+        eval_split='v0.1.4',
+        prompt_template='{prompt}',
+        review_timeout=240,
+        extra_params=_EXTRA_PARAMS,
+        sandbox_config=_SANDBOX_CONFIG,
+    )
+)
+class BigCodeBenchAdapter(DefaultDataAdapter):
+    """
+    BigCodeBench adapter for evaluating code generation with diverse function calls.
+    Supports both 'complete' (docstring-based) and 'instruct' (NL-based) evaluation modes.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._split = self.extra_params.get('split', 'instruct')
+        self._calibrate = self.extra_params.get('calibrate', True)
+        # Dataset uses version-based splits (e.g. v0.1.4), override eval_split if version is specified
+        version = self.extra_params.get('version', 'default')
+        if version != 'default':
+            self.eval_split = version
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        """Convert a data record to a Sample object."""
+        prompt = record[f'{self._split}_prompt']
+
+        return Sample(
+            input=[ChatMessageUser(content=prompt)],
+            target=record['canonical_solution'],
+            metadata={
+                'task_id': record['task_id'],
+                'entry_point': record['entry_point'],
+                'complete_prompt': record['complete_prompt'],
+                'code_prompt': record['code_prompt'],
+                'test': record['test'],
+            }
+        )
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        """Extract code from the prediction."""
+        from evalscope.utils.code_utils import extract_code_from_freeform_completion
+
+        code, _ = extract_code_from_freeform_completion(prediction, 'python', first_block_only=True)
+        if not code.strip():
+            # Fallback: return prediction as-is if extraction fails
+            code = prediction
+        return code
+
+    def match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        """Evaluate the generated code by running unittest in sandbox."""
+        if not self.use_sandbox:
+            raise RuntimeError(
+                f'{self.pretty_name} benchmark requires sandboxed code execution '
+                'due to its 70+ library dependencies. Please enable sandbox in the task configuration.'
+            )
+
+        score = Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+        )
+        problem = task_state.metadata
+        solution = filtered_prediction
+
+        # Calibrate: prepend code_prompt to ensure function signature alignment
+        if self._calibrate:
+            solution = problem['code_prompt'] + '\n    pass\n' + solution
+
+        # Construct full test program: solution + unittest test class
+        check_program = solution + '\n' + problem['test']
+
+        # Execute in sandbox
+        res = self.execute_code_in_sandbox(code=check_program, timeout=self.review_timeout, language='python')
+        passed = res.get('status') == 'success'
+
+        # Set score values
+        score.value = {'acc': passed}
+        score.metadata = {
+            'task_id': problem['task_id'],
+            'timeout': self.review_timeout,
+            'execution_result': res,
+        }
+        score.main_score_name = 'acc'
+
+        return score
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='bigcodebench_hard',
+        pretty_name='BigCodeBench-Hard',
+        tags=[Tags.CODING],
+        description=HARD_DESCRIPTION,
+        dataset_id='evalscope/bigcodebench-hard',
+        subset_list=['default'],
+        metric_list=['acc'],
+        aggregation='mean_and_pass_at_k',
+        eval_split='v0.1.4',
+        prompt_template='{prompt}',
+        review_timeout=240,
+        extra_params=_EXTRA_PARAMS,
+        sandbox_config=_SANDBOX_CONFIG,
+    )
+)
+class BigCodeBenchHardAdapter(BigCodeBenchAdapter):
+    """
+    BigCodeBench-Hard adapter. Inherits all logic from BigCodeBenchAdapter.
+    Uses the curated hard subset (148 tasks) of BigCodeBench.
+    """
+    pass

--- a/evalscope/run.py
+++ b/evalscope/run.py
@@ -37,12 +37,27 @@ def run_single_task(task_cfg: TaskConfig) -> dict:
         result = run_non_native_backend(task_cfg, outputs)
     else:
         logger.info('Running with native backend')
-        result = evaluate_model(task_cfg, outputs)
+        try:
+            result = evaluate_model(task_cfg, outputs)
 
-        logger.info(f'Finished evaluation for {task_cfg.model_id} on {task_cfg.datasets}')
-        logger.info(f'Output directory: {outputs.outputs_dir}')
+            logger.info(f'Finished evaluation for {task_cfg.model_id} on {task_cfg.datasets}')
+            logger.info(f'Output directory: {outputs.outputs_dir}')
+        finally:
+            shutdown_sandbox_service_if_enabled(task_cfg)
 
     return result
+
+
+def shutdown_sandbox_service_if_enabled(task_cfg: TaskConfig) -> None:
+    """Tear down sandbox managers before Python starts interpreter shutdown."""
+    if not task_cfg.sandbox or not task_cfg.sandbox.enabled:
+        return
+
+    try:
+        from evalscope.api.sandbox import shutdown_sandbox_service
+        shutdown_sandbox_service()
+    except Exception as exc:
+        logger.warning(f'Failed to shut down sandbox service: {exc}')
 
 
 def setup_work_directory(task_cfg: TaskConfig):

--- a/tests/agent/test_sandbox_service.py
+++ b/tests/agent/test_sandbox_service.py
@@ -21,8 +21,10 @@ from evalscope.api.sandbox import (
     build_sandbox_config,
     merge_sandbox_config_dicts,
     resolve_engine,
+    shutdown_sandbox_service,
 )
 from evalscope.config import SandboxTaskConfig, TaskConfig
+from evalscope.run import shutdown_sandbox_service_if_enabled
 
 # ===========================================================================
 # Engine resolution
@@ -143,6 +145,43 @@ class TestSandboxServiceCache:
             assert service._managers == {}
 
         asyncio.run(_run())
+
+    def test_shutdown_sandbox_service_noop_when_uncreated(self):
+        from evalscope.api.sandbox import service as service_module
+
+        old_service = service_module._SERVICE
+        try:
+            service_module._SERVICE = None
+            shutdown_sandbox_service()
+        finally:
+            service_module._SERVICE = old_service
+
+    def test_shutdown_sandbox_service_uses_existing_singleton(self):
+        from evalscope.api.sandbox import service as service_module
+
+        fake = MagicMock()
+        old_service = service_module._SERVICE
+        try:
+            service_module._SERVICE = fake
+            shutdown_sandbox_service()
+            fake.shutdown_all.assert_called_once()
+        finally:
+            service_module._SERVICE = old_service
+
+
+class TestSandboxServiceRunTeardown:
+
+    def test_shutdown_skipped_when_sandbox_disabled(self):
+        cfg = TaskConfig()
+        with patch('evalscope.api.sandbox.shutdown_sandbox_service') as shutdown:
+            shutdown_sandbox_service_if_enabled(cfg)
+        shutdown.assert_not_called()
+
+    def test_shutdown_called_when_sandbox_enabled(self):
+        cfg = TaskConfig(sandbox={'enabled': True, 'engine': 'docker'})
+        with patch('evalscope.api.sandbox.shutdown_sandbox_service') as shutdown:
+            shutdown_sandbox_service_if_enabled(cfg)
+        shutdown.assert_called_once_with()
 
 
 # ===========================================================================

--- a/tests/benchmark/test_sandbox.py
+++ b/tests/benchmark/test_sandbox.py
@@ -212,3 +212,33 @@ class TestCodeBenchmark(TestBenchmark):
         ],
         }
         self._run_dataset_test('multiple_humaneval', dataset_args=dataset_args, limit=10, sandbox_type=sandbox_type, use_sandbox=use_sandbox, sandbox_manager_config=sandbox_manager_config)
+
+    def test_bigcodebench(self):
+        """Test BigCodeBench dataset (instruct mode)."""
+        dataset_args = {
+            'extra_params': {
+                'split': 'instruct',
+                'calibrate': True,
+            }
+        }
+        self._run_dataset_test('bigcodebench', dataset_args=dataset_args, limit=5)
+
+    def test_bigcodebench_complete(self):
+        """Test BigCodeBench dataset (complete mode)."""
+        dataset_args = {
+            'extra_params': {
+                'split': 'complete',
+                'calibrate': True,
+            }
+        }
+        self._run_dataset_test('bigcodebench', dataset_args=dataset_args, limit=5)
+
+    def test_bigcodebench_hard(self):
+        """Test BigCodeBench-Hard dataset."""
+        dataset_args = {
+            'extra_params': {
+                'split': 'instruct',
+                'calibrate': True,
+            }
+        }
+        self._run_dataset_test('bigcodebench_hard', dataset_args=dataset_args, limit=5)


### PR DESCRIPTION
## Summary

Add support for BigCodeBench and BigCodeBench-Hard benchmarks with sandbox-based evaluation.

## Changes

- **New benchmark adapter**: `evalscope/benchmarks/bigcodebench/bigcodebench_adapter.py`
  - `bigcodebench`: 1140 Python programming tasks covering 139 libraries / 723 API calls
  - `bigcodebench_hard`: 148 challenging subset tasks
- **Evaluation modes**: `complete` (docstring completion) and `instruct` (NL instruction) via `extra_params.split`
- **Version support**: Dataset versions (v0.1.0_hf ~ v0.1.4) selectable via `extra_params.version`
- **Sandbox execution**: Uses official Docker image `bigcodebench/bigcodebench-evaluate:latest` (70+ pre-installed libs)
- **Calibrate option**: Prepends `code_prompt` to align function signatures before test execution
- **Unit tests**: Added tests for both benchmarks in `tests/benchmark/test_sandbox.py`

## Dataset IDs

- `evalscope/bigcodebench` (full, 1140 tasks)
- `evalscope/bigcodebench-hard` (hard subset, 148 tasks)

## Usage

```python
from evalscope import run_task, TaskConfig

run_task(TaskConfig(
    model='Qwen/Qwen2.5-Coder-7B-Instruct',
    datasets=['bigcodebench'],
    use_sandbox=True,
    dataset_args={
        'bigcodebench': {
            'extra_params': {
                'split': 'instruct',
                'version': 'v0.1.4',
                'calibrate': True,
            }
        }
    },
))
```

## No extra host dependencies required

All 70+ evaluation libraries are provided inside the official Docker sandbox image.

Closes #1369