### PR TITLE
fix(scicode): pin scipy below 1.14

### DIFF
--- a/evalscope/benchmarks/scicode/docker/docker_requirements.txt
+++ b/evalscope/benchmarks/scicode/docker/docker_requirements.txt
@@ -1,4 +1,5 @@
 h5py
 numpy
-scipy
+# Problems 2 and 28 import scipy.integrate.simps, which was removed in SciPy 1.14.
+scipy<1.14
 sympy


### PR DESCRIPTION
## Summary

This PR constrains SciPy to `<1.14` in the SciCode benchmark Docker image so benchmark problems that depend on `scipy.integrate.simps` can execute.

Without the constraint, a fresh image installs a current SciPy release where `simps` is unavailable. The benchmark then fails while importing its declared dependencies, before the generated solution or its tests are evaluated.

## Root Cause

The SciCode Docker requirements currently contain an unconstrained dependency:

```text
scipy
```

At least two records in the current `evalscope/SciCode` dataset declare this dependency:

- problem 2, `Gaussian_Beam_Focus`
- problem 28, `Gaussian_Beam_Intensity`

Their `required_dependencies` include:

```python
import numpy as np
from scipy.integrate import simps
```

`scipy.integrate.simps` was removed in SciPy 1.14. A newly built SciCode image can therefore install a version that is incompatible with the benchmark data.

## Changes

Change the SciCode image requirement from:

```text
scipy
```

to:

```text
scipy<1.14
```

The requirement file also documents the affected problem IDs and the reason for the upper bound.

## Docker Reproduction

Two clean images were built from the same SciCode Dockerfile. The before image used the requirements from the current `main` branch, while the after image used this PR's constraint.

The same command was executed in both images:

```bash
python -c "import scipy; print('scipy', scipy.__version__); from scipy.integrate import simps; print('simps import OK')"
```

### Before

Requirements:

```text
h5py
numpy
scipy
sympy
```

Result from a clean Docker build:

```text
scipy 1.17.1
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'simps' from 'scipy.integrate' (/usr/local/lib/python3.11/site-packages/scipy/integrate/__init__.py)
exit_code=1
```

### After

Requirements:

```text
h5py
numpy
scipy<1.14
sympy
```

Result from a clean Docker build:

```text
scipy 1.13.1
simps import OK
exit_code=0
```

## Expected Behavior

SciCode's declared dependencies should import successfully before generated code and test cases run. A benchmark sample should not receive a failing score because the benchmark image installed an incompatible dependency version.

## Scope

This constraint applies only to the dedicated `scicode-benchmark` Docker image. It does not constrain SciPy for EvalScope itself or for other benchmarks.
