### PR TITLE
(feat) Parallelize CPU-bound perf request generation

### DIFF
--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -187,6 +187,14 @@ class Arguments(BaseArgument):
     in_flight_task_multiplier: int = 2
     """Max scheduled tasks = parallel * this multiplier."""
 
+    request_generation_workers: int = 0
+    """Number of worker processes for CPU-bound request generation.
+
+    Set to 0 for auto-detection based on the current CPU affinity, 1 to force
+    serial generation, or >1 to explicitly choose the worker count. Only
+    dataset plugins that advertise parallel generation use this setting.
+    """
+
     # Logging and debugging
     log_every_n_query: int = 100
     """Log every N queries."""
@@ -430,6 +438,13 @@ class Arguments(BaseArgument):
     def _validate_in_flight_task_multiplier(cls, v):
         return max(v, 1) if v <= 0 else v
 
+    @field_validator('request_generation_workers', mode='after')
+    @classmethod
+    def _validate_request_generation_workers(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError('--request-generation-workers must be >= 0')
+        return v
+
     # --- Model validator (cross-field logic) ---
 
     @model_validator(mode='after')
@@ -611,6 +626,15 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--db-commit-interval', type=int, default=1000, help='Rows buffered before SQLite commit')
     parser.add_argument('--queue-size-multiplier', type=int, default=5, help='Queue maxsize = parallel * multiplier')
     parser.add_argument('--in-flight-task-multiplier', type=int, default=2, help='Max scheduled tasks = parallel * multiplier')  # noqa: E501
+    parser.add_argument(
+        '--request-generation-workers',
+        type=int,
+        default=0,
+        help=(
+            'Worker processes for CPU-bound request generation. '
+            '0=auto from CPU affinity, 1=serial, >1=explicit worker count.'
+        ),
+    )
 
     # Logging and debugging
     parser.add_argument('--log-every-n-query', type=int, default=100, help='Logging every n query')

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -187,8 +187,8 @@ class Arguments(BaseArgument):
     in_flight_task_multiplier: int = 2
     """Max scheduled tasks = parallel * this multiplier."""
 
-    request_generation_workers: int = 0
-    """Number of worker processes for CPU-bound request generation.
+    num_workers: int = 0
+    """Number of worker processes for CPU-bound dataset/request generation.
 
     Set to 0 for auto-detection based on the current CPU affinity, 1 to force
     serial generation, or >1 to explicitly choose the worker count. Only
@@ -438,11 +438,11 @@ class Arguments(BaseArgument):
     def _validate_in_flight_task_multiplier(cls, v):
         return max(v, 1) if v <= 0 else v
 
-    @field_validator('request_generation_workers', mode='after')
+    @field_validator('num_workers', mode='after')
     @classmethod
-    def _validate_request_generation_workers(cls, v: int) -> int:
+    def _validate_num_workers(cls, v: int) -> int:
         if v < 0:
-            raise ValueError('--request-generation-workers must be >= 0')
+            raise ValueError('--num-workers must be >= 0')
         return v
 
     # --- Model validator (cross-field logic) ---
@@ -466,6 +466,13 @@ class Arguments(BaseArgument):
 
         # Validate sweep params (number/parallel/rate consistency)
         self._validate_sweep_params()
+
+        if (
+            self.num_workers == 0 and self.multi_turn_args is not None
+            and 'num_workers' in self.multi_turn_args.model_fields_set
+        ):
+            logger.warning('`multi_turn_args.num_workers` is deprecated. Please use top-level `--num-workers` instead.')
+            self.num_workers = self.multi_turn_args.num_workers
 
         return self
 
@@ -627,11 +634,11 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--queue-size-multiplier', type=int, default=5, help='Queue maxsize = parallel * multiplier')
     parser.add_argument('--in-flight-task-multiplier', type=int, default=2, help='Max scheduled tasks = parallel * multiplier')  # noqa: E501
     parser.add_argument(
-        '--request-generation-workers',
+        '--num-workers',
         type=int,
         default=0,
         help=(
-            'Worker processes for CPU-bound request generation. '
+            'Worker processes for CPU-bound dataset/request generation. '
             '0=auto from CPU affinity, 1=serial, >1=explicit worker count.'
         ),
     )
@@ -753,7 +760,8 @@ def add_argument(parser: argparse.ArgumentParser):
             'Example: \'{"first_turn_length": 65000, "subsequent_turn_length": 500, '
             '"chars_per_token": 3.0}\'. '
             'Note: min_turns and max_turns are top-level --min-turns / --max-turns arguments '
-            '(per-conversation turn count is sampled from [min_turns, max_turns]).'
+            '(per-conversation turn count is sampled from [min_turns, max_turns]); '
+            'use top-level --num-workers for live construction parallelism.'
         ),
     )
     # yapf: enable

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -468,7 +468,7 @@ class Arguments(BaseArgument):
         self._validate_sweep_params()
 
         if (
-            self.num_workers == 0 and self.multi_turn_args is not None
+            'num_workers' not in self.model_fields_set and self.multi_turn_args is not None
             and 'num_workers' in self.multi_turn_args.model_fields_set
         ):
             logger.warning('`multi_turn_args.num_workers` is deprecated. Please use top-level `--num-workers` instead.')
@@ -636,7 +636,7 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument(
         '--num-workers',
         type=int,
-        default=0,
+        default=None,
         help=(
             'Worker processes for CPU-bound dataset/request generation. '
             '0=auto from CPU affinity, 1=serial, >1=explicit worker count.'

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -1,6 +1,5 @@
 import asyncio
 import numpy as np
-import os
 from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, Tuple
 
 from evalscope.perf.arguments import Arguments
@@ -10,6 +9,7 @@ from evalscope.perf.core.strategies import ClosedLoopStrategy, OpenLoopStrategy
 from evalscope.perf.plugin import ApiRegistry, DatasetRegistry
 from evalscope.perf.utils.db_util import load_prompt, summary_result
 from evalscope.perf.utils.handler import exception_handler
+from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 from evalscope.utils.logger import get_logger
 from evalscope.utils.tqdm_utils import TqdmLogging as tqdm
 
@@ -20,37 +20,6 @@ if TYPE_CHECKING:
     from evalscope.perf.utils.workload_timeline import WorkloadThroughput
 
 logger = get_logger()
-
-_MAX_AUTO_REQUEST_GENERATION_WORKERS = 32
-_MIN_AUTO_REQUESTS_PER_WORKER = 64
-
-
-def _available_cpu_count() -> int:
-    """Return the CPU count available to this process."""
-    if hasattr(os, 'sched_getaffinity'):
-        try:
-            return max(1, len(os.sched_getaffinity(0)))
-        except Exception:
-            pass
-    return max(1, os.cpu_count() or 1)
-
-
-def _resolve_request_generation_workers(
-    args: Arguments,
-    total_count: int,
-    supports_parallel_generation: bool,
-) -> int:
-    """Resolve the process count for CPU-bound request generation."""
-    if total_count <= 1 or not supports_parallel_generation:
-        return 1
-
-    configured_workers = args.request_generation_workers
-    if configured_workers == 1:
-        return 1
-    if configured_workers > 1:
-        return min(configured_workers, total_count)
-    amortized_workers = max(1, total_count // _MIN_AUTO_REQUESTS_PER_WORKER)
-    return min(_available_cpu_count(), total_count, _MAX_AUTO_REQUEST_GENERATION_WORKERS, amortized_workers)
 
 
 @exception_handler
@@ -82,18 +51,18 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
         """Generate requests by cycling through a dataset."""
         message_generator = DatasetRegistry.get_class(args.dataset)(args)
         supports_parallel_generation = message_generator.supports_parallel_message_generation()
-        request_generation_workers = _resolve_request_generation_workers(
+        dataset_generation_workers = resolve_dataset_generation_workers(
             args=args,
             total_count=total_count,
             supports_parallel_generation=supports_parallel_generation,
         )
         dataset_messages: List = []
 
-        if request_generation_workers > 1:
-            logger.info(f'Using {request_generation_workers} workers for CPU-bound request generation.')
+        if dataset_generation_workers > 1:
+            logger.info(f'Using {dataset_generation_workers} workers for CPU-bound request generation.')
             dataset_messages = message_generator.build_messages_parallel(
                 total_count=total_count,
-                workers=request_generation_workers,
+                workers=dataset_generation_workers,
             )
         else:
             # Load dataset messages into memory (limited by total_count).

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -1,6 +1,7 @@
 import asyncio
 import numpy as np
-from typing import TYPE_CHECKING, AsyncGenerator, Optional, Tuple
+import os
+from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, Tuple
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.core.http_client import AioHttpClient
@@ -19,6 +20,37 @@ if TYPE_CHECKING:
     from evalscope.perf.utils.workload_timeline import WorkloadThroughput
 
 logger = get_logger()
+
+_MAX_AUTO_REQUEST_GENERATION_WORKERS = 32
+_MIN_AUTO_REQUESTS_PER_WORKER = 64
+
+
+def _available_cpu_count() -> int:
+    """Return the CPU count available to this process."""
+    if hasattr(os, 'sched_getaffinity'):
+        try:
+            return max(1, len(os.sched_getaffinity(0)))
+        except Exception:
+            pass
+    return max(1, os.cpu_count() or 1)
+
+
+def _resolve_request_generation_workers(
+    args: Arguments,
+    total_count: int,
+    supports_parallel_generation: bool,
+) -> int:
+    """Resolve the process count for CPU-bound request generation."""
+    if total_count <= 1 or not supports_parallel_generation:
+        return 1
+
+    configured_workers = args.request_generation_workers
+    if configured_workers == 1:
+        return 1
+    if configured_workers > 1:
+        return min(configured_workers, total_count)
+    amortized_workers = max(1, total_count // _MIN_AUTO_REQUESTS_PER_WORKER)
+    return min(_available_cpu_count(), total_count, _MAX_AUTO_REQUEST_GENERATION_WORKERS, amortized_workers)
 
 
 @exception_handler
@@ -49,20 +81,33 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
     async def _generate_from_dataset():
         """Generate requests by cycling through a dataset."""
         message_generator = DatasetRegistry.get_class(args.dataset)(args)
-        dataset_messages = []
+        supports_parallel_generation = message_generator.supports_parallel_message_generation()
+        request_generation_workers = _resolve_request_generation_workers(
+            args=args,
+            total_count=total_count,
+            supports_parallel_generation=supports_parallel_generation,
+        )
+        dataset_messages: List = []
 
-        # Load dataset messages into memory (limited by total_count).
-        with tqdm(
-            message_generator.build_messages(),
-            desc='Generating[requests]',
-            total=total_count,
-            initial=1,
-            logger=logger
-        ) as pbar:
-            for messages in pbar:
-                dataset_messages.append(messages)
-                if len(dataset_messages) >= total_count:
-                    break
+        if request_generation_workers > 1:
+            logger.info(f'Using {request_generation_workers} workers for CPU-bound request generation.')
+            dataset_messages = message_generator.build_messages_parallel(
+                total_count=total_count,
+                workers=request_generation_workers,
+            )
+        else:
+            # Load dataset messages into memory (limited by total_count).
+            with tqdm(
+                message_generator.build_messages(),
+                desc='Generating[requests]',
+                total=total_count,
+                initial=1,
+                logger=logger
+            ) as pbar:
+                for messages in pbar:
+                    dataset_messages.append(messages)
+                    if len(dataset_messages) >= total_count:
+                        break
 
         if not dataset_messages:
             raise ValueError('Dataset is empty!')

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -50,7 +50,7 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
     async def _generate_from_dataset():
         """Generate requests by cycling through a dataset."""
         message_generator = DatasetRegistry.get_class(args.dataset)(args)
-        supports_parallel_generation = message_generator.supports_parallel_message_generation()
+        supports_parallel_generation = message_generator.supports_parallel_message_generation(total_count)
         dataset_generation_workers = resolve_dataset_generation_workers(
             args=args,
             total_count=total_count,
@@ -70,7 +70,7 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
                 message_generator.build_messages(),
                 desc='Generating[requests]',
                 total=total_count,
-                initial=1,
+                initial=0,
                 logger=logger
             ) as pbar:
                 for messages in pbar:

--- a/evalscope/perf/multi_turn_args.py
+++ b/evalscope/perf/multi_turn_args.py
@@ -49,7 +49,7 @@ class MultiTurnArgs(BaseModel):
     """Estimated characters per token used for pre-filtering when no tokenizer is available."""
 
     num_workers: int = 4
-    """Number of parallel worker processes for live conversation building (>1 uses multiprocessing.Pool)."""
+    """Deprecated. Use top-level ``--num-workers`` for live dataset construction workers."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -63,6 +63,13 @@ class MultiTurnArgs(BaseModel):
                 raise ValueError(f'IntOrRange list min must be <= max, got {v}')
             if v[0] < 0:
                 raise ValueError(f'IntOrRange list values must be >= 0, got {v}')
+        return v
+
+    @field_validator('num_workers', mode='after')
+    @classmethod
+    def _validate_num_workers(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError('multi_turn_args.num_workers must be >= 0')
         return v
 
     def sample_params(self) -> dict:

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -67,7 +67,7 @@ class DatasetPluginBase:
         """
         raise NotImplementedError
 
-    def supports_parallel_message_generation(self) -> bool:
+    def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
         """Return whether this dataset can build messages by independent index chunks."""
         return False
 

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -67,6 +67,19 @@ class DatasetPluginBase:
         """
         raise NotImplementedError
 
+    def supports_parallel_message_generation(self) -> bool:
+        """Return whether this dataset can build messages by independent index chunks."""
+        return False
+
+    def build_messages_parallel(self, total_count: int, workers: int) -> List[Any]:
+        """Build messages using multiple worker processes.
+
+        Dataset plugins should override this only when each output item can be
+        generated independently and then reassembled by index without changing
+        benchmark semantics.
+        """
+        raise NotImplementedError
+
     def dataset_line_by_line(self, dataset: str) -> Iterator[str]:
         """Get content line by line of dataset.
 

--- a/evalscope/perf/plugin/datasets/random_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_dataset.py
@@ -3,9 +3,9 @@ import multiprocessing
 import numpy as np
 import os
 import re
-import sys
-import threading
 from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from multiprocessing.context import BaseContext
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
@@ -17,19 +17,25 @@ from evalscope.utils.tqdm_utils import TqdmLogging as tqdm
 
 logger = get_logger()
 
-_RANDOM_GENERATION_STATE: Dict[str, Any] = {}
-_MIN_AUTO_PARALLEL_PROMPT_LENGTH = 2048
+_RANDOM_GENERATION_WORKER_STATE: Optional['_RandomGenerationWorkerState'] = None
+_MIN_AUTO_PARALLEL_PROMPT_LENGTH = 8192
+_MIN_AUTO_PARALLEL_TOKEN_WORK = 4 * 1024 * 1024
 
 
-def _get_random_generation_context() -> Optional[Any]:
-    """Return a fork context only when it is safe for random request generation."""
-    if os.name != 'posix' or not sys.platform.startswith('linux') or threading.active_count() != 1:
-        return None
+@dataclass
+class _RandomGenerationWorkerState:
+    """Process-local state initialized once per random generation worker."""
 
-    available_methods = multiprocessing.get_all_start_methods()
-    if 'fork' in available_methods:
-        return multiprocessing.get_context('fork')
-    return None
+    tokenizer: Optional[Any]
+    tokenize_prompt: bool
+    apply_chat_template: bool
+    prefix_ids: List[int]
+    allowed_tokens: np.ndarray
+
+
+def _get_random_generation_context() -> BaseContext:
+    """Return the spawn context used for random request generation workers."""
+    return multiprocessing.get_context('spawn')
 
 
 def _init_random_generation_worker(
@@ -37,36 +43,36 @@ def _init_random_generation_worker(
     tokenize_prompt: bool,
     apply_chat_template: bool,
     prefix_ids: List[int],
-    allowed_tokens: List[int],
+    allowed_tokens: np.ndarray,
 ) -> None:
     """Initialize per-process state for random request generation."""
+    global _RANDOM_GENERATION_WORKER_STATE
     os.environ['TOKENIZERS_PARALLELISM'] = 'false'
-    existing_allowed_tokens = _RANDOM_GENERATION_STATE.get('allowed_tokens')
-    existing_prefix_ids = _RANDOM_GENERATION_STATE.get('prefix_ids')
     tokenizer = None if tokenize_prompt else load_tokenizer(tokenizer_path)
-    _RANDOM_GENERATION_STATE.clear()
-    _RANDOM_GENERATION_STATE.update({
-        'tokenizer': tokenizer,
-        'tokenize_prompt': tokenize_prompt,
-        'apply_chat_template': apply_chat_template,
-        'prefix_ids': existing_prefix_ids if existing_prefix_ids is not None else prefix_ids,
-        'allowed_tokens': (
-            existing_allowed_tokens if existing_allowed_tokens is not None else np.asarray(allowed_tokens)
-        ),
-    })
+    _RANDOM_GENERATION_WORKER_STATE = _RandomGenerationWorkerState(
+        tokenizer=tokenizer,
+        tokenize_prompt=tokenize_prompt,
+        apply_chat_template=apply_chat_template,
+        prefix_ids=prefix_ids,
+        allowed_tokens=np.asarray(allowed_tokens),
+    )
 
 
 def _build_random_message_worker(
     task: Tuple[int, int, int, Optional[int]],
 ) -> Tuple[int, Union[List[Dict], List[int], str], int]:
     """Build one random message from an index-level generation task."""
+    if _RANDOM_GENERATION_WORKER_STATE is None:
+        raise RuntimeError('Random request generation worker state is not initialized.')
+
     index, input_len, offset, seed = task
-    allowed_tokens = _RANDOM_GENERATION_STATE['allowed_tokens']
-    prefix_ids = _RANDOM_GENERATION_STATE['prefix_ids']
+    state = _RANDOM_GENERATION_WORKER_STATE
+    allowed_tokens = state.allowed_tokens
+    prefix_ids = state.prefix_ids
     inner_seq = allowed_tokens[(offset + index + np.arange(input_len)) % len(allowed_tokens)].tolist()
     token_sequence = prefix_ids + inner_seq
 
-    if _RANDOM_GENERATION_STATE['tokenize_prompt']:
+    if state.tokenize_prompt:
         return index, token_sequence, 0
 
     if seed is None:
@@ -74,7 +80,7 @@ def _build_random_message_worker(
     np.random.seed(seed)
     target_token_len = len(prefix_ids) + int(input_len)
     prompt, adjusted_token_sequence, token_mismatch = gen_prompt_decode_to_target_len(
-        tokenizer=_RANDOM_GENERATION_STATE['tokenizer'],
+        tokenizer=state.tokenizer,
         token_sequence=token_sequence,
         target_token_len=target_token_len,
         add_special_tokens=False,
@@ -83,7 +89,7 @@ def _build_random_message_worker(
     if len(adjusted_token_sequence) != target_token_len:
         token_mismatch = len(adjusted_token_sequence) - target_token_len
 
-    if _RANDOM_GENERATION_STATE['apply_chat_template']:
+    if state.apply_chat_template:
         return index, [{'role': 'user', 'content': prompt}], token_mismatch
     return index, prompt, token_mismatch
 
@@ -124,8 +130,11 @@ class RandomDatasetPlugin(DatasetPluginBase):
     def build_messages(self) -> Iterator[Union[List[Dict], List[int], str]]:
         """Yield prompts as text messages or, when --tokenize-prompt is set, as raw
         token-ID lists that bypass the decode/re-encode round-trip entirely."""
-        plan = self._create_generation_plan(self.number, include_seeds=not self.query_parameters.tokenize_prompt)
+        yield from self._build_messages_for_count(self.number)
 
+    def _build_messages_for_count(self, total_count: int) -> Iterator[Union[List[Dict], List[int], str]]:
+        """Yield random prompts for a fixed item count."""
+        plan = self._create_generation_plan(total_count, include_seeds=not self.query_parameters.tokenize_prompt)
         token_mismatch_total = 0
         for index, input_len, offset, seed in self._iter_generation_plan(plan):
             message, token_mismatch = self._build_random_message(input_len, offset, index, seed)
@@ -136,81 +145,55 @@ class RandomDatasetPlugin(DatasetPluginBase):
 
     def supports_parallel_message_generation(self) -> bool:
         """Random prompts are independent by index and can be generated in worker processes."""
-        if _get_random_generation_context() is None:
-            if self.query_parameters.request_generation_workers > 1:
-                logger.warning(
-                    'Parallel random request generation requires a fork-safe Linux single-thread context; '
-                    'falling back to serial request generation.'
-                )
-            return False
-        if self.query_parameters.request_generation_workers > 1:
+        if self.query_parameters.num_workers > 1:
             return True
         if self.query_parameters.tokenize_prompt:
             return False
         prompt_length_estimate = (
             self.query_parameters.min_prompt_length + self.query_parameters.max_prompt_length
         ) // 2
-        return prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
+        token_work_estimate = prompt_length_estimate * self.number
+        return (
+            prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
+            and token_work_estimate >= _MIN_AUTO_PARALLEL_TOKEN_WORK
+        )
 
     def build_messages_parallel(self, total_count: int, workers: int) -> List[Union[List[Dict], List[int], str]]:
         """Build random request messages across multiple worker processes."""
         if total_count <= 0:
             return []
 
-        self.number = total_count
         workers = max(1, min(workers, total_count))
         if workers == 1:
-            return list(self.build_messages())
+            return list(self._build_messages_for_count(total_count))
 
         process_context = _get_random_generation_context()
-        if process_context is None:
-            logger.warning(
-                'Parallel random request generation requires a fork-safe Linux single-thread context; '
-                'falling back to serial request generation.'
-            )
-            return list(self.build_messages())
-
         plan = self._create_generation_plan(total_count, include_seeds=not self.query_parameters.tokenize_prompt)
         messages: List[Union[List[Dict], List[int], str, None]] = [None] * total_count
         token_mismatch_total = 0
         chunk_size = max(1, min(64, math.ceil(total_count / (workers * 8))))
 
-        _RANDOM_GENERATION_STATE.clear()
-        _RANDOM_GENERATION_STATE.update({
-            'tokenizer': None,
-            'tokenize_prompt': self.query_parameters.tokenize_prompt,
-            'apply_chat_template': self.query_parameters.apply_chat_template,
-            'prefix_ids': self.prefix_ids,
-            'allowed_tokens': self.allowed_tokens,
-        })
-        use_copy_on_write_state = (process_context is not None and process_context.get_start_method() == 'fork')
-        prefix_ids = [] if use_copy_on_write_state else self.prefix_ids
-        allowed_tokens = [] if use_copy_on_write_state else self.allowed_tokens.tolist()
-
-        try:
-            with tqdm(total=total_count, desc='Generating[requests]', logger=logger) as pbar:
-                with ProcessPoolExecutor(
-                    max_workers=workers,
-                    mp_context=process_context,
-                    initializer=_init_random_generation_worker,
-                    initargs=(
-                        self.query_parameters.tokenizer_path,
-                        self.query_parameters.tokenize_prompt,
-                        self.query_parameters.apply_chat_template,
-                        prefix_ids,
-                        allowed_tokens,
-                    ),
-                ) as executor:
-                    for index, message, token_mismatch in executor.map(
-                        _build_random_message_worker,
-                        self._iter_generation_plan(plan),
-                        chunksize=chunk_size,
-                    ):
-                        messages[index] = message
-                        token_mismatch_total += token_mismatch
-                        pbar.update(1)
-        finally:
-            _RANDOM_GENERATION_STATE.clear()
+        with tqdm(total=total_count, desc='Generating[requests]', logger=logger) as pbar:
+            with ProcessPoolExecutor(
+                max_workers=workers,
+                mp_context=process_context,
+                initializer=_init_random_generation_worker,
+                initargs=(
+                    self.query_parameters.tokenizer_path,
+                    self.query_parameters.tokenize_prompt,
+                    self.query_parameters.apply_chat_template,
+                    self.prefix_ids,
+                    self.allowed_tokens,
+                ),
+            ) as executor:
+                for index, message, token_mismatch in executor.map(
+                    _build_random_message_worker,
+                    self._iter_generation_plan(plan),
+                    chunksize=chunk_size,
+                ):
+                    messages[index] = message
+                    token_mismatch_total += token_mismatch
+                    pbar.update(1)
 
         missing = [index for index, message in enumerate(messages) if message is None]
         if missing:

--- a/evalscope/perf/plugin/datasets/random_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_dataset.py
@@ -58,6 +58,18 @@ def _init_random_generation_worker(
     )
 
 
+def _assemble_token_sequence(
+    allowed_tokens: np.ndarray,
+    prefix_ids: List[int],
+    offset: int,
+    index: int,
+    input_len: int,
+) -> List[int]:
+    """Build the raw token-ID list for one random prompt."""
+    inner_seq = allowed_tokens[(offset + index + np.arange(input_len)) % len(allowed_tokens)].tolist()
+    return prefix_ids + inner_seq
+
+
 def _build_random_message_worker(
     task: Tuple[int, int, int, Optional[int]],
 ) -> Tuple[int, Union[List[Dict], List[int], str], int]:
@@ -69,8 +81,7 @@ def _build_random_message_worker(
     state = _RANDOM_GENERATION_WORKER_STATE
     allowed_tokens = state.allowed_tokens
     prefix_ids = state.prefix_ids
-    inner_seq = allowed_tokens[(offset + index + np.arange(input_len)) % len(allowed_tokens)].tolist()
-    token_sequence = prefix_ids + inner_seq
+    token_sequence = _assemble_token_sequence(allowed_tokens, prefix_ids, offset, index, input_len)
 
     if state.tokenize_prompt:
         return index, token_sequence, 0
@@ -79,16 +90,13 @@ def _build_random_message_worker(
         raise ValueError('Parallel random request generation requires a per-item seed.')
     np.random.seed(seed)
     target_token_len = len(prefix_ids) + int(input_len)
-    prompt, adjusted_token_sequence, token_mismatch = gen_prompt_decode_to_target_len(
+    prompt, _, token_mismatch = gen_prompt_decode_to_target_len(
         tokenizer=state.tokenizer,
         token_sequence=token_sequence,
         target_token_len=target_token_len,
         add_special_tokens=False,
         allowed_tokens=allowed_tokens,
     )
-    if len(adjusted_token_sequence) != target_token_len:
-        token_mismatch = len(adjusted_token_sequence) - target_token_len
-
     if state.apply_chat_template:
         return index, [{'role': 'user', 'content': prompt}], token_mismatch
     return index, prompt, token_mismatch
@@ -107,7 +115,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
         self.prefix_length = self.query_parameters.prefix_length
         # Include warmup_count so the generator produces enough unique items
         # to cover both warmup and benchmark requests without cycling reuse.
-        self.number = self.query_parameters.total_count or 1
+        self.number = self.query_parameters.total_count
 
         # Filter out special tokens and byte-fallback tokens from vocabulary.
         # Byte-fallback tokens (e.g. <0xE4>) are NOT in all_special_ids but decode to
@@ -143,16 +151,17 @@ class RandomDatasetPlugin(DatasetPluginBase):
 
         self._log_token_mismatch(token_mismatch_total)
 
-    def supports_parallel_message_generation(self) -> bool:
+    def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
         """Random prompts are independent by index and can be generated in worker processes."""
         if self.query_parameters.num_workers > 1:
             return True
         if self.query_parameters.tokenize_prompt:
             return False
+        count = self.number if total_count is None else total_count
         prompt_length_estimate = (
             self.query_parameters.min_prompt_length + self.query_parameters.max_prompt_length
         ) // 2
-        token_work_estimate = prompt_length_estimate * self.number
+        token_work_estimate = prompt_length_estimate * count
         return (
             prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
             and token_work_estimate >= _MIN_AUTO_PARALLEL_TOKEN_WORK
@@ -200,7 +209,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
             raise RuntimeError(f'Parallel random request generation missed {len(missing)} items.')
 
         self._log_token_mismatch(token_mismatch_total)
-        return [message for message in messages if message is not None]
+        return messages
 
     def _resolve_prompt_length_bounds(self) -> Tuple[int, int]:
         """Resolve the random prompt length sampling interval."""
@@ -306,8 +315,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
         The result is intended to be sent directly as `prompt=[int, ...]` to the
         /v1/completions endpoint via the --tokenize-prompt path.
         """
-        inner_seq = self.allowed_tokens[(offset + index + np.arange(input_len)) % len(self.allowed_tokens)].tolist()
-        return self.prefix_ids + inner_seq
+        return _assemble_token_sequence(self.allowed_tokens, self.prefix_ids, offset, index, input_len)
 
     def generate_token_sequence(
         self,
@@ -321,10 +329,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
         Uses a deterministic sequence based on offset and index to ensure reproducibility,
         then decodes and re-encodes to handle tokenizer inconsistencies.
         """
-        # Build the inner sequence by sampling sequentially from allowed tokens
-        inner_seq = self.allowed_tokens[(offset + index + np.arange(input_len)) % len(self.allowed_tokens)].tolist()
-        token_sequence = self.prefix_ids + inner_seq
-
+        token_sequence = _assemble_token_sequence(self.allowed_tokens, self.prefix_ids, offset, index, input_len)
         # Decode, then re-encode with retry logic to match target length
         total_input_len = self.prefix_length + int(input_len)
         prompt, adjusted_token_sequence, token_mismatch = gen_prompt_decode_to_target_len(

--- a/evalscope/perf/plugin/datasets/random_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_dataset.py
@@ -70,36 +70,80 @@ def _assemble_token_sequence(
     return prefix_ids + inner_seq
 
 
+def _build_one_random_message(
+    tokenizer: Optional[Any],
+    allowed_tokens: np.ndarray,
+    prefix_ids: List[int],
+    tokenize_prompt: bool,
+    apply_chat_template: bool,
+    input_len: int,
+    offset: int,
+    index: int,
+    seed: Optional[int] = None,
+) -> Tuple[Union[List[Dict], List[int], str], int]:
+    """Build one random message (shared by serial and worker paths).
+
+    This is a pure function that does not depend on instance or global state
+    so that both the in-process serial path and spawned worker processes can
+    call it without code duplication.
+    """
+    token_sequence = _assemble_token_sequence(allowed_tokens, prefix_ids, offset, index, input_len)
+
+    if tokenize_prompt:
+        return token_sequence, 0
+
+    target_token_len = len(prefix_ids) + int(input_len)
+
+    if seed is not None:
+        random_state = np.random.get_state()
+        np.random.seed(seed)
+        try:
+            prompt, _, token_mismatch = gen_prompt_decode_to_target_len(
+                tokenizer=tokenizer,
+                token_sequence=token_sequence,
+                target_token_len=target_token_len,
+                add_special_tokens=False,
+                allowed_tokens=allowed_tokens,
+            )
+        finally:
+            np.random.set_state(random_state)
+    else:
+        prompt, _, token_mismatch = gen_prompt_decode_to_target_len(
+            tokenizer=tokenizer,
+            token_sequence=token_sequence,
+            target_token_len=target_token_len,
+            add_special_tokens=False,
+            allowed_tokens=allowed_tokens,
+        )
+
+    if apply_chat_template:
+        return [{'role': 'user', 'content': prompt}], token_mismatch
+    return prompt, token_mismatch
+
+
 def _build_random_message_worker(
     task: Tuple[int, int, int, Optional[int]],
 ) -> Tuple[int, Union[List[Dict], List[int], str], int]:
-    """Build one random message from an index-level generation task."""
+    """Worker entry point: unpack task tuple and delegate to shared builder."""
     if _RANDOM_GENERATION_WORKER_STATE is None:
         raise RuntimeError('Random request generation worker state is not initialized.')
 
     index, input_len, offset, seed = task
     state = _RANDOM_GENERATION_WORKER_STATE
-    allowed_tokens = state.allowed_tokens
-    prefix_ids = state.prefix_ids
-    token_sequence = _assemble_token_sequence(allowed_tokens, prefix_ids, offset, index, input_len)
-
-    if state.tokenize_prompt:
-        return index, token_sequence, 0
-
-    if seed is None:
+    if seed is None and not state.tokenize_prompt:
         raise ValueError('Parallel random request generation requires a per-item seed.')
-    np.random.seed(seed)
-    target_token_len = len(prefix_ids) + int(input_len)
-    prompt, _, token_mismatch = gen_prompt_decode_to_target_len(
+    message, token_mismatch = _build_one_random_message(
         tokenizer=state.tokenizer,
-        token_sequence=token_sequence,
-        target_token_len=target_token_len,
-        add_special_tokens=False,
-        allowed_tokens=allowed_tokens,
+        allowed_tokens=state.allowed_tokens,
+        prefix_ids=state.prefix_ids,
+        tokenize_prompt=state.tokenize_prompt,
+        apply_chat_template=state.apply_chat_template,
+        input_len=input_len,
+        offset=offset,
+        index=index,
+        seed=seed,
     )
-    if state.apply_chat_template:
-        return index, [{'role': 'user', 'content': prompt}], token_mismatch
-    return index, prompt, token_mismatch
+    return index, message, token_mismatch
 
 
 @register_dataset('random')
@@ -152,7 +196,15 @@ class RandomDatasetPlugin(DatasetPluginBase):
         self._log_token_mismatch(token_mismatch_total)
 
     def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
-        """Random prompts are independent by index and can be generated in worker processes."""
+        """Random prompts are independent by index and can be generated in worker processes.
+
+        Args:
+            total_count: Override for the item count used in auto-parallel heuristics.
+                When ``None``, falls back to ``self.number`` (the value set at
+                ``__init__`` time).  The caller in ``benchmark.py`` always passes
+                the resolved ``total_count`` explicitly; the default exists for
+                convenient use in tests and standalone scripts.
+        """
         if self.query_parameters.num_workers > 1:
             return True
         if self.query_parameters.tokenize_prompt:
@@ -172,6 +224,8 @@ class RandomDatasetPlugin(DatasetPluginBase):
         if total_count <= 0:
             return []
 
+        # Defensive guard: benchmark.py already ensures workers > 1 before
+        # calling this method, but direct callers may pass any value.
         workers = max(1, min(workers, total_count))
         if workers == 1:
             return list(self._build_messages_for_count(total_count))
@@ -264,33 +318,22 @@ class RandomDatasetPlugin(DatasetPluginBase):
         index: int,
         seed: Optional[int] = None,
     ) -> Tuple[Union[List[Dict], List[int], str], int]:
-        """Build one random message in the current process."""
-        if self.query_parameters.tokenize_prompt:
-            token_ids = self.generate_token_ids_only(input_len=input_len, offset=offset, index=index)
-            return token_ids, 0
+        """Build one random message in the current process.
 
-        if seed is None:
-            prompt, _, token_mismatch = self.generate_token_sequence(
-                input_len=input_len,
-                offset=offset,
-                index=index,
-            )
-        else:
-            random_state = np.random.get_state()
-            np.random.seed(seed)
-            try:
-                prompt, _, token_mismatch = self.generate_token_sequence(
-                    input_len=input_len,
-                    offset=offset,
-                    index=index,
-                )
-            finally:
-                np.random.set_state(random_state)
-
-        if self.query_parameters.apply_chat_template:
-            message = self.create_message(prompt)
-            return [message], token_mismatch
-        return prompt, token_mismatch
+        Delegates to the shared pure function ``_build_one_random_message`` so
+        that serial and parallel paths share identical generation logic.
+        """
+        return _build_one_random_message(
+            tokenizer=self.tokenizer,
+            allowed_tokens=self.allowed_tokens,
+            prefix_ids=self.prefix_ids,
+            tokenize_prompt=self.query_parameters.tokenize_prompt,
+            apply_chat_template=self.query_parameters.apply_chat_template,
+            input_len=input_len,
+            offset=offset,
+            index=index,
+            seed=seed,
+        )
 
     def _log_token_mismatch(self, token_mismatch_total: int) -> None:
         """Log aggregate token mismatch from decode/re-encode prompt generation."""

--- a/evalscope/perf/plugin/datasets/random_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_dataset.py
@@ -1,14 +1,91 @@
+import math
+import multiprocessing
 import numpy as np
+import os
 import re
-from typing import Dict, Iterator, List, Tuple, Union
+import sys
+import threading
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
-from evalscope.perf.plugin.datasets.utils import gen_prompt_decode_to_target_len, tokenize_chat_messages
+from evalscope.perf.plugin.datasets.utils import gen_prompt_decode_to_target_len, load_tokenizer, tokenize_chat_messages
 from evalscope.perf.plugin.registry import register_dataset
 from evalscope.utils import get_logger
+from evalscope.utils.tqdm_utils import TqdmLogging as tqdm
 
 logger = get_logger()
+
+_RANDOM_GENERATION_STATE: Dict[str, Any] = {}
+_MIN_AUTO_PARALLEL_PROMPT_LENGTH = 2048
+
+
+def _get_random_generation_context() -> Optional[Any]:
+    """Return a fork context only when it is safe for random request generation."""
+    if os.name != 'posix' or not sys.platform.startswith('linux') or threading.active_count() != 1:
+        return None
+
+    available_methods = multiprocessing.get_all_start_methods()
+    if 'fork' in available_methods:
+        return multiprocessing.get_context('fork')
+    return None
+
+
+def _init_random_generation_worker(
+    tokenizer_path: str,
+    tokenize_prompt: bool,
+    apply_chat_template: bool,
+    prefix_ids: List[int],
+    allowed_tokens: List[int],
+) -> None:
+    """Initialize per-process state for random request generation."""
+    os.environ['TOKENIZERS_PARALLELISM'] = 'false'
+    existing_allowed_tokens = _RANDOM_GENERATION_STATE.get('allowed_tokens')
+    existing_prefix_ids = _RANDOM_GENERATION_STATE.get('prefix_ids')
+    tokenizer = None if tokenize_prompt else load_tokenizer(tokenizer_path)
+    _RANDOM_GENERATION_STATE.clear()
+    _RANDOM_GENERATION_STATE.update({
+        'tokenizer': tokenizer,
+        'tokenize_prompt': tokenize_prompt,
+        'apply_chat_template': apply_chat_template,
+        'prefix_ids': existing_prefix_ids if existing_prefix_ids is not None else prefix_ids,
+        'allowed_tokens': (
+            existing_allowed_tokens if existing_allowed_tokens is not None else np.asarray(allowed_tokens)
+        ),
+    })
+
+
+def _build_random_message_worker(
+    task: Tuple[int, int, int, Optional[int]],
+) -> Tuple[int, Union[List[Dict], List[int], str], int]:
+    """Build one random message from an index-level generation task."""
+    index, input_len, offset, seed = task
+    allowed_tokens = _RANDOM_GENERATION_STATE['allowed_tokens']
+    prefix_ids = _RANDOM_GENERATION_STATE['prefix_ids']
+    inner_seq = allowed_tokens[(offset + index + np.arange(input_len)) % len(allowed_tokens)].tolist()
+    token_sequence = prefix_ids + inner_seq
+
+    if _RANDOM_GENERATION_STATE['tokenize_prompt']:
+        return index, token_sequence, 0
+
+    if seed is None:
+        raise ValueError('Parallel random request generation requires a per-item seed.')
+    np.random.seed(seed)
+    target_token_len = len(prefix_ids) + int(input_len)
+    prompt, adjusted_token_sequence, token_mismatch = gen_prompt_decode_to_target_len(
+        tokenizer=_RANDOM_GENERATION_STATE['tokenizer'],
+        token_sequence=token_sequence,
+        target_token_len=target_token_len,
+        add_special_tokens=False,
+        allowed_tokens=allowed_tokens,
+    )
+    if len(adjusted_token_sequence) != target_token_len:
+        token_mismatch = len(adjusted_token_sequence) - target_token_len
+
+    if _RANDOM_GENERATION_STATE['apply_chat_template']:
+        return index, [{'role': 'user', 'content': prompt}], token_mismatch
+    return index, prompt, token_mismatch
 
 
 @register_dataset('random')
@@ -16,6 +93,7 @@ class RandomDatasetPlugin(DatasetPluginBase):
     """Read dataset and return prompt."""
 
     def __init__(self, query_parameters: Arguments):
+        os.environ['TOKENIZERS_PARALLELISM'] = 'false'
         assert query_parameters.tokenizer_path, 'Tokenizer path is required for random data generation, please provide it with `--tokenizer-path`.'  # noqa: E501
         super().__init__(query_parameters)
 
@@ -43,12 +121,107 @@ class RandomDatasetPlugin(DatasetPluginBase):
             f'(excluded {len(prohibited_tokens)} special/byte-fallback tokens)'
         )
 
-    def build_messages(self) -> Iterator[Union[List[Dict], List[int]]]:
+    def build_messages(self) -> Iterator[Union[List[Dict], List[int], str]]:
         """Yield prompts as text messages or, when --tokenize-prompt is set, as raw
         token-ID lists that bypass the decode/re-encode round-trip entirely."""
-        tokenize_prompt = self.query_parameters.tokenize_prompt
+        plan = self._create_generation_plan(self.number, include_seeds=not self.query_parameters.tokenize_prompt)
 
-        if self.query_parameters.apply_chat_template and not tokenize_prompt:
+        token_mismatch_total = 0
+        for index, input_len, offset, seed in self._iter_generation_plan(plan):
+            message, token_mismatch = self._build_random_message(input_len, offset, index, seed)
+            token_mismatch_total += token_mismatch
+            yield message
+
+        self._log_token_mismatch(token_mismatch_total)
+
+    def supports_parallel_message_generation(self) -> bool:
+        """Random prompts are independent by index and can be generated in worker processes."""
+        if _get_random_generation_context() is None:
+            if self.query_parameters.request_generation_workers > 1:
+                logger.warning(
+                    'Parallel random request generation requires a fork-safe Linux single-thread context; '
+                    'falling back to serial request generation.'
+                )
+            return False
+        if self.query_parameters.request_generation_workers > 1:
+            return True
+        if self.query_parameters.tokenize_prompt:
+            return False
+        prompt_length_estimate = (
+            self.query_parameters.min_prompt_length + self.query_parameters.max_prompt_length
+        ) // 2
+        return prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
+
+    def build_messages_parallel(self, total_count: int, workers: int) -> List[Union[List[Dict], List[int], str]]:
+        """Build random request messages across multiple worker processes."""
+        if total_count <= 0:
+            return []
+
+        self.number = total_count
+        workers = max(1, min(workers, total_count))
+        if workers == 1:
+            return list(self.build_messages())
+
+        process_context = _get_random_generation_context()
+        if process_context is None:
+            logger.warning(
+                'Parallel random request generation requires a fork-safe Linux single-thread context; '
+                'falling back to serial request generation.'
+            )
+            return list(self.build_messages())
+
+        plan = self._create_generation_plan(total_count, include_seeds=not self.query_parameters.tokenize_prompt)
+        messages: List[Union[List[Dict], List[int], str, None]] = [None] * total_count
+        token_mismatch_total = 0
+        chunk_size = max(1, min(64, math.ceil(total_count / (workers * 8))))
+
+        _RANDOM_GENERATION_STATE.clear()
+        _RANDOM_GENERATION_STATE.update({
+            'tokenizer': None,
+            'tokenize_prompt': self.query_parameters.tokenize_prompt,
+            'apply_chat_template': self.query_parameters.apply_chat_template,
+            'prefix_ids': self.prefix_ids,
+            'allowed_tokens': self.allowed_tokens,
+        })
+        use_copy_on_write_state = (process_context is not None and process_context.get_start_method() == 'fork')
+        prefix_ids = [] if use_copy_on_write_state else self.prefix_ids
+        allowed_tokens = [] if use_copy_on_write_state else self.allowed_tokens.tolist()
+
+        try:
+            with tqdm(total=total_count, desc='Generating[requests]', logger=logger) as pbar:
+                with ProcessPoolExecutor(
+                    max_workers=workers,
+                    mp_context=process_context,
+                    initializer=_init_random_generation_worker,
+                    initargs=(
+                        self.query_parameters.tokenizer_path,
+                        self.query_parameters.tokenize_prompt,
+                        self.query_parameters.apply_chat_template,
+                        prefix_ids,
+                        allowed_tokens,
+                    ),
+                ) as executor:
+                    for index, message, token_mismatch in executor.map(
+                        _build_random_message_worker,
+                        self._iter_generation_plan(plan),
+                        chunksize=chunk_size,
+                    ):
+                        messages[index] = message
+                        token_mismatch_total += token_mismatch
+                        pbar.update(1)
+        finally:
+            _RANDOM_GENERATION_STATE.clear()
+
+        missing = [index for index, message in enumerate(messages) if message is None]
+        if missing:
+            raise RuntimeError(f'Parallel random request generation missed {len(missing)} items.')
+
+        self._log_token_mismatch(token_mismatch_total)
+        return [message for message in messages if message is not None]
+
+    def _resolve_prompt_length_bounds(self) -> Tuple[int, int]:
+        """Resolve the random prompt length sampling interval."""
+        if self.query_parameters.apply_chat_template and not self.query_parameters.tokenize_prompt:
             template_len = self.get_template_len()
             min_prompt_length = self.query_parameters.min_prompt_length - template_len
             max_prompt_length = self.query_parameters.max_prompt_length - template_len + 1
@@ -63,41 +236,73 @@ class RandomDatasetPlugin(DatasetPluginBase):
             max_prompt_length = self.query_parameters.max_prompt_length + 1
 
         assert max_prompt_length >= min_prompt_length, 'max_prompt_length should be greater than or equal to min_prompt_length.'  # noqa: E501
-
         logger.info(f'Sampling input lengths from [{min_prompt_length}, {max_prompt_length})')
+        return min_prompt_length, max_prompt_length
 
-        # Sample input lengths
-        input_lens = np.random.randint(min_prompt_length, max_prompt_length, size=self.number)
+    def _create_generation_plan(
+        self,
+        total_count: int,
+        include_seeds: bool,
+    ) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
+        """Pre-sample all per-index random inputs in the parent process."""
+        min_prompt_length, max_prompt_length = self._resolve_prompt_length_bounds()
+        input_lens = np.random.randint(min_prompt_length, max_prompt_length, size=total_count)
         global_offset = self.query_parameters.dataset_offset
-        offsets = (np.random.randint(0, len(self.allowed_tokens), size=self.number)
+        offsets = (np.random.randint(0, len(self.allowed_tokens), size=total_count)
                    + global_offset) % len(self.allowed_tokens)
+        seeds = None
+        if include_seeds:
+            seeds = np.random.randint(0, np.iinfo(np.uint32).max, size=total_count, dtype=np.uint32)
+        return input_lens, offsets, seeds
 
-        token_mismatch_total = 0
-        for i in range(self.number):
-            if tokenize_prompt:
-                # Fast path: yield token IDs directly, no decode/re-encode step.
-                # The API plugin will send them as `prompt=[int, ...]` to /v1/completions.
-                token_ids = self.generate_token_ids_only(
-                    input_len=int(input_lens[i]),
-                    offset=int(offsets[i]),
-                    index=i,
+    def _iter_generation_plan(
+        self,
+        plan: Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]],
+    ) -> Iterator[Tuple[int, int, int, Optional[int]]]:
+        """Iterate over pre-sampled generation tasks."""
+        input_lens, offsets, seeds = plan
+        for index in range(len(input_lens)):
+            seed = None if seeds is None else int(seeds[index])
+            yield index, int(input_lens[index]), int(offsets[index]), seed
+
+    def _build_random_message(
+        self,
+        input_len: int,
+        offset: int,
+        index: int,
+        seed: Optional[int] = None,
+    ) -> Tuple[Union[List[Dict], List[int], str], int]:
+        """Build one random message in the current process."""
+        if self.query_parameters.tokenize_prompt:
+            token_ids = self.generate_token_ids_only(input_len=input_len, offset=offset, index=index)
+            return token_ids, 0
+
+        if seed is None:
+            prompt, _, token_mismatch = self.generate_token_sequence(
+                input_len=input_len,
+                offset=offset,
+                index=index,
+            )
+        else:
+            random_state = np.random.get_state()
+            np.random.seed(seed)
+            try:
+                prompt, _, token_mismatch = self.generate_token_sequence(
+                    input_len=input_len,
+                    offset=offset,
+                    index=index,
                 )
-                yield token_ids
-            else:
-                prompt, total_input_len, token_mismatch = self.generate_token_sequence(
-                    input_len=int(input_lens[i]),
-                    offset=int(offsets[i]),
-                    index=i,
-                )
-                token_mismatch_total += token_mismatch
+            finally:
+                np.random.set_state(random_state)
 
-                if self.query_parameters.apply_chat_template:
-                    message = self.create_message(prompt)
-                    yield [message]
-                else:
-                    yield prompt
+        if self.query_parameters.apply_chat_template:
+            message = self.create_message(prompt)
+            return [message], token_mismatch
+        return prompt, token_mismatch
 
-        if not tokenize_prompt and token_mismatch_total != 0:
+    def _log_token_mismatch(self, token_mismatch_total: int) -> None:
+        """Log aggregate token mismatch from decode/re-encode prompt generation."""
+        if not self.query_parameters.tokenize_prompt and token_mismatch_total != 0:
             sign = 'more' if token_mismatch_total > 0 else 'fewer'
             logger.warning(
                 f'Across all generated prompts, there were {abs(token_mismatch_total)} {sign} tokens '

--- a/evalscope/perf/plugin/datasets/random_vl_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_vl_dataset.py
@@ -1,6 +1,6 @@
 import random
 from PIL import Image, ImageDraw
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Optional
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin
@@ -43,7 +43,7 @@ class RandomVLDatasetPlugin(RandomDatasetPlugin):
             message = self.create_message(text=prompt, image_urls=images_b64)
             yield [message]
 
-    def supports_parallel_message_generation(self) -> bool:
+    def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
         """Random VL includes image generation and currently uses the serial path."""
         return False
 

--- a/evalscope/perf/plugin/datasets/random_vl_dataset.py
+++ b/evalscope/perf/plugin/datasets/random_vl_dataset.py
@@ -43,6 +43,10 @@ class RandomVLDatasetPlugin(RandomDatasetPlugin):
             message = self.create_message(text=prompt, image_urls=images_b64)
             yield [message]
 
+    def supports_parallel_message_generation(self) -> bool:
+        """Random VL includes image generation and currently uses the serial path."""
+        return False
+
     def _generate_random_image_b64(self) -> str:
         """Generate a random image and return as base64 string."""
         # Create a random colored image

--- a/evalscope/perf/plugin/datasets/swe_smith.py
+++ b/evalscope/perf/plugin/datasets/swe_smith.py
@@ -17,7 +17,7 @@ This plugin supports two data-source modes:
    then shuffled.  For each candidate ``num_turns`` is sampled uniformly from
    ``[min_turns, max_turns]`` (``--min-turns`` / ``--max-turns``).  All work
    items are dispatched to a ``multiprocessing.Pool``
-   (size ``multi_turn_args.num_workers``); results are collected until
+   (size controlled by top-level ``--num-workers``); results are collected until
    ``number`` valid conversations have been built.
 """
 
@@ -31,6 +31,7 @@ from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import Conversation, DatasetPluginBase, Message, Messages, Turn
 from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
 from evalscope.perf.plugin.registry import register_dataset
+from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -260,7 +261,7 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
     * ``first_turn_length``      – target tokens for turn 1
     * ``subsequent_turn_length`` – token growth per subsequent turn
     * ``chars_per_token``        – pre-filter estimate
-    * ``num_workers``            – multiprocessing pool size
+    * Top-level ``--num-workers`` – multiprocessing pool size
     """
 
     def __init__(self, query_parameters: Arguments):
@@ -335,7 +336,7 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
         max_turns = self.query_parameters.max_turns if self.query_parameters.max_turns is not None else min_turns
         if max_turns < min_turns:
             raise ValueError(f'--max-turns ({max_turns}) must be >= --min-turns ({min_turns})')
-        num_workers = mt_args.num_workers if mt_args else 1
+        target_count = max(1, self.query_parameters.total_count)
 
         # For pre-filtering, use the upper-bound of first_turn_length as the minimum
         # char threshold (conservative: trajectories need at least that many tokens).
@@ -352,13 +353,11 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
 
         logger.info(
             f'Live construction: offset={offset}, min_turns={min_turns}, max_turns={max_turns}, '
-            f'num_workers={num_workers}, min_chars={min_chars}'
+            f'target_count={target_count}, min_chars={min_chars}'
         )
 
         from modelscope import MsDataset
         dataset = MsDataset.load(_DEFAULT_DATASET_NAME, split=_DEFAULT_SPLIT)
-
-        target_count = max(1, self.query_parameters.number)
 
         candidates = []
         skipped_short = 0
@@ -405,6 +404,11 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
                 num_turns,
             ))
 
+        num_workers = resolve_dataset_generation_workers(
+            args=self.query_parameters,
+            total_count=len(work_items),
+            supports_parallel_generation=True,
+        )
         logger.info(
             f'Building up to {target_count} conversations from {len(work_items)} candidates '
             f'using {num_workers} worker(s)...'

--- a/evalscope/perf/plugin/datasets/swe_smith.py
+++ b/evalscope/perf/plugin/datasets/swe_smith.py
@@ -406,7 +406,7 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
 
         num_workers = resolve_dataset_generation_workers(
             args=self.query_parameters,
-            total_count=len(work_items),
+            total_count=min(len(work_items), target_count),
             supports_parallel_generation=True,
         )
         logger.info(

--- a/evalscope/perf/utils/worker_util.py
+++ b/evalscope/perf/utils/worker_util.py
@@ -1,5 +1,8 @@
 import os
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evalscope.perf.arguments import Arguments
 
 _MAX_AUTO_DATASET_WORKERS = 32
 _MIN_AUTO_ITEMS_PER_WORKER = 128
@@ -16,7 +19,7 @@ def available_cpu_count() -> int:
 
 
 def resolve_dataset_generation_workers(
-    args: Any,
+    args: 'Arguments',
     total_count: int,
     supports_parallel_generation: bool,
 ) -> int:

--- a/evalscope/perf/utils/worker_util.py
+++ b/evalscope/perf/utils/worker_util.py
@@ -1,0 +1,34 @@
+import os
+from typing import Any
+
+_MAX_AUTO_DATASET_WORKERS = 32
+_MIN_AUTO_ITEMS_PER_WORKER = 128
+
+
+def available_cpu_count() -> int:
+    """Return the CPU count available to this process."""
+    if hasattr(os, 'sched_getaffinity'):
+        try:
+            return max(1, len(os.sched_getaffinity(0)))
+        except Exception:
+            pass
+    return max(1, os.cpu_count() or 1)
+
+
+def resolve_dataset_generation_workers(
+    args: Any,
+    total_count: int,
+    supports_parallel_generation: bool,
+) -> int:
+    """Resolve worker count for CPU-bound dataset/request generation."""
+    if total_count <= 1 or not supports_parallel_generation:
+        return 1
+
+    configured_workers = args.num_workers
+    if configured_workers == 1:
+        return 1
+    if configured_workers > 1:
+        return min(configured_workers, total_count)
+
+    amortized_workers = max(1, total_count // _MIN_AUTO_ITEMS_PER_WORKER)
+    return min(available_cpu_count(), total_count, _MAX_AUTO_DATASET_WORKERS, amortized_workers)

--- a/examples/perf/benchmark_random_request_generation.py
+++ b/examples/perf/benchmark_random_request_generation.py
@@ -1,0 +1,222 @@
+"""Benchmark random dataset request generation without sending HTTP requests.
+
+This script exercises the same ``get_requests()`` path used by ``evalscope perf``
+and measures only local request construction.  It is intended for comparing
+serial generation (``--num-workers 1``) with multiprocessing generation for the
+``random`` dataset.
+
+Example:
+    python examples/perf/benchmark_random_request_generation.py \
+        --tokenizer-path Qwen/Qwen2.5-0.5B-Instruct \
+        --numbers 128 512 \
+        --prompt-lengths 2048 8192 \
+        --workers 1 2 4 8 0
+"""
+
+import argparse
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.benchmark import get_requests
+from evalscope.perf.plugin.datasets.random_dataset import (
+    _MIN_AUTO_PARALLEL_PROMPT_LENGTH,
+    _MIN_AUTO_PARALLEL_TOKEN_WORK,
+)
+from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
+
+_BENCHMARK_URL = 'http://127.0.0.1:8000/v1/chat/completions'
+
+
+class _NoopApiPlugin:
+    """Build request dictionaries without touching the network."""
+
+    def build_request(self, messages: Any) -> Dict[str, Any]:
+        return {'messages': messages}
+
+
+@dataclass
+class _BenchmarkResult:
+    number: int
+    prompt_length: int
+    configured_workers: int
+    resolved_workers: int
+    repeat: int
+    seconds: float
+    requests_per_second: float
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Benchmark random request generation throughput.')
+    parser.add_argument(
+        '--tokenizer-path',
+        type=str,
+        default='Qwen/Qwen2.5-0.5B-Instruct',
+        help='Tokenizer path or model id used by the random dataset.',
+    )
+    parser.add_argument(
+        '--numbers',
+        type=int,
+        nargs='+',
+        default=[128, 512],
+        help='Request counts to benchmark.',
+    )
+    parser.add_argument(
+        '--prompt-lengths',
+        type=int,
+        nargs='+',
+        default=[2048, 8192],
+        help='Fixed prompt lengths to benchmark.',
+    )
+    parser.add_argument(
+        '--workers',
+        type=int,
+        nargs='+',
+        default=[1, 2, 4, 8, 0],
+        help='Configured --num-workers values. Use 0 for auto.',
+    )
+    parser.add_argument(
+        '--repeat',
+        type=int,
+        default=1,
+        help='Number of repeats per case.',
+    )
+    parser.add_argument(
+        '--apply-chat-template',
+        action='store_true',
+        default=False,
+        help='Generate chat-template-shaped messages instead of raw text prompts.',
+    )
+    parser.add_argument(
+        '--tokenize-prompt',
+        action='store_true',
+        default=False,
+        help='Benchmark token-id prompt generation for the completions endpoint.',
+    )
+    return parser.parse_args()
+
+
+def _make_arguments(
+    tokenizer_path: str,
+    number: int,
+    prompt_length: int,
+    workers: int,
+    apply_chat_template: bool,
+    tokenize_prompt: bool,
+) -> Arguments:
+    return Arguments(
+        model='request-generation-benchmark',
+        url=_BENCHMARK_URL,
+        dataset='random',
+        tokenizer_path=tokenizer_path,
+        number=number,
+        parallel=1,
+        num_workers=workers,
+        min_prompt_length=prompt_length,
+        max_prompt_length=prompt_length,
+        max_tokens=1,
+        apply_chat_template=apply_chat_template,
+        tokenize_prompt=tokenize_prompt,
+    )
+
+
+def _random_dataset_supports_parallel(args: Arguments) -> bool:
+    if args.num_workers > 1:
+        return True
+    if args.tokenize_prompt:
+        return False
+    prompt_length_estimate = (args.min_prompt_length + args.max_prompt_length) // 2
+    token_work_estimate = prompt_length_estimate * args.total_count
+    return (
+        prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
+        and token_work_estimate >= _MIN_AUTO_PARALLEL_TOKEN_WORK
+    )
+
+
+async def _consume_requests(args: Arguments) -> int:
+    count = 0
+    async for _request, _is_warmup in get_requests(args, _NoopApiPlugin()):
+        count += 1
+    return count
+
+
+def _run_case(
+    tokenizer_path: str,
+    number: int,
+    prompt_length: int,
+    workers: int,
+    repeat: int,
+    apply_chat_template: bool,
+    tokenize_prompt: bool,
+) -> _BenchmarkResult:
+    args = _make_arguments(
+        tokenizer_path=tokenizer_path,
+        number=number,
+        prompt_length=prompt_length,
+        workers=workers,
+        apply_chat_template=apply_chat_template,
+        tokenize_prompt=tokenize_prompt,
+    )
+    resolved_workers = resolve_dataset_generation_workers(
+        args=args,
+        total_count=args.total_count,
+        supports_parallel_generation=_random_dataset_supports_parallel(args),
+    )
+
+    start = time.perf_counter()
+    count = asyncio.run(_consume_requests(args))
+    seconds = time.perf_counter() - start
+    if count != args.total_count:
+        raise RuntimeError(f'Expected {args.total_count} requests, got {count}.')
+
+    return _BenchmarkResult(
+        number=number,
+        prompt_length=prompt_length,
+        configured_workers=workers,
+        resolved_workers=resolved_workers,
+        repeat=repeat,
+        seconds=seconds,
+        requests_per_second=count / seconds,
+    )
+
+
+def _run_matrix(args: argparse.Namespace) -> List[_BenchmarkResult]:
+    results = []
+    for number in args.numbers:
+        for prompt_length in args.prompt_lengths:
+            for workers in args.workers:
+                for repeat_index in range(args.repeat):
+                    results.append(
+                        _run_case(
+                            tokenizer_path=args.tokenizer_path,
+                            number=number,
+                            prompt_length=prompt_length,
+                            workers=workers,
+                            repeat=repeat_index + 1,
+                            apply_chat_template=args.apply_chat_template,
+                            tokenize_prompt=args.tokenize_prompt,
+                        )
+                    )
+    return results
+
+
+def _print_results(results: List[_BenchmarkResult]) -> None:
+    print('number,prompt_length,configured_workers,resolved_workers,repeat,seconds,requests_per_second')
+    for result in results:
+        print(
+            f'{result.number},{result.prompt_length},{result.configured_workers},'
+            f'{result.resolved_workers},{result.repeat},{result.seconds:.3f},'
+            f'{result.requests_per_second:.2f}'
+        )
+
+
+def main() -> None:
+    args = _parse_args()
+    results = _run_matrix(args)
+    _print_results(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/perf/benchmark_random_request_generation.py
+++ b/examples/perf/benchmark_random_request_generation.py
@@ -21,10 +21,7 @@ from typing import Any, Dict, List
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.benchmark import get_requests
-from evalscope.perf.plugin.datasets.random_dataset import (
-    _MIN_AUTO_PARALLEL_PROMPT_LENGTH,
-    _MIN_AUTO_PARALLEL_TOKEN_WORK,
-)
+from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin
 from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 
 _BENCHMARK_URL = 'http://127.0.0.1:8000/v1/chat/completions'
@@ -123,16 +120,10 @@ def _make_arguments(
 
 
 def _random_dataset_supports_parallel(args: Arguments) -> bool:
-    if args.num_workers > 1:
-        return True
-    if args.tokenize_prompt:
-        return False
-    prompt_length_estimate = (args.min_prompt_length + args.max_prompt_length) // 2
-    token_work_estimate = prompt_length_estimate * args.total_count
-    return (
-        prompt_length_estimate >= _MIN_AUTO_PARALLEL_PROMPT_LENGTH
-        and token_work_estimate >= _MIN_AUTO_PARALLEL_TOKEN_WORK
-    )
+    plugin = object.__new__(RandomDatasetPlugin)
+    plugin.query_parameters = args
+    plugin.number = args.total_count
+    return plugin.supports_parallel_message_generation(args.total_count)
 
 
 async def _consume_requests(args: Arguments) -> int:

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -1,7 +1,7 @@
 import asyncio
 import numpy as np
 from pytest import MonkeyPatch
-from typing import Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.benchmark import get_requests
@@ -17,7 +17,7 @@ class _ParallelDatasetPlugin(DatasetPluginBase):
     def build_messages(self) -> Iterator[str]:
         raise AssertionError('serial generation should not be used')
 
-    def supports_parallel_message_generation(self) -> bool:
+    def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
         return True
 
     def build_messages_parallel(self, total_count: int, workers: int) -> List[str]:
@@ -99,9 +99,22 @@ def test_dataset_generation_workers_can_disable_parallel_path() -> None:
 
 
 def test_multi_turn_num_workers_is_promoted_to_top_level() -> None:
-    args = _make_args(num_workers=0, multi_turn_args={'num_workers': 3})
+    args = Arguments(
+        model='test-model',
+        url='http://127.0.0.1:8000/v1/chat/completions',
+        dataset='unit_parallel_dataset',
+        number=3,
+        parallel=1,
+        multi_turn_args={'num_workers': 3},
+    )
 
     assert args.num_workers == 3
+
+
+def test_top_level_num_workers_takes_precedence_over_multi_turn_value() -> None:
+    args = _make_args(num_workers=0, multi_turn_args={'num_workers': 3})
+
+    assert args.num_workers == 0
 
 
 def test_random_dataset_parallel_uses_spawn_context() -> None:

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -4,10 +4,11 @@ from pytest import MonkeyPatch
 from typing import Dict, Iterator, List, Tuple
 
 from evalscope.perf.arguments import Arguments
-from evalscope.perf.benchmark import _resolve_request_generation_workers, get_requests
+from evalscope.perf.benchmark import get_requests
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
-from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin
+from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin, _get_random_generation_context
 from evalscope.perf.plugin.registry import DatasetRegistry
+from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 
 
 class _ParallelDatasetPlugin(DatasetPluginBase):
@@ -30,12 +31,6 @@ class _FakeApiPlugin:
         return {'payload': messages}
 
 
-class _ForkContext:
-
-    def get_start_method(self) -> str:
-        return 'fork'
-
-
 async def _collect_requests(args: Arguments) -> List:
     return [item async for item in get_requests(args, _FakeApiPlugin())]
 
@@ -47,7 +42,7 @@ def _make_args(**kwargs) -> Arguments:
         'dataset': 'unit_parallel_dataset',
         'number': 3,
         'parallel': 1,
-        'request_generation_workers': 2,
+        'num_workers': 2,
     }
     params.update(kwargs)
     return Arguments(**params)
@@ -68,113 +63,117 @@ def test_parallel_dataset_generation_hook_preserves_order_and_warmup() -> None:
     ]
 
 
-def test_request_generation_worker_auto_respects_cpu_affinity(monkeypatch: MonkeyPatch) -> None:
-    args = _make_args(number=256, request_generation_workers=0)
-    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: {0, 1, 2, 3}, raising=False)
+def test_dataset_generation_worker_auto_respects_cpu_affinity(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=512, num_workers=0)
+    monkeypatch.setattr('evalscope.perf.utils.worker_util.os.sched_getaffinity', lambda _: {0, 1, 2, 3}, raising=False)
 
-    workers = _resolve_request_generation_workers(args, total_count=256, supports_parallel_generation=True)
+    workers = resolve_dataset_generation_workers(args, total_count=512, supports_parallel_generation=True)
 
     assert workers == 4
 
 
-def test_request_generation_worker_auto_amortizes_small_runs(monkeypatch: MonkeyPatch) -> None:
-    args = _make_args(number=24, request_generation_workers=0)
-    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
+def test_dataset_generation_worker_auto_amortizes_small_runs(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=127, num_workers=0)
+    monkeypatch.setattr('evalscope.perf.utils.worker_util.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
 
-    workers = _resolve_request_generation_workers(args, total_count=24, supports_parallel_generation=True)
+    workers = resolve_dataset_generation_workers(args, total_count=127, supports_parallel_generation=True)
 
     assert workers == 1
 
 
-def test_request_generation_worker_auto_is_capped(monkeypatch: MonkeyPatch) -> None:
-    args = _make_args(number=4096, request_generation_workers=0)
-    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
+def test_dataset_generation_worker_auto_is_capped(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=4096, num_workers=0)
+    monkeypatch.setattr('evalscope.perf.utils.worker_util.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
 
-    workers = _resolve_request_generation_workers(args, total_count=4096, supports_parallel_generation=True)
+    workers = resolve_dataset_generation_workers(args, total_count=4096, supports_parallel_generation=True)
 
     assert workers == 32
 
 
-def test_request_generation_workers_can_disable_parallel_path() -> None:
-    args = _make_args(number=10, request_generation_workers=1)
+def test_dataset_generation_workers_can_disable_parallel_path() -> None:
+    args = _make_args(number=10, num_workers=1)
 
-    workers = _resolve_request_generation_workers(args, total_count=10, supports_parallel_generation=True)
+    workers = resolve_dataset_generation_workers(args, total_count=10, supports_parallel_generation=True)
 
     assert workers == 1
 
 
-def test_random_dataset_auto_parallel_requires_long_prompts(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr('evalscope.perf.plugin.datasets.random_dataset._get_random_generation_context',
-                        lambda: _ForkContext())
+def test_multi_turn_num_workers_is_promoted_to_top_level() -> None:
+    args = _make_args(num_workers=0, multi_turn_args={'num_workers': 3})
 
+    assert args.num_workers == 3
+
+
+def test_random_dataset_parallel_uses_spawn_context() -> None:
+    assert _get_random_generation_context().get_start_method() == 'spawn'
+
+
+def test_random_dataset_auto_parallel_requires_large_long_prompt_work() -> None:
     short_args = _make_args(
         dataset='random',
         number=512,
-        request_generation_workers=0,
+        num_workers=0,
         min_prompt_length=64,
         max_prompt_length=64,
         tokenize_prompt=False,
     )
     short_plugin = object.__new__(RandomDatasetPlugin)
     short_plugin.query_parameters = short_args
+    short_plugin.number = short_args.total_count
 
     mid_args = _make_args(
         dataset='random',
         number=512,
-        request_generation_workers=0,
-        min_prompt_length=1024,
-        max_prompt_length=1024,
-        tokenize_prompt=False,
-    )
-    mid_plugin = object.__new__(RandomDatasetPlugin)
-    mid_plugin.query_parameters = mid_args
-
-    long_args = _make_args(
-        dataset='random',
-        number=512,
-        request_generation_workers=0,
+        num_workers=0,
         min_prompt_length=2048,
         max_prompt_length=2048,
         tokenize_prompt=False,
     )
-    long_plugin = object.__new__(RandomDatasetPlugin)
-    long_plugin.query_parameters = long_args
+    mid_plugin = object.__new__(RandomDatasetPlugin)
+    mid_plugin.query_parameters = mid_args
+    mid_plugin.number = mid_args.total_count
+
+    small_long_args = _make_args(
+        dataset='random',
+        number=128,
+        num_workers=0,
+        min_prompt_length=8192,
+        max_prompt_length=8192,
+        tokenize_prompt=False,
+    )
+    small_long_plugin = object.__new__(RandomDatasetPlugin)
+    small_long_plugin.query_parameters = small_long_args
+    small_long_plugin.number = small_long_args.total_count
+
+    large_long_args = _make_args(
+        dataset='random',
+        number=512,
+        num_workers=0,
+        min_prompt_length=8192,
+        max_prompt_length=8192,
+        tokenize_prompt=False,
+    )
+    large_long_plugin = object.__new__(RandomDatasetPlugin)
+    large_long_plugin.query_parameters = large_long_args
+    large_long_plugin.number = large_long_args.total_count
 
     explicit_args = _make_args(
         dataset='random',
         number=512,
-        request_generation_workers=2,
+        num_workers=2,
         min_prompt_length=64,
         max_prompt_length=64,
         tokenize_prompt=False,
     )
     explicit_plugin = object.__new__(RandomDatasetPlugin)
     explicit_plugin.query_parameters = explicit_args
+    explicit_plugin.number = explicit_args.total_count
 
     assert not short_plugin.supports_parallel_message_generation()
     assert not mid_plugin.supports_parallel_message_generation()
-    assert long_plugin.supports_parallel_message_generation()
+    assert not small_long_plugin.supports_parallel_message_generation()
+    assert large_long_plugin.supports_parallel_message_generation()
     assert explicit_plugin.supports_parallel_message_generation()
-
-
-def test_random_dataset_parallel_requires_fork_safe_context(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr('evalscope.perf.plugin.datasets.random_dataset._get_random_generation_context', lambda: None)
-
-    args = _make_args(
-        dataset='random',
-        number=512,
-        request_generation_workers=2,
-        min_prompt_length=2048,
-        max_prompt_length=2048,
-        tokenize_prompt=False,
-    )
-    plugin = object.__new__(RandomDatasetPlugin)
-    plugin.query_parameters = args
-    plugin.number = args.total_count
-    plugin.build_messages = lambda: iter(['serial-0', 'serial-1'])
-
-    assert not plugin.supports_parallel_message_generation()
-    assert plugin.build_messages_parallel(total_count=2, workers=2) == ['serial-0', 'serial-1']
 
 
 def test_random_dataset_serial_generation_uses_item_local_seeds(monkeypatch: MonkeyPatch) -> None:
@@ -191,7 +190,7 @@ def test_random_dataset_serial_generation_uses_item_local_seeds(monkeypatch: Mon
     args = _make_args(
         dataset='random',
         number=8,
-        request_generation_workers=1,
+        num_workers=1,
         min_prompt_length=4,
         max_prompt_length=4,
         apply_chat_template=False,

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -1,0 +1,223 @@
+import asyncio
+import numpy as np
+from pytest import MonkeyPatch
+from typing import Dict, Iterator, List, Tuple
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.benchmark import _resolve_request_generation_workers, get_requests
+from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin
+from evalscope.perf.plugin.registry import DatasetRegistry
+
+
+class _ParallelDatasetPlugin(DatasetPluginBase):
+    last_workers: int = 0
+
+    def build_messages(self) -> Iterator[str]:
+        raise AssertionError('serial generation should not be used')
+
+    def supports_parallel_message_generation(self) -> bool:
+        return True
+
+    def build_messages_parallel(self, total_count: int, workers: int) -> List[str]:
+        type(self).last_workers = workers
+        return [f'message-{index}' for index in range(total_count)]
+
+
+class _FakeApiPlugin:
+
+    def build_request(self, messages: str) -> Dict[str, str]:
+        return {'payload': messages}
+
+
+class _ForkContext:
+
+    def get_start_method(self) -> str:
+        return 'fork'
+
+
+async def _collect_requests(args: Arguments) -> List:
+    return [item async for item in get_requests(args, _FakeApiPlugin())]
+
+
+def _make_args(**kwargs) -> Arguments:
+    params = {
+        'model': 'test-model',
+        'url': 'http://127.0.0.1:8000/v1/chat/completions',
+        'dataset': 'unit_parallel_dataset',
+        'number': 3,
+        'parallel': 1,
+        'request_generation_workers': 2,
+    }
+    params.update(kwargs)
+    return Arguments(**params)
+
+
+def test_parallel_dataset_generation_hook_preserves_order_and_warmup() -> None:
+    DatasetRegistry.register('unit_parallel_dataset', _ParallelDatasetPlugin)
+    args = _make_args(warmup_num=1)
+
+    requests = asyncio.run(_collect_requests(args))
+
+    assert _ParallelDatasetPlugin.last_workers == 2
+    assert requests == [
+        ({'payload': 'message-0'}, True),
+        ({'payload': 'message-1'}, False),
+        ({'payload': 'message-2'}, False),
+        ({'payload': 'message-3'}, False),
+    ]
+
+
+def test_request_generation_worker_auto_respects_cpu_affinity(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=256, request_generation_workers=0)
+    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: {0, 1, 2, 3}, raising=False)
+
+    workers = _resolve_request_generation_workers(args, total_count=256, supports_parallel_generation=True)
+
+    assert workers == 4
+
+
+def test_request_generation_worker_auto_amortizes_small_runs(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=24, request_generation_workers=0)
+    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
+
+    workers = _resolve_request_generation_workers(args, total_count=24, supports_parallel_generation=True)
+
+    assert workers == 1
+
+
+def test_request_generation_worker_auto_is_capped(monkeypatch: MonkeyPatch) -> None:
+    args = _make_args(number=4096, request_generation_workers=0)
+    monkeypatch.setattr('evalscope.perf.benchmark.os.sched_getaffinity', lambda _: set(range(128)), raising=False)
+
+    workers = _resolve_request_generation_workers(args, total_count=4096, supports_parallel_generation=True)
+
+    assert workers == 32
+
+
+def test_request_generation_workers_can_disable_parallel_path() -> None:
+    args = _make_args(number=10, request_generation_workers=1)
+
+    workers = _resolve_request_generation_workers(args, total_count=10, supports_parallel_generation=True)
+
+    assert workers == 1
+
+
+def test_random_dataset_auto_parallel_requires_long_prompts(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr('evalscope.perf.plugin.datasets.random_dataset._get_random_generation_context',
+                        lambda: _ForkContext())
+
+    short_args = _make_args(
+        dataset='random',
+        number=512,
+        request_generation_workers=0,
+        min_prompt_length=64,
+        max_prompt_length=64,
+        tokenize_prompt=False,
+    )
+    short_plugin = object.__new__(RandomDatasetPlugin)
+    short_plugin.query_parameters = short_args
+
+    mid_args = _make_args(
+        dataset='random',
+        number=512,
+        request_generation_workers=0,
+        min_prompt_length=1024,
+        max_prompt_length=1024,
+        tokenize_prompt=False,
+    )
+    mid_plugin = object.__new__(RandomDatasetPlugin)
+    mid_plugin.query_parameters = mid_args
+
+    long_args = _make_args(
+        dataset='random',
+        number=512,
+        request_generation_workers=0,
+        min_prompt_length=2048,
+        max_prompt_length=2048,
+        tokenize_prompt=False,
+    )
+    long_plugin = object.__new__(RandomDatasetPlugin)
+    long_plugin.query_parameters = long_args
+
+    explicit_args = _make_args(
+        dataset='random',
+        number=512,
+        request_generation_workers=2,
+        min_prompt_length=64,
+        max_prompt_length=64,
+        tokenize_prompt=False,
+    )
+    explicit_plugin = object.__new__(RandomDatasetPlugin)
+    explicit_plugin.query_parameters = explicit_args
+
+    assert not short_plugin.supports_parallel_message_generation()
+    assert not mid_plugin.supports_parallel_message_generation()
+    assert long_plugin.supports_parallel_message_generation()
+    assert explicit_plugin.supports_parallel_message_generation()
+
+
+def test_random_dataset_parallel_requires_fork_safe_context(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr('evalscope.perf.plugin.datasets.random_dataset._get_random_generation_context', lambda: None)
+
+    args = _make_args(
+        dataset='random',
+        number=512,
+        request_generation_workers=2,
+        min_prompt_length=2048,
+        max_prompt_length=2048,
+        tokenize_prompt=False,
+    )
+    plugin = object.__new__(RandomDatasetPlugin)
+    plugin.query_parameters = args
+    plugin.number = args.total_count
+    plugin.build_messages = lambda: iter(['serial-0', 'serial-1'])
+
+    assert not plugin.supports_parallel_message_generation()
+    assert plugin.build_messages_parallel(total_count=2, workers=2) == ['serial-0', 'serial-1']
+
+
+def test_random_dataset_serial_generation_uses_item_local_seeds(monkeypatch: MonkeyPatch) -> None:
+    def fake_generate_token_sequence(
+        self: RandomDatasetPlugin,
+        input_len: int,
+        offset: int,
+        index: int,
+    ) -> Tuple[str, int, int]:
+        return f'{input_len}-{offset}-{index}-{np.random.randint(0, 100000)}', input_len, 0
+
+    monkeypatch.setattr(RandomDatasetPlugin, 'generate_token_sequence', fake_generate_token_sequence)
+
+    args = _make_args(
+        dataset='random',
+        number=8,
+        request_generation_workers=1,
+        min_prompt_length=4,
+        max_prompt_length=4,
+        apply_chat_template=False,
+        tokenize_prompt=False,
+    )
+
+    np.random.seed(123)
+    serial_plugin = object.__new__(RandomDatasetPlugin)
+    serial_plugin.query_parameters = args
+    serial_plugin.number = args.total_count
+    serial_plugin.allowed_tokens = np.arange(100)
+    serial_plugin.prefix_ids = []
+    serial_plugin.prefix_length = 0
+    serial = list(serial_plugin.build_messages())
+
+    np.random.seed(123)
+    expected_plugin = object.__new__(RandomDatasetPlugin)
+    expected_plugin.query_parameters = args
+    expected_plugin.number = args.total_count
+    expected_plugin.allowed_tokens = np.arange(100)
+    expected_plugin.prefix_ids = []
+    expected_plugin.prefix_length = 0
+    plan = expected_plugin._create_generation_plan(args.total_count, include_seeds=True)
+    expected = [
+        expected_plugin._build_random_message(input_len, offset, index, seed)[0]
+        for index, input_len, offset, seed in expected_plugin._iter_generation_plan(plan)
+    ]
+
+    assert serial == expected

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -10,6 +10,21 @@ from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin, _
 from evalscope.perf.plugin.registry import DatasetRegistry
 from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_random_plugin(args: Arguments) -> RandomDatasetPlugin:
+    """Create a lightweight RandomDatasetPlugin without running ``__init__``."""
+    plugin = object.__new__(RandomDatasetPlugin)
+    plugin.query_parameters = args
+    plugin.number = args.total_count
+    plugin.tokenizer = None
+    plugin.allowed_tokens = np.arange(100)
+    plugin.prefix_ids = []
+    plugin.prefix_length = 0
+    return plugin
+
 
 class _ParallelDatasetPlugin(DatasetPluginBase):
     last_workers: int = 0
@@ -122,65 +137,26 @@ def test_random_dataset_parallel_uses_spawn_context() -> None:
 
 
 def test_random_dataset_auto_parallel_requires_large_long_prompt_work() -> None:
-    short_args = _make_args(
-        dataset='random',
-        number=512,
-        num_workers=0,
-        min_prompt_length=64,
-        max_prompt_length=64,
-        tokenize_prompt=False,
-    )
-    short_plugin = object.__new__(RandomDatasetPlugin)
-    short_plugin.query_parameters = short_args
-    short_plugin.number = short_args.total_count
-
-    mid_args = _make_args(
-        dataset='random',
-        number=512,
-        num_workers=0,
-        min_prompt_length=2048,
-        max_prompt_length=2048,
-        tokenize_prompt=False,
-    )
-    mid_plugin = object.__new__(RandomDatasetPlugin)
-    mid_plugin.query_parameters = mid_args
-    mid_plugin.number = mid_args.total_count
-
-    small_long_args = _make_args(
-        dataset='random',
-        number=128,
-        num_workers=0,
-        min_prompt_length=8192,
-        max_prompt_length=8192,
-        tokenize_prompt=False,
-    )
-    small_long_plugin = object.__new__(RandomDatasetPlugin)
-    small_long_plugin.query_parameters = small_long_args
-    small_long_plugin.number = small_long_args.total_count
-
-    large_long_args = _make_args(
-        dataset='random',
-        number=512,
-        num_workers=0,
-        min_prompt_length=8192,
-        max_prompt_length=8192,
-        tokenize_prompt=False,
-    )
-    large_long_plugin = object.__new__(RandomDatasetPlugin)
-    large_long_plugin.query_parameters = large_long_args
-    large_long_plugin.number = large_long_args.total_count
-
-    explicit_args = _make_args(
-        dataset='random',
-        number=512,
-        num_workers=2,
-        min_prompt_length=64,
-        max_prompt_length=64,
-        tokenize_prompt=False,
-    )
-    explicit_plugin = object.__new__(RandomDatasetPlugin)
-    explicit_plugin.query_parameters = explicit_args
-    explicit_plugin.number = explicit_args.total_count
+    short_plugin = _make_random_plugin(_make_args(
+        dataset='random', number=512, num_workers=0,
+        min_prompt_length=64, max_prompt_length=64, tokenize_prompt=False,
+    ))
+    mid_plugin = _make_random_plugin(_make_args(
+        dataset='random', number=512, num_workers=0,
+        min_prompt_length=2048, max_prompt_length=2048, tokenize_prompt=False,
+    ))
+    small_long_plugin = _make_random_plugin(_make_args(
+        dataset='random', number=128, num_workers=0,
+        min_prompt_length=8192, max_prompt_length=8192, tokenize_prompt=False,
+    ))
+    large_long_plugin = _make_random_plugin(_make_args(
+        dataset='random', number=512, num_workers=0,
+        min_prompt_length=8192, max_prompt_length=8192, tokenize_prompt=False,
+    ))
+    explicit_plugin = _make_random_plugin(_make_args(
+        dataset='random', number=512, num_workers=2,
+        min_prompt_length=64, max_prompt_length=64, tokenize_prompt=False,
+    ))
 
     assert not short_plugin.supports_parallel_message_generation()
     assert not mid_plugin.supports_parallel_message_generation()
@@ -190,15 +166,16 @@ def test_random_dataset_auto_parallel_requires_large_long_prompt_work() -> None:
 
 
 def test_random_dataset_serial_generation_uses_item_local_seeds(monkeypatch: MonkeyPatch) -> None:
-    def fake_generate_token_sequence(
-        self: RandomDatasetPlugin,
-        input_len: int,
-        offset: int,
-        index: int,
-    ) -> Tuple[str, int, int]:
-        return f'{input_len}-{offset}-{index}-{np.random.randint(0, 100000)}', input_len, 0
+    def fake_gen_prompt(tokenizer, token_sequence, target_token_len, add_special_tokens, allowed_tokens):
+        """Return a prompt that embeds the current numpy random state so we can
+        verify that seeds are applied before each item."""
+        prompt = f'{target_token_len}-{np.random.randint(0, 100000)}'
+        return prompt, token_sequence, 0
 
-    monkeypatch.setattr(RandomDatasetPlugin, 'generate_token_sequence', fake_generate_token_sequence)
+    monkeypatch.setattr(
+        'evalscope.perf.plugin.datasets.random_dataset.gen_prompt_decode_to_target_len',
+        fake_gen_prompt,
+    )
 
     args = _make_args(
         dataset='random',
@@ -211,21 +188,11 @@ def test_random_dataset_serial_generation_uses_item_local_seeds(monkeypatch: Mon
     )
 
     np.random.seed(123)
-    serial_plugin = object.__new__(RandomDatasetPlugin)
-    serial_plugin.query_parameters = args
-    serial_plugin.number = args.total_count
-    serial_plugin.allowed_tokens = np.arange(100)
-    serial_plugin.prefix_ids = []
-    serial_plugin.prefix_length = 0
+    serial_plugin = _make_random_plugin(args)
     serial = list(serial_plugin.build_messages())
 
     np.random.seed(123)
-    expected_plugin = object.__new__(RandomDatasetPlugin)
-    expected_plugin.query_parameters = args
-    expected_plugin.number = args.total_count
-    expected_plugin.allowed_tokens = np.arange(100)
-    expected_plugin.prefix_ids = []
-    expected_plugin.prefix_length = 0
+    expected_plugin = _make_random_plugin(args)
     plan = expected_plugin._create_generation_plan(args.total_count, include_seeds=True)
     expected = [
         expected_plugin._build_random_message(input_len, offset, index, seed)[0]


### PR DESCRIPTION
## Summary

Add shared CPU-bound dataset/request generation workers for perf benchmarks.

This now uses the existing `num_workers` concept instead of adding a separate request-generation-only option. The top-level perf CLI option is `--num-workers`; legacy `multi_turn_args.num_workers` is still accepted only as a compatibility bridge when top-level `num_workers` is left at `0`.

Closes #1433

## Parallel Acceleration Algorithm

1. Worker count is configured by top-level `--num-workers`:

- `0`: auto mode.
- `1`: force serial generation.
- `>1`: explicitly use up to that many worker processes, capped by the item count.

2. Shared worker resolution lives in `evalscope/perf/utils/worker_util.py` and is used by both `benchmark.py` and `swe_smith` live construction:

```python
amortized_workers = max(1, total_count // 128)
workers = min(available_cpu_count, total_count, 32, amortized_workers)
```

`available_cpu_count` honors Linux CPU affinity via `os.sched_getaffinity(0)` before falling back to `os.cpu_count()`.

3. Random dataset auto mode has an additional dataset-level gate because spawn is not free:

- Explicit `--num-workers > 1` is honored.
- `--tokenize-prompt` does not auto-enable multiprocessing because that path is already cheap.
- Auto multiprocessing requires `prompt_length_estimate >= 8192`.
- Auto multiprocessing also requires `prompt_length_estimate * total_count >= 4 * 1024 * 1024` token-work units.

This intentionally avoids regressions on small/medium workloads where process startup, tokenizer reload, and IPC dominate.

4. Process start mode is `spawn`, not `fork`.

Each random-generation worker initializes process-local state through `ProcessPoolExecutor(initializer=...)`:

- `TOKENIZERS_PARALLELISM=false` is set in the child.
- A fresh tokenizer is loaded in each child when text prompt decoding is needed.
- Tokenizer objects are not reused across a fork boundary.
- Worker state is held in a `_RandomGenerationWorkerState` dataclass instead of a mutable global dict / copy-on-write relay.

5. Random generation itself remains deterministic and order-stable:

- The parent pre-samples the full per-item plan: `(input_len, offset, seed)`.
- Workers receive independent tasks: `(index, input_len, offset, seed)`.
- The parent fills the result array by `index`, so warmup remains first and request order remains stable.
- Missing indexes raise immediately.
- Token mismatch accounting is aggregated after worker results return.

6. `swe_smith` live construction now uses the same top-level worker resolver. It resolves workers after candidate work items are known, so the resolver is based on CPU work item count rather than requested output count.

## Benchmark Evidence

Command:

```bash
python3 examples/perf/benchmark_random_request_generation.py \
  --numbers 128 512 \
  --prompt-lengths 2048 8192 \
  --workers 1 2 4 8 0 \
  --tokenizer-path Qwen/Qwen2.5-0.5B-Instruct
```

Environment: local 32-core CPU affinity, Python 3.12, no HTTP requests, raw text prompts (`--apply-chat-template` disabled).

| number | prompt_length | configured_workers | resolved_workers | seconds | req/s |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 2048 | 1 | 1 | 5.519 | 23.19 |
| 128 | 2048 | 2 | 2 | 7.685 | 16.66 |
| 128 | 2048 | 4 | 4 | 10.466 | 12.23 |
| 128 | 2048 | 8 | 8 | 16.939 | 7.56 |
| 128 | 2048 | 0 | 1 | 3.437 | 37.24 |
| 128 | 8192 | 1 | 1 | 6.543 | 19.56 |
| 128 | 8192 | 2 | 2 | 9.224 | 13.88 |
| 128 | 8192 | 4 | 4 | 10.488 | 12.20 |
| 128 | 8192 | 8 | 8 | 16.950 | 7.55 |
| 128 | 8192 | 0 | 1 | 5.998 | 21.34 |
| 512 | 2048 | 1 | 1 | 10.426 | 49.11 |
| 512 | 2048 | 2 | 2 | 11.683 | 43.82 |
| 512 | 2048 | 4 | 4 | 11.752 | 43.57 |
| 512 | 2048 | 8 | 8 | 17.470 | 29.31 |
| 512 | 2048 | 0 | 1 | 10.026 | 51.07 |
| 512 | 8192 | 1 | 1 | 20.339 | 25.17 |
| 512 | 8192 | 2 | 2 | 17.174 | 29.81 |
| 512 | 8192 | 4 | 4 | 14.669 | 34.90 |
| 512 | 8192 | 8 | 8 | 17.479 | 29.29 |
| 512 | 8192 | 0 | 4 | 14.331 | 35.73 |

Interpretation: spawn overhead is material. Auto mode now stays serial where multiprocessing is slower, and enables 4 workers for the 512x8192 case where it improves wall-clock time from 20.339s to 14.331s (~1.42x).

## Validation

- `pytest tests/perf/test_request_generation.py -q`
- `python3 examples/perf/benchmark_random_request_generation.py --numbers 128 512 --prompt-lengths 2048 8192 --workers 1 2 4 8 0 --tokenizer-path Qwen/Qwen2.5-0.5B-Instruct`
- `make lint`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`