### PR TITLE
feat: support anthropic prompt caching

### DIFF
--- a/evalscope/agent/external/bridge/server.py
+++ b/evalscope/agent/external/bridge/server.py
@@ -914,7 +914,30 @@ def _build_generate_config(body: Dict[str, Any]) -> GenerateConfig:
         kwargs['top_p'] = body['top_p']
     if 'stop_sequences' in body and body['stop_sequences']:
         kwargs['stop_seqs'] = list(body['stop_sequences'])
+    cache_control = body.get('cache_control')
+    if isinstance(cache_control, dict) and not _has_anthropic_block_cache_control(body):
+        kwargs['anthropic_cache_control'] = cache_control
+        kwargs['anthropic_cache_strategy'] = 'recent_messages'
     return GenerateConfig(**kwargs)
+
+
+def _has_anthropic_block_cache_control(body: Dict[str, Any]) -> bool:
+    if _has_cache_control_marker(body.get('system')):
+        return True
+    if any(isinstance(tool, dict) and isinstance(tool.get('cache_control'), dict) for tool in body.get('tools') or []):
+        return True
+    return any(
+        isinstance(message, dict) and _has_cache_control_marker(message.get('content'))
+        for message in body.get('messages') or []
+    )
+
+
+def _has_cache_control_marker(value: Any) -> bool:
+    if isinstance(value, dict):
+        return isinstance(value.get('cache_control'), dict) or _has_cache_control_marker(value.get('content'))
+    if isinstance(value, list):
+        return any(_has_cache_control_marker(item) for item in value)
+    return False
 
 
 def _build_openai_generate_config(body: Dict[str, Any]) -> GenerateConfig:

--- a/evalscope/agent/external/bridge/server.py
+++ b/evalscope/agent/external/bridge/server.py
@@ -915,29 +915,10 @@ def _build_generate_config(body: Dict[str, Any]) -> GenerateConfig:
     if 'stop_sequences' in body and body['stop_sequences']:
         kwargs['stop_seqs'] = list(body['stop_sequences'])
     cache_control = body.get('cache_control')
-    if isinstance(cache_control, dict) and not _has_anthropic_block_cache_control(body):
+    if isinstance(cache_control, dict):
         kwargs['anthropic_cache_control'] = cache_control
         kwargs['anthropic_cache_strategy'] = 'recent_messages'
     return GenerateConfig(**kwargs)
-
-
-def _has_anthropic_block_cache_control(body: Dict[str, Any]) -> bool:
-    if _has_cache_control_marker(body.get('system')):
-        return True
-    if any(isinstance(tool, dict) and isinstance(tool.get('cache_control'), dict) for tool in body.get('tools') or []):
-        return True
-    return any(
-        isinstance(message, dict) and _has_cache_control_marker(message.get('content'))
-        for message in body.get('messages') or []
-    )
-
-
-def _has_cache_control_marker(value: Any) -> bool:
-    if isinstance(value, dict):
-        return isinstance(value.get('cache_control'), dict) or _has_cache_control_marker(value.get('content'))
-    if isinstance(value, list):
-        return any(_has_cache_control_marker(item) for item in value)
-    return False
 
 
 def _build_openai_generate_config(body: Dict[str, Any]) -> GenerateConfig:

--- a/evalscope/agent/external/bridge/sse_anthropic.py
+++ b/evalscope/agent/external/bridge/sse_anthropic.py
@@ -25,7 +25,7 @@ from typing import Any, AsyncIterator, Dict, Optional
 
 from evalscope.api.model import ModelOutput
 from ._sse_common import PING_INTERVAL_S, TEXT_CHUNK, TOOL_INPUT_CHUNK, iter_chunks
-from .translate_anthropic import map_stop_reason_to_anthropic, unpack_tool_call
+from .translate_anthropic import anthropic_usage_payload, map_stop_reason_to_anthropic, unpack_tool_call
 
 
 def _sse(event_type: str, data: Dict[str, Any]) -> bytes:
@@ -107,17 +107,13 @@ async def stream_anthropic_response(
 
     # 4. message_delta — stop reason + cumulative usage.
     stop_reason = map_stop_reason_to_anthropic(output.choices[0].stop_reason if output.choices else 'stop')
-    usage = output.usage
     delta_payload: Dict[str, Any] = {
         'type': 'message_delta',
         'delta': {
             'stop_reason': stop_reason,
             'stop_sequence': None
         },
-        'usage': {
-            'input_tokens': usage.input_tokens if usage else 0,
-            'output_tokens': usage.output_tokens if usage else 0,
-        },
+        'usage': anthropic_usage_payload(output.usage),
     }
     yield _sse('message_delta', delta_payload)
 

--- a/evalscope/agent/external/bridge/translate_anthropic.py
+++ b/evalscope/agent/external/bridge/translate_anthropic.py
@@ -1,7 +1,8 @@
 """Anthropic Messages API ⇄ EvalScope native type translation.
 
-P0 scope: text + ``tool_use`` + ``tool_result`` blocks, no streaming, no
-``cache_control``, no extended-thinking blocks.  See
+P0 scope: text + ``tool_use`` + ``tool_result`` blocks, no extended-thinking
+blocks.  Anthropic ``cache_control`` markers are preserved through EvalScope
+provider-specific ``internal`` / ``options`` fields.  See
 ``.qoder/plans/agent_bridge_design.md`` §7.4 for known-lossy cases.
 """
 
@@ -14,6 +15,7 @@ from evalscope.api.messages import (
     ChatMessageSystem,
     ChatMessageTool,
     ChatMessageUser,
+    ContentText,
 )
 from evalscope.api.model import ModelOutput
 from evalscope.api.tool import ToolCall, ToolCallError, ToolFunction, ToolInfo, ToolParams
@@ -47,9 +49,10 @@ def anthropic_request_to_messages(body: Dict[str, Any]) -> List[ChatMessage]:
     if isinstance(system, str) and system:
         messages.append(ChatMessageSystem(content=system))
     elif isinstance(system, list):
-        text = ''.join(b.get('text', '') for b in system if isinstance(b, dict) and b.get('type') == 'text')
-        if text:
-            messages.append(ChatMessageSystem(content=text))
+        content = [_content_text_from_block(b) for b in system if isinstance(b, dict) and b.get('type') == 'text']
+        content = [c for c in content if c.text]
+        if content:
+            messages.append(ChatMessageSystem(content=content))
 
     for entry in body.get('messages') or []:
         if not isinstance(entry, dict):
@@ -68,21 +71,21 @@ def _user_blocks_to_messages(content: Any) -> List[ChatMessage]:
         return [ChatMessageUser(content=content)]
     if not isinstance(content, list):
         return []
-    user_text_parts: List[str] = []
+    user_content: List[ContentText] = []
     tool_msgs: List[ChatMessage] = []
     for block in content:
         if not isinstance(block, dict):
             continue
         btype = block.get('type')
         if btype == 'text':
-            user_text_parts.append(block.get('text', ''))
+            user_content.append(_content_text_from_block(block))
         elif btype == 'tool_result':
             tool_msgs.append(_tool_result_to_message(block))
     # Tool results precede any new user text so the model sees the
     # observation first, then the new prompt (matches OpenAI ordering).
     out: List[ChatMessage] = list(tool_msgs)
-    if user_text_parts:
-        out.append(ChatMessageUser(content='\n'.join(p for p in user_text_parts if p)))
+    if user_content:
+        out.append(ChatMessageUser(content=_content_or_text(user_content)))
     return out
 
 
@@ -98,13 +101,14 @@ def _tool_result_to_message(block: Dict[str, Any]) -> ChatMessageTool:
         content=text,
         tool_call_id=block.get('tool_use_id'),
         error=error,
+        internal=_anthropic_internal_from_block(block),
     )
 
 
 def _assistant_blocks_to_message(content: Any) -> ChatMessageAssistant:
     if isinstance(content, str):
         return ChatMessageAssistant(content=content)
-    text_parts: List[str] = []
+    text_content: List[ContentText] = []
     tool_calls: List[ToolCall] = []
     if isinstance(content, list):
         for block in content:
@@ -112,7 +116,7 @@ def _assistant_blocks_to_message(content: Any) -> ChatMessageAssistant:
                 continue
             btype = block.get('type')
             if btype == 'text':
-                text_parts.append(block.get('text', ''))
+                text_content.append(_content_text_from_block(block))
             elif btype == 'tool_use':
                 tool_calls.append(
                     ToolCall(
@@ -121,12 +125,40 @@ def _assistant_blocks_to_message(content: Any) -> ChatMessageAssistant:
                             name=block.get('name', ''),
                             arguments=block.get('input') or {},
                         ),
+                        internal=_anthropic_internal_from_block(block),
                         type='function',
                     )
                 )
     return ChatMessageAssistant(
-        content='\n'.join(p for p in text_parts if p),
+        content=_content_or_text(text_content),
         tool_calls=tool_calls or None,
+    )
+
+
+def _content_text_from_block(block: Dict[str, Any]) -> ContentText:
+    return ContentText(
+        text=block.get('text', ''),
+        internal=_anthropic_internal_from_block(block),
+    )
+
+
+def _content_or_text(content: List[ContentText]) -> Any:
+    if any(_has_anthropic_cache_control(c.internal) for c in content):
+        return content
+    return '\n'.join(c.text for c in content if c.text)
+
+
+def _anthropic_internal_from_block(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    cache_control = block.get('cache_control')
+    if isinstance(cache_control, dict):
+        return {'anthropic': {'cache_control': cache_control}}
+    return None
+
+
+def _has_anthropic_cache_control(internal: Any) -> bool:
+    return (
+        isinstance(internal, dict) and isinstance(internal.get('anthropic'), dict)
+        and isinstance(internal['anthropic'].get('cache_control'), dict)
     )
 
 
@@ -142,11 +174,14 @@ def anthropic_tools_to_tool_infos(tools: Sequence[Dict[str, Any]]) -> List[ToolI
             continue
         schema = spec.get('input_schema') or {}
         params = ToolParams() if not isinstance(schema, dict) else _safe_tool_params(schema)
-        out.append(ToolInfo(
-            name=name,
-            description=spec.get('description', '') or '',
-            parameters=params,
-        ))
+        out.append(
+            ToolInfo(
+                name=name,
+                description=spec.get('description', '') or '',
+                parameters=params,
+                options=_anthropic_internal_from_block(spec),
+            )
+        )
     return out
 
 
@@ -185,7 +220,7 @@ def model_output_to_anthropic_response(
         blocks.append({'type': 'text', 'text': ''})
 
     stop_reason = map_stop_reason_to_anthropic(output.choices[0].stop_reason if output.choices else 'stop')
-    usage = output.usage
+    usage = anthropic_usage_payload(output.usage)
     return {
         'id': output.id or f'msg_{uuid.uuid4().hex[:24]}',
         'type': 'message',
@@ -194,10 +229,7 @@ def model_output_to_anthropic_response(
         'model': request_model or output.model or '',
         'stop_reason': stop_reason,
         'stop_sequence': None,
-        'usage': {
-            'input_tokens': usage.input_tokens if usage else 0,
-            'output_tokens': usage.output_tokens if usage else 0,
-        },
+        'usage': usage,
     }
 
 
@@ -218,3 +250,15 @@ def map_stop_reason_to_anthropic(reason: str) -> str:
     table lives in exactly one place.
     """
     return _STOP_REASON_MAP.get(reason, 'end_turn')
+
+
+def anthropic_usage_payload(usage: Any) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        'input_tokens': usage.input_tokens if usage else 0,
+        'output_tokens': usage.output_tokens if usage else 0,
+    }
+    if usage and usage.input_tokens_cache_write is not None:
+        payload['cache_creation_input_tokens'] = usage.input_tokens_cache_write
+    if usage and usage.input_tokens_cache_read is not None:
+        payload['cache_read_input_tokens'] = usage.input_tokens_cache_read
+    return payload

--- a/evalscope/api/model/__init__.py
+++ b/evalscope/api/model/__init__.py
@@ -1,4 +1,4 @@
-from .generate_config import GenerateConfig
+from .generate_config import AnthropicCacheControl, GenerateConfig
 from .lazy_model import LazyModel
 from .model import Model, ModelAPI, get_model, get_model_with_task_config
 from .model_output import (

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -112,16 +112,13 @@ class GenerateConfig(BaseModel):
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
 
     anthropic_cache_control: Optional[AnthropicCacheControl] = Field(default=None)
-    """Anthropic prompt cache control.
-
-    For prompt caching, set this to ``{"type": "ephemeral"}`` to add explicit cache breakpoints.
-    """
+    """Anthropic prompt cache control. Set to ``{"type": "ephemeral"}`` to enable prompt caching."""
 
     anthropic_cache_strategy: Literal['evaluation', 'recent_messages'] = Field(default='evaluation')
     """Anthropic prompt cache breakpoint placement strategy.
 
     ``evaluation`` caches stable evaluation prefixes such as tools, system prompts, and few-shot examples.
-    ``recent_messages`` caches the most recent message content block for multi-turn agent workloads.
+    ``recent_messages`` caches stable agent prefixes and the growing multi-turn conversation history.
     """
 
     reasoning_summary: Optional[Literal['concise', 'detailed', 'auto']] = Field(default=None)

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -1,6 +1,6 @@
 # flake8: noqa: E501
 from copy import deepcopy
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Any, Dict, List, Literal, Optional
 
 from evalscope.utils.json_schema import JSONSchema
@@ -21,6 +21,18 @@ class ResponseSchema(BaseModel):
     strict: Optional[bool] = Field(default=None)
     """Whether to enable strict schema adherence when generating the output. If set to true, the model will always follow the exact schema defined in the schema field.
     OpenAI and Mistral only."""
+
+
+class AnthropicCacheControl(BaseModel):
+    """Anthropic prompt cache control."""
+
+    model_config = {'extra': 'forbid'}
+
+    type: Literal['ephemeral'] = Field(default='ephemeral')
+    """Anthropic cache type."""
+
+    ttl: Optional[Literal['5m', '1h']] = Field(default=None)
+    """Optional cache time-to-live."""
 
 
 class GenerateConfig(BaseModel):
@@ -99,6 +111,19 @@ class GenerateConfig(BaseModel):
     reasoning_tokens: Optional[int] = Field(default=None)
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
 
+    anthropic_cache_control: Optional[AnthropicCacheControl] = Field(default=None)
+    """Anthropic prompt cache control.
+
+    For prompt caching, set this to ``{"type": "ephemeral"}`` to add explicit cache breakpoints.
+    """
+
+    anthropic_cache_strategy: Literal['evaluation', 'recent_messages'] = Field(default='evaluation')
+    """Anthropic prompt cache breakpoint placement strategy.
+
+    ``evaluation`` caches stable evaluation prefixes such as tools, system prompts, and few-shot examples.
+    ``recent_messages`` caches the most recent message content block for multi-turn agent workloads.
+    """
+
     reasoning_summary: Optional[Literal['concise', 'detailed', 'auto']] = Field(default=None)
     """Provide summary of reasoning steps (defaults to no summary). Use 'auto' to access the most detailed summarizer available for the current model. OpenAI reasoning models only."""
 
@@ -143,6 +168,16 @@ class GenerateConfig(BaseModel):
 
     guidance_scale: Optional[float] = Field(default=None)
     """Guidance scale for image generation model only"""
+
+    @model_validator(mode='before')
+    @classmethod
+    def reject_legacy_anthropic_cache_config(cls, data: Any) -> Any:
+        if isinstance(data, dict) and 'anthropic_content_cache_control' in data:
+            raise ValueError(
+                '`anthropic_content_cache_control` has been replaced by `anthropic_cache_control`. '
+                'Use `anthropic_cache_strategy` to choose breakpoint placement.'
+            )
+        return data
 
     def merge(self, other: 'GenerateConfig') -> 'GenerateConfig':
         """Merge another model configuration into this one.

--- a/evalscope/models/anthropic_compatible.py
+++ b/evalscope/models/anthropic_compatible.py
@@ -138,9 +138,14 @@ class AnthropicCompatibleAPI(ModelAPI):
 
         # Build completion parameters
         completion_params = self.completion_params(config)
+        cache_control = self.cache_control_params(config)
 
         # Convert messages to Anthropic format
-        system_message, messages = anthropic_chat_messages(input)
+        system_message, messages = anthropic_chat_messages(
+            input,
+            cache_control=cache_control,
+            cache_strategy=config.anthropic_cache_strategy,
+        )
 
         # Build request
         request = dict(
@@ -154,7 +159,11 @@ class AnthropicCompatibleAPI(ModelAPI):
 
         # Add tools if present
         if len(tools) > 0:
-            request['tools'] = anthropic_chat_tools(tools)
+            request['tools'] = anthropic_chat_tools(
+                tools,
+                cache_control=cache_control,
+                cache_strategy=config.anthropic_cache_strategy,
+            )
             request['tool_choice'] = anthropic_chat_tool_choice(tool_choice)
 
         # Handle streaming
@@ -218,8 +227,13 @@ class AnthropicCompatibleAPI(ModelAPI):
         tools, tool_choice, config = self.resolve_tools(tools, tool_choice, config)
 
         completion_params = self.completion_params(config)
+        cache_control = self.cache_control_params(config)
 
-        system_message, messages = anthropic_chat_messages(input)
+        system_message, messages = anthropic_chat_messages(
+            input,
+            cache_control=cache_control,
+            cache_strategy=config.anthropic_cache_strategy,
+        )
 
         request = dict(
             messages=messages,
@@ -230,7 +244,11 @@ class AnthropicCompatibleAPI(ModelAPI):
             request['system'] = system_message
 
         if len(tools) > 0:
-            request['tools'] = anthropic_chat_tools(tools)
+            request['tools'] = anthropic_chat_tools(
+                tools,
+                cache_control=cache_control,
+                cache_strategy=config.anthropic_cache_strategy,
+            )
             request['tool_choice'] = anthropic_chat_tool_choice(tool_choice)
 
         if config.stream:
@@ -285,6 +303,12 @@ class AnthropicCompatibleAPI(ModelAPI):
             model=self.model_name,
             config=config,
         )
+
+    def cache_control_params(self, config: GenerateConfig) -> Optional[Dict[str, Any]]:
+        """Build Anthropic cache_control parameters from config."""
+        if config.anthropic_cache_control is None:
+            return None
+        return config.anthropic_cache_control.model_dump(exclude_none=True)
 
     def validate_request_params(self, params: Dict[str, Any]):
         """Hook for subclasses to do custom request parameter validation."""

--- a/evalscope/models/anthropic_compatible.py
+++ b/evalscope/models/anthropic_compatible.py
@@ -138,12 +138,12 @@ class AnthropicCompatibleAPI(ModelAPI):
 
         # Build completion parameters
         completion_params = self.completion_params(config)
-        cache_control = self.cache_control_params(config)
+        explicit_cache_control = self.explicit_cache_control_params(config)
 
         # Convert messages to Anthropic format
         system_message, messages = anthropic_chat_messages(
             input,
-            cache_control=cache_control,
+            cache_control=explicit_cache_control,
             cache_strategy=config.anthropic_cache_strategy,
         )
 
@@ -161,7 +161,7 @@ class AnthropicCompatibleAPI(ModelAPI):
         if len(tools) > 0:
             request['tools'] = anthropic_chat_tools(
                 tools,
-                cache_control=cache_control,
+                cache_control=explicit_cache_control,
                 cache_strategy=config.anthropic_cache_strategy,
             )
             request['tool_choice'] = anthropic_chat_tool_choice(tool_choice)
@@ -227,11 +227,11 @@ class AnthropicCompatibleAPI(ModelAPI):
         tools, tool_choice, config = self.resolve_tools(tools, tool_choice, config)
 
         completion_params = self.completion_params(config)
-        cache_control = self.cache_control_params(config)
+        explicit_cache_control = self.explicit_cache_control_params(config)
 
         system_message, messages = anthropic_chat_messages(
             input,
-            cache_control=cache_control,
+            cache_control=explicit_cache_control,
             cache_strategy=config.anthropic_cache_strategy,
         )
 
@@ -246,7 +246,7 @@ class AnthropicCompatibleAPI(ModelAPI):
         if len(tools) > 0:
             request['tools'] = anthropic_chat_tools(
                 tools,
-                cache_control=cache_control,
+                cache_control=explicit_cache_control,
                 cache_strategy=config.anthropic_cache_strategy,
             )
             request['tool_choice'] = anthropic_chat_tool_choice(tool_choice)
@@ -309,6 +309,12 @@ class AnthropicCompatibleAPI(ModelAPI):
         if config.anthropic_cache_control is None:
             return None
         return config.anthropic_cache_control.model_dump(exclude_none=True)
+
+    def explicit_cache_control_params(self, config: GenerateConfig) -> Optional[Dict[str, Any]]:
+        """Return cache_control only for strategies that require explicit breakpoints."""
+        if config.anthropic_cache_strategy != 'evaluation':
+            return None
+        return self.cache_control_params(config)
 
     def validate_request_params(self, params: Dict[str, Any]):
         """Hook for subclasses to do custom request parameter validation."""

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -582,9 +582,7 @@ def collect_stream_response(
                 role = event.message.role
             if event.message.usage:
                 usage_input_tokens = event.message.usage.input_tokens
-                usage_cache_creation_input_tokens = getattr(
-                    event.message.usage, 'cache_creation_input_tokens', None
-                )
+                usage_cache_creation_input_tokens = getattr(event.message.usage, 'cache_creation_input_tokens', None)
                 usage_cache_read_input_tokens = getattr(event.message.usage, 'cache_read_input_tokens', None)
 
         elif isinstance(event, ContentBlockStartEvent):
@@ -753,9 +751,7 @@ async def async_collect_stream_response(
                 role = event.message.role
             if event.message.usage:
                 usage_input_tokens = event.message.usage.input_tokens
-                usage_cache_creation_input_tokens = getattr(
-                    event.message.usage, 'cache_creation_input_tokens', None
-                )
+                usage_cache_creation_input_tokens = getattr(event.message.usage, 'cache_creation_input_tokens', None)
                 usage_cache_read_input_tokens = getattr(event.message.usage, 'cache_read_input_tokens', None)
 
         elif isinstance(event, ContentBlockStartEvent):

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -97,8 +97,10 @@ def anthropic_chat_tools(
 ) -> List[ToolParam]:
     """Convert list of ToolInfo to list of Anthropic ToolParam."""
     tool_params = [anthropic_tool_param(tool) for tool in tools]
-    if cache_control and cache_strategy in ('evaluation', 'recent_messages') and tool_params:
+    if cache_control and cache_strategy == 'evaluation' and tool_params:
         _add_cache_control(cast(Dict[str, Any], tool_params[-1]), cache_control)
+    elif cache_strategy not in ('evaluation', 'recent_messages'):
+        raise ValueError(f'Unknown Anthropic cache strategy: {cache_strategy}')
     return tool_params
 
 
@@ -257,8 +259,8 @@ def anthropic_chat_messages(
             system_message = _system_message_with_cache_control(system_message, cache_control)
             _add_cache_control_to_evaluation_prefix(message_params, cache_control)
         elif cache_strategy == 'recent_messages':
-            system_message = _system_message_with_cache_control(system_message, cache_control)
-            _add_cache_control_to_recent_block(message_params, cache_control)
+            # Top-level cache_control handles Anthropic automatic caching for this strategy.
+            pass
         else:
             raise ValueError(f'Unknown Anthropic cache strategy: {cache_strategy}')
 
@@ -324,18 +326,6 @@ def _add_cache_control_to_evaluation_prefix(
     _add_cache_control_to_last_block(messages[:-1], cache_control)
 
 
-def _add_cache_control_to_recent_block(
-    messages: List[MessageParam],
-    cache_control: Dict[str, Any],
-) -> None:
-    """Attach cache_control to the penultimate cacheable content block when possible."""
-    blocks = _cacheable_content_blocks(messages)
-    if not blocks:
-        return
-    block = blocks[-2] if len(blocks) >= 2 else blocks[-1]
-    _add_cache_control(block, cache_control)
-
-
 def _add_cache_control_to_last_block(
     messages: List[MessageParam],
     cache_control: Dict[str, Any],
@@ -346,19 +336,6 @@ def _add_cache_control_to_last_block(
             _add_cache_control(block, cache_control)
             return True
     return False
-
-
-def _cacheable_content_blocks(messages: List[MessageParam]) -> List[Dict[str, Any]]:
-    blocks: List[Dict[str, Any]] = []
-    for message in messages:
-        content = message['content']
-        if isinstance(content, str):
-            content = [TextBlockParam(type='text', text=content)]
-            message['content'] = content
-        for block in content:
-            if isinstance(block, dict) and _is_cacheable_content_block(block):
-                blocks.append(cast(Dict[str, Any], block))
-    return blocks
 
 
 def _add_cache_control_to_last_block_list(

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -41,6 +41,9 @@ from evalscope.utils.url_utils import data_uri_mime_type, data_uri_to_base64, fi
 
 BASE_64_DATA_REMOVED = '<base64-data-removed>'
 NO_CONTENT = '[No content]'
+MAX_ANTHROPIC_CACHE_CONTROL_BLOCKS = 4
+AnthropicCacheStrategy = Literal['evaluation', 'recent_messages']
+AnthropicSystemParam = Union[str, List[TextBlockParam]]
 
 
 class AnthropicResponseError(Exception):
@@ -63,9 +66,16 @@ def anthropic_tool_param(tool: ToolInfo) -> ToolParam:
     )
 
 
-def anthropic_chat_tools(tools: List[ToolInfo]) -> List[ToolParam]:
+def anthropic_chat_tools(
+    tools: List[ToolInfo],
+    cache_control: Optional[Dict[str, Any]] = None,
+    cache_strategy: AnthropicCacheStrategy = 'evaluation',
+) -> List[ToolParam]:
     """Convert list of ToolInfo to list of Anthropic ToolParam."""
-    return [anthropic_tool_param(tool) for tool in tools]
+    tool_params = [anthropic_tool_param(tool) for tool in tools]
+    if cache_control and cache_strategy == 'evaluation' and tool_params:
+        _add_cache_control(cast(Dict[str, Any], tool_params[-1]), cache_control)
+    return tool_params
 
 
 def anthropic_chat_tool_choice(tool_choice: ToolChoice) -> ToolChoiceParam:
@@ -94,6 +104,12 @@ def anthropic_image_block_param(image: str) -> ImageBlockParam:
         type='image',
         source=dict(type='base64', media_type=cast(Any, media_type), data=image_data),
     )
+
+
+def _add_cache_control(block: Dict[str, Any], cache_control: Optional[Dict[str, Any]]) -> None:
+    """Attach Anthropic cache_control to a content block when requested."""
+    if cache_control:
+        block['cache_control'] = cache_control
 
 
 def anthropic_content_block_param(content: Content) -> List[ContentBlockParam]:
@@ -188,7 +204,11 @@ def anthropic_message_param(message: ChatMessage) -> MessageParam:
         return MessageParam(role='user', content=content)
 
 
-def anthropic_chat_messages(messages: List[ChatMessage], ) -> Tuple[Optional[str], List[MessageParam]]:
+def anthropic_chat_messages(
+    messages: List[ChatMessage],
+    cache_control: Optional[Dict[str, Any]] = None,
+    cache_strategy: AnthropicCacheStrategy = 'evaluation',
+) -> Tuple[Optional[AnthropicSystemParam], List[MessageParam]]:
     """Convert list of ChatMessages to Anthropic format.
 
     Returns:
@@ -210,7 +230,72 @@ def anthropic_chat_messages(messages: List[ChatMessage], ) -> Tuple[Optional[str
     # Collapse consecutive user messages (required by Anthropic)
     message_params = _collapse_consecutive_messages(message_params, 'user')
 
+    if cache_control:
+        if cache_strategy == 'evaluation':
+            system_param = _system_message_with_cache_control(system_message, cache_control)
+            _add_cache_control_to_evaluation_prefix(message_params, cache_control)
+            return system_param, message_params
+        elif cache_strategy == 'recent_messages':
+            _add_cache_control_to_recent_block(message_params, cache_control)
+        else:
+            raise ValueError(f'Unknown Anthropic cache strategy: {cache_strategy}')
+
     return system_message, message_params
+
+
+def _system_message_with_cache_control(
+    system_message: Optional[str],
+    cache_control: Dict[str, Any],
+) -> Optional[List[TextBlockParam]]:
+    if not system_message:
+        return None
+
+    system_blocks = [TextBlockParam(type='text', text=system_message)]
+    _add_cache_control(cast(Dict[str, Any], system_blocks[-1]), cache_control)
+    return system_blocks
+
+
+def _add_cache_control_to_evaluation_prefix(
+    messages: List[MessageParam],
+    cache_control: Dict[str, Any],
+) -> None:
+    """Attach cache_control to the stable message prefix before the final sample message."""
+    if len(messages) <= 1:
+        return
+
+    _add_cache_control_to_last_block(messages[:-1], cache_control)
+
+
+def _add_cache_control_to_recent_block(
+    messages: List[MessageParam],
+    cache_control: Dict[str, Any],
+) -> None:
+    """Attach cache_control to the most recent cacheable message content block."""
+    _add_cache_control_to_last_block(messages, cache_control)
+
+
+def _add_cache_control_to_last_block(
+    messages: List[MessageParam],
+    cache_control: Dict[str, Any],
+) -> bool:
+    for message in reversed(messages):
+        block = _last_cacheable_content_block(message)
+        if block is not None:
+            _add_cache_control(block, cache_control)
+            return True
+    return False
+
+
+def _last_cacheable_content_block(message: MessageParam) -> Optional[Dict[str, Any]]:
+    content = message['content']
+    if isinstance(content, str):
+        content = [TextBlockParam(type='text', text=content)]
+        message['content'] = content
+
+    for block in reversed(content):
+        if isinstance(block, dict):
+            return cast(Dict[str, Any], block)
+    return None
 
 
 def _collapse_consecutive_messages(messages: List[MessageParam], role: Literal['user',
@@ -476,6 +561,8 @@ def collect_stream_response(
     stop_reason: Optional[str] = None
     usage_input_tokens: int = 0
     usage_output_tokens: int = 0
+    usage_cache_creation_input_tokens: Optional[int] = None
+    usage_cache_read_input_tokens: Optional[int] = None
 
     current_block_index: int = -1
     current_text: str = ''
@@ -495,6 +582,10 @@ def collect_stream_response(
                 role = event.message.role
             if event.message.usage:
                 usage_input_tokens = event.message.usage.input_tokens
+                usage_cache_creation_input_tokens = getattr(
+                    event.message.usage, 'cache_creation_input_tokens', None
+                )
+                usage_cache_read_input_tokens = getattr(event.message.usage, 'cache_read_input_tokens', None)
 
         elif isinstance(event, ContentBlockStartEvent):
             # Save previous block if exists
@@ -533,6 +624,16 @@ def collect_stream_response(
             stop_reason = event.delta.stop_reason
             if event.usage:
                 usage_output_tokens = event.usage.output_tokens
+                usage_cache_creation_input_tokens = _usage_token_value(
+                    usage_cache_creation_input_tokens,
+                    event.usage,
+                    'cache_creation_input_tokens',
+                )
+                usage_cache_read_input_tokens = _usage_token_value(
+                    usage_cache_read_input_tokens,
+                    event.usage,
+                    'cache_read_input_tokens',
+                )
 
     # Append the last block
     if current_block_index >= 0:
@@ -546,8 +647,37 @@ def collect_stream_response(
         content=content_blocks,
         stop_reason=stop_reason,  # type: ignore
         stop_sequence=None,
-        usage=Usage(input_tokens=usage_input_tokens, output_tokens=usage_output_tokens),
+        usage=Usage(
+            **_anthropic_usage_params(
+                input_tokens=usage_input_tokens,
+                output_tokens=usage_output_tokens,
+                cache_creation_input_tokens=usage_cache_creation_input_tokens,
+                cache_read_input_tokens=usage_cache_read_input_tokens,
+            )
+        ),
     ), ttft
+
+
+def _usage_token_value(current_value: Optional[int], usage: Any, field: str) -> Optional[int]:
+    value = getattr(usage, field, None)
+    return value if value is not None else current_value
+
+
+def _anthropic_usage_params(
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_input_tokens: Optional[int],
+    cache_read_input_tokens: Optional[int],
+) -> Dict[str, Any]:
+    usage_params: Dict[str, Any] = {
+        'input_tokens': input_tokens,
+        'output_tokens': output_tokens,
+    }
+    if cache_creation_input_tokens is not None:
+        usage_params['cache_creation_input_tokens'] = cache_creation_input_tokens
+    if cache_read_input_tokens is not None:
+        usage_params['cache_read_input_tokens'] = cache_read_input_tokens
+    return usage_params
 
 
 def _append_content_block(
@@ -603,6 +733,8 @@ async def async_collect_stream_response(
     stop_reason: Optional[str] = None
     usage_input_tokens: int = 0
     usage_output_tokens: int = 0
+    usage_cache_creation_input_tokens: Optional[int] = None
+    usage_cache_read_input_tokens: Optional[int] = None
 
     current_block_index: int = -1
     current_text: str = ''
@@ -621,6 +753,10 @@ async def async_collect_stream_response(
                 role = event.message.role
             if event.message.usage:
                 usage_input_tokens = event.message.usage.input_tokens
+                usage_cache_creation_input_tokens = getattr(
+                    event.message.usage, 'cache_creation_input_tokens', None
+                )
+                usage_cache_read_input_tokens = getattr(event.message.usage, 'cache_read_input_tokens', None)
 
         elif isinstance(event, ContentBlockStartEvent):
             if current_block_index >= 0:
@@ -657,6 +793,16 @@ async def async_collect_stream_response(
             stop_reason = event.delta.stop_reason
             if event.usage:
                 usage_output_tokens = event.usage.output_tokens
+                usage_cache_creation_input_tokens = _usage_token_value(
+                    usage_cache_creation_input_tokens,
+                    event.usage,
+                    'cache_creation_input_tokens',
+                )
+                usage_cache_read_input_tokens = _usage_token_value(
+                    usage_cache_read_input_tokens,
+                    event.usage,
+                    'cache_read_input_tokens',
+                )
 
     # Append the last block
     if current_block_index >= 0:
@@ -670,5 +816,12 @@ async def async_collect_stream_response(
         content=content_blocks,
         stop_reason=stop_reason,  # type: ignore
         stop_sequence=None,
-        usage=Usage(input_tokens=usage_input_tokens, output_tokens=usage_output_tokens),
+        usage=Usage(
+            **_anthropic_usage_params(
+                input_tokens=usage_input_tokens,
+                output_tokens=usage_output_tokens,
+                cache_creation_input_tokens=usage_cache_creation_input_tokens,
+                cache_read_input_tokens=usage_cache_read_input_tokens,
+            )
+        ),
     ), ttft

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -41,7 +41,6 @@ from evalscope.utils.url_utils import data_uri_mime_type, data_uri_to_base64, fi
 
 BASE_64_DATA_REMOVED = '<base64-data-removed>'
 NO_CONTENT = '[No content]'
-MAX_ANTHROPIC_CACHE_CONTROL_BLOCKS = 4
 AnthropicCacheStrategy = Literal['evaluation', 'recent_messages']
 AnthropicSystemParam = Union[str, List[TextBlockParam]]
 
@@ -57,13 +56,38 @@ class AnthropicResponseError(Exception):
         return f'{self.code}: {self.message}'
 
 
+def _anthropic_internal(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        anthropic_value = value.get('anthropic')
+        if isinstance(anthropic_value, dict):
+            return anthropic_value
+    return {}
+
+
+def _cache_control_from_internal(value: Any) -> Optional[Dict[str, Any]]:
+    cache_control = _anthropic_internal(value).get('cache_control')
+    return cache_control if isinstance(cache_control, dict) else None
+
+
+def _add_cache_control(block: Dict[str, Any], cache_control: Optional[Dict[str, Any]]) -> None:
+    """Attach Anthropic cache_control without overwriting caller-provided markers."""
+    if cache_control and 'cache_control' not in block:
+        block['cache_control'] = cache_control
+
+
+def _preserve_cache_control(block: Dict[str, Any], internal: Any) -> None:
+    _add_cache_control(block, _cache_control_from_internal(internal))
+
+
 def anthropic_tool_param(tool: ToolInfo) -> ToolParam:
     """Convert ToolInfo to Anthropic ToolParam."""
-    return ToolParam(
+    tool_param = ToolParam(
         name=tool.name,
         description=tool.description,
         input_schema=tool.parameters.model_dump(exclude_none=True),
     )
+    _preserve_cache_control(cast(Dict[str, Any], tool_param), tool.options)
+    return tool_param
 
 
 def anthropic_chat_tools(
@@ -73,7 +97,7 @@ def anthropic_chat_tools(
 ) -> List[ToolParam]:
     """Convert list of ToolInfo to list of Anthropic ToolParam."""
     tool_params = [anthropic_tool_param(tool) for tool in tools]
-    if cache_control and cache_strategy == 'evaluation' and tool_params:
+    if cache_control and cache_strategy in ('evaluation', 'recent_messages') and tool_params:
         _add_cache_control(cast(Dict[str, Any], tool_params[-1]), cache_control)
     return tool_params
 
@@ -106,18 +130,16 @@ def anthropic_image_block_param(image: str) -> ImageBlockParam:
     )
 
 
-def _add_cache_control(block: Dict[str, Any], cache_control: Optional[Dict[str, Any]]) -> None:
-    """Attach Anthropic cache_control to a content block when requested."""
-    if cache_control:
-        block['cache_control'] = cache_control
-
-
 def anthropic_content_block_param(content: Content) -> List[ContentBlockParam]:
     """Convert Content to list of Anthropic ContentBlockParam."""
     if content.type == 'text':
-        return [TextBlockParam(type='text', text=content.text or NO_CONTENT)]
+        block = TextBlockParam(type='text', text=content.text or NO_CONTENT)
+        _preserve_cache_control(cast(Dict[str, Any], block), content.internal)
+        return [block]
     elif content.type == 'image':
-        return [anthropic_image_block_param(content.image)]
+        block = anthropic_image_block_param(content.image)
+        _preserve_cache_control(cast(Dict[str, Any], block), content.internal)
+        return [block]
     elif content.type == 'reasoning':
         # For reasoning content, we convert to text with think tags
         reasoning_text = f'<think>\n{content.reasoning}\n</think>'
@@ -152,17 +174,14 @@ def anthropic_message_param(message: ChatMessage) -> MessageParam:
             for c in tool_message.content:
                 result_content.extend(anthropic_content_block_param(c))
 
-        return MessageParam(
-            role='user',
-            content=[
-                ToolResultBlockParam(
-                    tool_use_id=str(tool_message.tool_call_id),
-                    type='tool_result',
-                    content=cast(List[TextBlockParam | ImageBlockParam], result_content),
-                    is_error=tool_message.error is not None,
-                )
-            ],
+        tool_result_block = ToolResultBlockParam(
+            tool_use_id=str(tool_message.tool_call_id),
+            type='tool_result',
+            content=cast(List[TextBlockParam | ImageBlockParam], result_content),
+            is_error=tool_message.error is not None,
         )
+        _preserve_cache_control(cast(Dict[str, Any], tool_result_block), tool_message.internal)
+        return MessageParam(role='user', content=[tool_result_block])
 
     elif message.role == 'assistant':
         assistant_message = cast(ChatMessageAssistant, message)
@@ -171,7 +190,9 @@ def anthropic_message_param(message: ChatMessage) -> MessageParam:
         # Add content blocks
         if isinstance(assistant_message.content, str):
             if assistant_message.content:
-                block_params.append(TextBlockParam(type='text', text=assistant_message.content))
+                block = TextBlockParam(type='text', text=assistant_message.content)
+                _preserve_cache_control(cast(Dict[str, Any], block), assistant_message.internal)
+                block_params.append(block)
         else:
             for c in assistant_message.content:
                 block_params.extend(anthropic_content_block_param(c))
@@ -179,21 +200,25 @@ def anthropic_message_param(message: ChatMessage) -> MessageParam:
         # Add tool use blocks
         if assistant_message.tool_calls:
             for tool_call in assistant_message.tool_calls:
-                block_params.append(
-                    ToolUseBlockParam(
-                        type='tool_use',
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        input=tool_call.function.arguments,
-                    )
+                tool_use_block = ToolUseBlockParam(
+                    type='tool_use',
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    input=tool_call.function.arguments,
                 )
+                _preserve_cache_control(cast(Dict[str, Any], tool_use_block), tool_call.internal)
+                block_params.append(tool_use_block)
 
         return MessageParam(role='assistant', content=block_params or [TextBlockParam(type='text', text=NO_CONTENT)])
 
     else:  # user message
         user_message = cast(ChatMessageUser, message)
         if isinstance(user_message.content, str):
-            content = user_message.content or NO_CONTENT
+            if _cache_control_from_internal(user_message.internal):
+                content = [TextBlockParam(type='text', text=user_message.content or NO_CONTENT)]
+                _preserve_cache_control(cast(Dict[str, Any], content[-1]), user_message.internal)
+            else:
+                content = user_message.content or NO_CONTENT
         else:
             content = []
             for c in user_message.content:
@@ -214,16 +239,13 @@ def anthropic_chat_messages(
     Returns:
         Tuple of (system_message, message_params)
     """
-    system_message: Optional[str] = None
+    system_message: Optional[AnthropicSystemParam] = None
     message_params: List[MessageParam] = []
 
     for message in messages:
         if message.role == 'system':
             # Anthropic requires system message as a separate parameter
-            if system_message is None:
-                system_message = message.text
-            else:
-                system_message = f'{system_message}\n\n{message.text}'
+            system_message = _merge_system_message(system_message, _system_param_from_message(message))
         else:
             message_params.append(anthropic_message_param(message))
 
@@ -232,35 +254,62 @@ def anthropic_chat_messages(
 
     if cache_control:
         if cache_strategy == 'evaluation':
-            system_param = _system_message_with_cache_control(system_message, cache_control)
+            system_message = _system_message_with_cache_control(system_message, cache_control)
             _add_cache_control_to_evaluation_prefix(message_params, cache_control)
-            return system_param, message_params
         elif cache_strategy == 'recent_messages':
-            # Anchor the stable prefix (tools + system) with a fixed breakpoint so it is
-            # cache-read on every turn, and add a rolling breakpoint on the most recent
-            # message block to incrementally cache the growing conversation history.
-            #
-            # Without the system anchor the only breakpoint moves forward each turn, so the
-            # cached prefix is written at a different length every request and later turns
-            # rarely find a matching entry -- i.e. the cache is created but almost never hit.
-            system_param = _system_message_with_cache_control(system_message, cache_control)
+            system_message = _system_message_with_cache_control(system_message, cache_control)
             _add_cache_control_to_recent_block(message_params, cache_control)
-            return system_param, message_params
         else:
             raise ValueError(f'Unknown Anthropic cache strategy: {cache_strategy}')
 
     return system_message, message_params
 
 
+def _system_param_from_message(message: ChatMessage) -> AnthropicSystemParam:
+    if isinstance(message.content, str):
+        block_cache_control = _cache_control_from_internal(message.internal)
+        if not block_cache_control:
+            return message.content
+        block = TextBlockParam(type='text', text=message.content or NO_CONTENT)
+        _add_cache_control(cast(Dict[str, Any], block), block_cache_control)
+        return [block]
+
+    blocks: List[TextBlockParam] = []
+    for content in message.content:
+        if content.type != 'text':
+            continue
+        block = TextBlockParam(type='text', text=content.text or NO_CONTENT)
+        _preserve_cache_control(cast(Dict[str, Any], block), content.internal)
+        blocks.append(block)
+    return blocks if blocks else message.text
+
+
+def _merge_system_message(
+    current: Optional[AnthropicSystemParam],
+    new_value: AnthropicSystemParam,
+) -> AnthropicSystemParam:
+    if current is None:
+        return new_value
+    if isinstance(current, str) and isinstance(new_value, str):
+        return f'{current}\n\n{new_value}'
+    return _system_blocks(current) + [TextBlockParam(type='text', text='\n\n')] + _system_blocks(new_value)
+
+
+def _system_blocks(value: AnthropicSystemParam) -> List[TextBlockParam]:
+    if isinstance(value, str):
+        return [TextBlockParam(type='text', text=value)]
+    return value
+
+
 def _system_message_with_cache_control(
-    system_message: Optional[str],
+    system_message: Optional[AnthropicSystemParam],
     cache_control: Dict[str, Any],
 ) -> Optional[List[TextBlockParam]]:
     if not system_message:
         return None
 
-    system_blocks = [TextBlockParam(type='text', text=system_message)]
-    _add_cache_control(cast(Dict[str, Any], system_blocks[-1]), cache_control)
+    system_blocks = _system_blocks(system_message)
+    _add_cache_control_to_last_block_list(system_blocks, cache_control)
     return system_blocks
 
 
@@ -279,8 +328,12 @@ def _add_cache_control_to_recent_block(
     messages: List[MessageParam],
     cache_control: Dict[str, Any],
 ) -> None:
-    """Attach cache_control to the most recent cacheable message content block."""
-    _add_cache_control_to_last_block(messages, cache_control)
+    """Attach cache_control to the penultimate cacheable content block when possible."""
+    blocks = _cacheable_content_blocks(messages)
+    if not blocks:
+        return
+    block = blocks[-2] if len(blocks) >= 2 else blocks[-1]
+    _add_cache_control(block, cache_control)
 
 
 def _add_cache_control_to_last_block(
@@ -295,19 +348,44 @@ def _add_cache_control_to_last_block(
     return False
 
 
+def _cacheable_content_blocks(messages: List[MessageParam]) -> List[Dict[str, Any]]:
+    blocks: List[Dict[str, Any]] = []
+    for message in messages:
+        content = message['content']
+        if isinstance(content, str):
+            content = [TextBlockParam(type='text', text=content)]
+            message['content'] = content
+        for block in content:
+            if isinstance(block, dict) and _is_cacheable_content_block(block):
+                blocks.append(cast(Dict[str, Any], block))
+    return blocks
+
+
+def _add_cache_control_to_last_block_list(
+    blocks: List[TextBlockParam],
+    cache_control: Dict[str, Any],
+) -> bool:
+    for block in reversed(blocks):
+        if isinstance(block, dict):
+            _add_cache_control(cast(Dict[str, Any], block), cache_control)
+            return True
+    return False
+
+
 def _last_cacheable_content_block(message: MessageParam) -> Optional[Dict[str, Any]]:
     content = message['content']
-
     if isinstance(content, str):
         content = [TextBlockParam(type='text', text=content)]
         message['content'] = content
 
     for block in reversed(content):
-        if isinstance(block, dict):
-            block_type = block.get('type')
-            if block_type in ('text', 'image'):
-                return cast(Dict[str, Any], block)
+        if isinstance(block, dict) and _is_cacheable_content_block(block):
+            return cast(Dict[str, Any], block)
     return None
+
+
+def _is_cacheable_content_block(block: Dict[str, Any]) -> bool:
+    return block.get('type') in ('text', 'image')
 
 
 def _collapse_consecutive_messages(messages: List[MessageParam], role: Literal['user',
@@ -319,6 +397,7 @@ def _collapse_consecutive_messages(messages: List[MessageParam], role: Literal['
     result: List[MessageParam] = []
     for message in messages:
         if message['role'] == role and result and result[-1]['role'] == role:
+            # Combine with previous message
             result[-1] = _combine_messages(result[-1], message)
         else:
             result.append(message)
@@ -377,6 +456,10 @@ def anthropic_completion_params(model: str, config: GenerateConfig) -> Dict[str,
     # Extended thinking / reasoning
     if config.reasoning_tokens is not None:
         params['thinking'] = dict(type='enabled', budget_tokens=config.reasoning_tokens)
+
+    # Anthropic top-level automatic prompt caching.
+    if config.anthropic_cache_control and config.anthropic_cache_strategy == 'recent_messages':
+        params['cache_control'] = config.anthropic_cache_control.model_dump(exclude_none=True)
 
     # Extra body parameters
     if config.extra_body:

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -288,13 +288,16 @@ def _add_cache_control_to_last_block(
 
 def _last_cacheable_content_block(message: MessageParam) -> Optional[Dict[str, Any]]:
     content = message['content']
+
     if isinstance(content, str):
         content = [TextBlockParam(type='text', text=content)]
         message['content'] = content
 
     for block in reversed(content):
         if isinstance(block, dict):
-            return cast(Dict[str, Any], block)
+            block_type = block.get('type')
+            if block_type in ('text', 'image'):
+                return cast(Dict[str, Any], block)
     return None
 
 
@@ -307,7 +310,6 @@ def _collapse_consecutive_messages(messages: List[MessageParam], role: Literal['
     result: List[MessageParam] = []
     for message in messages:
         if message['role'] == role and result and result[-1]['role'] == role:
-            # Combine with previous message
             result[-1] = _combine_messages(result[-1], message)
         else:
             result.append(message)

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -236,7 +236,16 @@ def anthropic_chat_messages(
             _add_cache_control_to_evaluation_prefix(message_params, cache_control)
             return system_param, message_params
         elif cache_strategy == 'recent_messages':
+            # Anchor the stable prefix (tools + system) with a fixed breakpoint so it is
+            # cache-read on every turn, and add a rolling breakpoint on the most recent
+            # message block to incrementally cache the growing conversation history.
+            #
+            # Without the system anchor the only breakpoint moves forward each turn, so the
+            # cached prefix is written at a different length every request and later turns
+            # rarely find a matching entry -- i.e. the cache is created but almost never hit.
+            system_param = _system_message_with_cache_control(system_message, cache_control)
             _add_cache_control_to_recent_block(message_params, cache_control)
+            return system_param, message_params
         else:
             raise ValueError(f'Unknown Anthropic cache strategy: {cache_strategy}')
 

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -272,7 +272,7 @@ def _system_param_from_message(message: ChatMessage) -> AnthropicSystemParam:
         block_cache_control = _cache_control_from_internal(message.internal)
         if not block_cache_control:
             return message.content
-        block = TextBlockParam(type='text', text=message.content or NO_CONTENT)
+        block = cast(TextBlockParam, {'type': 'text', 'text': message.content or NO_CONTENT})
         _add_cache_control(cast(Dict[str, Any], block), block_cache_control)
         return [block]
 
@@ -280,7 +280,7 @@ def _system_param_from_message(message: ChatMessage) -> AnthropicSystemParam:
     for content in message.content:
         if content.type != 'text':
             continue
-        block = TextBlockParam(type='text', text=content.text or NO_CONTENT)
+        block = cast(TextBlockParam, {'type': 'text', 'text': content.text or NO_CONTENT})
         _preserve_cache_control(cast(Dict[str, Any], block), content.internal)
         blocks.append(block)
     return blocks if blocks else message.text
@@ -294,12 +294,15 @@ def _merge_system_message(
         return new_value
     if isinstance(current, str) and isinstance(new_value, str):
         return f'{current}\n\n{new_value}'
-    return _system_blocks(current) + [TextBlockParam(type='text', text='\n\n')] + _system_blocks(new_value)
+    return _system_blocks(current) + [cast(TextBlockParam, {
+        'type': 'text',
+        'text': '\n\n'
+    })] + _system_blocks(new_value)
 
 
 def _system_blocks(value: AnthropicSystemParam) -> List[TextBlockParam]:
     if isinstance(value, str):
-        return [TextBlockParam(type='text', text=value)]
+        return [cast(TextBlockParam, {'type': 'text', 'text': value})]
     return value
 
 
@@ -352,7 +355,7 @@ def _add_cache_control_to_last_block_list(
 def _last_cacheable_content_block(message: MessageParam) -> Optional[Dict[str, Any]]:
     content = message['content']
     if isinstance(content, str):
-        content = [TextBlockParam(type='text', text=content)]
+        content = [cast(TextBlockParam, {'type': 'text', 'text': content})]
         message['content'] = content
 
     for block in reversed(content):

--- a/tests/agent/external/test_anthropic_bridge_prompt_cache.py
+++ b/tests/agent/external/test_anthropic_bridge_prompt_cache.py
@@ -1,0 +1,160 @@
+import asyncio
+import json
+
+from evalscope.agent.external.bridge.server import _build_generate_config
+from evalscope.agent.external.bridge.sse_anthropic import stream_anthropic_response
+from evalscope.agent.external.bridge.translate_anthropic import (
+    anthropic_request_to_messages,
+    anthropic_tools_to_tool_infos,
+)
+from evalscope.api.model import ModelOutput, ModelUsage
+
+
+def _cache_control(ttl='5m'):
+    return {'type': 'ephemeral', 'ttl': ttl}
+
+
+def test_anthropic_bridge_top_level_cache_control_enables_recent_messages_strategy():
+    config = _build_generate_config({
+        'max_tokens': 1024,
+        'cache_control': _cache_control('1h'),
+        'messages': [{
+            'role': 'user',
+            'content': 'hi',
+        }],
+    })
+
+    assert config.anthropic_cache_control is not None
+    assert config.anthropic_cache_control.model_dump(exclude_none=True) == _cache_control('1h')
+    assert config.anthropic_cache_strategy == 'recent_messages'
+    assert config.extra_body is None
+
+
+def test_anthropic_bridge_top_level_cache_control_does_not_auto_mark_explicit_blocks():
+    config = _build_generate_config({
+        'cache_control': _cache_control('1h'),
+        'messages': [{
+            'role': 'user',
+            'content': [{
+                'type': 'text',
+                'text': 'hi',
+                'cache_control': _cache_control(),
+            }],
+        }],
+    })
+
+    assert config.anthropic_cache_control is None
+    assert config.anthropic_cache_strategy == 'evaluation'
+    assert config.extra_body is None
+
+
+def test_anthropic_bridge_tool_schema_cache_control_property_does_not_disable_top_level_cache():
+    config = _build_generate_config({
+        'cache_control': _cache_control('1h'),
+        'messages': [{
+            'role': 'user',
+            'content': 'hi',
+        }],
+        'tools': [{
+            'name': 'configure',
+            'description': 'Configure cache settings.',
+            'input_schema': {
+                'type': 'object',
+                'properties': {
+                    'cache_control': {'type': 'string'},
+                },
+            },
+        }],
+    })
+
+    assert config.anthropic_cache_control is not None
+    assert config.anthropic_cache_control.model_dump(exclude_none=True) == _cache_control('1h')
+    assert config.anthropic_cache_strategy == 'recent_messages'
+
+
+def test_anthropic_bridge_preserves_block_level_cache_control():
+    body = {
+        'system': [{
+            'type': 'text',
+            'text': 'stable system',
+            'cache_control': _cache_control('1h'),
+        }],
+        'messages': [
+            {
+                'role': 'user',
+                'content': [{
+                    'type': 'text',
+                    'text': 'cached user',
+                    'cache_control': _cache_control(),
+                }],
+            },
+            {
+                'role': 'assistant',
+                'content': [{
+                    'type': 'tool_use',
+                    'id': 'toolu_1',
+                    'name': 'search',
+                    'input': {'q': 'x'},
+                    'cache_control': _cache_control('1h'),
+                }],
+            },
+            {
+                'role': 'user',
+                'content': [{
+                    'type': 'tool_result',
+                    'tool_use_id': 'toolu_1',
+                    'content': 'result',
+                    'cache_control': _cache_control(),
+                }],
+            },
+        ],
+        'tools': [{
+            'name': 'search',
+            'description': 'Search docs.',
+            'input_schema': {'type': 'object', 'properties': {}, 'required': []},
+            'cache_control': _cache_control('1h'),
+        }],
+    }
+
+    messages = anthropic_request_to_messages(body)
+    tools = anthropic_tools_to_tool_infos(body['tools'])
+
+    assert messages[0].role == 'system'
+    assert messages[0].content[0].internal == {'anthropic': {'cache_control': _cache_control('1h')}}
+    assert messages[1].role == 'user'
+    assert messages[1].content[0].internal == {'anthropic': {'cache_control': _cache_control()}}
+    assert messages[2].role == 'assistant'
+    assert messages[2].tool_calls[0].internal == {'anthropic': {'cache_control': _cache_control('1h')}}
+    assert messages[3].role == 'tool'
+    assert messages[3].internal == {'anthropic': {'cache_control': _cache_control()}}
+    assert tools[0].options == {'anthropic': {'cache_control': _cache_control('1h')}}
+
+
+def test_anthropic_bridge_sse_usage_includes_cache_tokens():
+
+    async def _go():
+        output = ModelOutput.from_content(model='claude', content='ok')
+        output.usage = ModelUsage(
+            input_tokens=10,
+            output_tokens=2,
+            total_tokens=19,
+            input_tokens_cache_write=3,
+            input_tokens_cache_read=4,
+        )
+        task = asyncio.create_task(asyncio.sleep(0, result=output))
+        events = []
+        async for chunk in stream_anthropic_response(task, request_model='claude'):
+            text = chunk.decode('utf-8')
+            if text.startswith('event: message_delta'):
+                data = text.split('data: ', 1)[1].strip()
+                events.append(json.loads(data))
+        return events
+
+    message_delta = asyncio.run(_go())[0]
+
+    assert message_delta['usage'] == {
+        'input_tokens': 10,
+        'output_tokens': 2,
+        'cache_creation_input_tokens': 3,
+        'cache_read_input_tokens': 4,
+    }

--- a/tests/agent/external/test_anthropic_bridge_prompt_cache.py
+++ b/tests/agent/external/test_anthropic_bridge_prompt_cache.py
@@ -30,7 +30,7 @@ def test_anthropic_bridge_top_level_cache_control_enables_recent_messages_strate
     assert config.extra_body is None
 
 
-def test_anthropic_bridge_top_level_cache_control_does_not_auto_mark_explicit_blocks():
+def test_anthropic_bridge_top_level_cache_control_is_preserved_with_explicit_blocks():
     config = _build_generate_config({
         'cache_control': _cache_control('1h'),
         'messages': [{
@@ -43,8 +43,9 @@ def test_anthropic_bridge_top_level_cache_control_does_not_auto_mark_explicit_bl
         }],
     })
 
-    assert config.anthropic_cache_control is None
-    assert config.anthropic_cache_strategy == 'evaluation'
+    assert config.anthropic_cache_control is not None
+    assert config.anthropic_cache_control.model_dump(exclude_none=True) == _cache_control('1h')
+    assert config.anthropic_cache_strategy == 'recent_messages'
     assert config.extra_body is None
 
 
@@ -61,7 +62,9 @@ def test_anthropic_bridge_tool_schema_cache_control_property_does_not_disable_to
             'input_schema': {
                 'type': 'object',
                 'properties': {
-                    'cache_control': {'type': 'string'},
+                    'cache_control': {
+                        'type': 'string'
+                    },
                 },
             },
         }],
@@ -94,7 +97,9 @@ def test_anthropic_bridge_preserves_block_level_cache_control():
                     'type': 'tool_use',
                     'id': 'toolu_1',
                     'name': 'search',
-                    'input': {'q': 'x'},
+                    'input': {
+                        'q': 'x'
+                    },
                     'cache_control': _cache_control('1h'),
                 }],
             },
@@ -111,7 +116,11 @@ def test_anthropic_bridge_preserves_block_level_cache_control():
         'tools': [{
             'name': 'search',
             'description': 'Search docs.',
-            'input_schema': {'type': 'object', 'properties': {}, 'required': []},
+            'input_schema': {
+                'type': 'object',
+                'properties': {},
+                'required': []
+            },
             'cache_control': _cache_control('1h'),
         }],
     }

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -3,9 +3,32 @@ import pytest
 from pydantic import ValidationError
 from types import SimpleNamespace
 
-from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageTool, ChatMessageUser
+from evalscope.api.messages import (
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    ContentText,
+)
 from evalscope.api.model import GenerateConfig
 from evalscope.api.tool import ToolCall, ToolFunction, ToolInfo
+
+
+def _anthropic_utils():
+    pytest.importorskip('anthropic')
+    from evalscope.models.utils import anthropic
+
+    return anthropic
+
+
+def _cache_control_blocks(messages):
+    blocks = []
+    for message in messages:
+        content = message['content']
+        if isinstance(content, str):
+            continue
+        blocks.extend(block for block in content if isinstance(block, dict) and 'cache_control' in block)
+    return blocks
 
 
 def test_anthropic_cache_control_accepts_typed_values():
@@ -27,12 +50,7 @@ def test_anthropic_cache_control_accepts_typed_values():
 
 def test_anthropic_cache_control_rejects_unknown_keys():
     with pytest.raises(ValidationError):
-        GenerateConfig(
-            anthropic_cache_control={
-                'type': 'ephemeral',
-                'unknown': True,
-            }
-        )
+        GenerateConfig(anthropic_cache_control={'type': 'ephemeral', 'unknown': True})
 
 
 def test_legacy_anthropic_content_cache_control_is_rejected():
@@ -40,24 +58,29 @@ def test_legacy_anthropic_content_cache_control_is_rejected():
         GenerateConfig(anthropic_content_cache_control={'type': 'ephemeral'})
 
 
-def _anthropic_utils():
-    pytest.importorskip('anthropic')
-    from evalscope.models.utils import anthropic
+def test_completion_params_do_not_enable_cache_by_default():
+    anthropic = _anthropic_utils()
 
-    return anthropic
+    params = anthropic.anthropic_completion_params('claude', GenerateConfig())
 
-
-def _cache_control_blocks(messages):
-    blocks = []
-    for message in messages:
-        content = message['content']
-        if isinstance(content, str):
-            continue
-        blocks.extend(block for block in content if isinstance(block, dict) and 'cache_control' in block)
-    return blocks
+    assert 'cache_control' not in params
 
 
-def test_evaluation_strategy_marks_system_and_fewshot_but_not_final_question():
+def test_recent_messages_sets_top_level_cache_control():
+    anthropic = _anthropic_utils()
+
+    params = anthropic.anthropic_completion_params(
+        'claude',
+        GenerateConfig(
+            anthropic_cache_control={'type': 'ephemeral', 'ttl': '5m'},
+            anthropic_cache_strategy='recent_messages',
+        ),
+    )
+
+    assert params['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}
+
+
+def test_evaluation_strategy_marks_system_tools_and_fewshot_but_not_final_question():
     anthropic = _anthropic_utils()
     cache_control = {'type': 'ephemeral'}
 
@@ -67,6 +90,14 @@ def test_evaluation_strategy_marks_system_and_fewshot_but_not_final_question():
             ChatMessageUser(content='Example question.'),
             ChatMessageAssistant(content='Example answer.'),
             ChatMessageUser(content='Current sample question.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='evaluation',
+    )
+    tools = anthropic.anthropic_chat_tools(
+        [
+            ToolInfo(name='search', description='Search docs.'),
+            ToolInfo(name='read', description='Read docs.'),
         ],
         cache_control=cache_control,
         cache_strategy='evaluation',
@@ -74,32 +105,20 @@ def test_evaluation_strategy_marks_system_and_fewshot_but_not_final_question():
 
     assert isinstance(system, list)
     assert system[-1]['cache_control'] == cache_control
+    assert tools[-1]['cache_control'] == cache_control
+    assert 'cache_control' not in tools[0]
     assert messages[-2]['content'][-1]['cache_control'] == cache_control
     assert 'cache_control' not in messages[-1]['content'][-1]
     assert len(_cache_control_blocks(messages)) == 1
 
 
-def test_evaluation_strategy_is_noop_without_stable_message_prefix():
-    anthropic = _anthropic_utils()
-
-    system, messages = anthropic.anthropic_chat_messages(
-        [ChatMessageUser(content='Current sample question.')],
-        cache_control={'type': 'ephemeral'},
-        cache_strategy='evaluation',
-    )
-
-    assert system is None
-    assert messages[0]['content'] == 'Current sample question.'
-    assert _cache_control_blocks(messages) == []
-
-
-def test_recent_messages_strategy_anchors_system_and_marks_tail_block():
+def test_recent_messages_anchors_system_tools_and_penultimate_message_block():
     anthropic = _anthropic_utils()
     cache_control = {'type': 'ephemeral'}
 
     system, messages = anthropic.anthropic_chat_messages(
         [
-            ChatMessageSystem(content='Stable evaluator instructions.'),
+            ChatMessageSystem(content='Stable agent instructions.'),
             ChatMessageUser(content='First turn.'),
             ChatMessageAssistant(content='First answer.'),
             ChatMessageUser(content='Second turn.'),
@@ -107,85 +126,83 @@ def test_recent_messages_strategy_anchors_system_and_marks_tail_block():
         cache_control=cache_control,
         cache_strategy='recent_messages',
     )
+    tools = anthropic.anthropic_chat_tools(
+        [ToolInfo(name='search', description='Search docs.')],
+        cache_control=cache_control,
+        cache_strategy='recent_messages',
+    )
 
-    # The stable system prefix is anchored with a fixed breakpoint so it is cache-read
-    # on every turn; without it the only breakpoint moves each turn and rarely gets a hit.
-    assert system == [{
-        'type': 'text',
-        'text': 'Stable evaluator instructions.',
-        'cache_control': cache_control,
-    }]
-    # A rolling breakpoint still marks the most recent message block for the growing history.
+    assert system == [{'type': 'text', 'text': 'Stable agent instructions.', 'cache_control': cache_control}]
+    assert tools[-1]['cache_control'] == cache_control
     assert len(_cache_control_blocks(messages)) == 1
-    assert messages[-1]['content'][-1]['cache_control'] == cache_control
-    assert 'cache_control' not in messages[-2]['content'][-1]
+    assert messages[-2]['content'][-1]['cache_control'] == cache_control
+    assert 'cache_control' not in messages[-1]['content'][-1]
 
 
-def test_cache_control_none_leaves_message_shape_unchanged():
+def test_user_supplied_cache_control_is_preserved_and_not_overwritten():
     anthropic = _anthropic_utils()
+    explicit = {'type': 'ephemeral', 'ttl': '1h'}
+    automatic = {'type': 'ephemeral', 'ttl': '5m'}
 
     system, messages = anthropic.anthropic_chat_messages(
         [
-            ChatMessageSystem(content='Stable evaluator instructions.'),
-            ChatMessageUser(content='Current sample question.'),
+            ChatMessageSystem(
+                content=[ContentText(text='Stable.', internal={'anthropic': {'cache_control': explicit}})]
+            ),
+            ChatMessageUser(
+                content=[ContentText(text='Question.', internal={'anthropic': {'cache_control': explicit}})]
+            ),
         ],
-        cache_control=None,
+        cache_control=automatic,
+        cache_strategy='recent_messages',
     )
 
-    assert system == 'Stable evaluator instructions.'
-    assert messages == [{
-        'role': 'user',
-        'content': 'Current sample question.',
-    }]
+    assert system[-1]['cache_control'] == explicit
+    assert messages[-1]['content'][-1]['cache_control'] == explicit
 
 
-def test_tool_cache_control_marks_only_last_tool_in_evaluation_strategy():
+def test_cache_control_skips_tool_result_blocks_for_automatic_marker():
     anthropic = _anthropic_utils()
-    cache_control = {'type': 'ephemeral'}
 
-    tools = anthropic.anthropic_chat_tools(
-        [
-            ToolInfo(name='search', description='Search docs.'),
-            ToolInfo(name='read', description='Read docs.'),
-        ],
-        cache_control=cache_control,
-        cache_strategy='evaluation',
+    messages = [
+        ChatMessageUser(content='What is the weather?'),
+        ChatMessageAssistant(
+            content='',
+            tool_calls=[ToolCall(id='call_123', function=ToolFunction(name='get_weather', arguments={'city': 'SF'}))],
+        ),
+        ChatMessageTool(tool_call_id='call_123', content='Sunny, 72F'),
+    ]
+
+    system, message_params = anthropic.anthropic_chat_messages(
+        messages, cache_control={'type': 'ephemeral'}, cache_strategy='recent_messages'
     )
 
-    assert 'cache_control' not in tools[0]
-    assert tools[1]['cache_control'] == cache_control
+    assert system is None
+    assert len(_cache_control_blocks(message_params)) == 1
+    assert message_params[0]['content'][-1]['cache_control'] == {'type': 'ephemeral'}
+
+    tool_result_block = [
+        block
+        for message in message_params
+        for block in message.get('content', [])
+        if isinstance(block, dict) and block.get('type') == 'tool_result'
+    ][0]
+    assert 'cache_control' not in tool_result_block
 
 
-def test_evaluation_strategy_stays_under_anthropic_breakpoint_limit():
+def test_tool_result_explicit_cache_control_is_preserved():
     anthropic = _anthropic_utils()
-    cache_control = {'type': 'ephemeral'}
+    cache_control = {'type': 'ephemeral', 'ttl': '1h'}
 
-    system, messages = anthropic.anthropic_chat_messages(
-        [
-            ChatMessageSystem(content='Stable evaluator instructions.'),
-            ChatMessageUser(content='Example question.'),
-            ChatMessageAssistant(content='Example answer.'),
-            ChatMessageUser(content='Current sample question.'),
-        ],
-        cache_control=cache_control,
-        cache_strategy='evaluation',
-    )
-    tools = anthropic.anthropic_chat_tools(
-        [
-            ToolInfo(name='search', description='Search docs.'),
-            ToolInfo(name='read', description='Read docs.'),
-        ],
-        cache_control=cache_control,
-        cache_strategy='evaluation',
+    message = ChatMessageTool(
+        tool_call_id='call_123',
+        content='Sunny',
+        internal={'anthropic': {'cache_control': cache_control}},
     )
 
-    system_blocks = [block for block in system if 'cache_control' in block]
-    tool_blocks = [tool for tool in tools if 'cache_control' in tool]
-    message_blocks = _cache_control_blocks(messages)
-    breakpoint_count = len(system_blocks) + len(tool_blocks) + len(message_blocks)
+    message_param = anthropic.anthropic_message_param(message)
 
-    assert breakpoint_count == 3
-    assert breakpoint_count <= anthropic.MAX_ANTHROPIC_CACHE_CONTROL_BLOCKS
+    assert message_param['content'][0]['cache_control'] == cache_control
 
 
 class _FakeUsage:
@@ -310,91 +327,3 @@ def test_async_collect_stream_response_preserves_cache_usage(monkeypatch):
     assert message.usage.output_tokens == 2
     assert message.usage.cache_creation_input_tokens == 3
     assert message.usage.cache_read_input_tokens == 4
-
-
-def test_cache_control_skips_tool_result_blocks():
-    anthropic = _anthropic_utils()
-
-    messages = [
-        ChatMessageUser(content='What is the weather?'),
-        ChatMessageAssistant(
-            content='',
-            tool_calls=[ToolCall(id='call_123', function=ToolFunction(name='get_weather', arguments={'city': 'SF'}))],
-        ),
-        ChatMessageTool(tool_call_id='call_123', content='Sunny, 72F'),
-    ]
-
-    system, message_params = anthropic.anthropic_chat_messages(
-        messages, cache_control={'type': 'ephemeral'}, cache_strategy='recent_messages'
-    )
-
-    assert system is None
-    assert len(_cache_control_blocks(message_params)) == 1
-    assert message_params[0]['content'][-1]['cache_control'] == {'type': 'ephemeral'}
-
-    tool_result_msgs = [
-        m
-        for m in message_params
-        if any(b.get('type') == 'tool_result' for b in m.get('content', []) if isinstance(b, dict))
-    ]
-    assert len(tool_result_msgs) == 1
-
-    tool_result_block = [
-        b for b in tool_result_msgs[0]['content'] if isinstance(b, dict) and b.get('type') == 'tool_result'
-    ][0]
-    assert 'cache_control' not in tool_result_block
-
-
-def test_consecutive_tool_results_collapse_into_immediate_user_message():
-    anthropic = _anthropic_utils()
-
-    messages = [
-        ChatMessageAssistant(
-            content='',
-            tool_calls=[
-                ToolCall(id='call_1', function=ToolFunction(name='get_weather', arguments={'city': 'SF'})),
-                ToolCall(id='call_2', function=ToolFunction(name='get_time', arguments={'city': 'SF'})),
-            ],
-        ),
-        ChatMessageTool(tool_call_id='call_1', content='Sunny, 72F'),
-        ChatMessageTool(tool_call_id='call_2', content='10:00 AM'),
-    ]
-
-    system, message_params = anthropic.anthropic_chat_messages(messages)
-
-    assert system is None
-    assert len(message_params) == 2
-    assert message_params[0]['role'] == 'assistant'
-    assert message_params[1]['role'] == 'user'
-
-    tool_use_ids = [
-        block['id']
-        for block in message_params[0]['content']
-        if isinstance(block, dict) and block.get('type') == 'tool_use'
-    ]
-    tool_result_ids = [
-        block['tool_use_id']
-        for block in message_params[1]['content']
-        if isinstance(block, dict) and block.get('type') == 'tool_result'
-    ]
-    assert tool_use_ids == ['call_1', 'call_2']
-    assert tool_result_ids == ['call_1', 'call_2']
-
-
-def test_last_cacheable_block_skips_tool_blocks():
-    anthropic = _anthropic_utils()
-    from anthropic.types import MessageParam, TextBlockParam, ToolResultBlockParam
-
-    message = MessageParam(
-        role='user',
-        content=[
-            TextBlockParam(type='text', text='Result:'),
-            ToolResultBlockParam(type='tool_result', tool_use_id='call_123', content='data'),
-        ],
-    )
-
-    block = anthropic._last_cacheable_content_block(message)
-
-    assert block is not None
-    assert block['type'] == 'text'
-    assert block['text'] == 'Result:'

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -72,12 +72,35 @@ def test_recent_messages_sets_top_level_cache_control():
     params = anthropic.anthropic_completion_params(
         'claude',
         GenerateConfig(
-            anthropic_cache_control={'type': 'ephemeral', 'ttl': '5m'},
+            anthropic_cache_control={
+                'type': 'ephemeral',
+                'ttl': '5m'
+            },
             anthropic_cache_strategy='recent_messages',
         ),
     )
 
     assert params['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}
+
+
+def test_anthropic_api_splits_automatic_and_explicit_cache_control():
+    pytest.importorskip('anthropic')
+    from evalscope.models.anthropic_compatible import AnthropicCompatibleAPI
+
+    api = AnthropicCompatibleAPI.__new__(AnthropicCompatibleAPI)
+    recent_config = GenerateConfig(
+        anthropic_cache_control={'type': 'ephemeral'},
+        anthropic_cache_strategy='recent_messages',
+    )
+    evaluation_config = GenerateConfig(
+        anthropic_cache_control={'type': 'ephemeral'},
+        anthropic_cache_strategy='evaluation',
+    )
+
+    assert api.cache_control_params(recent_config) == {'type': 'ephemeral'}
+    assert api.explicit_cache_control_params(recent_config) is None
+    assert api.cache_control_params(evaluation_config) == {'type': 'ephemeral'}
+    assert api.explicit_cache_control_params(evaluation_config) == {'type': 'ephemeral'}
 
 
 def test_evaluation_strategy_marks_system_tools_and_fewshot_but_not_final_question():
@@ -112,7 +135,7 @@ def test_evaluation_strategy_marks_system_tools_and_fewshot_but_not_final_questi
     assert len(_cache_control_blocks(messages)) == 1
 
 
-def test_recent_messages_anchors_system_tools_and_penultimate_message_block():
+def test_recent_messages_uses_top_level_cache_control_without_manual_block_markers():
     anthropic = _anthropic_utils()
     cache_control = {'type': 'ephemeral'}
 
@@ -132,11 +155,9 @@ def test_recent_messages_anchors_system_tools_and_penultimate_message_block():
         cache_strategy='recent_messages',
     )
 
-    assert system == [{'type': 'text', 'text': 'Stable agent instructions.', 'cache_control': cache_control}]
-    assert tools[-1]['cache_control'] == cache_control
-    assert len(_cache_control_blocks(messages)) == 1
-    assert messages[-2]['content'][-1]['cache_control'] == cache_control
-    assert 'cache_control' not in messages[-1]['content'][-1]
+    assert system == 'Stable agent instructions.'
+    assert 'cache_control' not in tools[-1]
+    assert len(_cache_control_blocks(messages)) == 0
 
 
 def test_user_supplied_cache_control_is_preserved_and_not_overwritten():
@@ -147,10 +168,14 @@ def test_user_supplied_cache_control_is_preserved_and_not_overwritten():
     system, messages = anthropic.anthropic_chat_messages(
         [
             ChatMessageSystem(
-                content=[ContentText(text='Stable.', internal={'anthropic': {'cache_control': explicit}})]
+                content=[ContentText(text='Stable.', internal={'anthropic': {
+                    'cache_control': explicit
+                }})]
             ),
             ChatMessageUser(
-                content=[ContentText(text='Question.', internal={'anthropic': {'cache_control': explicit}})]
+                content=[ContentText(text='Question.', internal={'anthropic': {
+                    'cache_control': explicit
+                }})]
             ),
         ],
         cache_control=automatic,
@@ -161,7 +186,7 @@ def test_user_supplied_cache_control_is_preserved_and_not_overwritten():
     assert messages[-1]['content'][-1]['cache_control'] == explicit
 
 
-def test_cache_control_skips_tool_result_blocks_for_automatic_marker():
+def test_evaluation_cache_control_skips_tool_result_blocks():
     anthropic = _anthropic_utils()
 
     messages = [
@@ -171,10 +196,11 @@ def test_cache_control_skips_tool_result_blocks_for_automatic_marker():
             tool_calls=[ToolCall(id='call_123', function=ToolFunction(name='get_weather', arguments={'city': 'SF'}))],
         ),
         ChatMessageTool(tool_call_id='call_123', content='Sunny, 72F'),
+        ChatMessageUser(content='What should I wear?'),
     ]
 
     system, message_params = anthropic.anthropic_chat_messages(
-        messages, cache_control={'type': 'ephemeral'}, cache_strategy='recent_messages'
+        messages, cache_control={'type': 'ephemeral'}, cache_strategy='evaluation'
     )
 
     assert system is None
@@ -182,9 +208,7 @@ def test_cache_control_skips_tool_result_blocks_for_automatic_marker():
     assert message_params[0]['content'][-1]['cache_control'] == {'type': 'ephemeral'}
 
     tool_result_block = [
-        block
-        for message in message_params
-        for block in message.get('content', [])
+        block for message in message_params for block in message.get('content', [])
         if isinstance(block, dict) and block.get('type') == 'tool_result'
     ][0]
     assert 'cache_control' not in tool_result_block
@@ -197,7 +221,9 @@ def test_tool_result_explicit_cache_control_is_preserved():
     message = ChatMessageTool(
         tool_call_id='call_123',
         content='Sunny',
-        internal={'anthropic': {'cache_control': cache_control}},
+        internal={'anthropic': {
+            'cache_control': cache_control
+        }},
     )
 
     message_param = anthropic.anthropic_message_param(message)
@@ -270,23 +296,21 @@ def test_collect_stream_response_preserves_cache_usage(monkeypatch):
     anthropic = _anthropic_utils()
     _patch_stream_event_types(monkeypatch, anthropic)
 
-    message, _ = anthropic.collect_stream_response(
-        [
-            _FakeMessageStartEvent(
-                _FakeMessage(
-                    id='msg_1',
-                    model='claude',
-                    role='assistant',
-                    usage=_FakeUsage(
-                        input_tokens=10,
-                        cache_creation_input_tokens=3,
-                        cache_read_input_tokens=4,
-                    ),
-                )
-            ),
-            _FakeMessageDeltaEvent(_FakeUsage(output_tokens=2)),
-        ]
-    )
+    message, _ = anthropic.collect_stream_response([
+        _FakeMessageStartEvent(
+            _FakeMessage(
+                id='msg_1',
+                model='claude',
+                role='assistant',
+                usage=_FakeUsage(
+                    input_tokens=10,
+                    cache_creation_input_tokens=3,
+                    cache_read_input_tokens=4,
+                ),
+            )
+        ),
+        _FakeMessageDeltaEvent(_FakeUsage(output_tokens=2)),
+    ])
 
     assert message.usage.input_tokens == 10
     assert message.usage.output_tokens == 2

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -93,7 +93,7 @@ def test_evaluation_strategy_is_noop_without_stable_message_prefix():
     assert _cache_control_blocks(messages) == []
 
 
-def test_recent_messages_strategy_marks_only_one_tail_block():
+def test_recent_messages_strategy_anchors_system_and_marks_tail_block():
     anthropic = _anthropic_utils()
     cache_control = {'type': 'ephemeral'}
 
@@ -108,7 +108,14 @@ def test_recent_messages_strategy_marks_only_one_tail_block():
         cache_strategy='recent_messages',
     )
 
-    assert system == 'Stable evaluator instructions.'
+    # The stable system prefix is anchored with a fixed breakpoint so it is cache-read
+    # on every turn; without it the only breakpoint moves each turn and rarely gets a hit.
+    assert system == [{
+        'type': 'text',
+        'text': 'Stable evaluator instructions.',
+        'cache_control': cache_control,
+    }]
+    # A rolling breakpoint still marks the most recent message block for the growing history.
     assert len(_cache_control_blocks(messages)) == 1
     assert messages[-1]['content'][-1]['cache_control'] == cache_control
     assert 'cache_control' not in messages[-2]['content'][-1]

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -1,8 +1,7 @@
 import asyncio
-from types import SimpleNamespace
-
 import pytest
 from pydantic import ValidationError
+from types import SimpleNamespace
 
 from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
 from evalscope.api.model import GenerateConfig

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -3,9 +3,9 @@ import pytest
 from pydantic import ValidationError
 from types import SimpleNamespace
 
-from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageTool, ChatMessageUser
 from evalscope.api.model import GenerateConfig
-from evalscope.api.tool import ToolInfo
+from evalscope.api.tool import ToolCall, ToolFunction, ToolInfo
 
 
 def test_anthropic_cache_control_accepts_typed_values():
@@ -303,3 +303,91 @@ def test_async_collect_stream_response_preserves_cache_usage(monkeypatch):
     assert message.usage.output_tokens == 2
     assert message.usage.cache_creation_input_tokens == 3
     assert message.usage.cache_read_input_tokens == 4
+
+
+def test_cache_control_skips_tool_result_blocks():
+    anthropic = _anthropic_utils()
+
+    messages = [
+        ChatMessageUser(content='What is the weather?'),
+        ChatMessageAssistant(
+            content='',
+            tool_calls=[ToolCall(id='call_123', function=ToolFunction(name='get_weather', arguments={'city': 'SF'}))],
+        ),
+        ChatMessageTool(tool_call_id='call_123', content='Sunny, 72F'),
+    ]
+
+    system, message_params = anthropic.anthropic_chat_messages(
+        messages, cache_control={'type': 'ephemeral'}, cache_strategy='recent_messages'
+    )
+
+    assert system is None
+    assert len(_cache_control_blocks(message_params)) == 1
+    assert message_params[0]['content'][-1]['cache_control'] == {'type': 'ephemeral'}
+
+    tool_result_msgs = [
+        m
+        for m in message_params
+        if any(b.get('type') == 'tool_result' for b in m.get('content', []) if isinstance(b, dict))
+    ]
+    assert len(tool_result_msgs) == 1
+
+    tool_result_block = [
+        b for b in tool_result_msgs[0]['content'] if isinstance(b, dict) and b.get('type') == 'tool_result'
+    ][0]
+    assert 'cache_control' not in tool_result_block
+
+
+def test_consecutive_tool_results_collapse_into_immediate_user_message():
+    anthropic = _anthropic_utils()
+
+    messages = [
+        ChatMessageAssistant(
+            content='',
+            tool_calls=[
+                ToolCall(id='call_1', function=ToolFunction(name='get_weather', arguments={'city': 'SF'})),
+                ToolCall(id='call_2', function=ToolFunction(name='get_time', arguments={'city': 'SF'})),
+            ],
+        ),
+        ChatMessageTool(tool_call_id='call_1', content='Sunny, 72F'),
+        ChatMessageTool(tool_call_id='call_2', content='10:00 AM'),
+    ]
+
+    system, message_params = anthropic.anthropic_chat_messages(messages)
+
+    assert system is None
+    assert len(message_params) == 2
+    assert message_params[0]['role'] == 'assistant'
+    assert message_params[1]['role'] == 'user'
+
+    tool_use_ids = [
+        block['id']
+        for block in message_params[0]['content']
+        if isinstance(block, dict) and block.get('type') == 'tool_use'
+    ]
+    tool_result_ids = [
+        block['tool_use_id']
+        for block in message_params[1]['content']
+        if isinstance(block, dict) and block.get('type') == 'tool_result'
+    ]
+    assert tool_use_ids == ['call_1', 'call_2']
+    assert tool_result_ids == ['call_1', 'call_2']
+
+
+def test_last_cacheable_block_skips_tool_blocks():
+    anthropic = _anthropic_utils()
+    from anthropic.types import MessageParam, TextBlockParam, ToolResultBlockParam
+
+    message = MessageParam(
+        role='user',
+        content=[
+            TextBlockParam(type='text', text='Result:'),
+            ToolResultBlockParam(type='tool_result', tool_use_id='call_123', content='data'),
+        ],
+    )
+
+    block = anthropic._last_cacheable_content_block(message)
+
+    assert block is not None
+    assert block['type'] == 'text'
+    assert block['text'] == 'Result:'

--- a/tests/models/test_anthropic_prompt_cache.py
+++ b/tests/models/test_anthropic_prompt_cache.py
@@ -1,0 +1,306 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
+from evalscope.api.model import GenerateConfig
+from evalscope.api.tool import ToolInfo
+
+
+def test_anthropic_cache_control_accepts_typed_values():
+    config = GenerateConfig(
+        anthropic_cache_control={
+            'type': 'ephemeral',
+            'ttl': '1h',
+        },
+        anthropic_cache_strategy='recent_messages',
+    )
+
+    assert config.anthropic_cache_control is not None
+    assert config.anthropic_cache_control.model_dump(exclude_none=True) == {
+        'type': 'ephemeral',
+        'ttl': '1h',
+    }
+    assert config.anthropic_cache_strategy == 'recent_messages'
+
+
+def test_anthropic_cache_control_rejects_unknown_keys():
+    with pytest.raises(ValidationError):
+        GenerateConfig(
+            anthropic_cache_control={
+                'type': 'ephemeral',
+                'unknown': True,
+            }
+        )
+
+
+def test_legacy_anthropic_content_cache_control_is_rejected():
+    with pytest.raises(ValidationError, match='anthropic_content_cache_control'):
+        GenerateConfig(anthropic_content_cache_control={'type': 'ephemeral'})
+
+
+def _anthropic_utils():
+    pytest.importorskip('anthropic')
+    from evalscope.models.utils import anthropic
+
+    return anthropic
+
+
+def _cache_control_blocks(messages):
+    blocks = []
+    for message in messages:
+        content = message['content']
+        if isinstance(content, str):
+            continue
+        blocks.extend(block for block in content if isinstance(block, dict) and 'cache_control' in block)
+    return blocks
+
+
+def test_evaluation_strategy_marks_system_and_fewshot_but_not_final_question():
+    anthropic = _anthropic_utils()
+    cache_control = {'type': 'ephemeral'}
+
+    system, messages = anthropic.anthropic_chat_messages(
+        [
+            ChatMessageSystem(content='Stable evaluator instructions.'),
+            ChatMessageUser(content='Example question.'),
+            ChatMessageAssistant(content='Example answer.'),
+            ChatMessageUser(content='Current sample question.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='evaluation',
+    )
+
+    assert isinstance(system, list)
+    assert system[-1]['cache_control'] == cache_control
+    assert messages[-2]['content'][-1]['cache_control'] == cache_control
+    assert 'cache_control' not in messages[-1]['content'][-1]
+    assert len(_cache_control_blocks(messages)) == 1
+
+
+def test_evaluation_strategy_is_noop_without_stable_message_prefix():
+    anthropic = _anthropic_utils()
+
+    system, messages = anthropic.anthropic_chat_messages(
+        [ChatMessageUser(content='Current sample question.')],
+        cache_control={'type': 'ephemeral'},
+        cache_strategy='evaluation',
+    )
+
+    assert system is None
+    assert messages[0]['content'] == 'Current sample question.'
+    assert _cache_control_blocks(messages) == []
+
+
+def test_recent_messages_strategy_marks_only_one_tail_block():
+    anthropic = _anthropic_utils()
+    cache_control = {'type': 'ephemeral'}
+
+    system, messages = anthropic.anthropic_chat_messages(
+        [
+            ChatMessageSystem(content='Stable evaluator instructions.'),
+            ChatMessageUser(content='First turn.'),
+            ChatMessageAssistant(content='First answer.'),
+            ChatMessageUser(content='Second turn.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='recent_messages',
+    )
+
+    assert system == 'Stable evaluator instructions.'
+    assert len(_cache_control_blocks(messages)) == 1
+    assert messages[-1]['content'][-1]['cache_control'] == cache_control
+    assert 'cache_control' not in messages[-2]['content'][-1]
+
+
+def test_cache_control_none_leaves_message_shape_unchanged():
+    anthropic = _anthropic_utils()
+
+    system, messages = anthropic.anthropic_chat_messages(
+        [
+            ChatMessageSystem(content='Stable evaluator instructions.'),
+            ChatMessageUser(content='Current sample question.'),
+        ],
+        cache_control=None,
+    )
+
+    assert system == 'Stable evaluator instructions.'
+    assert messages == [{
+        'role': 'user',
+        'content': 'Current sample question.',
+    }]
+
+
+def test_tool_cache_control_marks_only_last_tool_in_evaluation_strategy():
+    anthropic = _anthropic_utils()
+    cache_control = {'type': 'ephemeral'}
+
+    tools = anthropic.anthropic_chat_tools(
+        [
+            ToolInfo(name='search', description='Search docs.'),
+            ToolInfo(name='read', description='Read docs.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='evaluation',
+    )
+
+    assert 'cache_control' not in tools[0]
+    assert tools[1]['cache_control'] == cache_control
+
+
+def test_evaluation_strategy_stays_under_anthropic_breakpoint_limit():
+    anthropic = _anthropic_utils()
+    cache_control = {'type': 'ephemeral'}
+
+    system, messages = anthropic.anthropic_chat_messages(
+        [
+            ChatMessageSystem(content='Stable evaluator instructions.'),
+            ChatMessageUser(content='Example question.'),
+            ChatMessageAssistant(content='Example answer.'),
+            ChatMessageUser(content='Current sample question.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='evaluation',
+    )
+    tools = anthropic.anthropic_chat_tools(
+        [
+            ToolInfo(name='search', description='Search docs.'),
+            ToolInfo(name='read', description='Read docs.'),
+        ],
+        cache_control=cache_control,
+        cache_strategy='evaluation',
+    )
+
+    system_blocks = [block for block in system if 'cache_control' in block]
+    tool_blocks = [tool for tool in tools if 'cache_control' in tool]
+    message_blocks = _cache_control_blocks(messages)
+    breakpoint_count = len(system_blocks) + len(tool_blocks) + len(message_blocks)
+
+    assert breakpoint_count == 3
+    assert breakpoint_count <= anthropic.MAX_ANTHROPIC_CACHE_CONTROL_BLOCKS
+
+
+class _FakeUsage:
+
+    def __init__(
+        self,
+        input_tokens=0,
+        output_tokens=0,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=None,
+    ):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_creation_input_tokens = cache_creation_input_tokens
+        self.cache_read_input_tokens = cache_read_input_tokens
+
+    def model_dump(self):
+        return {
+            'input_tokens': self.input_tokens,
+            'output_tokens': self.output_tokens,
+            'cache_creation_input_tokens': self.cache_creation_input_tokens,
+            'cache_read_input_tokens': self.cache_read_input_tokens,
+        }
+
+
+class _FakeMessage:
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _FakeMessageStartEvent:
+
+    def __init__(self, message):
+        self.message = message
+
+
+class _FakeMessageDeltaEvent:
+
+    def __init__(self, usage):
+        self.delta = SimpleNamespace(stop_reason='end_turn')
+        self.usage = usage
+
+
+class _FakeContentBlockStartEvent:
+    pass
+
+
+class _FakeContentBlockDeltaEvent:
+    pass
+
+
+def _patch_stream_event_types(monkeypatch, anthropic_utils):
+    import anthropic.types as anthropic_types
+
+    monkeypatch.setattr(anthropic_utils, 'Message', _FakeMessage)
+    monkeypatch.setattr(anthropic_types, 'MessageStartEvent', _FakeMessageStartEvent)
+    monkeypatch.setattr(anthropic_types, 'MessageDeltaEvent', _FakeMessageDeltaEvent)
+    monkeypatch.setattr(anthropic_types, 'ContentBlockStartEvent', _FakeContentBlockStartEvent)
+    monkeypatch.setattr(anthropic_types, 'ContentBlockDeltaEvent', _FakeContentBlockDeltaEvent)
+    monkeypatch.setattr(anthropic_types, 'Usage', _FakeUsage)
+
+
+def test_collect_stream_response_preserves_cache_usage(monkeypatch):
+    anthropic = _anthropic_utils()
+    _patch_stream_event_types(monkeypatch, anthropic)
+
+    message, _ = anthropic.collect_stream_response(
+        [
+            _FakeMessageStartEvent(
+                _FakeMessage(
+                    id='msg_1',
+                    model='claude',
+                    role='assistant',
+                    usage=_FakeUsage(
+                        input_tokens=10,
+                        cache_creation_input_tokens=3,
+                        cache_read_input_tokens=4,
+                    ),
+                )
+            ),
+            _FakeMessageDeltaEvent(_FakeUsage(output_tokens=2)),
+        ]
+    )
+
+    assert message.usage.input_tokens == 10
+    assert message.usage.output_tokens == 2
+    assert message.usage.cache_creation_input_tokens == 3
+    assert message.usage.cache_read_input_tokens == 4
+
+
+async def _fake_async_events(events):
+    for event in events:
+        yield event
+
+
+def test_async_collect_stream_response_preserves_cache_usage(monkeypatch):
+    anthropic = _anthropic_utils()
+    _patch_stream_event_types(monkeypatch, anthropic)
+
+    message, _ = asyncio.run(
+        anthropic.async_collect_stream_response(
+            _fake_async_events([
+                _FakeMessageStartEvent(
+                    _FakeMessage(
+                        id='msg_1',
+                        model='claude',
+                        role='assistant',
+                        usage=_FakeUsage(
+                            input_tokens=10,
+                            cache_creation_input_tokens=3,
+                            cache_read_input_tokens=4,
+                        ),
+                    )
+                ),
+                _FakeMessageDeltaEvent(_FakeUsage(output_tokens=2)),
+            ])
+        )
+    )
+
+    assert message.usage.input_tokens == 10
+    assert message.usage.output_tokens == 2
+    assert message.usage.cache_creation_input_tokens == 3
+    assert message.usage.cache_read_input_tokens == 4


### PR DESCRIPTION
Summary:
- Add typed Anthropic prompt cache configuration to GenerateConfig.
- Attach Anthropic cache_control breakpoints for evaluation and recent-message strategies.
- Preserve Anthropic cache usage token fields in streaming responses.
- Add unit coverage for cache config, breakpoint placement, tools, and stream usage.