### PR TITLE
fix(openai): include delta.reasoning in streaming TTFT

### DIFF
--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -823,13 +823,13 @@ def collect_stream_response(
         collected_chunks.append(chunk)
         for choice in chunk.choices:
             reasoning_content = getattr(choice.delta, 'reasoning_content', None)
-            if reasoning_content is None:
+            if reasoning_content is None or reasoning_content == '':
                 reasoning_content = getattr(choice.delta, 'reasoning', None)
 
             # Detect first meaningful content chunk for TTFT
-            has_content = ((choice.delta.content is not None and choice.delta.content != '') or (
-                reasoning_content is not None and reasoning_content != ''
-            ) or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
+            has_content = ((choice.delta.content is not None and choice.delta.content != '')
+                           or (reasoning_content is not None and reasoning_content != '')
+                           or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
             if ttft is None and has_content:
                 ttft = time.monotonic() - t_start
 
@@ -954,13 +954,13 @@ async def async_collect_stream_response(
         collected_chunks.append(chunk)
         for choice in chunk.choices:
             reasoning_content = getattr(choice.delta, 'reasoning_content', None)
-            if reasoning_content is None:
+            if reasoning_content is None or reasoning_content == '':
                 reasoning_content = getattr(choice.delta, 'reasoning', None)
 
             # Detect first meaningful content chunk for TTFT
-            has_content = ((choice.delta.content is not None and choice.delta.content != '') or (
-                reasoning_content is not None and reasoning_content != ''
-            ) or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
+            has_content = ((choice.delta.content is not None and choice.delta.content != '')
+                           or (reasoning_content is not None and reasoning_content != '')
+                           or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
             if ttft is None and has_content:
                 ttft = time.monotonic() - t_start
 

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -822,17 +822,20 @@ def collect_stream_response(
             continue
         collected_chunks.append(chunk)
         for choice in chunk.choices:
+            reasoning_content = getattr(choice.delta, 'reasoning_content', None)
+            if reasoning_content is None:
+                reasoning_content = getattr(choice.delta, 'reasoning', None)
+
             # Detect first meaningful content chunk for TTFT
             has_content = ((choice.delta.content is not None and choice.delta.content != '') or (
-                hasattr(choice.delta, 'reasoning_content') and choice.delta.reasoning_content is not None
-                and choice.delta.reasoning_content != ''
+                reasoning_content is not None and reasoning_content != ''
             ) or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
             if ttft is None and has_content:
                 ttft = time.monotonic() - t_start
 
             # Handle reasoning content
-            if hasattr(choice.delta, 'reasoning_content') and choice.delta.reasoning_content is not None:
-                collected_reasoning[choice.index].append(choice.delta.reasoning_content)
+            if reasoning_content is not None:
+                collected_reasoning[choice.index].append(str(reasoning_content))
 
             # Handle regular content
             if choice.delta.content is not None:
@@ -950,17 +953,20 @@ async def async_collect_stream_response(
             continue
         collected_chunks.append(chunk)
         for choice in chunk.choices:
+            reasoning_content = getattr(choice.delta, 'reasoning_content', None)
+            if reasoning_content is None:
+                reasoning_content = getattr(choice.delta, 'reasoning', None)
+
             # Detect first meaningful content chunk for TTFT
             has_content = ((choice.delta.content is not None and choice.delta.content != '') or (
-                hasattr(choice.delta, 'reasoning_content') and choice.delta.reasoning_content is not None
-                and choice.delta.reasoning_content != ''
+                reasoning_content is not None and reasoning_content != ''
             ) or (hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls))
             if ttft is None and has_content:
                 ttft = time.monotonic() - t_start
 
             # Handle reasoning content
-            if hasattr(choice.delta, 'reasoning_content') and choice.delta.reasoning_content is not None:
-                collected_reasoning[choice.index].append(choice.delta.reasoning_content)
+            if reasoning_content is not None:
+                collected_reasoning[choice.index].append(str(reasoning_content))
 
             # Handle regular content
             if choice.delta.content is not None:

--- a/tests/models/test_openai_stream_reasoning.py
+++ b/tests/models/test_openai_stream_reasoning.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+from openai.types.chat import ChatCompletionChunk
+
+from evalscope.models.utils.openai import async_collect_stream_response, collect_stream_response
+
+
+def _chunk(*, reasoning=None, content=None, finish_reason=None):
+    return ChatCompletionChunk.model_validate({
+        'id': 'completion-id',
+        'created': 1,
+        'model': 'test-model',
+        'object': 'chat.completion.chunk',
+        'choices': [{
+            'index': 0,
+            'finish_reason': finish_reason,
+            'delta': {'content': content, 'reasoning': reasoning},
+        }],
+    })
+
+
+def test_collects_reasoning_and_measures_ttft_from_reasoning(monkeypatch):
+    clock = [10.0]
+    monkeypatch.setattr('evalscope.models.utils.openai.time.monotonic', lambda: clock[0])
+
+    def stream():
+        clock[0] = 10.25
+        yield _chunk(reasoning='thinking')
+        clock[0] = 11.0
+        yield _chunk(content='answer', finish_reason='stop')
+
+    completion, ttft = collect_stream_response(stream(), request_start=10.0)
+
+    assert completion.choices[0].message.content == 'answer'
+    assert (getattr(completion.choices[0].message, 'reasoning_content', None), ttft) == (
+        'thinking', pytest.approx(0.25)
+    )
+
+
+def test_async_collects_reasoning_and_measures_ttft_from_reasoning(monkeypatch):
+    clock = [20.0]
+    monkeypatch.setattr('evalscope.models.utils.openai.time.monotonic', lambda: clock[0])
+
+    async def stream():
+        clock[0] = 20.25
+        yield _chunk(reasoning='thinking')
+        clock[0] = 21.0
+        yield _chunk(content='answer', finish_reason='stop')
+
+    completion, ttft = asyncio.run(async_collect_stream_response(stream(), request_start=20.0))
+
+    assert completion.choices[0].message.content == 'answer'
+    assert (getattr(completion.choices[0].message, 'reasoning_content', None), ttft) == (
+        'thinking', pytest.approx(0.25)
+    )

--- a/tests/models/test_openai_stream_reasoning.py
+++ b/tests/models/test_openai_stream_reasoning.py
@@ -1,12 +1,11 @@
 import asyncio
-
 import pytest
 from openai.types.chat import ChatCompletionChunk
 
 from evalscope.models.utils.openai import async_collect_stream_response, collect_stream_response
 
 
-def _chunk(*, reasoning=None, content=None, finish_reason=None):
+def _chunk(*, reasoning_content=None, reasoning=None, content=None, finish_reason=None):
     return ChatCompletionChunk.model_validate({
         'id': 'completion-id',
         'created': 1,
@@ -15,7 +14,7 @@ def _chunk(*, reasoning=None, content=None, finish_reason=None):
         'choices': [{
             'index': 0,
             'finish_reason': finish_reason,
-            'delta': {'content': content, 'reasoning': reasoning},
+            'delta': {'content': content, 'reasoning_content': reasoning_content, 'reasoning': reasoning},
         }],
     })
 
@@ -54,3 +53,37 @@ def test_async_collects_reasoning_and_measures_ttft_from_reasoning(monkeypatch):
     assert (getattr(completion.choices[0].message, 'reasoning_content', None), ttft) == (
         'thinking', pytest.approx(0.25)
     )
+
+
+def test_falls_back_to_reasoning_when_reasoning_content_is_empty(monkeypatch):
+    clock = [10.0]
+    monkeypatch.setattr('evalscope.models.utils.openai.time.monotonic', lambda: clock[0])
+
+    def stream():
+        clock[0] = 10.25
+        yield _chunk(reasoning_content='', reasoning='thinking')
+        clock[0] = 11.0
+        yield _chunk(content='answer', finish_reason='stop')
+
+    completion, ttft = collect_stream_response(stream(), request_start=10.0)
+
+    assert completion.choices[0].message.content == 'answer'
+    assert getattr(completion.choices[0].message, 'reasoning_content', None) == 'thinking'
+    assert ttft == pytest.approx(0.25)
+
+
+def test_async_falls_back_to_reasoning_when_reasoning_content_is_empty(monkeypatch):
+    clock = [20.0]
+    monkeypatch.setattr('evalscope.models.utils.openai.time.monotonic', lambda: clock[0])
+
+    async def stream():
+        clock[0] = 20.25
+        yield _chunk(reasoning_content='', reasoning='thinking')
+        clock[0] = 21.0
+        yield _chunk(content='answer', finish_reason='stop')
+
+    completion, ttft = asyncio.run(async_collect_stream_response(stream(), request_start=20.0))
+
+    assert completion.choices[0].message.content == 'answer'
+    assert getattr(completion.choices[0].message, 'reasoning_content', None) == 'thinking'
+    assert ttft == pytest.approx(0.25)


### PR DESCRIPTION
## Summary

This PR fixes streaming TTFT and TPOT metrics for OpenAI-compatible providers, such as GLM-5.2 deployments, that return reasoning tokens in `choice.delta.reasoning` instead of `choice.delta.reasoning_content`.

The change also preserves `delta.reasoning` in the aggregated assistant message. Both synchronous and asynchronous stream collectors are covered.

## Root Cause

The current first-token detection only recognizes non-empty values from:

- `delta.content`
- `delta.reasoning_content`
- `delta.tool_calls`

Some OpenAI-compatible providers stream their reasoning tokens through `delta.reasoning`. Those chunks are ignored until a later `delta.content` chunk arrives.

This records TTFT too late. EvalScope calculates TPOT as:

```text
(latency - ttft) / (output_tokens - 1)
```

The provider's usage metadata still includes the reasoning tokens in `output_tokens`. A late TTFT therefore makes the decoding interval too short while leaving the token count unchanged, significantly underestimating TPOT and overestimating decoding performance.

## Changes

- Prefer the standard `delta.reasoning_content` field.
- Fall back to `delta.reasoning` when `reasoning_content` is absent.
- Treat either reasoning field as meaningful first-token content for TTFT.
- Preserve the selected reasoning field in the aggregated assistant message.
- Apply identical behavior to synchronous and asynchronous stream aggregation.
- Add deterministic regression tests for reasoning aggregation and TTFT.

The fallback avoids concatenating both fields if a provider returns both aliases in the same chunk.

## Reproduction

The regression tests simulate this stream:

```text
10.25s: delta.reasoning = "thinking"
11.00s: delta.content = "answer"
```

On the unmodified `main` branch, both stream collectors return:

```text
(reasoning_content, ttft) = (None, 1.0)
```

The expected result is:

```text
(reasoning_content, ttft) = ("thinking", 0.25)
content = "answer"
```

## Validation

```bash
python -m pytest \
  tests/models/test_openai_stream_reasoning.py \
  tests/models/test_openai_reasoning.py -q
```

Result:

```text
14 passed
```

The new tests fail on the unmodified `main` branch for both synchronous and asynchronous collection with:

```text
assert (None, 1.0) == ("thinking", 0.25)
```

### GLM-5.2 provider validation

**Before**

<img width="1270" height="574" alt="GLM-5.2 performance metrics before the fix" src="https://github.com/user-attachments/assets/2b51ce18-b759-4f1d-97b6-49cbfefb0cbb" />

**After**

<img width="1354" height="238" alt="GLM-5.2 performance metrics after the fix" src="https://github.com/user-attachments/assets/47964fd6-8ee4-4130-a5e5-6d968f32c8ed" />

After applying the change, a 30-sample AIME26 performance run using a GLM-5.2 deployment reported:

```text
Avg latency:       387.963 s
Avg TTFT:          925.32 ms
Avg TPOT:          17.75 ms
Avg output tokens: 21769.4
```

The reasoning stream is now recognized as the start of model output, and the resulting TTFT/TPOT values are consistent with the observed end-to-end latency and output-token volume.

## Scope

This PR only changes OpenAI-compatible stream aggregation and the timing derived from the first meaningful stream chunk. It does not change non-streaming responses, request parameters, provider usage metadata, tool-call aggregation, or retry behavior.
