### PR TITLE
fix: adapt thinkbench to new ReviewResult format

### DIFF
--- a/docs/en/best_practice/think_eval.md
+++ b/docs/en/best_practice/think_eval.md
@@ -102,15 +102,16 @@ Once we have the model's reasoning results, we can begin evaluating its thinking
     - **`keywords`**: Decompose using marker words (e.g., `alternatively`, `but wait`, `let me reconsider`).
     - **`llm`**: Remove the `\n` markers from the response, use an LLM to rewrite the response, and insert `\n\n` markers for decomposition.
 
-Using `Qwen2.5-72B-Instruct` as the judging model, simply run the following command to start the evaluation and obtain results:
+Using `qwen-max` as the judging model, simply run the following command to start the evaluation and obtain results:
 
 ```python
+import os
 from evalscope.third_party.thinkbench import run_task
 
 judge_config = dict(  # Evaluation service configuration
-    api_key='EMPTY',
-    base_url='http://0.0.0.0:8801/v1',
-    model_name='Qwen2.5-72B-Instruct',
+    api_key=os.getenv('DASHSCOPE_API_KEY'),
+    base_url='https://dashscope.aliyuncs.com/compatible-mode/v1',
+    model_name='qwen-max',
 )
 
 model_config = dict(

--- a/docs/zh/best_practice/think_eval.md
+++ b/docs/zh/best_practice/think_eval.md
@@ -103,15 +103,16 @@ run_task(task_config)
     - **`keywords`**：使用标志词（如`alternatively`、`but wait`、`let me reconsider`）进行分解。
     - **`llm`**：去除回复中的`\n`标志，使用LLM重写回复并插入`\n\n`标志进行分解。
 
-下面以`Qwen2.5-72B-Instruct`作为检测模型进行评估，只需运行以下命令，即可启动评估并获取结果：
+下面以`qwen-max`作为检测模型进行评估，只需运行以下命令，即可启动评估并获取结果：
 
 ```python
+import os
 from evalscope.third_party.thinkbench import run_task
 
 judge_config = dict(  # 评测服务配置
-    api_key='EMPTY',
-    base_url='http://0.0.0.0:8801/v1',
-    model_name='Qwen2.5-72B-Instruct',
+    api_key=os.getenv('DASHSCOPE_API_KEY'),
+    base_url='https://dashscope.aliyuncs.com/compatible-mode/v1',
+    model_name='qwen-max',
 )
 
 model_config = dict(

--- a/evalscope/third_party/thinkbench/eval.py
+++ b/evalscope/third_party/thinkbench/eval.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from modelscope import AutoTokenizer
 from plotly.subplots import make_subplots
 from tqdm.contrib.concurrent import thread_map
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from evalscope.third_party.thinkbench.tools.llm import request_url
 from evalscope.third_party.thinkbench.tools.utils import extract_answer
@@ -16,19 +16,36 @@ from evalscope.utils.io_utils import dict_to_json, dump_jsonl_data, json_to_dict
 
 cur_path = os.path.dirname(os.path.abspath(__file__))
 
+
 class EvalThink:
-    def __init__(self, report_path, tokenizer_path, model_name, dataset_name, subsets, split_strategies='llm', judge_config=None):
+
+    def __init__(
+        self,
+        report_path: str,
+        tokenizer_path: str,
+        model_name: str,
+        dataset_name: str,
+        subsets: List[str],
+        split_strategies: str = 'llm',
+        judge_config: Optional[Dict[str, str]] = None,
+    ):
         self.report_path = report_path
         self.reformat_template = open(os.path.join(cur_path, 'resources/reformat_template.txt'), 'r').read()
         self.critique_template = open(os.path.join(cur_path, 'resources/critique_template.txt'), 'r').read()
-        self.switch_tokens = ['alternatively', 'but wait', 'let me reconsider', 'another way', 'another approach', 'another method', 'another angle']
-        self.subset_dict = defaultdict(lambda: defaultdict(list))
+        self.switch_tokens = [
+            'alternatively', 'but wait', 'let me reconsider',
+            'another way', 'another approach', 'another method', 'another angle',
+        ]
+        self.subset_dict: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
         self.think_end_token = '</think>'
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
         self.model_name = model_name
         self.dataset_name = dataset_name
         self.subsets = subsets
-        self.metrics = ['reasoning_tokens', 'first_correct_tokens', 'reflection_tokens','token_efficiency', 'thought_num', 'accuracy']
+        self.metrics = [
+            'reasoning_tokens', 'first_correct_tokens', 'reflection_tokens',
+            'token_efficiency', 'thought_num', 'accuracy',
+        ]
         self.split_strategies = split_strategies  # split by llm, keywords, separator
         self.judge_config = judge_config
         self.model_parse_file_path = os.path.join(self.report_path, 'answer_index.jsonl')
@@ -36,56 +53,129 @@ class EvalThink:
 
     def __init_parse_file(self):
         if not os.path.exists(self.model_parse_file_path):
-           return {}
+            return {}
         else:
-            list_file =  jsonl_to_list(self.model_parse_file_path)
+            list_file = jsonl_to_list(self.model_parse_file_path)
             # convert to dict prompt as key, answer_index as value
             return {item['prompt']: item['answer_index'] for item in list_file}
 
-    def get_think_part(self, message: dict) -> str:
-        if 'reasoning_content' in message and message['reasoning_content']:
-            return message['reasoning_content']
-        else:
-            text = message['content']
-            last_think_end = text.rfind(self.think_end_token)
-            return text[:last_think_end]
+    def _get_assistant_message(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract the last assistant message from a review item.
+
+        Supports both old format (choices array) and new format (messages list).
+        """
+        # New format: messages is a list of {role, content, ...}
+        if 'messages' in item:
+            messages = item['messages']
+            if isinstance(messages, list):
+                for msg in reversed(messages):
+                    if isinstance(msg, dict) and msg.get('role') == 'assistant':
+                        return msg
+        # Legacy format: choices array
+        if 'choices' in item:
+            choices = item['choices']
+            if isinstance(choices, list) and len(choices) > 0:
+                return choices[0].get('message', {})
+        return {}
+
+    def _get_gold_answer(self, item: Dict[str, Any]) -> str:
+        """Extract the gold/target answer from a review item."""
+        # New format
+        if 'target' in item and item['target'] is not None and not pd.isna(item['target']):
+            return str(item['target'])
+        # Legacy format
+        if 'choices' in item:
+            choices = item['choices']
+            if isinstance(choices, list) and len(choices) > 0:
+                return choices[0].get('review', {}).get('gold', '')
+        return ''
+
+    def _get_problem(self, item: Dict[str, Any]) -> str:
+        """Extract the problem text from a review item."""
+        # Legacy format
+        if 'raw_input' in item and isinstance(item['raw_input'], dict):
+            return item['raw_input'].get('question') or item['raw_input'].get('problem') or ''
+        # New format: first user message content
+        if 'messages' in item and isinstance(item['messages'], list):
+            for msg in item['messages']:
+                if isinstance(msg, dict) and msg.get('role') == 'user':
+                    content = msg.get('content', '')
+                    if isinstance(content, str):
+                        return content
+                    # Handle list-of-blocks format
+                    if isinstance(content, list):
+                        parts = []
+                        for block in content:
+                            if isinstance(block, dict) and block.get('type') == 'text':
+                                parts.append(block.get('text', ''))
+                            elif isinstance(block, str):
+                                parts.append(block)
+                        return '\n'.join(parts)
+        return ''
+
+    def _get_content(self, message: Dict[str, Any]) -> str:
+        """Get text content from a message, handling list-of-blocks format."""
+        content = message.get('content') or ''
+        if isinstance(content, list):
+            # Multimodal format: list of content blocks
+            parts = []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get('type') == 'text':
+                        parts.append(block.get('text') or '')
+                    elif block.get('type') == 'reasoning':
+                        parts.append(block.get('reasoning') or '')
+                elif isinstance(block, str):
+                    parts.append(block)
+            return '\n'.join(parts)
+        return content
+
+    def get_think_part(self, message: Dict[str, Any]) -> str:
+        """Extract the thinking/reasoning portion from an assistant message."""
+        # Check for explicit reasoning_content field
+        reasoning = message.get('reasoning_content') or ''
+        if reasoning:
+            return reasoning
+        # Check for reasoning block in content list
+        content = message.get('content', '')
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get('type') == 'reasoning':
+                    return block.get('reasoning', '')
+        # Fallback: extract text before </think> token
+        text = self._get_content(message)
+        last_think_end = text.rfind(self.think_end_token)
+        if last_think_end == -1:
+            # No think token found, treat entire output as thinking
+            return text
+        return text[:last_think_end]
 
     @lru_cache(maxsize=None)
     def cal_tokens(self, text: str):
         return len(self.tokenizer.encode(text, add_special_tokens=False))
 
-    def process_choice(self, choice, problem):
-        think_part = self.get_think_part(choice['message'])
-        answer = choice['review']['gold']
+    def process_item(self, item: Dict[str, Any]):
+        """Process a single review item and compute thinking efficiency metrics."""
+        problem = self._get_problem(item)
+        assistant_msg = self._get_assistant_message(item)
+        answer = self._get_gold_answer(item)
+
+        think_part = self.get_think_part(assistant_msg)
         tokens = self.cal_tokens(think_part)
         switch_count = sum(think_part.lower().count(token) for token in self.switch_tokens)
         useful_tokens = self.cal_tokens(self.get_first_correct(think_part, problem, answer))
         reflection_tokens = tokens - useful_tokens
-        # score = choice['review']['result']
         score = 0 if useful_tokens == 0 else 1
-        return tokens, switch_count, useful_tokens, reflection_tokens, score
 
-    def process_item(self, item):
-        problem = item['raw_input'].get('question') or item['raw_input'].get('problem') or ''
-        results = []
-        for choice in item['choices']:
-            results.append(self.process_choice(choice, problem))
-            break  # only process the first choice
-
-        total_tokens, switch_counts, useful_tokens, reflection_tokens, scores = zip(*results)
-
-        avg_tokens = sum(total_tokens) / len(total_tokens)
-        avg_thought_num = sum(switch_counts) / len(switch_counts)
-        avg_token_efficiency = sum(useful_tokens) / sum(total_tokens)
-        avg_accuracy = sum(scores) / len(scores)
-        avg_useful_tokens = sum(useful_tokens) / len(useful_tokens)
-        avg_reflection_tokens = sum(reflection_tokens) / len(reflection_tokens)
-        return avg_tokens, avg_thought_num, avg_token_efficiency, avg_accuracy, avg_useful_tokens, avg_reflection_tokens
+        token_efficiency = useful_tokens / tokens if tokens > 0 else 0.0
+        return tokens, switch_count, token_efficiency, score, useful_tokens, reflection_tokens
 
     def split_by_llm(self, response, problem) -> List[str]:
-        response = response.replace('\n', ' ') # remove newline characters
+        response = response.replace('\n', ' ')  # remove newline characters
         prompt = self.reformat_template.format(problem=problem, response=response)
         llm_response = request_url(self.judge_config, prompt)
+        if not llm_response:
+            return [response]
         return llm_response.split('\n\n')
 
     def split_by_keywords(self, text) -> List[str]:
@@ -143,17 +233,16 @@ class EvalThink:
         # Change layout to 2x3
         fig = make_subplots(rows=2, cols=3,
                             subplot_titles=('Reasoning Tokens', 'First Correct Tokens', 'Reflection Tokens',
-                                          'Token Efficiency', 'Thought Num', 'Accuracy'),
+                                            'Token Efficiency', 'Thought Num', 'Accuracy'),
                             shared_xaxes=True, x_title='Subsets',
-                            vertical_spacing=0.1,  # Decrease vertical spacing between subplots
-                            horizontal_spacing=0.1)  # Decrease horizontal spacing between subplots
+                            vertical_spacing=0.1,
+                            horizontal_spacing=0.1)
 
         metrics_order = ['reasoning_tokens', 'first_correct_tokens', 'reflection_tokens',
-                        'token_efficiency', 'thought_num', 'accuracy']
+                         'token_efficiency', 'thought_num', 'accuracy']
 
         for i, metric in enumerate(metrics_order, start=1):
             y_values = [results[metric][subset] for subset in self.subsets]
-            # Determine row and column for 2x3 layout
             row = (i - 1) // 3 + 1
             col = (i - 1) % 3 + 1
             fig.add_trace(
@@ -162,21 +251,17 @@ class EvalThink:
                            name=metric.replace('_', ' ').title()),
                 row=row, col=col
             )
-            # Add annotations for each data point
             for j, y in enumerate(y_values):
                 fig.add_annotation(
-                    x=j,
-                    y=y,
+                    x=j, y=y,
                     text=f'{y:.2f}',
-                    showarrow=False,
-                    yshift=10,
-                    row=row,
-                    col=col
+                    showarrow=False, yshift=10,
+                    row=row, col=col
                 )
 
         fig.update_layout(
-            height=800,  # Adjust height for 2x3 layout
-            width=1200,   # Adjust width for 2x3 layout
+            height=800,
+            width=1200,
             title_text=f'Evaluation Metrics for {self.model_name} on {self.dataset_name}',
             legend=dict(orientation='h', yanchor='bottom', y=1.02, xanchor='right', x=1)
         )
@@ -189,7 +274,7 @@ class EvalThink:
                 tickvals=list(range(len(self.subsets))),
                 row=row, col=col
             )
-            fig.update_yaxes(title_text=metrics_order[i-1].replace('_', ' ').title(), row=row, col=col)
+            fig.update_yaxes(title_text=metrics_order[i - 1].replace('_', ' ').title(), row=row, col=col)
 
         # Update y-axis ranges
         fig.update_yaxes(range=[500, 5000], row=1, col=1)  # Reasoning Tokens
@@ -204,238 +289,169 @@ class EvalThink:
         fig.write_image(output_path)
         print(f'save figure to: {output_path}')
 
+    def filter_df(self, df: pd.DataFrame, response_len: int = 8000, count: int = 10) -> pd.DataFrame:
+        """Filter rows by response token length and return the first `count` rows."""
 
-
-    def filter_df(self, df, response_len: int = 8000, count: int=10):
-        def is_valid_row(row):
-            return all(self.cal_tokens(choice['message']['content']) <= response_len for choice in row['choices'])
+        def is_valid_row(row: Dict[str, Any]) -> bool:
+            # New format: get assistant message content token count
+            if 'messages' in row and isinstance(row['messages'], list):
+                for msg in reversed(row['messages']):
+                    if isinstance(msg, dict) and msg.get('role') == 'assistant':
+                        content = self._get_content(msg)
+                        return self.cal_tokens(content) <= response_len
+                return True
+            # Legacy format: choices array
+            if 'choices' in row and isinstance(row['choices'], list):
+                return all(
+                    self.cal_tokens(choice['message']['content']) <= response_len
+                    for choice in row['choices']
+                )
+            return True
 
         bools = df.apply(is_valid_row, axis=1)
-
         return df[bools].head(count)
 
-
-    def evaluate(self, output_dir, max_tokens=8000, count=50, workers=128):
+    def evaluate(self, output_dir: str, max_tokens: int = 8000, count: int = 50, workers: int = 128):
+        """Run thinking efficiency evaluation across all subsets."""
         for subset in self.subsets:
-            review_path = os.path.join(self.report_path, 'reviews', self.model_name, f'{self.dataset_name}_{subset}.jsonl')
+            review_path = os.path.join(
+                self.report_path, 'reviews', self.model_name, f'{self.dataset_name}_{subset}.jsonl'
+            )
+            if not os.path.exists(review_path):
+                print(f'Warning: Review file not found for subset {subset}: {review_path}, skipping.')
+                continue
             review_df = pd.read_json(review_path, lines=True)
-
             review_df = self.filter_df(review_df, response_len=max_tokens, count=count)
+
+            if len(review_df) == 0:
+                print(f'Warning: No valid samples found for subset {subset}, skipping.')
+                continue
 
             results = thread_map(
                 self.process_item,
                 (item for _, item in review_df.iterrows()),
                 desc=f'Evaluating {subset}',
                 total=len(review_df),
-                max_workers=workers
+                max_workers=workers,
             )
 
-            avg_tokens, avg_thought_num, avg_token_efficiency, avg_accuracy, avg_useful_tokens, avg_reflection_tokens = zip(*results)
+            all_tokens, all_thought_num, all_efficiency, all_accuracy, all_useful, all_reflection = zip(*results)
 
-            self.subset_dict[subset]['reasoning_tokens'] = sum(avg_tokens) / len(avg_tokens)
-            self.subset_dict[subset]['thought_num'] = sum(avg_thought_num) / len(avg_thought_num)
-            self.subset_dict[subset]['token_efficiency'] = sum(avg_token_efficiency) / len(avg_token_efficiency)
-            self.subset_dict[subset]['accuracy'] = sum(avg_accuracy) / len(avg_accuracy)
-            self.subset_dict[subset]['first_correct_tokens'] = sum(avg_useful_tokens) / len(avg_useful_tokens)
-            self.subset_dict[subset]['reflection_tokens'] = sum(avg_reflection_tokens) / len(avg_reflection_tokens)
+            n = len(all_tokens)
+            self.subset_dict[subset]['reasoning_tokens'] = sum(all_tokens) / n
+            self.subset_dict[subset]['thought_num'] = sum(all_thought_num) / n
+            self.subset_dict[subset]['token_efficiency'] = sum(all_efficiency) / n
+            self.subset_dict[subset]['accuracy'] = sum(all_accuracy) / n
+            self.subset_dict[subset]['first_correct_tokens'] = sum(all_useful) / n
+            self.subset_dict[subset]['reflection_tokens'] = sum(all_reflection) / n
 
+        final_results = {
+            metric: {subset: self.subset_dict[subset][metric] for subset in self.subsets}
+            for metric in self.metrics
+        }
 
-        results = {metric: {subset: self.subset_dict[subset][metric] for subset in self.subsets}
-                   for metric in self.metrics}
-
-        self.plot_metrics(results, output_dir)
+        self.plot_metrics(final_results, output_dir)
 
         # save results to json
-        dict_to_json(results, os.path.join(self.report_path, f'think_eval_results.json'))
-        return results
+        dict_to_json(final_results, os.path.join(self.report_path, 'think_eval_results.json'))
+        return final_results
 
-def run_task(config, output_dir='outputs', max_tokens=8000, count=50, workers=128):
-    evaluator = EvalThink(**config,)
+
+def run_task(config: dict, output_dir: str = 'outputs', max_tokens: int = 8000, count: int = 50, workers: int = 128):
+    """Entry point for thinking efficiency evaluation.
+
+    Args:
+        config: Dict with keys: report_path, tokenizer_path, model_name,
+                dataset_name, subsets, split_strategies, judge_config.
+        output_dir: Directory to save output plots.
+        max_tokens: Filter out samples whose response exceeds this token count.
+        count: Number of samples per subset to evaluate.
+        workers: Number of parallel workers for evaluation.
+    """
+    evaluator = EvalThink(**config)
     results = evaluator.evaluate(output_dir, max_tokens, count, workers)
     print(results)
 
+
 def combine_results(configs: List[dict], output_path: str):
-    """
-    Combine evaluation results from multiple model configs into one plot.
-    All models' results for the same metric will be shown in the same subplot for easy comparison.
+    """Combine evaluation results from multiple model configs into one comparison plot.
 
     Args:
-        configs: List of model config dicts containing model_name and report_path
+        configs: List of model config dicts containing model_name and report_path.
+        output_path: Path to save the comparison plot image.
     """
-    # Combine results from different runs
+    if not configs:
+        return {}
     combined_results = defaultdict(lambda: defaultdict(dict))
     for config in configs:
         model_name = config['model_name']
         report_path = config['report_path']
-        # Results is a dict with metric as key and subset as value
-        results = json_to_dict(os.path.join(report_path, f'think_eval_results.json'))
+        results = json_to_dict(os.path.join(report_path, 'think_eval_results.json'))
         combined_results[model_name] = results
 
-    # Create a 2x3 subplot layout, one subplot per metric
-    fig = make_subplots(rows=2, cols=3,
-                       subplot_titles=('Reasoning Tokens', 'First Correct Tokens', 'Reflection Tokens',
-                                     'Token Efficiency', 'Thought Num', 'Accuracy'),
-                       shared_xaxes=True, x_title='Subsets',
-                       vertical_spacing=0.08,  # 减小垂直间距
-                       horizontal_spacing=0.05)  # 减小水平间距
+    fig = make_subplots(
+        rows=2, cols=3,
+        subplot_titles=(
+            'Reasoning Tokens', 'First Correct Tokens', 'Reflection Tokens',
+            'Token Efficiency', 'Thought Num', 'Accuracy',
+        ),
+        shared_xaxes=True, x_title='Subsets',
+        vertical_spacing=0.08,
+        horizontal_spacing=0.05,
+    )
 
-    metrics_order = ['reasoning_tokens', 'first_correct_tokens', 'reflection_tokens',
-                    'token_efficiency', 'thought_num', 'accuracy']
+    metrics_order = [
+        'reasoning_tokens', 'first_correct_tokens', 'reflection_tokens',
+        'token_efficiency', 'thought_num', 'accuracy',
+    ]
 
-    # Assign different colors for each model
     colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b']
 
-    # Plot each metric in a separate subplot
     for i, metric in enumerate(metrics_order, start=1):
         row = (i - 1) // 3 + 1
         col = (i - 1) % 3 + 1
 
-        # Get subsets from first model (assuming all models have same subsets)
         subsets = list(next(iter(combined_results.values()))[metric].keys())
 
-        # Add all models' data for this metric to the same subplot
         for j, (model_name, results) in enumerate(combined_results.items()):
             y_values = [results[metric][subset] for subset in subsets]
 
             fig.add_trace(
-                go.Scatter(x=subsets, y=y_values,
-                          mode='lines+markers',
-                          name=model_name,  # Just model name since metrics are shown in subplot titles
-                          line=dict(color=colors[j % len(colors)]),
-                          showlegend=(i == 1)),  # Only show legend for first metric
-                row=row, col=col
+                go.Scatter(
+                    x=subsets, y=y_values,
+                    mode='lines+markers',
+                    name=model_name,
+                    line=dict(color=colors[j % len(colors)]),
+                    showlegend=(i == 1),
+                ),
+                row=row, col=col,
             )
 
-            # Add value annotations
             for k, y in enumerate(y_values):
                 fig.add_annotation(
-                    x=subsets[k],
-                    y=y,
+                    x=subsets[k], y=y,
                     text=f'{y:.2f}',
-                    showarrow=False,
-                    yshift=10,
+                    showarrow=False, yshift=10,
                     font=dict(size=12, color=colors[j % len(colors)]),
-                    row=row, col=col
+                    row=row, col=col,
                 )
-
-        # Update axis ranges and labels based on metric type
-        # if metric == 'token_efficiency':
-        #     fig.update_yaxes(range=[0.2, 0.7], row=row, col=col)
-        # elif metric == 'accuracy':
-        #     fig.update_yaxes(range=[0.8, 1], row=row, col=col)
 
         fig.update_yaxes(title_text=metric.replace('_', ' ').title(), row=row, col=col)
 
-    # Update layout
     fig.update_layout(
-        height=1000,  # 增加高度
-        width=1500,   # 增加宽度
-        title_text=f'Model Comparison Across Evaluation Metrics on MATH-500',
-        title=dict(font=dict(size=22)),  # 增大标题字号
-        font=dict(size=14),  # 增大整体字号
+        height=1000,
+        width=1500,
+        title_text='Model Comparison Across Evaluation Metrics on MATH-500',
+        title=dict(font=dict(size=22)),
+        font=dict(size=14),
         legend=dict(
-            orientation='h',
-            yanchor='bottom',
-            y=1.02,
-            xanchor='right',
-            x=1,
-            font=dict(size=14)  # 增大图例字号
-        )
+            orientation='h', yanchor='bottom', y=1.02, xanchor='right', x=1,
+            font=dict(size=14),
+        ),
     )
 
-    # Save plot
-    os.makedirs('outputs', exist_ok=True)
+    os.makedirs(os.path.dirname(output_path) or 'outputs', exist_ok=True)
     fig.write_image(output_path)
     print(f'Model comparison plot saved to {output_path}')
 
     return combined_results
-
-judge_config = dict(
-    api_key='EMPTY',
-    base_url='http://0.0.0.0:8801/v1',
-    model_name='Qwen2.5-72B-Instruct',
-)
-
-distill_qwen_config = dict(
-    report_path = '../eval-scope/outputs/20250218_180219',
-    model_name = 'DeepSeek-R1-Distill-Qwen-7B',
-    tokenizer_path = 'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-math_qwen_config = dict(
-    report_path = '../eval-scope/outputs/20250219_202358',
-    model_name = 'Qwen2.5-Math-7B-Instruct',
-    tokenizer_path = 'Qwen/Qwen2.5-Math-7B-Instruct',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-r1_config = dict(
-    report_path = '../eval-scope/outputs/20250307_000404',
-    model_name = 'deepseek-r1',
-    tokenizer_path = 'deepseek-ai/DeepSeek-R1',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-qwq_preview_config = dict(
-    report_path = '../eval-scope/outputs/20250221_105911',
-    model_name = 'qwq-32b-preview',
-    tokenizer_path = 'Qwen/QwQ-32B-Preview',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-qwq_config = dict(
-    report_path = '../eval-scope/outputs/20250306_181550',
-    model_name = 'QwQ-32B',
-    tokenizer_path = 'Qwen/QwQ-32B',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-distill_qwen_32b = dict(
-    report_path = '../eval-scope/outputs/20250306_235951',
-    model_name = 'deepseek-r1-distill-qwen-32b',
-    tokenizer_path = 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-qwen3_32b_think = dict(
-    report_path = '../eval-scope/outputs/20250428_151817',
-    model_name = 'Qwen3-32B',
-    tokenizer_path = 'Qwen/Qwen3-32B',
-    dataset_name = 'math_500',
-    subsets = ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5'],
-    split_strategies='separator',
-    judge_config=judge_config
-)
-
-if __name__ == '__main__':
-    # run_task(distill_qwen_config, count=80)
-    # run_task(math_qwen_config)
-    # run_task(qwq_preview_config, max_tokens=20000, count=200, workers=128)
-    # run_task(r1_config, max_tokens=20000, count=200, workers=128)
-    # run_task(qwq_config, max_tokens=20000, count=200, workers=128)
-    run_task(qwen3_32b_think, max_tokens=20000, count=200, workers=128)
-    # run_task(distill_qwen_32b, max_tokens=20000, count=200, workers=128)
-
-    # combine_results([qwq_config, r1_config, qwq_preview_config,  distill_qwen_32b], output_path='outputs/model_comparison_metrics.png')
-    # combine_results([qwq_config, r1_config, distill_qwen_32b], output_path='outputs/model_comparison_metrics_3models.png')
-    # combine_results([distill_qwen_config, math_qwen_config, qwq_config, r1_config, qwq_preview_config, distill_qwen_32b], output_path='outputs/model_comparison_metrics_6models.png')
-    combine_results([qwq_config, r1_config, distill_qwen_32b, qwen3_32b_think], output_path='outputs/model_comparison_metrics_4models.png')

--- a/evalscope/third_party/thinkbench/tools/llm.py
+++ b/evalscope/third_party/thinkbench/tools/llm.py
@@ -1,8 +1,20 @@
 import os
 from openai import OpenAI
+from typing import Dict, Optional
 
 
-def request_url(llm_config, content):
+def request_url(llm_config: Dict[str, str], content: str) -> Optional[str]:
+    """Send a chat completion request using the provided LLM config.
+
+    Args:
+        llm_config: Dict with keys 'api_key', 'base_url', 'model_name'.
+        content: The user message content to send.
+
+    Returns:
+        The assistant response text, or None on failure.
+    """
+    if not llm_config or not all(k in llm_config for k in ('api_key', 'base_url', 'model_name')):
+        return None
     try:
         client = OpenAI(
             api_key=llm_config['api_key'],
@@ -10,39 +22,29 @@ def request_url(llm_config, content):
         )
         completion = client.chat.completions.create(
             model=llm_config['model_name'],
-            messages=[{'role': 'user', 'content': content}]
+            messages=[{'role': 'user', 'content': content}],
         )
         return completion.choices[0].message.content
     except Exception as e:
         print(e)
         return None
 
-def request_qwen(content):
+
+def request_qwen(content: str) -> Optional[str]:
+    """Send a chat completion request to DashScope qwen-max.
+
+    Requires DASHSCOPE_API_KEY environment variable to be set.
+    """
     try:
         client = OpenAI(
             api_key=os.getenv('DASHSCOPE_API_KEY'),
             base_url='https://dashscope.aliyuncs.com/compatible-mode/v1',
         )
-
         completion = client.chat.completions.create(
             model='qwen-max',
-            messages=[{'role': 'user', 'content': content}]
+            messages=[{'role': 'user', 'content': content}],
         )
         return completion.choices[0].message.content
     except Exception as e:
         print(e)
-
-
-def request_local(content):
-    try:
-        client = OpenAI(
-            api_key='EMPTY',
-            base_url='http://0.0.0.0:8801/v1',
-        )
-        completion = client.chat.completions.create(
-            model='Qwen2.5-72B-Instruct',
-            messages=[{'role': 'user', 'content': content}]
-        )
-        return completion.choices[0].message.content
-    except Exception as e:
-        print(e)
+        return None


### PR DESCRIPTION
## Summary

Fix `KeyError: 'choices'` in thinkbench module when running model thinking efficiency evaluation.

Closes #902

## Root Cause

EvalScope v1.0.0 refactored the review JSONL output format from a legacy `choices` array structure to the new `ReviewResult` format (`messages` + `sample_score`). The thinkbench module was not updated to handle the new format.

## Changes

- **`evalscope/third_party/thinkbench/eval.py`**: Rewrite data parsing logic to support both new and legacy formats. Added helper methods (`_get_assistant_message`, `_get_gold_answer`, `_get_problem`, `_get_content`) for format-agnostic data extraction.
- **`evalscope/third_party/thinkbench/tools/llm.py`**: Remove hardcoded `request_local()` function; add type hints and docstrings.
- **`docs/zh/best_practice/think_eval.md`** & **`docs/en/best_practice/think_eval.md`**: Update judge_config example to use DashScope online API instead of local vllm service.

## Verification

End-to-end tested with DashScope API:
1. Ran model inference on math_500 (Level 1, 5 samples) with `qwen-plus`
2. Ran thinkbench thinking efficiency evaluation with `qwen-max` as judge
3. All metrics computed successfully without errors:
   ```
   {'reasoning_tokens': {'Level 1': 1141.6}, 'token_efficiency': {'Level 1': 0.605}, 'accuracy': {'Level 1': 1.0}}
   ```
