### PR TITLE
fix(agent): use login shell for SWE-bench sandboxes

### DIFF
--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import shlex
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from evalscope.api.agent import AgentEnvironment
 from evalscope.api.agent.types import ExecResult
@@ -42,6 +42,7 @@ logger = get_logger()
 _DEFAULT_DOCKER_IMAGE = 'python:3.11-slim'
 _DEFAULT_WORKDIR = '/workspace'
 _DEFAULT_TOOLS: List[str] = ['shell_executor', 'python_executor']
+_DEFAULT_INTERPRETER: List[str] = ['bash', '-c']
 
 
 @register_environment(['enclave', 'docker', 'volcengine'])
@@ -64,6 +65,11 @@ class EnclaveAgentEnvironment(AgentEnvironment):
     timeout:
         Default command timeout (seconds) used when :meth:`exec` is called
         without an explicit timeout.
+    interpreter:
+        Command interpreter argv prefix. The rendered command string is
+        appended as the final argument. Defaults to ``['bash', '-c']`` for
+        backward compatibility; benchmark adapters may use ``['bash', '-lc']``
+        when login-shell initialization is required.
     """
 
     name: str = 'enclave'
@@ -75,6 +81,7 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         sandbox_config: Optional[Dict[str, Any]] = None,
         manager_config: Optional[Dict[str, Any]] = None,
         timeout: float = 60.0,
+        interpreter: Optional[Sequence[str]] = None,
         **_: Any,
     ) -> None:
         # ms_enclave is mandatory for this environment. Fail fast at construction
@@ -84,6 +91,12 @@ class EnclaveAgentEnvironment(AgentEnvironment):
 
         self._engine: SandboxEngine = resolve_engine(engine)
         self._timeout = float(timeout)
+        self._interpreter: List[str] = list(_DEFAULT_INTERPRETER if interpreter is None else interpreter)
+        invalid_interpreter = not self._interpreter or any(
+            not isinstance(part, str) or not part for part in self._interpreter
+        )
+        if invalid_interpreter:
+            raise ValueError('EnclaveAgentEnvironment.interpreter must be a non-empty sequence of non-empty strings.')
         self._manager_config: Dict[str, Any] = dict(manager_config or {})
         self._sandbox_config_dict: Dict[str, Any] = self._apply_engine_defaults(dict(sandbox_config or {}))
         self._handle: Optional[SandboxHandle] = None
@@ -146,6 +159,22 @@ class EnclaveAgentEnvironment(AgentEnvironment):
     # AgentEnvironment interface
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _unwrap_bash_c(cmd: Any) -> Optional[str]:
+        """Return the payload for common bash-tool wrappers.
+
+        The generic ``bash`` tool already passes ``/bin/bash -c <command>``.
+        Enclave itself also provides a configurable shell wrapper, so unwrap
+        that shape to avoid running the agent command in a nested non-login
+        shell when the environment interpreter is ``bash -lc``.
+        """
+        if not isinstance(cmd, list) or len(cmd) != 3:
+            return None
+        executable, flag, command = cmd
+        if executable not in {'bash', '/bin/bash'} or flag != '-c' or not isinstance(command, str):
+            return None
+        return command
+
     async def exec(
         self,
         cmd: List[str],
@@ -157,23 +186,25 @@ class EnclaveAgentEnvironment(AgentEnvironment):
     ) -> ExecResult:
         handle = await self._ensure_sandbox()
 
-        if isinstance(cmd, list):
+        unwrapped_command = self._unwrap_bash_c(cmd)
+        if unwrapped_command is not None:
+            command = unwrapped_command
+        elif isinstance(cmd, list):
             command = ' '.join(shlex.quote(c) for c in cmd)
         else:
             command = str(cmd)
-        if env:
-            # Prepend ``KEY=VAL`` pairs so the agent CLI inherits them.
-            # Using ``env -- ... <cmd>`` would be cleaner but is not always
-            # available inside minimal images; inline assignment works in any
-            # POSIX shell.
-            prefix = ' '.join(f'{k}={shlex.quote(v)}' for k, v in env.items())
-            command = f'{prefix} {command}' if prefix else command
         if cwd:
             command = f'cd {shlex.quote(cwd)} && {command}'
+        if env:
+            # Export inside the wrapper shell so compound commands and any
+            # child process inherit the requested environment.
+            prefix = ' '.join(f'export {k}={shlex.quote(v)};' for k, v in env.items())
+            command = f'{prefix} {command}' if prefix else command
 
         # ms_enclave's shell_executor splits a bare string with no shell
-        # wrapping; wrap as ``bash -c`` so cd/&&/env-prefix/quoting survive.
-        shell_argv = ['bash', '-c', command]
+        # wrapping; use an explicit interpreter so cd/&&/env-prefix/quoting
+        # survive, while allowing benchmarks to request login-shell setup.
+        shell_argv = [*self._interpreter, command]
 
         timeout_s = float(timeout or self._timeout)
 

--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -182,6 +182,10 @@ class EnclaveAgentEnvironment(AgentEnvironment):
             return None
         return command
 
+    def _interpreter_is_bash(self) -> bool:
+        executable = self._interpreter[0]
+        return executable == 'bash' or executable.endswith('/bash')
+
     @staticmethod
     def _render_env_exports(env: Dict[str, str]) -> str:
         exports = []
@@ -203,7 +207,7 @@ class EnclaveAgentEnvironment(AgentEnvironment):
     ) -> ExecResult:
         handle = await self._ensure_sandbox()
 
-        unwrapped_command = self._unwrap_bash_c(cmd)
+        unwrapped_command = self._unwrap_bash_c(cmd) if self._interpreter_is_bash() else None
         if unwrapped_command is not None:
             command = unwrapped_command
         elif isinstance(cmd, list):

--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -19,6 +19,7 @@ shared ``atexit`` hook.
 
 from __future__ import annotations
 
+import re
 import shlex
 import time
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -43,6 +44,7 @@ _DEFAULT_DOCKER_IMAGE = 'python:3.11-slim'
 _DEFAULT_WORKDIR = '/workspace'
 _DEFAULT_TOOLS: List[str] = ['shell_executor', 'python_executor']
 _DEFAULT_INTERPRETER: List[str] = ['bash', '-c']
+_ENV_KEY_PATTERN = r'[A-Za-z_][A-Za-z0-9_]*'
 
 
 @register_environment(['enclave', 'docker', 'volcengine'])
@@ -91,6 +93,11 @@ class EnclaveAgentEnvironment(AgentEnvironment):
 
         self._engine: SandboxEngine = resolve_engine(engine)
         self._timeout = float(timeout)
+        if isinstance(interpreter, str):
+            raise TypeError(
+                'EnclaveAgentEnvironment.interpreter must be a non-empty sequence of non-empty strings, '
+                'not a single string.'
+            )
         self._interpreter: List[str] = list(_DEFAULT_INTERPRETER if interpreter is None else interpreter)
         invalid_interpreter = not self._interpreter or any(
             not isinstance(part, str) or not part for part in self._interpreter
@@ -168,12 +175,22 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         that shape to avoid running the agent command in a nested non-login
         shell when the environment interpreter is ``bash -lc``.
         """
-        if not isinstance(cmd, list) or len(cmd) != 3:
+        if not isinstance(cmd, (list, tuple)) or len(cmd) != 3:
             return None
         executable, flag, command = cmd
         if executable not in {'bash', '/bin/bash'} or flag != '-c' or not isinstance(command, str):
             return None
         return command
+
+    @staticmethod
+    def _render_env_exports(env: Dict[str, str]) -> str:
+        exports = []
+        for raw_key, raw_value in env.items():
+            key = str(raw_key)
+            if not re.fullmatch(_ENV_KEY_PATTERN, key):
+                raise ValueError(f'Invalid environment variable name: {key!r}')
+            exports.append(f'export {key}={shlex.quote(str(raw_value))};')
+        return ' '.join(exports)
 
     async def exec(
         self,
@@ -198,7 +215,7 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         if env:
             # Export inside the wrapper shell so compound commands and any
             # child process inherit the requested environment.
-            prefix = ' '.join(f'export {k}={shlex.quote(v)};' for k, v in env.items())
+            prefix = self._render_env_exports(env)
             command = f'{prefix} {command}' if prefix else command
 
         # ms_enclave's shell_executor splits a bare string with no shell

--- a/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
@@ -45,7 +45,7 @@ logger = get_logger()
 
 # SWE-bench images activate their per-instance testbed from shell startup files;
 # mini-swe-agent's DockerEnvironment therefore runs commands through bash -lc.
-_SWE_BENCH_INTERPRETER: List[str] = ['bash', '-lc']
+_SWE_BENCH_INTERPRETER: tuple[str, ...] = ('bash', '-lc')
 
 # ---------------------------------------------------------------------------
 # instance_template — mirrors mini-swe-agent swebench.yaml

--- a/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
@@ -43,6 +43,10 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+# SWE-bench images activate their per-instance testbed from shell startup files;
+# mini-swe-agent's DockerEnvironment therefore runs commands through bash -lc.
+_SWE_BENCH_INTERPRETER: List[str] = ['bash', '-lc']
+
 # ---------------------------------------------------------------------------
 # instance_template — mirrors mini-swe-agent swebench.yaml
 # ---------------------------------------------------------------------------
@@ -388,6 +392,7 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
             engine='docker',
             sandbox_config=sandbox_config,
             timeout=self.command_timeout,
+            interpreter=_SWE_BENCH_INTERPRETER,
         )
 
     def build_initial_messages(self, sample: Sample) -> List[Any]:

--- a/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
@@ -37,7 +37,7 @@ logger = get_logger()
 
 # Keep command execution aligned with mini-swe-agent and images that initialize
 # their runtime environment from shell startup files.
-_SWE_BENCH_PRO_INTERPRETER: List[str] = ['bash', '-lc']
+_SWE_BENCH_PRO_INTERPRETER: tuple[str, ...] = ('bash', '-lc')
 
 INSTANCE_TEMPLATE = """\
 <pr_description>

--- a/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench_pro/swe_bench_pro_agentic_adapter.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+# Keep command execution aligned with mini-swe-agent and images that initialize
+# their runtime environment from shell startup files.
+_SWE_BENCH_PRO_INTERPRETER: List[str] = ['bash', '-lc']
+
 INSTANCE_TEMPLATE = """\
 <pr_description>
 Consider the following PR description:
@@ -346,6 +350,7 @@ class SWEBenchProAgenticAdapter(AgentLoopAdapter):
             engine='docker',
             sandbox_config=sandbox_config,
             timeout=self.command_timeout,
+            interpreter=_SWE_BENCH_PRO_INTERPRETER,
         )
 
     def build_initial_messages(self, sample: Sample) -> List[Any]:

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -13,7 +13,9 @@ Test plan:
 
 import os
 import pytest
+import sys
 import tempfile
+import types
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -69,6 +71,50 @@ def _check_docker() -> bool:
 
 DOCKER_AVAILABLE = _check_docker()
 docker_mark = pytest.mark.skipif(not DOCKER_AVAILABLE, reason='Docker daemon not available')
+
+
+class _FakeExecutionStatus:
+    SUCCESS = 'success'
+    TIMEOUT = 'timeout'
+
+
+class _FakeSandboxHandle:
+    sandbox_id = 'fake-sandbox'
+
+    def __init__(self) -> None:
+        self.tool_name: Optional[str] = None
+        self.payload: Optional[Dict[str, Any]] = None
+        self.closed = False
+
+    async def execute_tool(self, tool_name: str, payload: Dict[str, Any]) -> Any:
+        self.tool_name = tool_name
+        self.payload = payload
+        return types.SimpleNamespace(
+            output='ok',
+            error='',
+            status=_FakeExecutionStatus.SUCCESS,
+            execution_time=0.1,
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake_ms_enclave(monkeypatch: pytest.MonkeyPatch) -> None:
+    ms_enclave_mod = types.ModuleType('ms_enclave')
+    sandbox_mod = types.ModuleType('ms_enclave.sandbox')
+    model_mod = types.ModuleType('ms_enclave.sandbox.model')
+    model_mod.ExecutionStatus = _FakeExecutionStatus
+    sandbox_mod.model = model_mod
+    ms_enclave_mod.sandbox = sandbox_mod
+    monkeypatch.setitem(sys.modules, 'ms_enclave', ms_enclave_mod)
+    monkeypatch.setitem(sys.modules, 'ms_enclave.sandbox', sandbox_mod)
+    monkeypatch.setitem(sys.modules, 'ms_enclave.sandbox.model', model_mod)
+
+
+def _allow_enclave_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    from evalscope.agent.environments import enclave as enclave_mod
+    monkeypatch.setattr(enclave_mod, 'check_import', lambda *args, **kwargs: None)
 
 
 # ===========================================================================
@@ -146,6 +192,119 @@ class TestEnvironmentRegistry:
         info = AGENT_TOOL_INFO_REGISTRY['python_exec']
         assert 'code' in info.parameters.properties
         assert 'code' in info.parameters.required
+
+
+# ===========================================================================
+# TestEnclaveEnvironmentInterpreter
+# ===========================================================================
+
+class TestEnclaveEnvironmentInterpreter:
+
+    def _run(self, coro: Any) -> Any:
+        return AsyncioLoopRunner.run(coro)
+
+    def _env_with_fake_handle(
+        self, monkeypatch: pytest.MonkeyPatch, *, interpreter: Optional[List[str]] = None
+    ) -> tuple[Any, _FakeSandboxHandle]:
+        from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
+
+        _allow_enclave_construction(monkeypatch)
+        _install_fake_ms_enclave(monkeypatch)
+        handle = _FakeSandboxHandle()
+        kwargs = {}
+        if interpreter is not None:
+            kwargs['interpreter'] = interpreter
+        env = EnclaveAgentEnvironment(
+            engine='docker',
+            sandbox_config={'image': 'python:3.11-slim'},
+            **kwargs,
+        )
+
+        async def _ensure_sandbox() -> _FakeSandboxHandle:
+            return handle
+
+        monkeypatch.setattr(env, '_ensure_sandbox', _ensure_sandbox)
+        return env, handle
+
+    def test_exec_uses_backward_compatible_default_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        result = self._run(env.exec(['echo', 'hello world'], cwd='/tmp', env={'FOO': 'bar'}))
+
+        assert result.returncode == 0
+        assert handle.tool_name == 'shell_executor'
+        assert handle.payload is not None
+        assert handle.payload['command'][:2] == ['bash', '-c']
+        assert handle.payload['command'][-1] == "export FOO=bar; cd /tmp && echo 'hello world'"
+
+    def test_exec_uses_configured_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch, interpreter=['bash', '-lc'])
+        result = self._run(env.exec(['python', '-V']))
+
+        assert result.returncode == 0
+        assert handle.payload is not None
+        assert handle.payload['command'][:2] == ['bash', '-lc']
+
+    def test_bash_tool_preserves_configured_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evalscope.agent.tools.bash import run_bash
+
+        env, handle = self._env_with_fake_handle(monkeypatch, interpreter=['bash', '-lc'])
+        call = _tool_call('bash', {'command': 'which python'})
+        obs = self._run(run_bash(call, env))
+
+        assert obs == 'ok'
+        assert handle.payload is not None
+        assert handle.payload['command'][:2] == ['bash', '-lc']
+        assert handle.payload['command'][-1] == 'which python'
+
+    def test_unwrapped_bash_command_exports_env_for_whole_script(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        result = self._run(env.exec(['/bin/bash', '-c', 'echo "$FOO" && env | grep "^FOO="'], env={'FOO': 'bar'}))
+
+        assert result.returncode == 0
+        assert handle.payload is not None
+        assert handle.payload['command'][-1] == 'export FOO=bar; echo "$FOO" && env | grep "^FOO="'
+
+    def test_empty_interpreter_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
+
+        _allow_enclave_construction(monkeypatch)
+        with pytest.raises(ValueError, match='interpreter'):
+            EnclaveAgentEnvironment(
+                engine='docker',
+                sandbox_config={'image': 'python:3.11-slim'},
+                interpreter=[],
+            )
+
+    def test_swe_bench_agentic_adapter_uses_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        _allow_enclave_construction(monkeypatch)
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter.working_dir = '/testbed'
+        adapter.command_timeout = 60.0
+        adapter.force_arch = ''
+        adapter._task_config = None
+        sample = types.SimpleNamespace(metadata={'docker_image': 'swebench/example:latest', 'instance_id': 'example'})
+
+        env = adapter.build_environment(sample)
+
+        assert env._interpreter == ['bash', '-lc']
+
+    def test_swe_bench_pro_adapter_uses_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evalscope.benchmarks.swe_bench_pro.swe_bench_pro_agentic_adapter import SWEBenchProAgenticAdapter
+
+        _allow_enclave_construction(monkeypatch)
+        adapter = object.__new__(SWEBenchProAgenticAdapter)
+        adapter.working_dir = '/app'
+        adapter.command_timeout = 60.0
+        adapter._task_config = None
+        sample = types.SimpleNamespace(
+            metadata={'docker_image': 'jefzda/sweap-images:example', 'instance_id': 'example'}
+        )
+
+        env = adapter.build_environment(sample)
+
+        assert env._interpreter == ['bash', '-lc']
 
 
 # ===========================================================================

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -256,6 +256,14 @@ class TestEnclaveEnvironmentInterpreter:
         assert handle.payload['command'][:2] == ['bash', '-lc']
         assert handle.payload['command'][-1] == 'which python'
 
+    def test_tuple_bash_c_wrapper_is_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch, interpreter=['bash', '-lc'])
+        result = self._run(env.exec(('bash', '-c', 'echo tuple')))
+
+        assert result.returncode == 0
+        assert handle.payload is not None
+        assert handle.payload['command'] == ['bash', '-lc', 'echo tuple']
+
     def test_unwrapped_bash_command_exports_env_for_whole_script(self, monkeypatch: pytest.MonkeyPatch) -> None:
         env, handle = self._env_with_fake_handle(monkeypatch)
         result = self._run(env.exec(['/bin/bash', '-c', 'echo "$FOO" && env | grep "^FOO="'], env={'FOO': 'bar'}))
@@ -263,6 +271,21 @@ class TestEnclaveEnvironmentInterpreter:
         assert result.returncode == 0
         assert handle.payload is not None
         assert handle.payload['command'][-1] == 'export FOO=bar; echo "$FOO" && env | grep "^FOO="'
+
+    def test_env_export_rejects_invalid_variable_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch)
+
+        with pytest.raises(ValueError, match='Invalid environment variable name'):
+            self._run(env.exec(['echo', 'x'], env={'BAD;KEY': 'value'}))
+        assert handle.payload is None
+
+    def test_env_export_casts_values_to_strings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        result = self._run(env.exec(['echo', 'x'], env={'COUNT': 3}))
+
+        assert result.returncode == 0
+        assert handle.payload is not None
+        assert handle.payload['command'][-1] == 'export COUNT=3; echo x'
 
     def test_empty_interpreter_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
@@ -273,6 +296,17 @@ class TestEnclaveEnvironmentInterpreter:
                 engine='docker',
                 sandbox_config={'image': 'python:3.11-slim'},
                 interpreter=[],
+            )
+
+    def test_string_interpreter_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
+
+        _allow_enclave_construction(monkeypatch)
+        with pytest.raises(TypeError, match='interpreter'):
+            EnclaveAgentEnvironment(
+                engine='docker',
+                sandbox_config={'image': 'python:3.11-slim'},
+                interpreter='bash -lc',
             )
 
     def test_swe_bench_agentic_adapter_uses_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -264,6 +264,14 @@ class TestEnclaveEnvironmentInterpreter:
         assert handle.payload is not None
         assert handle.payload['command'] == ['bash', '-lc', 'echo tuple']
 
+    def test_bash_c_wrapper_is_not_unwrapped_for_non_bash_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch, interpreter=['sh', '-c'])
+        result = self._run(env.exec(['/bin/bash', '-c', 'echo bash contract']))
+
+        assert result.returncode == 0
+        assert handle.payload is not None
+        assert handle.payload['command'] == ['sh', '-c', "/bin/bash -c 'echo bash contract'"]
+
     def test_unwrapped_bash_command_exports_env_for_whole_script(self, monkeypatch: pytest.MonkeyPatch) -> None:
         env, handle = self._env_with_fake_handle(monkeypatch)
         result = self._run(env.exec(['/bin/bash', '-c', 'echo "$FOO" && env | grep "^FOO="'], env={'FOO': 'bar'}))


### PR DESCRIPTION
## Summary

  Fixes #1456.

  This PR fixes the SWE-bench agentic sandbox environment so agent commands run under the intended per-instance testbed environment, matching mini-swe-agent's `bash -lc` behavior.

## Root Cause

  Previously, `EnclaveAgentEnvironment` always wrapped sandbox commands as:

  ```python
  ['bash', '-c', command]
```

  For SWE-bench official images such as `swebench/sweb.eval.x86_64.`, the correct Python environment is initialized from shell startup files, where `/root/.bashrc` activates the testbed conda env. Since `bash -c` does not perform login-shell
  initialization, the agent interaction phase could run under the base miniconda Python instead of `/opt/miniconda3/envs/testbed/bin/python`.

  This caused the agent to see a broken or incomplete runtime environment during exploration and testing, even though final SWE-bench scoring runs through the official evaluation script and activates the environment correctly.

  For SWE-bench agentic tasks this means the agent command path did not match mini-swe-agent, whose Docker environment defaults to:

```
  ['bash', '-lc']
```

  As a result, commands like which python, python -c "import asgiref", or repository tests could run in the wrong conda environment.

  ## Changes

  This PR makes the sandbox command interpreter configurable in EnclaveAgentEnvironment:
```
  interpreter: Optional[Sequence[str]] = None
```
  The default remains:
```
  ['bash', '-c']
```
  This preserves backward compatibility for all existing generic sandbox users.

  For SWE-bench agentic adapters, the interpreter is explicitly set to:
```
  ['bash', '-lc']
```
  This is applied to `swe_bench_*_agentic` and `swe_bench_pro`

  ## Validation

```
 python3 -m pytest tests/agent/test_t2_environment.py -q
```

  Also manually verified with a real SWE-bench image and ms_enclave.
