### PR TITLE
feat(perf): unify dataset loading with --data-source parameter

### DIFF
--- a/docs/en/get_started/faq.md
+++ b/docs/en/get_started/faq.md
@@ -207,6 +207,21 @@ Reference documentation: [Judge Model Parameters](https://evalscope.readthedocs.
 
 **A:** Specify `--dataset-path` and set `--dataset line_by_line`. The program will read file content line by line as prompts.
 
+**Q: How to use pre-downloaded datasets in offline environments?**
+
+**A:** Use `--dataset-path` to point to the local dataset path. Two approaches are supported:
+
+- **Point to a directory** (for Arrow/Parquet format datasets like `flickr8k`, `kontext_bench`, `longalpaca`):
+  ```bash
+  evalscope perf --dataset kontext_bench --dataset-path /path/to/local/kontext-bench ...
+  ```
+- **Point to a file** (for JSONL format datasets like `openqa`, `share_gpt_zh`):
+  ```bash
+  evalscope perf --dataset openqa --dataset-path /path/to/open_qa.jsonl ...
+  ```
+
+You can also use `--data-source` to specify the data source (defaults to `modelscope`, can be switched to `huggingface`).
+
 **Q: How to stress test multimodal models?**
 
 **A:** Currently supports the `flickr8k` dataset for multimodal stress testing. Set `--dataset flickr8k`.

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -85,9 +85,10 @@ For details on using the SLA auto-tuning feature, see the [Auto-tuning Guide](./
 ## Dataset Configuration
 
 | Parameter | Type | Description | Default |
-|-----------|------|-------------|---------|
+|-----------|------|-------------|--------|
 | `--dataset` | `str` | Dataset mode, see table below for details | - |
-| `--dataset-path` | `str` | Dataset file path<br>Used in conjunction with dataset | - |
+| `--dataset-path` | `str` | Dataset file or directory path<br>Points to a file: read directly; points to a directory: looks for the corresponding data file inside (for offline use with pre-downloaded dataset cache) | - |
+| `--data-source` | `str` | Data source for dataset loading: `modelscope`, `huggingface`, or `local`<br>Defaults to `modelscope` when not specified; automatically treated as `local` when `--dataset-path` is a local directory | `modelscope` |
 
 ### Dataset Mode Description
 
@@ -105,8 +106,8 @@ For details on using the SLA auto-tuning feature, see the [Auto-tuning Guide](./
 
 | Mode | Description | Supports dataset-path |
 |------|-------------|----------------------|
-| `flickr8k` | Automatically downloads [Flick8k](https://www.modelscope.cn/datasets/clip-benchmark/wds_flickr8k/dataPeview) from ModelScope<br>Builds image-text inputs; large dataset suitable for evaluating multimodal models | ✗ |
-| `kontext_bench` | Automatically downloads [Kontext-Bench](https://modelscope.cn/datasets/black-forest-labs/kontext-bench/dataPeview) from ModelScope<br>Builds image-text inputs; approximately 1,000 samples, suitable for quick evaluation of multimodal models | ✗ |
+| `flickr8k` | Automatically downloads [Flick8k](https://www.modelscope.cn/datasets/clip-benchmark/wds_flickr8k/dataPeview) from ModelScope<br>Builds image-text inputs; large dataset suitable for evaluating multimodal models<br>Supports `--dataset-path` pointing to a local dataset directory (offline) | ✓ (directory) |
+| `kontext_bench` | Automatically downloads [Kontext-Bench](https://modelscope.cn/datasets/black-forest-labs/kontext-bench/dataPeview) from ModelScope<br>Builds image-text inputs; approximately 1,000 samples, suitable for quick evaluation of multimodal models<br>Supports `--dataset-path` pointing to a local dataset directory (offline) | ✓ (directory) |
 | `random_vl` | Randomly generates both image and text inputs<br>Based on `random`, with additional image-related parameters<br>[Usage example](./examples.md#using-the-random-multimodal-dataset) | ✗ |
 
 **Embedding**

--- a/docs/zh/get_started/faq.md
+++ b/docs/zh/get_started/faq.md
@@ -209,6 +209,21 @@ judge_model_args={
 
 **A:** 指定 `--dataset-path` 并设置 `--dataset line_by_line`，程序会逐行读取文件内容作为 Prompt。
 
+**Q: 离线环境下如何使用已下载的数据集？**
+
+**A:** 通过 `--dataset-path` 指向本地数据集路径即可。支持两种方式：
+
+- **指向目录**（适用于Arrow/Parquet格式数据集，如 `flickr8k`、`kontext_bench`、`longalpaca`）：
+  ```bash
+  evalscope perf --dataset kontext_bench --dataset-path /path/to/local/kontext-bench ...
+  ```
+- **指向文件**（适用于JSONL格式数据集，如 `openqa`、`share_gpt_zh`）：
+  ```bash
+  evalscope perf --dataset openqa --dataset-path /path/to/open_qa.jsonl ...
+  ```
+
+还可以通过 `--data-source` 指定数据源（默认为 `modelscope`，可切换为 `huggingface`）。
+
 **Q: 如何压测多模态模型？**
 
 **A:** 目前支持 `flickr8k` 数据集进行多模态压测。设置 `--dataset flickr8k` 即可。

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -88,7 +88,8 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
 | `--dataset` | `str` | 数据集模式，详见下表 | - |
-| `--dataset-path` | `str` | 数据集文件路径<br>与数据集结合使用 | - |
+| `--dataset-path` | `str` | 数据集文件或目录路径<br>指向文件时直接读取；指向目录时在目录内查找对应数据文件（适用于离线环境使用已下载的数据集缓存） | - |
+| `--data-source` | `str` | 数据集加载源，可选值：`modelscope`、`huggingface`、`local`<br>未指定时默认使用 `modelscope`；当 `--dataset-path` 为本地目录时自动视为 `local` | `modelscope` |
 
 ### dataset 模式说明
 
@@ -106,8 +107,8 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 
 | 模式 | 说明 | 支持dataset-path |
 |------|------|------------------|
-| `flickr8k` | 从ModelScope自动下载[Flick8k](https://www.modelscope.cn/datasets/clip-benchmark/wds_flickr8k/dataPeview)<br>构建图文输入，数据集较大，适合评测多模态模型 | ✗ |
-| `kontext_bench` | 从ModelScope自动下载[Kontext-Bench](https://modelscope.cn/datasets/black-forest-labs/kontext-bench/dataPeview)<br>构建图文输入，约1000条数据，适合快速评测多模态模型 | ✗ |
+| `flickr8k` | 从ModelScope自动下载[Flick8k](https://www.modelscope.cn/datasets/clip-benchmark/wds_flickr8k/dataPeview)<br>构建图文输入，数据集较大，适合评测多模态模型<br>支持`--dataset-path`指向本地数据集目录（离线环境） | ✓（目录） |
+| `kontext_bench` | 从ModelScope自动下载[Kontext-Bench](https://modelscope.cn/datasets/black-forest-labs/kontext-bench/dataPeview)<br>构建图文输入，约1000条数据，适合快速评测多模态模型<br>支持`--dataset-path`指向本地数据集目录（离线环境） | ✓（目录） |
 | `random_vl` | 随机生成图像和文本输入<br>在`random`基础上增加图像相关参数<br>[使用示例](./examples.md#使用random图文数据集) | ✗ |
 
 **Embedding 类**

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -684,7 +684,7 @@ def add_argument(parser: argparse.ArgumentParser):
 
     # Dataset settings
     parser.add_argument('--dataset', type=str, default='openqa', help='Specify the dataset')
-    parser.add_argument('--dataset-path', type=str, required=False, help='Path to the dataset file')
+    parser.add_argument('--dataset-path', type=str, required=False, help='Path to the dataset file or directory')
     parser.add_argument(
         '--data-source',
         type=str,

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -273,6 +273,11 @@ class Arguments(BaseArgument):
     dataset_path: Optional[str] = None
     """Path to the dataset."""
 
+    data_source: Optional[str] = None
+    """Data source for loading datasets. One of: 'modelscope', 'huggingface', 'local'.
+    Defaults to 'modelscope' when not specified. When --dataset-path points to a local
+    directory containing Arrow/Parquet files, this is automatically treated as 'local'."""
+
     dataset_offset: int = 0
     """Global token-sequence offset for random datasets.
 
@@ -680,6 +685,13 @@ def add_argument(parser: argparse.ArgumentParser):
     # Dataset settings
     parser.add_argument('--dataset', type=str, default='openqa', help='Specify the dataset')
     parser.add_argument('--dataset-path', type=str, required=False, help='Path to the dataset file')
+    parser.add_argument(
+        '--data-source',
+        type=str,
+        default=None,
+        choices=['modelscope', 'huggingface', 'local'],
+        help='Data source for dataset loading: modelscope, huggingface, or local (default: modelscope)',
+    )
     parser.add_argument(
         '--dataset-offset',
         type=int,

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -192,8 +192,9 @@ class DatasetPluginBase:
         dataset_path = self.query_parameters.dataset_path
         data_source = self.query_parameters.data_source or HubType.MODELSCOPE
 
-        # If dataset_path is a local directory, treat as local dataset
-        if dataset_path and os.path.isdir(dataset_path):
+        if dataset_path:
+            if not os.path.exists(dataset_path):
+                raise FileNotFoundError(f"The specified dataset_path '{dataset_path}' does not exist.")
             data_id_or_path = dataset_path
             data_source = HubType.LOCAL
         else:
@@ -230,7 +231,7 @@ class DatasetPluginBase:
         # dataset_path is a directory -> look for file inside
         if dataset_path and os.path.isdir(dataset_path):
             candidate = os.path.join(dataset_path, file_name)
-            if os.path.exists(candidate):
+            if os.path.isfile(candidate):
                 return candidate
             # Fallback: treat directory as a hub-local dataset root
             return download_dataset_file(
@@ -238,6 +239,10 @@ class DatasetPluginBase:
                 file_path=file_name,
                 data_source=HubType.LOCAL,
             )
+
+        # dataset_path is set but does not exist -> error
+        if dataset_path:
+            raise FileNotFoundError(f"The specified dataset_path '{dataset_path}' does not exist.")
 
         # Remote download
         return download_dataset_file(

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -1,8 +1,11 @@
 import json
+import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
+from evalscope.api.dataset.hub import download_dataset_file, load_dataset_from_hub
+from evalscope.constants import HubType
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.utils import load_tokenizer, tokenize_chat_messages
 
@@ -171,3 +174,74 @@ class DatasetPluginBase:
             prompt_length = len(self.tokenizer.encode(prompt))
         is_valid = self.query_parameters.min_prompt_length <= prompt_length <= self.query_parameters.max_prompt_length
         return is_valid, prompt_length
+
+    def load_hub_dataset(self, dataset_id: str, split: str = 'train', subset: str = 'default') -> Any:
+        """Load a dataset from the configured data source.
+
+        If dataset_path is a local directory, loads from there directly.
+        Otherwise loads from ModelScope/HuggingFace based on data_source.
+
+        Args:
+            dataset_id (str): Remote dataset identifier (e.g. 'AI-ModelScope/LongAlpaca-12k').
+            split (str): Dataset split to load (default: 'train').
+            subset (str): Dataset subset/config name (default: 'default').
+
+        Returns:
+            A datasets.Dataset object.
+        """
+        dataset_path = self.query_parameters.dataset_path
+        data_source = self.query_parameters.data_source or HubType.MODELSCOPE
+
+        # If dataset_path is a local directory, treat as local dataset
+        if dataset_path and os.path.isdir(dataset_path):
+            data_id_or_path = dataset_path
+            data_source = HubType.LOCAL
+        else:
+            data_id_or_path = dataset_id
+
+        return load_dataset_from_hub(
+            data_id_or_path=data_id_or_path,
+            split=split,
+            subset=subset,
+            data_source=data_source,
+        )
+
+    def download_hub_file(self, dataset_id: str, file_name: str) -> str:
+        """Download/resolve a single file from the configured data source.
+
+        If dataset_path is an existing file, returns it directly.
+        If dataset_path is a directory, looks for file_name inside it.
+        Otherwise downloads from ModelScope/HuggingFace.
+
+        Args:
+            dataset_id (str): Remote dataset identifier (e.g. 'AI-ModelScope/HC3-Chinese').
+            file_name (str): The file name to download or resolve.
+
+        Returns:
+            str: The resolved local file path.
+        """
+        dataset_path = self.query_parameters.dataset_path
+        data_source = self.query_parameters.data_source or HubType.MODELSCOPE
+
+        # dataset_path points to an existing file -> use directly
+        if dataset_path and os.path.isfile(dataset_path):
+            return dataset_path
+
+        # dataset_path is a directory -> look for file inside
+        if dataset_path and os.path.isdir(dataset_path):
+            candidate = os.path.join(dataset_path, file_name)
+            if os.path.exists(candidate):
+                return candidate
+            # Fallback: treat directory as a hub-local dataset root
+            return download_dataset_file(
+                data_id_or_path=dataset_path,
+                file_path=file_name,
+                data_source=HubType.LOCAL,
+            )
+
+        # Remote download
+        return download_dataset_file(
+            data_id_or_path=dataset_id,
+            file_path=file_name,
+            data_source=data_source,
+        )

--- a/evalscope/perf/plugin/datasets/flickr8k.py
+++ b/evalscope/perf/plugin/datasets/flickr8k.py
@@ -16,8 +16,7 @@ class FlickrDatasetPlugin(DatasetPluginBase):
         super().__init__(query_parameters)
 
     def build_messages(self) -> Iterator[List[Dict]]:
-        from modelscope.msdatasets import MsDataset
-        dataset = MsDataset.load('clip-benchmark/wds_flickr8k', split='test')
+        dataset = self.load_hub_dataset(dataset_id='clip-benchmark/wds_flickr8k', split='test')
 
         for item in dataset:
             pil_image = item['jpg']

--- a/evalscope/perf/plugin/datasets/kontext_bench.py
+++ b/evalscope/perf/plugin/datasets/kontext_bench.py
@@ -16,8 +16,7 @@ class KontextDatasetPlugin(DatasetPluginBase):
         super().__init__(query_parameters)
 
     def build_messages(self) -> Iterator[List[Dict]]:
-        from modelscope.msdatasets import MsDataset
-        dataset = MsDataset.load('black-forest-labs/kontext-bench', subset_name='default', split='test')
+        dataset = self.load_hub_dataset(dataset_id='black-forest-labs/kontext-bench', split='test')
 
         for item in dataset:
             pil_image = item['image']

--- a/evalscope/perf/plugin/datasets/longalpaca.py
+++ b/evalscope/perf/plugin/datasets/longalpaca.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Iterator, List
 
 from evalscope.perf.arguments import Arguments
@@ -15,11 +16,10 @@ class LongAlpacaDatasetPlugin(DatasetPluginBase):
         super().__init__(query_parameters)
 
     def build_messages(self) -> Iterator[List[Dict]]:
-        if not self.query_parameters.dataset_path:
-            from modelscope import MsDataset
-            ds = MsDataset.load('AI-ModelScope/LongAlpaca-12k', subset_name='default', split='train')
-        else:
+        if self.query_parameters.dataset_path and os.path.isfile(self.query_parameters.dataset_path):
             ds = self.dataset_json_list(self.query_parameters.dataset_path)
+        else:
+            ds = self.load_hub_dataset(dataset_id='AI-ModelScope/LongAlpaca-12k', split='train')
         for item in ds:
             prompt = item['instruction'].strip()
             is_valid, _ = self.check_prompt_length(prompt)

--- a/evalscope/perf/plugin/datasets/multi_turn.py
+++ b/evalscope/perf/plugin/datasets/multi_turn.py
@@ -184,11 +184,10 @@ class ShareGPTMultiTurnBase(ShareGPTDatasetPluginBase):
 
     def build_messages(self) -> Iterator[Conversation]:
         """Yield full conversations as ``Conversation`` (one ``Turn`` per user turn)."""
-        if not self.query_parameters.dataset_path:
-            from modelscope import dataset_snapshot_download
-
-            local_path = dataset_snapshot_download('swift/sharegpt', allow_patterns=[self.FILE_NAME])
-            self.query_parameters.dataset_path = os.path.join(local_path, self.FILE_NAME)
+        if not self.query_parameters.dataset_path or os.path.isdir(self.query_parameters.dataset_path):
+            self.query_parameters.dataset_path = self.download_hub_file(
+                dataset_id='swift/sharegpt', file_name=self.FILE_NAME
+            )
 
         for item in self.dataset_line_by_line(self.query_parameters.dataset_path):
             item = json.loads(item)

--- a/evalscope/perf/plugin/datasets/openqa.py
+++ b/evalscope/perf/plugin/datasets/openqa.py
@@ -17,12 +17,10 @@ class OpenqaDatasetPlugin(DatasetPluginBase):
         super().__init__(query_parameters)
 
     def build_messages(self) -> Iterator[List[Dict]]:
-        if not self.query_parameters.dataset_path:
-            from modelscope import dataset_snapshot_download
-
-            file_name = 'open_qa.jsonl'
-            local_path = dataset_snapshot_download('AI-ModelScope/HC3-Chinese', allow_patterns=[file_name])
-            self.query_parameters.dataset_path = os.path.join(local_path, file_name)
+        if not self.query_parameters.dataset_path or os.path.isdir(self.query_parameters.dataset_path):
+            self.query_parameters.dataset_path = self.download_hub_file(
+                dataset_id='AI-ModelScope/HC3-Chinese', file_name='open_qa.jsonl'
+            )
 
         for item in self.dataset_line_by_line(self.query_parameters.dataset_path):
             item = json.loads(item)

--- a/evalscope/perf/plugin/datasets/share_gpt.py
+++ b/evalscope/perf/plugin/datasets/share_gpt.py
@@ -61,11 +61,10 @@ class ShareGPTDatasetPluginBase(DatasetPluginBase):
         return messages
 
     def build_messages(self) -> Iterator[List[Dict]]:
-        if not self.query_parameters.dataset_path:
-            from modelscope import dataset_snapshot_download
-
-            local_path = dataset_snapshot_download('swift/sharegpt', allow_patterns=[self.FILE_NAME])
-            self.query_parameters.dataset_path = os.path.join(local_path, self.FILE_NAME)
+        if not self.query_parameters.dataset_path or os.path.isdir(self.query_parameters.dataset_path):
+            self.query_parameters.dataset_path = self.download_hub_file(
+                dataset_id='swift/sharegpt', file_name=self.FILE_NAME
+            )
 
         for item in self.dataset_line_by_line(self.query_parameters.dataset_path):
             item = json.loads(item)

--- a/evalscope/perf/plugin/datasets/swe_smith.py
+++ b/evalscope/perf/plugin/datasets/swe_smith.py
@@ -356,8 +356,7 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
             f'target_count={target_count}, min_chars={min_chars}'
         )
 
-        from modelscope import MsDataset
-        dataset = MsDataset.load(_DEFAULT_DATASET_NAME, split=_DEFAULT_SPLIT)
+        dataset = self.load_hub_dataset(dataset_id=_DEFAULT_DATASET_NAME, split=_DEFAULT_SPLIT)
 
         candidates = []
         skipped_short = 0

--- a/evalscope/perf/plugin/datasets/trie.py
+++ b/evalscope/perf/plugin/datasets/trie.py
@@ -75,11 +75,9 @@ class TrieReplayBase(RandomDatasetPlugin):
             )
 
     def _resolve_dataset_path(self) -> str:
-        if self.query_parameters.dataset_path:
+        if self.query_parameters.dataset_path and os.path.isfile(self.query_parameters.dataset_path):
             return self.query_parameters.dataset_path
-        from modelscope import dataset_snapshot_download
-        local_path = dataset_snapshot_download(_HUB_REPO, allow_patterns=[self.FILE_NAME])
-        path = os.path.join(local_path, self.FILE_NAME)
+        path = self.download_hub_file(dataset_id=_HUB_REPO, file_name=self.FILE_NAME)
         self.query_parameters.dataset_path = path
         return path
 


### PR DESCRIPTION
## Summary

Resolves #1447 — perf mode cannot load local datasets in offline environments.

## Changes

- **New `--data-source` parameter**: Supports `modelscope` (default), `huggingface`, and `local`.
- **New helper methods** in `DatasetPluginBase`:
  - `load_hub_dataset()` — loads Arrow/Parquet datasets via `evalscope.api.dataset.hub.load_dataset_from_hub()`
  - `download_hub_file()` — downloads/resolves single files via `evalscope.api.dataset.hub.download_dataset_file()`
- **Refactored 8 dataset plugins** to use the unified interface:
  - `flickr8k`, `kontext_bench`: now support `--dataset-path` pointing to local directory
  - `longalpaca`: supports both local JSON file and hub dataset loading
  - `openqa`, `share_gpt`, `multi_turn`: support directory-based resolution
  - `trie`, `swe_smith`: use unified download/load methods
- **Documentation updated** (zh + en): parameters.md and faq.md

## Usage

```bash
# Offline: point to local dataset directory (Arrow/Parquet)
evalscope perf --dataset kontext_bench --dataset-path /path/to/local/kontext-bench ...

# Offline: point to local file (JSONL)
evalscope perf --dataset openqa --dataset-path /path/to/open_qa.jsonl ...

# Switch to HuggingFace as data source
evalscope perf --dataset longalpaca --data-source huggingface ...
```

## Testing

All 9 dataset plugins tested end-to-end with real API calls (DashScope):
- openqa (remote + local dir) ✓
- longalpaca ✓
- share_gpt_zh + multi_turn ✓
- flickr8k + kontext_bench (multimodal) ✓
- trie (data load + conversation build) ✓
- swe_smith (load_hub_dataset) ✓