### PR TITLE
Fix tau3_bench crash when completion usage is missing

### DIFF
--- a/evalscope/benchmarks/tau_bench/tau3_bench/generation.py
+++ b/evalscope/benchmarks/tau_bench/tau3_bench/generation.py
@@ -119,7 +119,7 @@ def patched_generate(
         ) for tool_call in tool_calls
     ]
     tool_calls = tool_calls or None
-    usage = completion.usage.model_dump(exclude_none=True)
+    usage = completion.usage.model_dump(exclude_none=True) if completion.usage is not None else None
 
     raw_data = completion.model_dump()
     perf = completion.message.perf_metrics


### PR DESCRIPTION
## Summary

This PR fixes a robustness issue in the `tau3_bench` integration where `patched_generate()` crashes if a model provider returns a completion response without usage metadata.

Currently, `patched_generate()` assumes `completion.usage` is always present:

```python
usage = completion.usage.model_dump(exclude_none=True)
```

However, some OpenAI-compatible providers or intermittent responses may return `usage=None`. In that case, the adapter raises:

```text
AttributeError: 'NoneType' object has no attribute 'model_dump'
```

This aborts the tau3 task even though the model response may otherwise contain a valid message.

## Root Cause

`evalscope/benchmarks/tau_bench/tau3_bench/generation.py` patches tau2's internal LLM generation path and converts EvalScope model outputs into tau2 `AssistantMessage` objects.

The current code does not guard against `completion.usage is None` before calling `.model_dump()`.

Since token usage metadata is optional for some providers/responses, missing usage should not be treated as a fatal task error.

## Fix

Handle missing usage metadata gracefully:

```python
usage = completion.usage.model_dump(exclude_none=True) if completion.usage is not None else None
```

The returned `AssistantMessage` can still preserve the model content, tool calls, and raw response data. Only the optional usage field is set to `None`.

## Why `None` instead of `{}`?

`None` preserves the semantic distinction between:

- usage metadata was not returned by the provider
- usage metadata was returned but happened to be empty

This also matches the optional nature of usage fields in many chat completion schemas.

## Expected Behavior

If `completion.usage` is missing, tau3_bench should continue running and construct an `AssistantMessage` with:

```python
usage=None
```

instead of crashing.

## Actual Behavior Before This PR

When `completion.usage is None`, tau3_bench crashes with:

```text
AttributeError: 'NoneType' object has no attribute 'model_dump'
```

This can cause a tau3 task to be marked as failed due to an adapter-side exception, even when the model output itself is otherwise usable.

## Scope

This is a minimal defensive fix. It does not change:

- tool call parsing
- message content handling
- raw response persistence
- tau2 orchestration behavior
- evaluation logic
- scoring logic

It only prevents an adapter crash when optional usage metadata is absent.

## Testing

- Ran `python -m py_compile evalscope/benchmarks/tau_bench/tau3_bench/generation.py`
- Ran `git diff --check`

I also observed this failure mode in a tau3_bench run with an OpenAI-compatible provider where occasional responses did not include usage metadata. Before this fix, such a response can fail with:

```text
'NoneType' object has no attribute 'model_dump'
```

After this fix, the adapter proceeds with `usage=None` and task execution can continue.

A minimal mock-style check for the changed behavior is:

```python
completion.usage = None
usage = completion.usage.model_dump(exclude_none=True) if completion.usage is not None else None
assert usage is None
```

## Related Context

This issue is separate from model/tool-call failures such as:

- unknown tool names
- invalid assistant messages with neither content nor tool calls
- provider responses containing only reasoning content

Those are different failure modes. This PR only addresses the case where the response usage object itself is missing.
