### PR TITLE
feat: add TVBench video benchmark

### DIFF
--- a/docs/en/benchmarks/tvbench.md
+++ b/docs/en/benchmarks/tvbench.md
@@ -1,0 +1,154 @@
+# TVBench
+
+
+## Overview
+
+TVBench is a temporal video understanding benchmark for evaluating whether multimodal models can reason over dynamic visual events rather than isolated frames. It covers a broad set of video reasoning skills, including action recognition, action counting, temporal localization, action order understanding, egocentric action sequencing, object counting, object shuffling, moving direction recognition, scene transition reasoning, and unexpected action detection.
+
+The EvalScope native adapter reads the official per-task JSON annotations from the dataset repository and resolves the corresponding video archives on demand. This keeps the default smoke-test path lightweight while still supporting the full benchmark through `subset_list`.
+
+## Task Description
+
+- **Task Type**: Video multiple-choice question answering (MCQ)
+- **Input**: A video clip or a time-bounded video segment, a natural-language question, and 2-4 answer candidates
+- **Output**: A single answer option letter selected from the provided candidates
+- **Default Subset**: `action_count`, selected because it is available as a standard MP4 archive in the public dataset repository
+- **Supported Subsets**: `action_antonym`, `action_count`, `action_localization`, `action_sequence`, `egocentric_sequence`, `moving_direction`, `object_count`, `object_shuffle`, `scene_transition`, and `unexpected_action`
+
+## Evaluation Notes
+
+- Default evaluation uses 0-shot Chain-of-Thought multiple-choice prompting via `MultipleChoiceTemplate.SINGLE_ANSWER_COT`.
+- Primary metric: Accuracy (`acc`). The dataset answer is stored as candidate text and is converted to the corresponding option letter before scoring.
+- Some subsets provide `start`/`end` fields. The adapter passes these values to `ContentVideo` and also adds a concise segment instruction to the prompt.
+- Video files are downloaded lazily from subset-specific archives. `egocentric_sequence` uses segmented archives under `video/egocentric_sequence/<prefix>.zip`.
+- The `action_antonym` annotations reference AVI files. If the repository media archive is unavailable, configure `extra_params.video_dir` to a local directory containing the AVI files.
+- The adapter supports local video layouts that are either flat (`video_dir/<video>`) or grouped by subset (`video_dir/<subset>/<video>`).
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `tvbench` |
+| **Dataset ID** | [evalscope/TVBench](https://modelscope.cn/datasets/evalscope/TVBench/summary) |
+| **Paper** | N/A |
+| **Tags** | `MCQ`, `MultiModal` |
+| **Metrics** | `acc` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `train` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 536 |
+| Prompt Length (Mean) | 326.44 chars |
+| Prompt Length (Min/Max) | 290 / 358 chars |
+
+**Video Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Videos | 536 |
+| Videos per Sample | min: 1, max: 1, mean: 1 |
+| Formats | mp4 |
+
+
+## Sample Example
+
+**Subset**: `action_count`
+
+```json
+{
+  "input": [
+    {
+      "id": "4b521c81",
+      "content": [
+        {
+          "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\nThe person makes sets of repeated actions. How many times did the person repeat the action in the last set?\n\nA) 2\nB) 3\nC) 5\nD) 4"
+        },
+        {
+          "video": "~/.cache/modelscope/hub/datasets/tvbench/videos/action_count/video_8686.mp4",
+          "format": "mp4"
+        }
+      ]
+    }
+  ],
+  "choices": [
+    "2",
+    "3",
+    "5",
+    "4"
+  ],
+  "target": "D",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "video": "video_8686.mp4",
+    "answer": "4",
+    "subset": "action_count",
+    "start": null,
+    "end": null,
+    "fps": null,
+    "accurate_start": null,
+    "accurate_end": null,
+    "video_length": null,
+    "question_id": null,
+    "dataset_id": "evalscope/TVBench",
+    "dataset_hub": "modelscope"
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of {letters}. Think step by step before answering.
+
+{question}
+
+{choices}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `video_dir` | `str` | `` | Optional local directory containing TVBench video files. It may be organized flat or by subset. |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets tvbench \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['tvbench'],
+    dataset_args={
+        'tvbench': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -53,6 +53,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `simple_vqa` | [SimpleVQA](../../benchmarks/simple_vqa.md) | `MultiModal`, `QA`, `Reasoning` |
 | `tir_bench` | [TIR-Bench](../../benchmarks/tir_bench.md) | `MultiModal`, `QA`, `Reasoning` |
 | `torgo` | [TORGO](../../benchmarks/torgo.md) | `Audio`, `SpeechRecognition` |
+| `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
@@ -114,6 +115,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/simple_vqa.md
 ../../benchmarks/tir_bench.md
 ../../benchmarks/torgo.md
+../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
 ../../benchmarks/visulogic.md
 ../../benchmarks/vqav2.md

--- a/docs/zh/benchmarks/tvbench.md
+++ b/docs/zh/benchmarks/tvbench.md
@@ -1,0 +1,153 @@
+# TVBench
+
+
+## 概述
+
+TVBench 是一个用于评估多模态模型是否能够对动态视觉事件（而非孤立帧）进行推理的时序视频理解基准测试。它涵盖了广泛的视频推理能力，包括动作识别、动作计数、时序定位、动作顺序理解、第一人称视角动作排序、物体计数、物体重排、运动方向识别、场景转换推理以及异常动作检测。
+
+EvalScope 原生适配器从数据集仓库中读取官方提供的按任务划分的 JSON 注释，并按需解析对应的视频压缩包。这种方式使得默认的冒烟测试路径保持轻量，同时仍可通过 `subset_list` 支持完整的基准测试。
+
+## 任务描述
+
+- **任务类型**：视频多项选择题问答（MCQ）
+- **输入**：一段视频片段或带时间范围的视频片段、一个自然语言问题以及 2-4 个候选答案
+- **输出**：从提供的候选答案中选择一个字母选项作为答案
+- **默认子集**：`action_count`，因其在公开数据集仓库中以标准 MP4 压缩包形式提供
+- **支持的子集**：`action_antonym`、`action_count`、`action_localization`、`action_sequence`、`egocentric_sequence`、`moving_direction`、`object_count`、`object_shuffle`、`scene_transition` 和 `unexpected_action`
+
+## 评估说明
+
+- 默认评估使用 0-shot 思维链（Chain-of-Thought）多项选择提示模板 `MultipleChoiceTemplate.SINGLE_ANSWER_COT`。
+- 主要指标：准确率（`acc`）。数据集中的答案以候选文本形式存储，在评分前会转换为对应的选项字母。
+- 部分子集提供 `start`/`end` 字段。适配器会将这些值传递给 `ContentVideo`，并在提示中添加简洁的片段说明。
+- 视频文件按需从子集特定的压缩包中懒加载下载。`egocentric_sequence` 使用位于 `video/egocentric_sequence/<prefix>.zip` 下的分段压缩包。
+- `action_antonym` 的注释引用 AVI 文件。如果仓库媒体压缩包不可用，请通过配置 `extra_params.video_dir` 指向包含 AVI 文件的本地目录。
+- 适配器支持两种本地视频布局：扁平结构（`video_dir/<video>`）或按子集分组结构（`video_dir/<subset>/<video>`）。
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `tvbench` |
+| **数据集ID** | [evalscope/TVBench](https://modelscope.cn/datasets/evalscope/TVBench/summary) |
+| **论文** | N/A |
+| **标签** | `MCQ`, `MultiModal` |
+| **指标** | `acc` |
+| **默认示例数（Shots）** | 0-shot |
+| **评估划分** | `train` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 536 |
+| 提示词长度（平均） | 326.44 字符 |
+| 提示词长度（最小/最大） | 290 / 358 字符 |
+
+**视频统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 总视频数 | 536 |
+| 每样本视频数 | 最小: 1, 最大: 1, 平均: 1 |
+| 格式 | mp4 |
+
+
+## 样例示例
+
+**子集**: `action_count`
+
+```json
+{
+  "input": [
+    {
+      "id": "4b521c81",
+      "content": [
+        {
+          "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\nThe person makes sets of repeated actions. How many times did the person repeat the action in the last set?\n\nA) 2\nB) 3\nC) 5\nD) 4"
+        },
+        {
+          "video": "~/.cache/modelscope/hub/datasets/tvbench/videos/action_count/video_8686.mp4",
+          "format": "mp4"
+        }
+      ]
+    }
+  ],
+  "choices": [
+    "2",
+    "3",
+    "5",
+    "4"
+  ],
+  "target": "D",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "video": "video_8686.mp4",
+    "answer": "4",
+    "subset": "action_count",
+    "start": null,
+    "end": null,
+    "fps": null,
+    "accurate_start": null,
+    "accurate_end": null,
+    "video_length": null,
+    "question_id": null,
+    "dataset_id": "evalscope/TVBench",
+    "dataset_hub": "modelscope"
+  }
+}
+```
+
+## 提示模板
+
+**提示模板：**
+```text
+Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of {letters}. Think step by step before answering.
+
+{question}
+
+{choices}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `video_dir` | `str` | `` | 可选的本地目录，包含 TVBench 视频文件。该目录可以是扁平结构，也可以按子集组织。 |
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets tvbench \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['tvbench'],
+    dataset_args={
+        'tvbench': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -53,6 +53,7 @@
 | `simple_vqa` | [SimpleVQA](../../benchmarks/simple_vqa.md) | `MultiModal`, `QA`, `Reasoning` |
 | `tir_bench` | [TIR-Bench](../../benchmarks/tir_bench.md) | `MultiModal`, `QA`, `Reasoning` |
 | `torgo` | [TORGO](../../benchmarks/torgo.md) | `Audio`, `SpeechRecognition` |
+| `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
@@ -114,6 +115,7 @@
 ../../benchmarks/simple_vqa.md
 ../../benchmarks/tir_bench.md
 ../../benchmarks/torgo.md
+../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
 ../../benchmarks/visulogic.md
 ../../benchmarks/vqav2.md

--- a/evalscope/api/messages/content.py
+++ b/evalscope/api/messages/content.py
@@ -80,8 +80,8 @@ class ContentVideo(ContentBase):
     video: str
     """Video file path, URL, or base64 encoded data URL."""
 
-    format: Literal['mp4', 'mpeg', 'mov']
-    """Format of video data ('mp4', 'mpeg', or 'mov')"""
+    format: Literal['mp4', 'mpeg', 'mov', 'avi']
+    """Format of video data ('mp4', 'mpeg', 'mov', or 'avi')"""
 
     start: Optional[float] = Field(default=None)
     """Optional start time of the relevant video segment in seconds."""

--- a/evalscope/benchmarks/_meta/tvbench.json
+++ b/evalscope/benchmarks/_meta/tvbench.json
@@ -1,0 +1,143 @@
+{
+  "meta": {
+    "pretty_name": "TVBench",
+    "dataset_id": "evalscope/TVBench",
+    "paper_url": null,
+    "tags": [
+      "MultiModal",
+      "MCQ"
+    ],
+    "metrics": [
+      "acc"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "train",
+    "train_split": "",
+    "subset_list": [
+      "action_count"
+    ],
+    "description": "\n## Overview\n\nTVBench is a temporal video understanding benchmark for evaluating whether multimodal models can reason over dynamic visual events rather than isolated frames. It covers a broad set of video reasoning skills, including action recognition, action counting, temporal localization, action order understanding, egocentric action sequencing, object counting, object shuffling, moving direction recognition, scene transition reasoning, and unexpected action detection.\n\nThe EvalScope native adapter reads the official per-task JSON annotations from the dataset repository and resolves the corresponding video archives on demand. This keeps the default smoke-test path lightweight while still supporting the full benchmark through `subset_list`.\n\n## Task Description\n\n- **Task Type**: Video multiple-choice question answering (MCQ)\n- **Input**: A video clip or a time-bounded video segment, a natural-language question, and 2-4 answer candidates\n- **Output**: A single answer option letter selected from the provided candidates\n- **Default Subset**: `action_count`, selected because it is available as a standard MP4 archive in the public dataset repository\n- **Supported Subsets**: `action_antonym`, `action_count`, `action_localization`, `action_sequence`, `egocentric_sequence`, `moving_direction`, `object_count`, `object_shuffle`, `scene_transition`, and `unexpected_action`\n\n## Evaluation Notes\n\n- Default evaluation uses 0-shot Chain-of-Thought multiple-choice prompting via `MultipleChoiceTemplate.SINGLE_ANSWER_COT`.\n- Primary metric: Accuracy (`acc`). The dataset answer is stored as candidate text and is converted to the corresponding option letter before scoring.\n- Some subsets provide `start`/`end` fields. The adapter passes these values to `ContentVideo` and also adds a concise segment instruction to the prompt.\n- Video files are downloaded lazily from subset-specific archives. `egocentric_sequence` uses segmented archives under `video/egocentric_sequence/<prefix>.zip`.\n- The `action_antonym` annotations reference AVI files. If the repository media archive is unavailable, configure `extra_params.video_dir` to a local directory containing the AVI files.\n- The adapter supports local video layouts that are either flat (`video_dir/<video>`) or grouped by subset (`video_dir/<subset>/<video>`).\n",
+    "prompt_template": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of {letters}. Think step by step before answering.\n\n{question}\n\n{choices}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "video_dir": {
+        "type": "str",
+        "description": "Optional local directory containing TVBench video files. It may be organized flat or by subset.",
+        "value": ""
+      }
+    },
+    "sandbox_config": {},
+    "category": "vlm"
+  },
+  "statistics": {
+    "total_samples": 536,
+    "subset_stats": [
+      {
+        "name": "action_count",
+        "sample_count": 536,
+        "prompt_length_mean": 326.44,
+        "prompt_length_min": 290,
+        "prompt_length_max": 358,
+        "prompt_length_std": 24.64,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": false,
+          "has_audio": false,
+          "has_video": true,
+          "video": {
+            "count_total": 536,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "duration": null,
+            "resolutions": [],
+            "formats": [
+              "mp4"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 326.44,
+      "min": 290,
+      "max": 358,
+      "std": 24.64
+    },
+    "target_length_mean": 1,
+    "computed_at": "2026-07-08T17:05:25.499892",
+    "multimodal": {
+      "has_images": false,
+      "has_audio": false,
+      "has_video": true,
+      "video": {
+        "count_total": 536,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "duration": null,
+        "resolutions": [],
+        "formats": [
+          "mp4"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "4b521c81",
+          "content": [
+            {
+              "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\nThe person makes sets of repeated actions. How many times did the person repeat the action in the last set?\n\nA) 2\nB) 3\nC) 5\nD) 4"
+            },
+            {
+              "video": "~/.cache/modelscope/hub/datasets/tvbench/videos/action_count/video_8686.mp4",
+              "format": "mp4"
+            }
+          ]
+        }
+      ],
+      "choices": [
+        "2",
+        "3",
+        "5",
+        "4"
+      ],
+      "target": "D",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "video": "video_8686.mp4",
+        "answer": "4",
+        "subset": "action_count",
+        "start": null,
+        "end": null,
+        "fps": null,
+        "accurate_start": null,
+        "accurate_end": null,
+        "video_length": null,
+        "question_id": null,
+        "dataset_id": "evalscope/TVBench",
+        "dataset_hub": "modelscope"
+      }
+    },
+    "subset": "action_count",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# TVBench\n\n\n## Overview\n\nTVBench is a temporal video understanding benchmark for evaluating whether multimodal models can reason over dynamic visual events rather than isolated frames. It covers a broad set of video reasoning skills, including action recognition, action counting, temporal localization, action order understanding, egocentric action sequencing, object counting, object shuffling, moving direction recognition, scene transition reasoning, and unexpected action detection.\n\nThe EvalScope native adapter reads the official per-task JSON annotations from the dataset repository and resolves the corresponding video archives on demand. This keeps the default smoke-test path lightweight while still supporting the full benchmark through `subset_list`.\n\n## Task Description\n\n- **Task Type**: Video multiple-choice question answering (MCQ)\n- **Input**: A video clip or a time-bounded video segment, a natural-language question, and 2-4 answer candidates\n- **Output**: A single answer option letter selected from the provided candidates\n- **Default Subset**: `action_count`, selected because it is available as a standard MP4 archive in the public dataset repository\n- **Supported Subsets**: `action_antonym`, `action_count`, `action_localization`, `action_sequence`, `egocentric_sequence`, `moving_direction`, `object_count`, `object_shuffle`, `scene_transition`, and `unexpected_action`\n\n## Evaluation Notes\n\n- Default evaluation uses 0-shot Chain-of-Thought multiple-choice prompting via `MultipleChoiceTemplate.SINGLE_ANSWER_COT`.\n- Primary metric: Accuracy (`acc`). The dataset answer is stored as candidate text and is converted to the corresponding option letter before scoring.\n- Some subsets provide `start`/`end` fields. The adapter passes these values to `ContentVideo` and also adds a concise segment instruction to the prompt.\n- Video files are downloaded lazily from subset-specific archives. `egocentric_sequence` uses segmented archives under `video/egocentric_sequence/<prefix>.zip`.\n- The `action_antonym` annotations reference AVI files. If the repository media archive is unavailable, configure `extra_params.video_dir` to a local directory containing the AVI files.\n- The adapter supports local video layouts that are either flat (`video_dir/<video>`) or grouped by subset (`video_dir/<subset>/<video>`).\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `tvbench` |\n| **Dataset ID** | [evalscope/TVBench](https://modelscope.cn/datasets/evalscope/TVBench/summary) |\n| **Paper** | N/A |\n| **Tags** | `MCQ`, `MultiModal` |\n| **Metrics** | `acc` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `train` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 536 |\n| Prompt Length (Mean) | 326.44 chars |\n| Prompt Length (Min/Max) | 290 / 358 chars |\n\n**Video Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Videos | 536 |\n| Videos per Sample | min: 1, max: 1, mean: 1 |\n| Formats | mp4 |\n\n\n## Sample Example\n\n**Subset**: `action_count`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"4b521c81\",\n      \"content\": [\n        {\n          \"text\": \"Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\\n\\nThe person makes sets of repeated actions. How many times did the person repeat the action in the last set?\\n\\nA) 2\\nB) 3\\nC) 5\\nD) 4\"\n        },\n        {\n          \"video\": \"~/.cache/modelscope/hub/datasets/tvbench/videos/action_count/video_8686.mp4\",\n          \"format\": \"mp4\"\n        }\n      ]\n    }\n  ],\n  \"choices\": [\n    \"2\",\n    \"3\",\n    \"5\",\n    \"4\"\n  ],\n  \"target\": \"D\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"video\": \"video_8686.mp4\",\n    \"answer\": \"4\",\n    \"subset\": \"action_count\",\n    \"start\": null,\n    \"end\": null,\n    \"fps\": null,\n    \"accurate_start\": null,\n    \"accurate_end\": null,\n    \"video_length\": null,\n    \"question_id\": null,\n    \"dataset_id\": \"evalscope/TVBench\",\n    \"dataset_hub\": \"modelscope\"\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\nAnswer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of {letters}. Think step by step before answering.\n\n{question}\n\n{choices}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `video_dir` | `str` | `` | Optional local directory containing TVBench video files. It may be organized flat or by subset. |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets tvbench \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['tvbench'],\n    dataset_args={\n        'tvbench': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# TVBench\n\n\n## 概述\n\nTVBench 是一个用于评估多模态模型是否能够对动态视觉事件（而非孤立帧）进行推理的时序视频理解基准测试。它涵盖了广泛的视频推理能力，包括动作识别、动作计数、时序定位、动作顺序理解、第一人称视角动作排序、物体计数、物体重排、运动方向识别、场景转换推理以及异常动作检测。\n\nEvalScope 原生适配器从数据集仓库中读取官方提供的按任务划分的 JSON 注释，并按需解析对应的视频压缩包。这种方式使得默认的冒烟测试路径保持轻量，同时仍可通过 `subset_list` 支持完整的基准测试。\n\n## 任务描述\n\n- **任务类型**：视频多项选择题问答（MCQ）\n- **输入**：一段视频片段或带时间范围的视频片段、一个自然语言问题以及 2-4 个候选答案\n- **输出**：从提供的候选答案中选择一个字母选项作为答案\n- **默认子集**：`action_count`，因其在公开数据集仓库中以标准 MP4 压缩包形式提供\n- **支持的子集**：`action_antonym`、`action_count`、`action_localization`、`action_sequence`、`egocentric_sequence`、`moving_direction`、`object_count`、`object_shuffle`、`scene_transition` 和 `unexpected_action`\n\n## 评估说明\n\n- 默认评估使用 0-shot 思维链（Chain-of-Thought）多项选择提示模板 `MultipleChoiceTemplate.SINGLE_ANSWER_COT`。\n- 主要指标：准确率（`acc`）。数据集中的答案以候选文本形式存储，在评分前会转换为对应的选项字母。\n- 部分子集提供 `start`/`end` 字段。适配器会将这些值传递给 `ContentVideo`，并在提示中添加简洁的片段说明。\n- 视频文件按需从子集特定的压缩包中懒加载下载。`egocentric_sequence` 使用位于 `video/egocentric_sequence/<prefix>.zip` 下的分段压缩包。\n- `action_antonym` 的注释引用 AVI 文件。如果仓库媒体压缩包不可用，请通过配置 `extra_params.video_dir` 指向包含 AVI 文件的本地目录。\n- 适配器支持两种本地视频布局：扁平结构（`video_dir/<video>`）或按子集分组结构（`video_dir/<subset>/<video>`）。\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `tvbench` |\n| **数据集ID** | [evalscope/TVBench](https://modelscope.cn/datasets/evalscope/TVBench/summary) |\n| **论文** | N/A |\n| **标签** | `MCQ`, `MultiModal` |\n| **指标** | `acc` |\n| **默认示例数（Shots）** | 0-shot |\n| **评估划分** | `train` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 536 |\n| 提示词长度（平均） | 326.44 字符 |\n| 提示词长度（最小/最大） | 290 / 358 字符 |\n\n**视频统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 总视频数 | 536 |\n| 每样本视频数 | 最小: 1, 最大: 1, 平均: 1 |\n| 格式 | mp4 |\n\n\n## 样例示例\n\n**子集**: `action_count`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"4b521c81\",\n      \"content\": [\n        {\n          \"text\": \"Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\\n\\nThe person makes sets of repeated actions. How many times did the person repeat the action in the last set?\\n\\nA) 2\\nB) 3\\nC) 5\\nD) 4\"\n        },\n        {\n          \"video\": \"~/.cache/modelscope/hub/datasets/tvbench/videos/action_count/video_8686.mp4\",\n          \"format\": \"mp4\"\n        }\n      ]\n    }\n  ],\n  \"choices\": [\n    \"2\",\n    \"3\",\n    \"5\",\n    \"4\"\n  ],\n  \"target\": \"D\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"video\": \"video_8686.mp4\",\n    \"answer\": \"4\",\n    \"subset\": \"action_count\",\n    \"start\": null,\n    \"end\": null,\n    \"fps\": null,\n    \"accurate_start\": null,\n    \"accurate_end\": null,\n    \"video_length\": null,\n    \"question_id\": null,\n    \"dataset_id\": \"evalscope/TVBench\",\n    \"dataset_hub\": \"modelscope\"\n  }\n}\n```\n\n## 提示模板\n\n**提示模板：**\n```text\nAnswer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of {letters}. Think step by step before answering.\n\n{question}\n\n{choices}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `video_dir` | `str` | `` | 可选的本地目录，包含 TVBench 视频文件。该目录可以是扁平结构，也可以按子集组织。 |\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets tvbench \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['tvbench'],\n    dataset_args={\n        'tvbench': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "07b952966bdbe262a75b6f98c7220524",
+    "needs_translation": false
+  },
+  "updated_at": "2026-07-08T17:05:25.967979",
+  "translation_updated_at": "2026-07-08T17:05:31"
+}

--- a/evalscope/benchmarks/msr_vtt/msr_vtt_adapter.py
+++ b/evalscope/benchmarks/msr_vtt/msr_vtt_adapter.py
@@ -42,7 +42,7 @@ with multiple reference captions.
 ## Evaluation Notes
 
 - Default data source: `AI-ModelScope/msr-vtt` on ModelScope, `validation` split
-- Hugging Face `VLM2Vec/MSR-VTT` remains available by setting `extra_params.dataset_hub="huggingface"`
+- Hugging Face `VLM2Vec/MSR-VTT` remains available by setting `dataset_hub="huggingface"` in TaskConfig
 - Primary metric: **CIDEr**
 - Additional metrics: BLEU-1/2/3/4, METEOR, ROUGE-L
 - Set `extra_params.video_dir` to prefer local media files over URL metadata
@@ -56,22 +56,6 @@ with multiple reference captions.
         eval_split='validation',
         prompt_template=DEFAULT_PROMPT,
         extra_params={
-            'dataset_hub': {
-                'type': 'str',
-                'description': 'Dataset hub used to load MSR-VTT annotations.',
-                'value': HubType.MODELSCOPE,
-                'choices': [HubType.HUGGINGFACE, HubType.MODELSCOPE, HubType.LOCAL],
-            },
-            'eval_split': {
-                'type': 'str',
-                'description': 'Source split to load; defaults to validation for ModelScope and test for Hugging Face.',
-                'value': '',
-            },
-            'dataset_revision': {
-                'type': 'str',
-                'description': 'Optional dataset revision; leave empty to use the hub default.',
-                'value': '',
-            },
             'video_dir': {
                 'type': 'str',
                 'description': 'Optional local directory containing MSR-VTT video files.',
@@ -103,28 +87,24 @@ class MSRVTTAdapter(VisionLanguageAdapter):
         self.add_aggregation_name = False
 
     @property
-    def source_dataset_hub(self) -> str:
-        return self.extra_params.get('dataset_hub') or HubType.MODELSCOPE
-
-    @property
     def source_dataset_id(self) -> str:
         if self.dataset_id != self.name and self.dataset_id not in self.SOURCE_DATASET_IDS.values():
             return self.dataset_id
-        return self.SOURCE_DATASET_IDS.get(self.source_dataset_hub, self.dataset_id)
+        return self.SOURCE_DATASET_IDS.get(self.dataset_hub, self.dataset_id)
 
     @property
     def source_eval_split(self) -> str:
-        return (
-            self.extra_params.get('eval_split')
-            or self.SOURCE_EVAL_SPLITS.get(self.source_dataset_hub, self.eval_split)
-        )
+        is_default_dataset = self.dataset_id in self.SOURCE_DATASET_IDS.values()
+        is_default_modelscope_split = self.eval_split == self.SOURCE_EVAL_SPLITS[HubType.MODELSCOPE]
+        if is_default_dataset and is_default_modelscope_split:
+            return self.SOURCE_EVAL_SPLITS.get(self.dataset_hub, self.eval_split)
+        return self.eval_split
 
     @property
     def source_dataset(self) -> DatasetHub:
         return DatasetHub(
             data_id_or_path=self.source_dataset_id,
-            data_source=self.source_dataset_hub,
-            revision=self.extra_params.get('dataset_revision') or None,
+            data_source=self.dataset_hub,
             force_redownload=self.force_redownload,
         )
 
@@ -171,7 +151,7 @@ class MSRVTTAdapter(VisionLanguageAdapter):
                 'references': references,
                 'subset': self.current_subset_name,
                 'dataset_id': self.source_dataset_id,
-                'dataset_hub': self.source_dataset_hub,
+                'dataset_hub': self.dataset_hub,
                 'video': video,
                 'start': start,
                 'end': end,
@@ -201,10 +181,10 @@ class MSRVTTAdapter(VisionLanguageAdapter):
 
     def _load_records(self) -> List[Dict[str, Any]]:
         subset = 'default'
-        if self.source_dataset_hub == HubType.HUGGINGFACE:
+        if self.dataset_hub == HubType.HUGGINGFACE:
             subset = 'test_1k'
         logger.info(
-            f'Loading MSR-VTT from {self.source_dataset_hub}: '
+            f'Loading MSR-VTT from {self.dataset_hub}: '
             f'{self.source_dataset_id}, subset={subset}, split={self.source_eval_split}.'
         )
         dataset = self.source_dataset.load(split=self.source_eval_split, subset=subset)

--- a/evalscope/benchmarks/msvd/msvd_adapter.py
+++ b/evalscope/benchmarks/msvd/msvd_adapter.py
@@ -41,7 +41,7 @@ The native adapter treats each video as one evaluation sample and uses all avail
 ## Evaluation Notes
 
 - Default data source: `evalscope/MSVD` on ModelScope, `test` split
-- Hugging Face `VLM2Vec/MSVD` remains available by setting `extra_params.dataset_hub="huggingface"`
+- Hugging Face `VLM2Vec/MSVD` remains available by setting `dataset_hub="huggingface"` in TaskConfig
 - Primary metric: **CIDEr**
 - Additional metrics: BLEU-1/2/3/4, METEOR, ROUGE-L
 - Set `extra_params.video_dir` when the dataset only provides video file names and local media files are required
@@ -54,22 +54,6 @@ The native adapter treats each video as one evaluation sample and uses all avail
         eval_split='test',
         prompt_template=DEFAULT_PROMPT,
         extra_params={
-            'dataset_hub': {
-                'type': 'str',
-                'description': 'Dataset hub used to load MSVD annotations.',
-                'value': HubType.MODELSCOPE,
-                'choices': [HubType.HUGGINGFACE, HubType.MODELSCOPE, HubType.LOCAL],
-            },
-            'eval_split': {
-                'type': 'str',
-                'description': 'Source split to load; defaults to test.',
-                'value': '',
-            },
-            'dataset_revision': {
-                'type': 'str',
-                'description': 'Optional dataset revision; leave empty to use the hub default.',
-                'value': '',
-            },
             'video_dir': {
                 'type': 'str',
                 'description': 'Optional local directory containing MSVD video files.',
@@ -97,25 +81,16 @@ class MSVDAdapter(VisionLanguageAdapter):
         self.add_aggregation_name = False
 
     @property
-    def source_dataset_hub(self) -> str:
-        return self.extra_params.get('dataset_hub') or HubType.MODELSCOPE
-
-    @property
     def source_dataset_id(self) -> str:
         if self.dataset_id != self.name and self.dataset_id not in self.SOURCE_DATASET_IDS.values():
             return self.dataset_id
-        return self.SOURCE_DATASET_IDS.get(self.source_dataset_hub, self.dataset_id)
-
-    @property
-    def source_eval_split(self) -> str:
-        return self.extra_params.get('eval_split') or self.eval_split
+        return self.SOURCE_DATASET_IDS.get(self.dataset_hub, self.dataset_id)
 
     @property
     def source_dataset(self) -> DatasetHub:
         return DatasetHub(
             data_id_or_path=self.source_dataset_id,
-            data_source=self.source_dataset_hub,
-            revision=self.extra_params.get('dataset_revision') or None,
+            data_source=self.dataset_hub,
             force_redownload=self.force_redownload,
         )
 
@@ -157,7 +132,7 @@ class MSVDAdapter(VisionLanguageAdapter):
                 'references': references,
                 'subset': self.current_subset_name,
                 'dataset_id': self.source_dataset_id,
-                'dataset_hub': self.source_dataset_hub,
+                'dataset_hub': self.dataset_hub,
                 'video': video,
                 'video_id': record.get('video_id'),
                 'source': record.get('source'),
@@ -183,11 +158,9 @@ class MSVDAdapter(VisionLanguageAdapter):
         return sample_scores
 
     def _load_records(self) -> List[Dict[str, Any]]:
-        logger.info(
-            f'Loading MSVD from {self.source_dataset_hub}: '
-            f'{self.source_dataset_id}, split={self.source_eval_split}.'
-        )
-        dataset = self.source_dataset.load(split=self.source_eval_split, subset='default')
+        logger.info(f'Loading MSVD from {self.dataset_hub}: '
+                    f'{self.source_dataset_id}, split={self.eval_split}.')
+        dataset = self.source_dataset.load(split=self.eval_split, subset='default')
         return list(dataset)
 
     def _group_records(self, records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/evalscope/benchmarks/mvbench/mvbench_adapter.py
+++ b/evalscope/benchmarks/mvbench/mvbench_adapter.py
@@ -11,7 +11,7 @@ from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter, VisionLan
 from evalscope.api.dataset import DatasetDict, DatasetHub, MemoryDataset, Sample
 from evalscope.api.messages import ChatMessageUser, Content, ContentText, ContentVideo
 from evalscope.api.registry import register_benchmark
-from evalscope.constants import HubType, Tags
+from evalscope.constants import Tags
 from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import MultipleChoiceTemplate, answer_character, prompt
 from evalscope.utils.url_utils import guess_video_format
@@ -85,24 +85,6 @@ optimized video archives.
         metric_list=['acc'],
         eval_split='train',
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
-        extra_params={
-            'dataset_id': {
-                'type': 'str',
-                'description': 'Dataset repository ID or local dataset root for MVBench annotations and videos.',
-                'value': 'PKU-Alignment/MVBench',
-            },
-            'dataset_hub': {
-                'type': 'str',
-                'description': 'Dataset hub used to load annotations and video archives.',
-                'value': HubType.MODELSCOPE,
-                'choices': [HubType.HUGGINGFACE, HubType.MODELSCOPE, HubType.LOCAL],
-            },
-            'dataset_revision': {
-                'type': 'str',
-                'description': 'Optional dataset revision; leave empty to use the hub default.',
-                'value': '',
-            },
-        },
     )
 )
 class MVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
@@ -119,23 +101,10 @@ class MVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
         return self._video_cache_dir
 
     @property
-    def source_dataset_id(self) -> str:
-        return self.extra_params.get('dataset_id') or self.dataset_id
-
-    @property
-    def source_dataset_hub(self) -> str:
-        return self.extra_params.get('dataset_hub') or HubType.MODELSCOPE
-
-    @property
-    def source_dataset_revision(self) -> Optional[str]:
-        return self.extra_params.get('dataset_revision') or None
-
-    @property
     def source_dataset(self) -> DatasetHub:
         return DatasetHub(
-            data_id_or_path=self.source_dataset_id,
-            data_source=self.source_dataset_hub,
-            revision=self.source_dataset_revision,
+            data_id_or_path=self.dataset_id,
+            data_source=self.dataset_hub,
             force_redownload=self.force_redownload,
         )
 
@@ -152,7 +121,7 @@ class MVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
                 samples = [self.record_to_sample(record) for record in records]
                 if self.repeats > 1:
                     samples = [copy.deepcopy(sample) for sample in samples for _ in range(self.repeats)]
-                dataset = MemoryDataset(samples=samples, name='mvbench', location=self.source_dataset_id)
+                dataset = MemoryDataset(samples=samples, name='mvbench', location=self.dataset_id)
                 dataset.reindex(group_size=self.repeats)
                 dataset_dict[subset] = dataset
 
@@ -162,7 +131,7 @@ class MVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
         return self.test_dataset
 
     def _load_subset_records(self, subset: str) -> List[Dict[str, Any]]:
-        logger.info(f'Loading MVBench subset {subset} from {self.source_dataset_hub}: {self.source_dataset_id}.')
+        logger.info(f'Loading MVBench subset {subset} from {self.dataset_hub}: {self.dataset_id}.')
         dataset = self.source_dataset.load(split=self.eval_split, subset=subset)
         records = list(dataset)
         if not records:
@@ -210,8 +179,8 @@ class MVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
                 'start': start,
                 'end': end,
                 'fps': fps,
-                'dataset_id': self.source_dataset_id,
-                'dataset_hub': self.source_dataset_hub,
+                'dataset_id': self.dataset_id,
+                'dataset_hub': self.dataset_hub,
             },
         )
 

--- a/evalscope/benchmarks/tvbench/tvbench_adapter.py
+++ b/evalscope/benchmarks/tvbench/tvbench_adapter.py
@@ -1,0 +1,308 @@
+# flake8: noqa: E501
+import copy
+import json
+import os
+import random
+import zipfile
+from typing import Any, Dict, List, Optional
+
+from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter, VisionLanguageAdapter
+from evalscope.api.dataset import DatasetDict, DatasetHub, MemoryDataset, Sample
+from evalscope.api.messages import ChatMessageUser, Content, ContentText, ContentVideo
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from evalscope.utils.logger import get_logger
+from evalscope.utils.multi_choices import MultipleChoiceTemplate, answer_character, prompt
+from evalscope.utils.url_utils import guess_video_format
+
+logger = get_logger()
+
+DATASET_ID = 'evalscope/TVBench'
+SUBSET_LIST = [
+    'action_antonym',
+    'action_count',
+    'action_localization',
+    'action_sequence',
+    'egocentric_sequence',
+    'moving_direction',
+    'object_count',
+    'object_shuffle',
+    'scene_transition',
+    'unexpected_action',
+]
+DEFAULT_SUBSET_LIST = ['action_count']
+
+DESCRIPTION = """
+## Overview
+
+TVBench is a temporal video understanding benchmark for evaluating whether multimodal models can reason over dynamic visual events rather than isolated frames. It covers a broad set of video reasoning skills, including action recognition, action counting, temporal localization, action order understanding, egocentric action sequencing, object counting, object shuffling, moving direction recognition, scene transition reasoning, and unexpected action detection.
+
+The EvalScope native adapter reads the official per-task JSON annotations from the dataset repository and resolves the corresponding video archives on demand. This keeps the default smoke-test path lightweight while still supporting the full benchmark through `subset_list`.
+
+## Task Description
+
+- **Task Type**: Video multiple-choice question answering (MCQ)
+- **Input**: A video clip or a time-bounded video segment, a natural-language question, and 2-4 answer candidates
+- **Output**: A single answer option letter selected from the provided candidates
+- **Default Subset**: `action_count`, selected because it is available as a standard MP4 archive in the public dataset repository
+- **Supported Subsets**: `action_antonym`, `action_count`, `action_localization`, `action_sequence`, `egocentric_sequence`, `moving_direction`, `object_count`, `object_shuffle`, `scene_transition`, and `unexpected_action`
+
+## Evaluation Notes
+
+- Default evaluation uses 0-shot Chain-of-Thought multiple-choice prompting via `MultipleChoiceTemplate.SINGLE_ANSWER_COT`.
+- Primary metric: Accuracy (`acc`). The dataset answer is stored as candidate text and is converted to the corresponding option letter before scoring.
+- Some subsets provide `start`/`end` fields. The adapter passes these values to `ContentVideo` and also adds a concise segment instruction to the prompt.
+- Video files are downloaded lazily from subset-specific archives. `egocentric_sequence` uses segmented archives under `video/egocentric_sequence/<prefix>.zip`.
+- The `action_antonym` annotations reference AVI files. If the repository media archive is unavailable, configure `extra_params.video_dir` to a local directory containing the AVI files.
+- The adapter supports local video layouts that are either flat (`video_dir/<video>`) or grouped by subset (`video_dir/<subset>/<video>`).
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='tvbench',
+        pretty_name='TVBench',
+        dataset_id=DATASET_ID,
+        tags=[Tags.MULTI_MODAL, Tags.MULTIPLE_CHOICE],
+        description=DESCRIPTION,
+        subset_list=DEFAULT_SUBSET_LIST,
+        metric_list=['acc'],
+        eval_split='train',
+        prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
+        extra_params={
+            'video_dir': {
+                'type': 'str',
+                'description': 'Optional local directory containing TVBench video files. It may be organized flat or by subset.',
+                'value': '',
+            },
+        },
+    )
+)
+class TVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
+    """Native adapter for the TVBench video multiple-choice benchmark."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._video_cache_dir: Optional[str] = None
+
+    @property
+    def video_cache_dir(self) -> str:
+        if self._video_cache_dir is None:
+            self._video_cache_dir = os.path.join(self.dataset_dir, 'tvbench', 'videos')
+        return self._video_cache_dir
+
+    @property
+    def source_dataset(self) -> DatasetHub:
+        return DatasetHub(
+            data_id_or_path=self.dataset_id,
+            data_source=self.dataset_hub,
+            force_redownload=self.force_redownload,
+        )
+
+    @property
+    def local_video_dir(self) -> str:
+        return self.extra_params.get('video_dir') or ''
+
+    def load_dataset(self) -> DatasetDict:
+        dataset_dict: Dict[str, MemoryDataset] = {}
+        for subset in self.subset_list:
+            if subset not in SUBSET_LIST:
+                raise ValueError(f'Unsupported TVBench subset: {subset}. Supported subsets: {SUBSET_LIST}')
+            with self._temporary_attribute('current_subset_name', subset):
+                records = self._load_subset_records(subset)
+                if self.shuffle:
+                    random.Random(self.seed).shuffle(records)
+                records = self._apply_limit(records)
+                samples = [self.record_to_sample(record) for record in records]
+                if self.repeats > 1:
+                    samples = [copy.deepcopy(sample) for sample in samples for _ in range(self.repeats)]
+                dataset = MemoryDataset(samples=samples, name='tvbench', location=self.dataset_id)
+                dataset.reindex(group_size=self.repeats)
+                dataset_dict[subset] = dataset
+
+        self.test_dataset = DatasetDict(dataset_dict)
+        self.fewshot_dataset = None
+        self._post_process_samples()
+        return self.test_dataset
+
+    def _load_subset_records(self, subset: str) -> List[Dict[str, Any]]:
+        logger.info(f'Loading TVBench subset {subset} from {self.dataset_hub}: {self.dataset_id}.')
+        json_path = self.source_dataset.download_file(f'json/{subset}.json')
+        with open(json_path, 'r', encoding='utf-8') as json_file:
+            records = json.load(json_file)
+        if not isinstance(records, list) or not records:
+            raise ValueError(f'No records found for TVBench subset: {subset}')
+        return records
+
+    def _apply_limit(self, records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if self.limit is None:
+            return records
+        if isinstance(self.limit, float):
+            limit = int(len(records) * self.limit)
+        else:
+            limit = self.limit
+        return records[:limit]
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        choices = [str(choice) for choice in record['candidates']]
+        answer = str(record['answer'])
+        if answer not in choices:
+            raise ValueError(f'Invalid TVBench answer {answer!r}; expected one of {choices!r}.')
+        target = answer_character(choices.index(answer))
+
+        start = self._optional_float(record.get('start'), 'start')
+        end = self._optional_float(record.get('end'), 'end')
+        fps = self._optional_float(record.get('fps'), 'fps')
+        if start is not None and end is not None and start > end:
+            raise ValueError(f'Invalid TVBench time boundary: start={start} is greater than end={end}.')
+
+        video_name = str(record['video'])
+        video_path = self._resolve_video(self.current_subset_name, video_name)
+        input_text = prompt(
+            question=self._question_with_video_context(record, start=start, end=end),
+            choices=choices,
+            template=self.prompt_template,
+        )
+        content_list: List[Content] = [
+            ContentText(text=input_text),
+            ContentVideo(video=video_path, format=guess_video_format(video_path), start=start, end=end, fps=fps),
+        ]
+
+        return Sample(
+            input=[ChatMessageUser(content=content_list)],
+            choices=choices,
+            target=target,
+            metadata={
+                'video': record.get('video'),
+                'answer': answer,
+                'subset': self.current_subset_name,
+                'start': start,
+                'end': end,
+                'fps': fps,
+                'accurate_start': record.get('accurate_start'),
+                'accurate_end': record.get('accurate_end'),
+                'video_length': record.get('video_length'),
+                'question_id': record.get('question_id'),
+                'dataset_id': self.dataset_id,
+                'dataset_hub': self.dataset_hub,
+            },
+        )
+
+    def _resolve_video(self, subset: str, video_name: str) -> str:
+        if self.local_video_dir:
+            return self._local_video_path(self.local_video_dir, subset, video_name)
+        return self._ensure_video_file(subset, video_name)
+
+    def _local_video_path(self, video_dir: str, subset: str, video_name: str) -> str:
+        root_dir = os.path.abspath(video_dir)
+        candidate_paths = [
+            self._safe_join(root_dir, subset, video_name),
+            self._safe_join(root_dir, video_name),
+        ]
+        for candidate_path in candidate_paths:
+            if os.path.exists(candidate_path):
+                return candidate_path
+        raise FileNotFoundError(
+            f'TVBench video {video_name!r} was not found under local video_dir {root_dir!r} '
+            f'(checked subset and flat layouts).'
+        )
+
+    def _ensure_video_file(self, subset: str, video_name: str) -> str:
+        output_path = self._cache_output_path(subset, video_name)
+        if os.path.exists(output_path) and not self.force_redownload:
+            return output_path
+
+        archive_path = self.source_dataset.download_file(self._archive_path(subset, video_name))
+        member_name = self._find_archive_member(archive_path, video_name)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with zipfile.ZipFile(archive_path) as zip_file:
+            with zip_file.open(member_name) as source, open(output_path, 'wb') as target:
+                target.write(source.read())
+        return output_path
+
+    def _cache_output_path(self, subset: str, video_name: str) -> str:
+        subset_dir = os.path.abspath(os.path.join(self.video_cache_dir, subset))
+        return self._safe_join(subset_dir, video_name)
+
+    @staticmethod
+    def _safe_join(root_dir: str, *path_parts: str) -> str:
+        output_path = os.path.abspath(os.path.join(root_dir, *path_parts))
+        if os.path.commonpath([root_dir, output_path]) != root_dir:
+            raise ValueError(f'Invalid TVBench video path: {os.path.join(*path_parts)}')
+        return output_path
+
+    @staticmethod
+    def _archive_path(subset: str, video_name: str) -> str:
+        if subset == 'action_antonym':
+            raise FileNotFoundError(
+                'The TVBench repository does not expose video/action_antonym.zip. '
+                'Please configure extra_params.video_dir with local action_antonym AVI files.'
+            )
+        if subset == 'egocentric_sequence':
+            archive_name = video_name.split('/', 1)[0]
+            if not archive_name or archive_name == video_name:
+                raise ValueError(f'Invalid TVBench egocentric video path: {video_name!r}')
+            return f'video/egocentric_sequence/{archive_name}.zip'
+        return f'video/{subset}.zip'
+
+    @staticmethod
+    def _find_archive_member(archive_path: str, video_name: str) -> str:
+        normalized_video_name = video_name.replace('\\', '/').lstrip('/')
+        video_basename = os.path.basename(normalized_video_name)
+        with zipfile.ZipFile(archive_path) as zip_file:
+            member_names = [name for name in zip_file.namelist() if not name.endswith('/')]
+        exact_matches = [
+            name for name in member_names if name.replace('\\', '/').endswith(f'/{normalized_video_name}')
+            or name.replace('\\', '/') == normalized_video_name
+        ]
+        if exact_matches:
+            return sorted(exact_matches)[0]
+
+        basename_matches = [
+            name for name in member_names if os.path.basename(name.replace('\\', '/')) == video_basename
+        ]
+        if basename_matches:
+            return sorted(basename_matches)[0]
+        raise FileNotFoundError(f'Video {video_name} was not found in archive {archive_path}.')
+
+    def _question_with_video_context(
+        self,
+        record: Dict[str, Any],
+        start: Optional[float],
+        end: Optional[float],
+    ) -> str:
+        context = self._format_video_context(start=start, end=end)
+        question = str(record['question'])
+        if not context:
+            return question
+        return f'{context}\n\n{question}'
+
+    @classmethod
+    def _format_video_context(cls, start: Optional[float], end: Optional[float]) -> str:
+        time_range = cls._format_time_range(start, end)
+        if not time_range:
+            return ''
+        return f'Answer based on the video segment {time_range}.'
+
+    @classmethod
+    def _format_time_range(cls, start: Optional[float], end: Optional[float]) -> str:
+        if start is None and end is None:
+            return ''
+        if start is not None and end is not None:
+            return f'from {cls._format_seconds(start)}s to {cls._format_seconds(end)}s'
+        if start is not None:
+            return f'after {cls._format_seconds(start)}s'
+        return f'before {cls._format_seconds(end)}s'
+
+    @staticmethod
+    def _format_seconds(value: float) -> str:
+        return f'{value:g}'
+
+    @staticmethod
+    def _optional_float(value: Any, field_name: str) -> Optional[float]:
+        if value is None or value == '':
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f'Invalid TVBench {field_name}: {value!r}') from exc

--- a/evalscope/benchmarks/tvbench/tvbench_adapter.py
+++ b/evalscope/benchmarks/tvbench/tvbench_adapter.py
@@ -3,6 +3,7 @@ import copy
 import json
 import os
 import random
+import shutil
 import zipfile
 from typing import Any, Dict, List, Optional
 
@@ -213,11 +214,11 @@ class TVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
             return output_path
 
         archive_path = self.source_dataset.download_file(self._archive_path(subset, video_name))
-        member_name = self._find_archive_member(archive_path, video_name)
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with zipfile.ZipFile(archive_path) as zip_file:
+            member_name = self._find_archive_member(zip_file, video_name)
             with zip_file.open(member_name) as source, open(output_path, 'wb') as target:
-                target.write(source.read())
+                shutil.copyfileobj(source, target)
         return output_path
 
     def _cache_output_path(self, subset: str, video_name: str) -> str:
@@ -246,11 +247,10 @@ class TVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
         return f'video/{subset}.zip'
 
     @staticmethod
-    def _find_archive_member(archive_path: str, video_name: str) -> str:
+    def _find_archive_member(zip_file: zipfile.ZipFile, video_name: str) -> str:
         normalized_video_name = video_name.replace('\\', '/').lstrip('/')
         video_basename = os.path.basename(normalized_video_name)
-        with zipfile.ZipFile(archive_path) as zip_file:
-            member_names = [name for name in zip_file.namelist() if not name.endswith('/')]
+        member_names = [name for name in zip_file.namelist() if not name.endswith('/')]
         exact_matches = [
             name for name in member_names if name.replace('\\', '/').endswith(f'/{normalized_video_name}')
             or name.replace('\\', '/') == normalized_video_name
@@ -263,7 +263,7 @@ class TVBenchAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
         ]
         if basename_matches:
             return sorted(basename_matches)[0]
-        raise FileNotFoundError(f'Video {video_name} was not found in archive {archive_path}.')
+        raise FileNotFoundError(f'Video {video_name} was not found in archive.')
 
     def _question_with_video_context(
         self,

--- a/evalscope/benchmarks/videomme_v2/videomme_v2_adapter.py
+++ b/evalscope/benchmarks/videomme_v2/videomme_v2_adapter.py
@@ -12,7 +12,7 @@ from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter, VisionLan
 from evalscope.api.dataset import DatasetDict, DatasetHub, MemoryDataset, Sample
 from evalscope.api.messages import ChatMessageUser, Content, ContentText, ContentVideo
 from evalscope.api.registry import register_benchmark
-from evalscope.constants import HubType, Tags
+from evalscope.constants import Tags
 from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import MultipleChoiceTemplate, prompt
 from evalscope.utils.url_utils import guess_video_format
@@ -63,22 +63,6 @@ downloads, so it exercises the same reusable video benchmark path as MVBench.
         eval_split='test',
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
         extra_params={
-            'dataset_id': {
-                'type': 'str',
-                'description': 'Dataset repository ID or local dataset root for Video-MME-v2.',
-                'value': DATASET_ID,
-            },
-            'dataset_hub': {
-                'type': 'str',
-                'description': 'Dataset hub used to load annotations, subtitles, and optional video archives.',
-                'value': HubType.MODELSCOPE,
-                'choices': [HubType.HUGGINGFACE, HubType.MODELSCOPE, HubType.LOCAL],
-            },
-            'dataset_revision': {
-                'type': 'str',
-                'description': 'Optional dataset revision; leave empty to use the hub default.',
-                'value': '',
-            },
             'video_source': {
                 'type': 'str',
                 'description': 'Use public URL fields for lightweight tests or official archived MP4 files.',
@@ -114,23 +98,10 @@ class VideoMMEv2Adapter(VisionLanguageAdapter, MultiChoiceAdapter):
         return self._video_cache_dir
 
     @property
-    def source_dataset_id(self) -> str:
-        return self.extra_params.get('dataset_id') or self.dataset_id
-
-    @property
-    def source_dataset_hub(self) -> str:
-        return self.extra_params.get('dataset_hub') or HubType.MODELSCOPE
-
-    @property
-    def source_dataset_revision(self) -> Optional[str]:
-        return self.extra_params.get('dataset_revision') or None
-
-    @property
     def source_dataset(self) -> DatasetHub:
         return DatasetHub(
-            data_id_or_path=self.source_dataset_id,
-            data_source=self.source_dataset_hub,
-            revision=self.source_dataset_revision,
+            data_id_or_path=self.dataset_id,
+            data_source=self.dataset_hub,
             force_redownload=self.force_redownload,
         )
 
@@ -159,7 +130,7 @@ class VideoMMEv2Adapter(VisionLanguageAdapter, MultiChoiceAdapter):
                 samples = [self.record_to_sample(record) for record in records]
                 if self.repeats > 1:
                     samples = [copy.deepcopy(sample) for sample in samples for _ in range(self.repeats)]
-                dataset = MemoryDataset(samples=samples, name='videomme_v2', location=self.source_dataset_id)
+                dataset = MemoryDataset(samples=samples, name='videomme_v2', location=self.dataset_id)
                 dataset.reindex(group_size=self.repeats)
                 dataset_dict[subset] = dataset
 
@@ -170,7 +141,7 @@ class VideoMMEv2Adapter(VisionLanguageAdapter, MultiChoiceAdapter):
 
     def _load_records(self) -> List[Dict[str, Any]]:
         if self._record_cache is None:
-            logger.info(f'Loading Video-MME-v2 records from {self.source_dataset_hub}: {self.source_dataset_id}.')
+            logger.info(f'Loading Video-MME-v2 records from {self.dataset_hub}: {self.dataset_id}.')
             dataset = self.source_dataset.load(split=self.eval_split)
             self._record_cache = list(dataset)
             if not self._record_cache:
@@ -227,8 +198,8 @@ class VideoMMEv2Adapter(VisionLanguageAdapter, MultiChoiceAdapter):
                 'answer': target,
                 'subset': self.current_subset_name,
                 'video_source': self.video_source,
-                'dataset_id': self.source_dataset_id,
-                'dataset_hub': self.source_dataset_hub,
+                'dataset_id': self.dataset_id,
+                'dataset_hub': self.dataset_hub,
             },
         )
 

--- a/evalscope/utils/url_utils.py
+++ b/evalscope/utils/url_utils.py
@@ -63,6 +63,8 @@ def guess_video_format(video: Optional[str], default: VideoFormat = 'mp4') -> Vi
         subtype = mime_type.split('/', 1)[1].lower()
         if subtype == 'quicktime':
             return 'mov'
+        if subtype == 'x-msvideo':
+            return 'avi'
         if subtype in SUPPORTED_VIDEO_FORMATS:
             return cast(VideoFormat, subtype)
 

--- a/evalscope/utils/url_utils.py
+++ b/evalscope/utils/url_utils.py
@@ -35,12 +35,13 @@ def data_uri_to_base64(data_uri: str) -> str:
     return stripped_uri
 
 
-VideoFormat = Literal['mp4', 'mpeg', 'mov']
-SUPPORTED_VIDEO_FORMATS: tuple[VideoFormat, ...] = ('mp4', 'mpeg', 'mov')
+VideoFormat = Literal['mp4', 'mpeg', 'mov', 'avi']
+SUPPORTED_VIDEO_FORMATS: tuple[VideoFormat, ...] = ('mp4', 'mpeg', 'mov', 'avi')
 VIDEO_FORMAT_TO_MIME_TYPE: dict[VideoFormat, str] = {
     'mp4': 'video/mp4',
     'mpeg': 'video/mpeg',
     'mov': 'video/quicktime',
+    'avi': 'video/x-msvideo',
 }
 
 

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -442,6 +442,18 @@ class TestVLMBenchmark(TestBenchmark):
         }
         self._run_dataset_test('videomme_v2', dataset_args=dataset_args, limit=10)
 
+    def test_tvbench(self):
+        dataset_args = {
+            'subset_list': ['action_count']
+        }
+        self._run_dataset_test('tvbench', dataset_args=dataset_args, limit=5)
+
+    def test_tvbench_mock(self):
+        dataset_args = {
+            'subset_list': ['action_count']
+        }
+        self._run_dataset_test('tvbench', dataset_args=dataset_args, limit=5, use_mock=True)
+
     def test_common_voice_15(self):
         dataset_args = {
             'subset_list': ['en'],


### PR DESCRIPTION
## Summary

1. Add native TVBench support as a video multiple-choice benchmark.
2. Extend video content format handling to support AVI files.
3. Clean up redundant dataset-related `extra_params` in existing video benchmark adapters.
4. Add TVBench benchmark docs, metadata, supported dataset entries, and VLM tests.

## Changes

1. Added `TVBenchAdapter` with:
   - 10 supported TVBench subsets
   - `VisionLanguageAdapter + MultiChoiceAdapter` integration
   - lazy video archive resolution
   - segment-aware `start` / `end` handling
   - local `video_dir` fallback for AVI files

2. Updated video format utilities:
   - added `avi` to supported video formats
   - mapped AVI to `video/x-msvideo`

3. Simplified existing video adapters:
   - removed redundant framework-level params from `extra_params`
   - kept only benchmark-specific options such as `video_dir`, `video_source`, and subtitles
   - reduced pure pass-through properties where possible

4. Generated TVBench documentation:
   - English / Chinese benchmark pages
   - benchmark meta JSON
   - supported VLM dataset tables

## Validation

1. `pytest tests/benchmark/test_vlm.py::TestVLMBenchmark::test_tvbench_mock -s -x -p no:warnings`
2. `pytest tests/benchmark/test_vlm.py::TestVLMBenchmark::test_tvbench -s -x -p no:warnings`
3. `make docs-pipeline BENCHMARK=tvbench FORCE=1`
4. `PATH=/mnt/nas2/anaconda3/envs/eval/bin:$PATH make docs`
5. pre-commit hooks during commit:
   - flake8
   - isort
   - yapf
   - trailing whitespace
   - end-of-file
   - double quoted strings
   - merge conflict check
   - mixed line ending check
