### PR TITLE
refactor: move run_agent_loop to evalscope.api.agent as public API

### DIFF
--- a/evalscope/agent/runner.py
+++ b/evalscope/agent/runner.py
@@ -13,8 +13,7 @@ per-benchmark overrides.
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
-from evalscope.api.agent import AgentEnvironment, AgentLoopResult
-from evalscope.api.benchmark.adapters._agent_loop_runner import run_agent_loop
+from evalscope.api.agent import AgentEnvironment, AgentLoopResult, run_agent_loop
 from evalscope.api.evaluator import InferenceResult
 from evalscope.api.messages import ChatMessageUser
 from evalscope.api.model import Model

--- a/evalscope/api/agent/__init__.py
+++ b/evalscope/api/agent/__init__.py
@@ -7,6 +7,7 @@ live in ``evalscope/agent``.
 
 from .environment import AgentEnvironment
 from .loop import AgentLoop
+from .runner import run_agent_loop
 from .strategy import AgentStrategy
 from .tool_executor import ToolExecutor, ToolHandler
 from .trace import AgentTrace, AgentTraceEvent, EventType
@@ -36,4 +37,5 @@ __all__ = [
     'ToolExecutor',
     'ToolHandler',
     'ToolSchemaMode',
+    'run_agent_loop',
 ]

--- a/evalscope/api/agent/runner.py
+++ b/evalscope/api/agent/runner.py
@@ -14,16 +14,12 @@ their adapter-specific hooks (e.g.
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from evalscope.api.agent import (
-    AgentContext,
-    AgentEnvironment,
-    AgentLoop,
-    AgentLoopResult,
-    AgentStrategy,
-    AgentTrace,
-    ToolExecutor,
-    ToolHandler,
-)
+from evalscope.api.agent.environment import AgentEnvironment
+from evalscope.api.agent.loop import AgentLoop
+from evalscope.api.agent.strategy import AgentStrategy
+from evalscope.api.agent.tool_executor import ToolExecutor, ToolHandler
+from evalscope.api.agent.trace import AgentTrace
+from evalscope.api.agent.types import AgentContext, AgentLoopResult
 from evalscope.api.messages import ChatMessage
 from evalscope.api.model import Model
 from evalscope.utils.function_utils import AsyncioLoopRunner

--- a/evalscope/api/agent/runner.py
+++ b/evalscope/api/agent/runner.py
@@ -14,19 +14,19 @@ their adapter-specific hooks (e.g.
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from evalscope.api.agent.environment import AgentEnvironment
-from evalscope.api.agent.loop import AgentLoop
-from evalscope.api.agent.strategy import AgentStrategy
-from evalscope.api.agent.tool_executor import ToolExecutor, ToolHandler
-from evalscope.api.agent.trace import AgentTrace
-from evalscope.api.agent.types import AgentContext, AgentLoopResult
 from evalscope.api.messages import ChatMessage
 from evalscope.api.model import Model
 from evalscope.utils.function_utils import AsyncioLoopRunner
 from evalscope.utils.logger import get_logger
+from .environment import AgentEnvironment
+from .loop import AgentLoop
+from .strategy import AgentStrategy
+from .tool_executor import ToolExecutor, ToolHandler
+from .trace import AgentTrace
+from .types import AgentContext, AgentLoopResult
 
 if TYPE_CHECKING:
-    from evalscope.api.agent.mcp import MCPServerConfig
+    from .mcp import MCPServerConfig
 
 logger = get_logger()
 
@@ -78,7 +78,7 @@ def run_agent_loop(
             merged_tools: List[Any] = list(all_tools)
 
             if mcp_configs:
-                from evalscope.api.agent.mcp import resolve_mcp_tools
+                from .mcp import resolve_mcp_tools
 
                 mcp_handler_map, mcp_tool_infos = await resolve_mcp_tools(mcp_configs, mcp_stack)
                 for tool_name, handler in mcp_handler_map.items():

--- a/evalscope/api/benchmark/adapters/agent_loop_adapter.py
+++ b/evalscope/api/benchmark/adapters/agent_loop_adapter.py
@@ -21,13 +21,12 @@ ignored here; agentic benchmarks define their own native harness.
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from evalscope.api.agent import AgentEnvironment, AgentLoopResult, AgentStrategy, ToolHandler
+from evalscope.api.agent import AgentEnvironment, AgentLoopResult, AgentStrategy, ToolHandler, run_agent_loop
 from evalscope.api.dataset import Sample
 from evalscope.api.evaluator import InferenceResult
 from evalscope.api.messages import ChatMessageUser
 from evalscope.api.model import Model
 from evalscope.api.registry import get_strategy
-from ._agent_loop_runner import run_agent_loop
 from .agent_adapter import AgentAdapter
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary

Move `run_agent_loop` from internal module `evalscope/api/benchmark/adapters/_agent_loop_runner.py` to `evalscope/api/agent/runner.py` as a public API.

## Motivation

The underscore-prefixed `_agent_loop_runner.py` was being imported by `evalscope/agent/runner.py` (a cross-package consumer), violating the Python convention that `_`-prefixed modules are package-internal implementation details.

## Changes

- **Move** `_agent_loop_runner.py` → `evalscope/api/agent/runner.py` (semantically belongs with `AgentLoop`, `AgentContext`, etc.)
- **Export** `run_agent_loop` from `evalscope.api.agent.__init__`
- **Update imports** in both consumers:
  - `evalscope/api/benchmark/adapters/agent_loop_adapter.py`
  - `evalscope/agent/runner.py`
- **Delete** the old internal module

## Testing

All related tests pass with no regression:
- `tests/agent/test_agent_loop.py` — 8 passed
- `tests/agent/external/test_agent_loop_external.py` — 2 passed
- `tests/agent/test_t2_environment.py` — 34 passed, 9 skipped
- `tests/benchmark/test_agent_loop.py` — 3 passed (1 pre-existing failure unrelated to this change)