### PR TITLE
Fix OpenAI-compatible streaming aggregation

### DIFF
--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -814,7 +814,12 @@ def collect_stream_response(
     t_start = request_start if request_start is not None else time.monotonic()
     ttft: Optional[float] = None
 
+    usage = None
     for chunk in response_stream:
+        if getattr(chunk, 'usage', None) is not None:
+            usage = chunk.usage
+        if not getattr(chunk, 'choices', None):
+            continue
         collected_chunks.append(chunk)
         for choice in chunk.choices:
             # Detect first meaningful content chunk for TTFT
@@ -897,6 +902,9 @@ def collect_stream_response(
         )
         choices.append(choice)
 
+    if not collected_chunks:
+        raise RuntimeError('No valid chat completion chunks received from stream')
+
     # build the final completion object
     return ChatCompletion(
         id=collected_chunks[0].id,
@@ -904,7 +912,7 @@ def collect_stream_response(
         created=collected_chunks[0].created,
         model=collected_chunks[0].model,
         object='chat.completion',
-        usage=collected_chunks[-1].usage  # use the usage from the last chunk
+        usage=usage if usage is not None else collected_chunks[-1].usage
     ), ttft
 
 
@@ -934,7 +942,12 @@ async def async_collect_stream_response(
     t_start = request_start if request_start is not None else time.monotonic()
     ttft: Optional[float] = None
 
+    usage = None
     async for chunk in response_stream:
+        if getattr(chunk, 'usage', None) is not None:
+            usage = chunk.usage
+        if not getattr(chunk, 'choices', None):
+            continue
         collected_chunks.append(chunk)
         for choice in chunk.choices:
             # Detect first meaningful content chunk for TTFT
@@ -1017,6 +1030,9 @@ async def async_collect_stream_response(
         )
         choices.append(choice)
 
+    if not collected_chunks:
+        raise RuntimeError('No valid chat completion chunks received from stream')
+
     # build the final completion object
     return ChatCompletion(
         id=collected_chunks[0].id,
@@ -1024,5 +1040,6 @@ async def async_collect_stream_response(
         created=collected_chunks[0].created,
         model=collected_chunks[0].model,
         object='chat.completion',
-        usage=collected_chunks[-1].usage  # use the usage from the last chunk
+        usage=usage if usage is not None else collected_chunks[-1].usage
     ), ttft
+

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -1042,4 +1042,3 @@ async def async_collect_stream_response(
         object='chat.completion',
         usage=usage if usage is not None else getattr(collected_chunks[-1], 'usage', None)
     ), ttft
-

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -912,7 +912,7 @@ def collect_stream_response(
         created=collected_chunks[0].created,
         model=collected_chunks[0].model,
         object='chat.completion',
-        usage=usage if usage is not None else collected_chunks[-1].usage
+        usage=usage if usage is not None else getattr(collected_chunks[-1], 'usage', None)
     ), ttft
 
 
@@ -1040,6 +1040,6 @@ async def async_collect_stream_response(
         created=collected_chunks[0].created,
         model=collected_chunks[0].model,
         object='chat.completion',
-        usage=usage if usage is not None else collected_chunks[-1].usage
+        usage=usage if usage is not None else getattr(collected_chunks[-1], 'usage', None)
     ), ttft
 


### PR DESCRIPTION
## What this PR does

This PR fixes OpenAI-compatible streaming response aggregation when the stream contains chunks without valid `choices`, such as keepalive-style chunks or usage-only chunks.

Previously, the collector could later access `collected_chunks[0]` even when no valid completion chunks were collected, causing:

~~~text
list index out of range
~~~

This can make streaming evaluations such as `general_fc` fail all samples and report zero scores.

## Changes

- Skip streaming chunks without `choices`.
- Preserve `usage` from usage-only chunks.
- Add a clear error when no valid completion chunks are received.
- Apply the same logic to both sync and async stream collectors.

## Validation

Validated with `general_fc` in streaming mode using an OpenAI-compatible endpoint.

Result:

~~~text
tool_call_f1: 0.625
count_finish_reason_tool_call: 10
count_successful_tool_call: 10
schema_accuracy: 1.0
~~~

Prediction summary:

~~~text
rows: 20
errors: 0
stop: 10
tool_calls: 10
~~~

No longer observed:

~~~text
list index out of range
~~~
