### PR TITLE
fix(gpqa): remove bracket-stripping regex that corrupts answer choices

### DIFF
--- a/docs/en/user_guides/stress_test/multi_turn.md
+++ b/docs/en/user_guides/stress_test/multi_turn.md
@@ -31,7 +31,7 @@ The number of turns per conversation is sampled from `[--min-turns, --max-turns]
 | `first_turn_length` | `int` | Target prompt token count for turn 1; trajectory messages are sliced until this length is reached | `65000` |
 | `subsequent_turn_length` | `int` | Target token increment per subsequent turn; controls the delta size added each round | `500` |
 | `chars_per_token` | `float` | Characters-per-token estimate used for pre-filtering trajectories when no tokenizer is available | `3.0` |
-| `num_workers` | `int` | Number of parallel workers for live conversation building (>1 uses multiprocessing.Pool) | `4` |
+| `num_workers` | `int` | **Deprecated**. Use top-level `--num-workers` instead. Previously controlled parallel workers for live conversation building. | `4` |
 
 ### Semantics of Existing Parameters in Multi-turn Mode
 

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -173,6 +173,7 @@ Must be used with `--multi-turn`. See the [Multi-turn Benchmark Guide](./multi_t
 | `--multi-turn` | `bool` | Enable multi-turn conversation benchmark mode; `--number` is the total number of turns to send and `--parallel` is the number of concurrent turn-level requests | `False` |
 | `--min-turns` | `int` | Minimum number of user turns per conversation; used by `random_multi_turn` and `swe_smith` | `1` |
 | `--max-turns` | `int` | Maximum number of user turns per conversation; required for `random_multi_turn`; optional for ShareGPT / `custom_multi_turn` (truncates long conversations); for `swe_smith` it's the upper bound for per-conversation turn sampling, falling back to `--min-turns` when unset | `None` |
+| `--num-workers` | `int` | Worker processes for CPU-bound dataset/request generation.<br>`0` = auto-detect from CPU affinity; `1` = serial (no multiprocessing); `>1` = explicit worker count.<br>Used by `random` (long-prompt parallel generation) and `swe_smith` (live construction). Supersedes the deprecated `multi_turn_args.num_workers`. | `0` |
 
 ```{seealso}
 For details on using the multi-turn benchmark feature, see the [Multi-turn Benchmark Guide](./multi_turn.md).

--- a/docs/zh/user_guides/stress_test/multi_turn.md
+++ b/docs/zh/user_guides/stress_test/multi_turn.md
@@ -31,7 +31,7 @@
 | `first_turn_length` | `int` 或 `[int, int]` | 第 1 轮目标 prompt token 数；从原始轨迹中截取恰好达到该长度的消息片段<br>• 单个整数：固定值，如 `65000`<br>• 两个整数的列表：`[最小值, 最大值]`，每条对话独立均匀随机采样，如 `[32000, 65000]` | `65000` |
 | `subsequent_turn_length` | `int` 或 `[int, int]` | 后续每轮在上一轮基础上新增的目标 token 数；决定每轮 delta 的大小<br>• 单个整数：固定值<br>• 两个整数的列表：`[最小值, 最大值]`，每条对话独立均匀随机采样 | `500` |
 | `chars_per_token` | `float` | 无 tokenizer 时的字符/token 估算比，用于预过滤原始轨迹 | `3.0` |
-| `num_workers` | `int` | live 构建模式下并行 worker 数量（>1 使用 multiprocessing.Pool） | `4` |
+| `num_workers` | `int` | **已废弃**，请使用顶层 `--num-workers` 参数。原用于控制 live 构建模式下的并行 worker 数量。 | `4` |
 
 ### 已有参数在多轮模式下的语义
 

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -174,6 +174,7 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 | `--multi-turn` | `bool` | 启用多轮对话压测模式；`--number` 表示总发送 turn 数，`--parallel` 表示并发 turn 数 | `False` |
 | `--min-turns` | `int` | 每个对话最少用户轮数；`random_multi_turn` 与 `swe_smith` 使用 | `1` |
 | `--max-turns` | `int` | 每个对话最多用户轮数；`random_multi_turn` 必需；ShareGPT/`custom_multi_turn` 可选（截断过长对话）；`swe_smith` 用作每个对话轮数采样上界，未设置时回退到 `--min-turns` | `None` |
+| `--num-workers` | `int` | CPU 密集型数据集/请求生成的 worker 进程数。<br>`0` = 根据 CPU 亲和性自动检测；`1` = 串行（无多进程）；`>1` = 显式指定 worker 数。<br>用于 `random`（长 prompt 并行生成）和 `swe_smith`（live 构建）。取代已废弃的 `multi_turn_args.num_workers`。 | `0` |
 
 ```{seealso}
 多轮对话压测使用详见[多轮对话压测指南](./multi_turn.md)。

--- a/evalscope/benchmarks/gpqa/gpqa_adapter.py
+++ b/evalscope/benchmarks/gpqa/gpqa_adapter.py
@@ -2,7 +2,6 @@
 
 import os
 import random
-import re
 from typing import Any, Dict
 
 from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter
@@ -95,11 +94,7 @@ class GPQAAdapter(MultiChoiceAdapter):
         def preprocess(text):
             if text is None:
                 return ' '
-            text = text.strip()
-            text = text.replace(' [title]', '. ')
-            text = re.sub('\\[.*?\\]', '', text)
-            text = text.replace('  ', ' ')
-            return text
+            return text.strip()
 
         choices = [
             preprocess(input_d['Incorrect Answer 1']),


### PR DESCRIPTION
## Problem

The `preprocess()` function in GPQA adapter was copied from HellaSwag and applied `re.sub('\\[.*?\\]', '', text)` to all answer choices. This strips any bracket-enclosed content, destroying valid mathematical/scientific notation in GPQA answers (e.g. `ln(2) = [ (T_1 - T_2) / (T1*T2)]` becomes `ln(2) =`), leading to random evaluation results.

## Root Cause

The preprocessing logic (`[title]` replacement + generic bracket removal + space collapsing) is designed for HellaSwag's Wikipedia-sourced data. GPQA is a graduate-level science Q&A benchmark with no `[title]` markers — the regex has no legitimate purpose here.

## Fix

Remove the bracket-stripping regex and related cleaning logic entirely, keeping only `strip()`. This aligns with EleutherAI's lm-evaluation-harness which also removed this regex in v2.2 (EleutherAI/lm-evaluation-harness#3691).

Closes #1446