### PR TITLE
fix(bfcl): normalize OpenAI base URL

### DIFF
--- a/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
+++ b/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
@@ -3,7 +3,7 @@ import os
 import traceback
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
 from evalscope.api.dataset import Sample
@@ -31,6 +31,13 @@ from .utils import (
 )
 
 logger = get_logger()
+
+
+def _normalize_openai_base_url(api_url: Optional[str]) -> str:
+    """Return the API root expected by the OpenAI SDK."""
+    if not api_url:
+        return ''
+    return api_url.strip().rstrip('/').removesuffix('/chat/completions')
 
 
 @register_benchmark(
@@ -170,8 +177,12 @@ class BFCLV4Adapter(AgentAdapter):
         from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
 
         # Set env variables for OpenAI API
+        base_url = _normalize_openai_base_url(self._task_config.api_url)
         os.environ['OPENAI_API_KEY'] = self._task_config.api_key
-        os.environ['OPENAI_BASE_URL'] = self._task_config.api_url
+        if base_url:
+            os.environ['OPENAI_BASE_URL'] = base_url
+        else:
+            os.environ.pop('OPENAI_BASE_URL', None)
 
         self.handler = OpenAICompletionsHandler(
             model_name=self._task_config.model,

--- a/tests/benchmark/test_bfcl_v4.py
+++ b/tests/benchmark/test_bfcl_v4.py
@@ -1,0 +1,20 @@
+import pytest
+
+from evalscope.benchmarks.bfcl.v4.bfcl_v4_adapter import _normalize_openai_base_url
+
+
+@pytest.mark.parametrize(
+    ('api_url', 'expected'),
+    [
+        ('https://example.test/v1', 'https://example.test/v1'),
+        ('https://example.test/v1/', 'https://example.test/v1'),
+        ('https://example.test/v1/chat/completions', 'https://example.test/v1'),
+        ('https://example.test/v1/chat/completions/', 'https://example.test/v1'),
+        ('  https://example.test/v1/chat/completions/  ', 'https://example.test/v1'),
+        ('', ''),
+        ('   ', ''),
+        (None, ''),
+    ],
+)
+def test_normalize_openai_base_url(api_url, expected):
+    assert _normalize_openai_base_url(api_url) == expected


### PR DESCRIPTION
## Summary

This PR normalizes the OpenAI base URL used by the BFCL-v4 adapter when the configured API URL is a full `/chat/completions` endpoint.

Without normalization, the BFCL OpenAI handler passes the full endpoint to the OpenAI SDK as `base_url`. The SDK then appends its own `/chat/completions` path, producing a duplicated request path and a 404 response.

## Root Cause

EvalScope accepts OpenAI-compatible API URLs in full endpoint form, for example:

```text
https://example.test/v1/chat/completions
```

The BFCL-v4 adapter currently assigns this value directly to:

```text
OPENAI_BASE_URL
```

`bfcl_eval.OpenAICompletionsHandler` constructs an OpenAI SDK client from that environment variable. When `client.chat.completions.create()` is called, the SDK appends `/chat/completions` and sends the request to:

```text
/v1/chat/completions/chat/completions
```

This path does not exist on a standard OpenAI-compatible endpoint.

## Changes

- Strip a trailing slash from the configured API URL.
- Remove a trailing `/chat/completions` endpoint before passing the value to the BFCL handler.
- Strip surrounding whitespace and handle missing or empty API URLs without raising an exception.
- Remove a stale `OPENAI_BASE_URL` environment variable when no URL is configured.
- Leave API-root URLs unchanged.
- Add regression tests for API-root, full-endpoint, whitespace, empty, and missing URL forms.

## Handler-level Reproduction

The issue was reproduced using the installed `bfcl_eval.OpenAICompletionsHandler` and a temporary local HTTP server. The server returned success only for the standard path:

```text
/v1/chat/completions
```

### Before

BFCL received this base URL:

```text
http://127.0.0.1:<port>/v1/chat/completions
```

Result:

```text
BEFORE FAILED status=404
request_path=/v1/chat/completions/chat/completions
```

### After

The adapter normalized the base URL to:

```text
http://127.0.0.1:<port>/v1
```

Result:

```text
AFTER SUCCESS
request_path=/v1/chat/completions
content=ok
```

No external model service or API key was required for this reproduction; the real BFCL handler and OpenAI SDK generated the request path.

## Validation

```bash
make lint
```

Result:

```text
flake8                         Passed
isort                          Passed
yapf                           Passed
trim trailing whitespace       Passed
check yaml                     Passed
fix end of files               Passed
fix requirements.txt           Passed
fix double quoted strings      Passed
check for merge conflicts      Passed
mixed line ending              Passed
```

```bash
python -m pytest tests/benchmark/test_bfcl_v4.py -q
```

Result:

```text
8 passed
```

Additional checks:

```bash
python -m py_compile \
  evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py \
  tests/benchmark/test_bfcl_v4.py

git diff --check
```

## Scope

This change only affects the base URL passed to the BFCL-v4 OpenAI handler. API keys, request bodies, model names, generation parameters, and non-BFCL adapters are unchanged.
