### PR TITLE
fix: Handle multi-line SSE format with id, event, and data fields

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -44,7 +44,16 @@ class StreamedResponseHandler:
             message, self.buffer = self.buffer.split('\n\n', 1)
             message = message.strip()
             if message:
-                messages.append(message)
+                # Extract the 'data:' field from multi-line SSE format
+                # SSE message may contain: id:..., event:..., data:..., etc.
+                data_line = None
+                for line in message.split('\n'):
+                    if line.startswith('data:'):
+                        data_line = line
+                        break
+                
+                if data_line:
+                    messages.append(data_line)
 
         # if self.buffer is not empty, check if it is a complete message
         # by removing data: prefix and check if it is a valid JSON

--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -46,14 +46,16 @@ class StreamedResponseHandler:
             if message:
                 # Extract the 'data:' field from multi-line SSE format
                 # SSE message may contain: id:..., event:..., data:..., etc.
-                data_line = None
+                data_values = []
                 for line in message.split('\n'):
                     if line.startswith('data:'):
-                        data_line = line
-                        break
+                        val = line[5:]
+                        if val.startswith(' '):
+                            val = val[1:]
+                        data_values.append(val)
                 
-                if data_line:
-                    messages.append(data_line)
+                if data_values:
+                    messages.append('data: ' + '\n'.join(data_values))
 
         # if self.buffer is not empty, check if it is a complete message
         # by removing data: prefix and check if it is a valid JSON

--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -44,18 +44,17 @@ class StreamedResponseHandler:
             message, self.buffer = self.buffer.split('\n\n', 1)
             message = message.strip()
             if message:
-                # Extract the 'data:' field from multi-line SSE format
+                # Extract the 'data:' field from multi-line SSE format.
                 # SSE message may contain: id:..., event:..., data:..., etc.
-                data_values = []
-                for line in message.split('\n'):
+                data_values: list[str] = []
+                for line in message.splitlines():
                     if line.startswith('data:'):
-                        val = line[5:]
-                        if val.startswith(' '):
-                            val = val[1:]
-                        data_values.append(val)
-                
+                        data_values.append(line.removeprefix('data:').lstrip(' '))
+
                 if data_values:
-                    messages.append('data: ' + '\n'.join(data_values))
+                    payload = ''.join(data_values).strip()
+                    if payload:
+                        messages.append(f'data: {payload}')
 
         # if self.buffer is not empty, check if it is a complete message
         # by removing data: prefix and check if it is a valid JSON

--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -23,6 +23,29 @@ class StreamedResponseHandler:
         # Keep decoder state across chunks to handle split multibyte sequences
         self.decoder = codecs.getincrementaldecoder('utf-8')()
 
+    @staticmethod
+    def _extract_sse_payload(message: str) -> str | None:
+        """Extract and flatten the 'data:' field(s) from an SSE message block.
+
+        SSE message blocks may contain multiple fields (id:, event:, retry:,
+        data:, ...). Only the 'data:' field(s) carry the JSON payload; other
+        fields are metadata and must be skipped, otherwise they would be fed
+        into ``json.loads`` and raise ``JSONDecodeError``. Multiple 'data:'
+        lines are flattened into a single line so downstream consumers that
+        only recognize one leading 'data:' prefix (e.g. this class itself and
+        ``_extract_sse_data`` in ``openai_responses_api.py``) don't silently
+        drop continuation lines.
+        """
+        data_values: list[str] = []
+        for line in message.strip().splitlines():
+            if line.startswith('data:'):
+                data_values.append(line.removeprefix('data:').lstrip(' '))
+
+        if not data_values:
+            return None
+        payload = ''.join(data_values).strip()
+        return f'data: {payload}' if payload else None
+
     def add_chunk(self, chunk_bytes: bytes) -> list[str]:
         """Add a chunk of bytes to the buffer and return any complete
         messages."""
@@ -42,31 +65,26 @@ class StreamedResponseHandler:
         # Split by double newlines (SSE message separator)
         while '\n\n' in self.buffer:
             message, self.buffer = self.buffer.split('\n\n', 1)
-            message = message.strip()
-            if message:
-                # Extract the 'data:' field from multi-line SSE format.
-                # SSE message may contain: id:..., event:..., data:..., etc.
-                data_values: list[str] = []
-                for line in message.splitlines():
-                    if line.startswith('data:'):
-                        data_values.append(line.removeprefix('data:').lstrip(' '))
+            normalized_message = self._extract_sse_payload(message)
+            if normalized_message:
+                messages.append(normalized_message)
 
-                if data_values:
-                    payload = ''.join(data_values).strip()
-                    if payload:
-                        messages.append(f'data: {payload}')
-
-        # if self.buffer is not empty, check if it is a complete message
-        # by removing data: prefix and check if it is a valid JSON
-        if self.buffer.startswith('data:'):
-            message_content = self.buffer.removeprefix('data:').strip()
+        # If self.buffer is not empty, check if it is a complete message by
+        # extracting the 'data:' field(s) and checking if it is valid JSON.
+        # This must reuse the same extraction as above, otherwise a leftover
+        # chunk that starts with metadata fields (id:/event:) instead of
+        # 'data:' would get stuck in the buffer forever when the stream ends
+        # without a trailing "\n\n" separator.
+        normalized_buffer = self._extract_sse_payload(self.buffer)
+        if normalized_buffer:
+            message_content = normalized_buffer.removeprefix('data:').strip()
             if message_content == '[DONE]':
-                messages.append(self.buffer.strip())
+                messages.append(normalized_buffer)
                 self.buffer = ''
             elif message_content:
                 try:
                     json.loads(message_content)
-                    messages.append(self.buffer.strip())
+                    messages.append(normalized_buffer)
                     self.buffer = ''
                 except json.JSONDecodeError:
                     # Incomplete JSON, wait for more chunks.

--- a/tests/perf/test_perf_streaming.py
+++ b/tests/perf/test_perf_streaming.py
@@ -4,11 +4,71 @@
 Covers SSE streaming against both the OpenAI-compatible chat/completions
 endpoint and the local model backend.
 """
+import json
 import unittest
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.main import run_perf_benchmark
+from evalscope.perf.plugin.api.default_api import StreamedResponseHandler
+from evalscope.perf.plugin.api.openai_responses_api import _extract_sse_data
 from tests.perf.perf_test_base import LOCAL_CHAT_URL, PerfTestBase
+
+
+class TestStreamedResponseHandler(unittest.TestCase):
+    """Unit tests for SSE chunk parsing, covering multi-field SSE blocks
+    (id:/event:/data:) and stream endings without a trailing separator."""
+
+    def test_extracts_data_from_sse_event_with_metadata(self) -> None:
+        handler = StreamedResponseHandler()
+
+        messages = handler.add_chunk(b'id: chunk-1\nevent: message\ndata: {"choices": []}\n\n')
+
+        self.assertEqual(messages, ['data: {"choices": []}'])
+        self.assertEqual(json.loads(messages[0].removeprefix('data:').strip()), {'choices': []})
+
+    def test_ignores_sse_metadata_without_data(self) -> None:
+        handler = StreamedResponseHandler()
+
+        messages = handler.add_chunk(b'event: ping\nid: keepalive\n\n')
+
+        self.assertEqual(messages, [])
+
+    def test_merges_multiple_data_lines_without_losing_content(self) -> None:
+        handler = StreamedResponseHandler()
+
+        messages = handler.add_chunk(b'event: message\ndata: {"a": 1,\ndata: "b": 2}\n\n')
+
+        self.assertEqual(len(messages), 1)
+        # The reconstructed message keeps a single leading 'data:' prefix, so
+        # downstream per-line extractors (e.g. _extract_sse_data) must not
+        # silently drop the continuation content.
+        self.assertEqual(_extract_sse_data(messages[0]), messages[0].removeprefix('data:').strip())
+        self.assertEqual(json.loads(messages[0].removeprefix('data:').strip()), {'a': 1, 'b': 2})
+
+    def test_flushes_leftover_buffer_starting_with_metadata_without_trailing_separator(self) -> None:
+        """A stream that ends right after the JSON payload (no trailing
+        '\\n\\n') must still be parsed, even if the leftover buffer starts
+        with SSE metadata fields (id:/event:) instead of 'data:'."""
+        handler = StreamedResponseHandler()
+
+        messages = handler.add_chunk(b'id: chunk-2\nevent: message\ndata: {"choices": []}')
+
+        self.assertEqual(messages, ['data: {"choices": []}'])
+        self.assertEqual(handler.buffer, '')
+
+    def test_flushes_leftover_done_starting_with_metadata(self) -> None:
+        handler = StreamedResponseHandler()
+
+        messages = handler.add_chunk(b'event: done\ndata: [DONE]')
+
+        self.assertEqual(messages, ['data: [DONE]'])
+        self.assertEqual(handler.buffer, '')
+
+    def test_waits_for_incomplete_json_buffer(self) -> None:
+        handler = StreamedResponseHandler()
+
+        self.assertEqual(handler.add_chunk(b'data: {"choices":'), [])
+        self.assertEqual(handler.add_chunk(b' []}'), ['data: {"choices": []}'])
 
 
 class TestPerfStreaming(PerfTestBase):


### PR DESCRIPTION
## Problem
当模型的流式响应包含多个 SSE 字段（如 id:、event: 等）时，代码会尝试解析整个消息块作为 JSON，导致 JSONDecodeError。

例如：
```
id: qa-d97kbe131308r73pa960
data: {"object":"chat.completion.chunk",...}
```

## Solution
在 StreamedResponseHandler.add_chunk() 中，从多行 SSE 消息中提取 data: 字段，跳过其他 SSE 元数据字段（id:、event:、retry: 等）。

## Changes
- 按行拆分 SSE 消息块
- 只提取 data: 字段进行 JSON 解析
- 自动跳过 SSE 元数据字段
- 防止 JSONDecodeError