### PR TITLE
fix(openai): retry interrupted streaming responses

### DIFF
--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -145,16 +145,21 @@ class OpenAICompatibleAPI(ModelAPI):
             t_start = time.monotonic()
             ttft: Optional[float] = None
 
-            # generate completion and save response for model call
-            completion = retry_call(
-                self.client.chat.completions.create,
+            # A streaming request is not complete when create() returns: the
+            # connection may still fail while its chunks are being consumed.
+            # Retry the whole request so a partial response is discarded and
+            # replaced by one complete response.
+            def _create_and_collect() -> Tuple[ChatCompletion, Optional[float]]:
+                raw_completion = self.client.chat.completions.create(**request)
+                if isinstance(raw_completion, ChatCompletion):
+                    return raw_completion, None
+                return collect_stream_response(raw_completion, request_start=t_start)
+
+            completion, ttft = retry_call(
+                _create_and_collect,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                **request
             )
-            # handle streaming response
-            if not isinstance(completion, ChatCompletion):
-                completion, ttft = collect_stream_response(completion, request_start=t_start)
 
             total_time = time.monotonic() - t_start
 
@@ -219,17 +224,20 @@ class OpenAICompatibleAPI(ModelAPI):
             t_start = time.monotonic()
             ttft: Optional[float] = None
 
-            # Async generation with retry
-            completion = await async_retry_call(
-                self.async_client.chat.completions.create,
+            # Keep stream consumption inside the retry boundary. If an async
+            # stream is interrupted, start a fresh request rather than
+            # returning or persisting its partial response.
+            async def _create_and_collect() -> Tuple[ChatCompletion, Optional[float]]:
+                raw_completion = await self.async_client.chat.completions.create(**request)
+                if isinstance(raw_completion, ChatCompletion):
+                    return raw_completion, None
+                return await async_collect_stream_response(raw_completion, request_start=t_start)
+
+            completion, ttft = await async_retry_call(
+                _create_and_collect,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                **request,
             )
-
-            # Handle streaming response
-            if not isinstance(completion, ChatCompletion):
-                completion, ttft = await async_collect_stream_response(completion, request_start=t_start)
 
             total_time = time.monotonic() - t_start
 

--- a/tests/models/test_openai_stream_retry.py
+++ b/tests/models/test_openai_stream_retry.py
@@ -1,0 +1,98 @@
+import asyncio
+from types import SimpleNamespace
+
+from openai.types.chat import ChatCompletionChunk
+
+from evalscope.api.model import GenerateConfig
+from evalscope.models.openai_compatible import OpenAICompatibleAPI
+
+
+def _chunk(content, *, finish_reason=None):
+    return ChatCompletionChunk.model_validate({
+        'id': 'completion-id',
+        'created': 1,
+        'model': 'test-model',
+        'object': 'chat.completion.chunk',
+        'choices': [{
+            'index': 0,
+            'finish_reason': finish_reason,
+            'delta': {'content': content},
+        }],
+    })
+
+
+def _prepare_api(monkeypatch):
+    api = object.__new__(OpenAICompatibleAPI)
+    api.base_url = 'https://example.test/v1'
+    api.model_name = 'test-model'
+    api.resolve_tools = lambda tools, tool_choice, config: (tools, tool_choice, config)
+    api.completion_params = lambda config, tools: {'model': 'test-model', 'stream': True}
+    api.validate_request_params = lambda request: None
+    api.on_response = lambda response: None
+    api.chat_choices_from_completion = lambda completion, tools: []
+
+    monkeypatch.setattr('evalscope.models.openai_compatible.openai_chat_messages', lambda *args, **kwargs: [])
+
+    def model_output(completion, choices):
+        return SimpleNamespace(
+            content=completion.choices[0].message.content,
+            usage=None,
+            message=SimpleNamespace(),
+            time=None,
+        )
+
+    monkeypatch.setattr('evalscope.models.openai_compatible.model_output_from_openai', model_output)
+    return api
+
+
+def test_generate_retries_when_stream_consumption_fails(monkeypatch):
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        attempt = attempts
+
+        def stream():
+            if attempt == 1:
+                yield _chunk('discarded partial response')
+                raise ConnectionError('stream interrupted by upstream gateway')
+            yield _chunk('complete response', finish_reason='stop')
+
+        return stream()
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    result = api.generate([], [], None, GenerateConfig(retries=2, retry_interval=0, stream=True))
+
+    assert attempts == 2
+    assert result.content == 'complete response'
+
+
+def test_generate_async_retries_when_stream_consumption_fails(monkeypatch):
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    async def create(**request):
+        nonlocal attempts
+        attempts += 1
+        attempt = attempts
+
+        async def stream():
+            if attempt == 1:
+                yield _chunk('discarded partial response')
+                raise ConnectionError('stream interrupted by upstream gateway')
+            yield _chunk('complete response', finish_reason='stop')
+
+        return stream()
+
+    async_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    monkeypatch.setattr(OpenAICompatibleAPI, 'async_client', property(lambda self: async_client))
+
+    result = asyncio.run(
+        api.generate_async([], [], None, GenerateConfig(retries=2, retry_interval=0, stream=True))
+    )
+
+    assert attempts == 2
+    assert result.content == 'complete response'

--- a/tests/models/test_openai_stream_retry.py
+++ b/tests/models/test_openai_stream_retry.py
@@ -1,13 +1,14 @@
 import asyncio
-from types import SimpleNamespace
-
+import pytest
 from openai.types.chat import ChatCompletionChunk
+from types import SimpleNamespace
+from typing import Optional
 
 from evalscope.api.model import GenerateConfig
 from evalscope.models.openai_compatible import OpenAICompatibleAPI
 
 
-def _chunk(content, *, finish_reason=None):
+def _chunk(content: str, *, finish_reason: Optional[str] = None) -> ChatCompletionChunk:
     return ChatCompletionChunk.model_validate({
         'id': 'completion-id',
         'created': 1,
@@ -21,7 +22,7 @@ def _chunk(content, *, finish_reason=None):
     })
 
 
-def _prepare_api(monkeypatch):
+def _prepare_api(monkeypatch: pytest.MonkeyPatch) -> OpenAICompatibleAPI:
     api = object.__new__(OpenAICompatibleAPI)
     api.base_url = 'https://example.test/v1'
     api.model_name = 'test-model'


### PR DESCRIPTION
## Summary

This PR retries OpenAI-compatible streaming requests when the response stream is interrupted after the initial request has already been established.

The fix applies to both synchronous and asynchronous generation. Partial output from a failed attempt is discarded, and the full model request is retried using the existing `retries` and `retry_interval` configuration.

## Root Cause

The current retry boundary only wraps:

```python
chat.completions.create(...)
```

For a streaming response, `create()` returns a stream object before all response chunks have been received. The stream is consumed later by `collect_stream_response()` or `async_collect_stream_response()`, outside the retry boundary.

If an upstream gateway closes the SSE connection after emitting partial output, stream consumption raises an exception such as a connection or protocol error. Although the request is configured with retries, the interrupted model call fails immediately because the exception occurs after `retry_call()` has returned.

With `ignore_errors=True`, evaluation may continue while the failed sample is missing from predictions, reviews, and the final report.

## Changes

- Treat request creation and complete stream consumption as one retryable operation.
- Retry the full request when synchronous stream consumption fails.
- Retry the full request when asynchronous stream consumption fails.
- Discard chunks collected by a failed attempt instead of mixing them into the successful retry.
- Keep non-streaming completion handling within the same operation without changing its response behavior.
- Add deterministic regression tests for synchronous and asynchronous interrupted streams.

## Reproduction

The tests simulate an upstream stream that behaves as follows:

```text
attempt 1: emit "discarded partial response" -> raise ConnectionError
attempt 2: emit "complete response" -> finish normally
```

On the unmodified `main` branch, both tests fail at the first interrupted stream:

```text
ConnectionError: stream interrupted by upstream gateway
```

The second request is never attempted even though `retries=2`.

After this change:

```text
attempts == 2
result.content == "complete response"
```

This also verifies that partial content from the failed attempt is not included in the final response.

## Validation

```bash
python -m pytest tests/models -q
```

Result:

```text
14 passed
```

Additional checks:

```bash
python -m py_compile \
  evalscope/models/openai_compatible.py \
  tests/models/test_openai_stream_retry.py

git diff --check
```

## Agent and Tool-call Safety

The stream is fully consumed before the model output is added to message history or any returned tool call is executed. Retrying an interrupted stream therefore does not repeat an already executed sandbox command or tool call.

## Scope

This PR does not change retry counts, retry intervals, request parameters, non-streaming response schemas, stream aggregation rules, or error handling after all configured attempts are exhausted.

### Additional provider validation

<!-- Add the provider/model, observed stream error, and before/after evaluation result here if available. -->
