### PR TITLE
fix(sandbox): clean up after manager stop failure

### DIFF
--- a/evalscope/api/sandbox/service.py
+++ b/evalscope/api/sandbox/service.py
@@ -248,6 +248,14 @@ class SandboxService:
                 logger.info('SandboxService: manager stopped.')
             except Exception as exc:
                 logger.warning(f'SandboxService: error stopping manager: {exc}')
+                cleanup_all = getattr(manager, 'cleanup_all_sandboxes', None)
+                if not callable(cleanup_all):
+                    continue
+                try:
+                    await cleanup_all()
+                    logger.info('SandboxService: fallback sandbox cleanup completed.')
+                except Exception as cleanup_exc:
+                    logger.warning(f'SandboxService: fallback sandbox cleanup failed: {cleanup_exc}')
 
     def shutdown_all(self) -> None:
         """Synchronous wrapper around :meth:`shutdown_all_async`."""

--- a/tests/agent/test_sandbox_service.py
+++ b/tests/agent/test_sandbox_service.py
@@ -214,6 +214,43 @@ class TestSandboxServiceCache:
 
         asyncio.run(_run())
 
+    def test_shutdown_all_async_falls_back_to_direct_cleanup(self):
+        service = SandboxService()
+        fake = self._make_mock_manager()
+        fake.stop.side_effect = RuntimeError('Event loop is closed')
+        fake.cleanup_all_sandboxes = AsyncMock()
+
+        async def _run():
+            with patch.object(service, '_construct_manager', return_value=fake):
+                await service.get_or_create_manager(SandboxEngine.DOCKER, {})
+            await service.shutdown_all_async()
+
+        asyncio.run(_run())
+        fake.stop.assert_awaited_once()
+        fake.cleanup_all_sandboxes.assert_awaited_once()
+        assert service._managers == {}
+
+    def test_shutdown_continues_when_fallback_cleanup_fails(self):
+        service = SandboxService()
+        fake_1 = self._make_mock_manager()
+        fake_2 = self._make_mock_manager()
+        fake_1.stop.side_effect = RuntimeError('first stop failed')
+        fake_2.stop.side_effect = RuntimeError('second stop failed')
+        fake_1.cleanup_all_sandboxes = AsyncMock(side_effect=RuntimeError('first cleanup failed'))
+        fake_2.cleanup_all_sandboxes = AsyncMock()
+
+        async def _run():
+            managers = iter([fake_1, fake_2])
+            with patch.object(service, '_construct_manager', side_effect=lambda *a, **kw: next(managers)):
+                await service.get_or_create_manager(SandboxEngine.DOCKER, {'base_url': 'x'})
+                await service.get_or_create_manager(SandboxEngine.DOCKER, {'base_url': 'y'})
+            await service.shutdown_all_async()
+
+        asyncio.run(_run())
+        fake_1.cleanup_all_sandboxes.assert_awaited_once()
+        fake_2.cleanup_all_sandboxes.assert_awaited_once()
+        assert service._managers == {}
+
     def test_shutdown_sandbox_service_noop_when_uncreated(self):
         from evalscope.api.sandbox import service as service_module
 


### PR DESCRIPTION
## Summary

This PR adds a best-effort fallback that removes registered sandboxes when a sandbox manager fails during shutdown before completing its normal cleanup sequence.

The issue was observed with pooled code-evaluation sandboxes when `manager.stop()` raised `RuntimeError: Event loop is closed`. The evaluation process could finish or abort while its `sandbox-*` containers remained running.

## Root Cause

`SandboxService.shutdown_all_async()` copies the cached managers, clears the manager cache, and then calls `manager.stop()` for each manager.

The manager's normal stop sequence includes cancelling its background cleanup task and removing registered sandboxes. If that task belongs to an event loop that has already closed, cancellation can raise before sandbox cleanup runs:

```text
manager.stop()
  -> cancel background cleanup task
  -> RuntimeError: Event loop is closed
  -> cleanup_all_sandboxes() is not reached
```

The service currently logs the exception and continues. Because its manager cache has already been cleared, there is no later shutdown attempt for those registered containers.

## Changes

- When `manager.stop()` fails, look up a callable `cleanup_all_sandboxes()` fallback.
- Run that cleanup directly from the active teardown loop.
- Keep the fallback best-effort: log cleanup errors instead of masking the original shutdown path.
- Isolate each manager so one failed fallback does not prevent later managers from being stopped or cleaned up.
- Add regression coverage for direct fallback cleanup and multi-manager failure handling.

## Reproduction

The first regression test simulates a manager whose stop operation fails because its event loop has closed:

```python
manager.stop.side_effect = RuntimeError('Event loop is closed')
manager.cleanup_all_sandboxes = AsyncMock()
```

On the unmodified `main` branch:

```text
manager.stop():                 awaited once
manager.cleanup_all_sandboxes(): never awaited
```

The second test uses two managers. The first fallback cleanup also raises, while the second manager remains cleanable. It verifies that cleanup is attempted for both managers.

Both tests fail on the unmodified `main` branch because no direct fallback cleanup is attempted.

## Expected Behavior

If normal manager shutdown fails but direct sandbox cleanup is available, EvalScope should still attempt to stop and remove all sandboxes registered by that manager.

Failure of this best-effort fallback should be logged without preventing cleanup of other managers.

## Validation

```bash
python -m pytest \
  tests/agent/test_sandbox_service.py::TestSandboxServiceCache -q
```

Result:

```text
7 passed
```

Additional checks:

```bash
python -m py_compile \
  evalscope/api/sandbox/service.py \
  tests/agent/test_sandbox_service.py

git diff --check
```

## Scope

This is a targeted best-effort fallback. It does not guarantee cleanup if the sandbox backend itself is unavailable or if `cleanup_all_sandboxes()` also fails. It does not change normal successful manager shutdown behavior, sandbox creation, pool sizing, or per-sample deletion.

### Additional Docker validation

<!-- Add Docker container listings or shutdown logs from a real affected evaluation here if available. -->
