### PR TITLE
fix(perf): tolerate missing completion_tokens in OpenAI usage block

### DIFF
--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -165,9 +165,19 @@ class OpenaiPlugin(DefaultApiPlugin):
             # when stream, the last response is the full usage
             # when non-stream, the last response is the first response
             last_response_js = responses[-1]
-            if 'usage' in last_response_js and last_response_js['usage']:
-                input_tokens = last_response_js['usage']['prompt_tokens']
-                output_tokens = last_response_js['usage']['completion_tokens']
+            usage = last_response_js.get('usage') if isinstance(last_response_js, dict) else None
+            if isinstance(usage, dict) and ('prompt_tokens' in usage or 'completion_tokens' in usage):
+                # Use .get() with safe defaults so a missing or null
+                # `completion_tokens` does not erase a valid `prompt_tokens`,
+                # and vice versa. Some OpenAI-compatible endpoints (e.g.
+                # Vertex AI's Gemini 2.5 reasoning mode) omit
+                # `completion_tokens` from the usage block when `max_tokens`
+                # is reached with only reasoning tokens emitted and no
+                # surface text. Bracket access used to raise KeyError, which
+                # the broad except caught and turned into (0, 0), silently
+                # discarding the valid `prompt_tokens`.
+                input_tokens = usage.get('prompt_tokens') or 0
+                output_tokens = usage.get('completion_tokens') or 0
                 return input_tokens, output_tokens
         except Exception as e:
             logger.error(f'Failed to parse usage from response: {e}. Response: {responses}')

--- a/tests/perf/test_openai_api_parse_responses.py
+++ b/tests/perf/test_openai_api_parse_responses.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``OpenaiPlugin.parse_responses``.
+
+These cover the behavior of the usage-block parsing branch, including
+the cases where an OpenAI-compatible endpoint returns a partial usage
+block (e.g. Vertex AI's Gemini 2.5 reasoning mode omits
+``completion_tokens`` from ``usage`` when ``max_tokens`` is reached
+with only reasoning tokens emitted).
+"""
+import pytest
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.api.openai_api import OpenaiPlugin
+
+
+@pytest.fixture
+def plugin():
+    """Return an ``OpenaiPlugin`` instance with no tokenizer configured.
+
+    Using ``tokenizer_path=None`` lets us assert that the usage-block
+    branch returns directly when ``prompt_tokens`` or
+    ``completion_tokens`` is present, without falling through to the
+    content-based tokenization path (which would raise ``ValueError``
+    because no tokenizer is available).
+    """
+    args = Arguments(model='test-model', api='openai', number=1, parallel=1)
+    return OpenaiPlugin(args)
+
+
+def test_parse_responses_full_usage(plugin):
+    """Standard case: both prompt_tokens and completion_tokens present."""
+    responses = [{'usage': {'prompt_tokens': 100, 'completion_tokens': 50}}]
+    assert plugin.parse_responses(responses) == (100, 50)
+
+
+def test_parse_responses_missing_completion_tokens(plugin):
+    """Vertex Gemini 2.5 reasoning-mode shape: completion_tokens omitted.
+
+    Before this fix, ``KeyError`` on the missing key was caught by the
+    broad ``except`` and the parser returned ``(0, 0)``, silently
+    discarding the valid ``prompt_tokens``.
+    """
+    responses = [{
+        'choices': [{
+            'finish_reason': 'length',
+            'index': 0
+        }],
+        'usage': {
+            'prompt_tokens': 7180,
+            'total_tokens': 7193,
+            'completion_tokens_details': {
+                'reasoning_tokens': 13
+            },
+        },
+    }]
+    assert plugin.parse_responses(responses) == (7180, 0)
+
+
+def test_parse_responses_missing_prompt_tokens(plugin):
+    """Symmetric case: only ``completion_tokens`` is present."""
+    responses = [{'usage': {'completion_tokens': 25}}]
+    assert plugin.parse_responses(responses) == (0, 25)
+
+
+def test_parse_responses_null_completion_tokens(plugin):
+    """``completion_tokens: null`` is treated the same as missing."""
+    responses = [{'usage': {'prompt_tokens': 42, 'completion_tokens': None}}]
+    assert plugin.parse_responses(responses) == (42, 0)
+
+
+def test_parse_responses_explicit_zero_tokens(plugin):
+    """Explicit ``0`` values are returned, not treated as missing.
+
+    Falling through to content-based tokenization here would raise
+    ``ValueError`` when no tokenizer is configured. The
+    ``'prompt_tokens' in usage or 'completion_tokens' in usage`` check
+    guarantees we honor explicit zeros and avoid the fall-through.
+    """
+    responses = [{'usage': {'prompt_tokens': 0, 'completion_tokens': 0}}]
+    assert plugin.parse_responses(responses) == (0, 0)
+
+
+def test_parse_responses_empty_response_list(plugin):
+    """An empty response list returns ``(0, 0)`` (unchanged behavior)."""
+    assert plugin.parse_responses([]) == (0, 0)
+
+
+def test_parse_responses_stream_last_chunk_usage(plugin):
+    """Streaming case: only the final chunk carries the usage block."""
+    responses = [
+        {
+            'choices': [{
+                'delta': {
+                    'content': 'hello'
+                }
+            }]
+        },
+        {
+            'choices': [{
+                'delta': {
+                    'content': ' world'
+                }
+            }]
+        },
+        {
+            'choices': [{
+                'finish_reason': 'stop'
+            }],
+            'usage': {
+                'prompt_tokens': 8,
+                'completion_tokens': 2
+            },
+        },
+    ]
+    assert plugin.parse_responses(responses) == (8, 2)
+
+
+def test_parse_responses_usage_present_but_empty_falls_through(plugin):
+    """An empty usage block (``{}``) should fall through to content parsing.
+
+    With no tokenizer configured and no parseable content, the
+    content-based path raises ``ValueError`` — verifying that the
+    usage-branch did NOT swallow this case and return ``(0, 0)`` (which
+    would mask a missing-tokenizer misconfiguration).
+    """
+    responses = [{'usage': {}}]
+    with pytest.raises(ValueError):
+        plugin.parse_responses(responses, request='{}')


### PR DESCRIPTION
## Problem

`OpenaiPlugin.parse_responses` reads the usage block with bracket access:

```python
input_tokens = last_response_js['usage']['prompt_tokens']
output_tokens = last_response_js['usage']['completion_tokens']
```

When an OpenAI-compatible endpoint returns a successful response with a partial usage block (e.g. `completion_tokens` absent), the `KeyError` is swallowed by the broad `except` and the parser returns `(0, 0)`. The valid `prompt_tokens` is discarded and per-request rows in `benchmark_data.db` record zeros, silently corrupting `avg_input_tokens_per_request` and `input_tok/s`.

Real trigger: Vertex AI's OpenAI-compat endpoint on Gemini 2.5 in reasoning mode. When `max_tokens` is reached with only reasoning tokens emitted, the response omits top-level `completion_tokens`:

```json
{
  "choices": [{"finish_reason": "length", "index": 0}],
  "usage": {
    "prompt_tokens": 7180,
    "total_tokens": 7193,
    "completion_tokens_details": {"reasoning_tokens": 13}
  }
}
```

Same shape can arise from tool-call-only responses and streaming final chunks that report only `finish_reason`.

## Fix

`evalscope/perf/plugin/api/openai_api.py`:

```diff
-            last_response_js = responses[-1]
-            if 'usage' in last_response_js and last_response_js['usage']:
-                input_tokens = last_response_js['usage']['prompt_tokens']
-                output_tokens = last_response_js['usage']['completion_tokens']
-                return input_tokens, output_tokens
+            last_response_js = responses[-1]
+            usage = last_response_js.get('usage') if isinstance(last_response_js, dict) else None
+            if isinstance(usage, dict) and ('prompt_tokens' in usage or 'completion_tokens' in usage):
+                input_tokens = usage.get('prompt_tokens') or 0
+                output_tokens = usage.get('completion_tokens') or 0
+                return input_tokens, output_tokens
```

| Usage shape                                           | Before           | After            |
| ----------------------------------------------------- | ---------------- | ---------------- |
| `{prompt_tokens: P, completion_tokens: C}`            | `(P, C)`         | `(P, C)`         |
| `{prompt_tokens: P}` *(no completion)*                | `(0, 0)` *(bug)* | `(P, 0)`         |
| `{completion_tokens: C}` *(no prompt)*                | `(0, 0)` *(bug)* | `(0, C)`         |
| `{prompt_tokens: P, completion_tokens: null}`         | `(0, 0)` *(bug)* | `(P, 0)`         |
| `{prompt_tokens: 0, completion_tokens: 0}`            | `(0, 0)`         | `(0, 0)`         |
| `{}` *(empty)*, no `usage` key                        | content fallback | content fallback |
| `responses == []`                                     | `(0, 0)`         | `(0, 0)`         |

The membership check `'prompt_tokens' in usage or 'completion_tokens' in usage` (rather than truthiness) is deliberate: when no tokenizer is configured — the common case for closed remote endpoints — the content fallback at `__calculate_tokens_from_content` raises `ValueError`. Falling through on an explicit `(0, 0)` would regress benchmarks that previously returned cleanly. Empty `{}` usage still falls through, which is the correct signal for a misconfiguration.

## Tests

Adds `tests/perf/test_openai_api_parse_responses.py` covering each row of the table above plus streaming last-chunk usage and empty-`usage`-with-no-tokenizer fall-through behavior.

## Validation

End-to-end benchmark run against two live endpoints confirms the fix on the real response shapes the PR is designed to handle.

**Vertex AI Direct — Gemini 2.5 (bug trigger)** — 10 requests, `openqa` dataset, `max_tokens=16`, concurrency=1:

| row | `prompt_tokens` | `completion_tokens` | `usage` has `completion_tokens` key | `finish_reason` |
|-----|-----------------|----------------------|-------------------------------------|-----------------|
| 1   | 15              | 1                    | yes                                 | length          |
| 2   | 24              | 0                    | **no**                              | length          |
| 3   | 20              | 1                    | yes                                 | length          |
| 4   | 13              | 0                    | **no**                              | length          |
| 5   | 22              | 0                    | **no**                              | length          |
| 6   | 21              | 0                    | **no**                              | length          |
| 7   | 33              | 0                    | **no**                              | length          |
| 8   | 31              | 0                    | **no**                              | length          |
| 9   | 12              | 1                    | yes                                 | length          |
| 10  | 27              | 0                    | **no**                              | length          |

7 of 10 responses had no top-level `completion_tokens` key in `usage` (only `completion_tokens_details.reasoning_tokens`). With the patch applied, all 10 rows recorded the correct `prompt_tokens` (12–33). Without the patch, the 7 reasoning-only responses would have been written as `prompt_tokens=0` due to the swallowed `KeyError`, dragging `avg_input_tokens_per_request` down from 21.8 to ~6.4.

**Regression check on a route returning standard responses** — Bifrost (LLM gateway) routing `vertex/gemini-2.5-flash`, same 10 prompts:

All 10 rows had full usage blocks (`completion_tokens` always present). Parsed values matched the underlying usage block 1:1 and the `avg_input_tokens_per_request = 21.8` matched Vertex Direct exactly, confirming no behavior change on responses with complete usage.

Inspected response payloads (pickled in `benchmark_data.db` `result.response_messages`) verified the patched parser is fielding both shapes correctly: reasoning-only responses keep their `prompt_tokens`, and standard responses are unchanged.