### PR TITLE
Add Toolathlon benchmark wrapper

### DIFF
--- a/docs/en/benchmarks/toolathlon.md
+++ b/docs/en/benchmarks/toolathlon.md
@@ -1,0 +1,152 @@
+# Toolathlon Official Service Wrapper
+
+
+## Overview
+
+Toolathlon is an agent benchmark for realistic, long-horizon tool use across many MCP-backed software
+environments. This EvalScope benchmark is a wrapper around the official Toolathlon remote evaluation service,
+not a local reimplementation of the MCP environments or official evaluator.
+
+## Evaluation Mode
+
+- Benchmark id: `toolathlon`
+- Supported mode: official service private mode
+- EvalScope controls model endpoint, task selection, job parameters, polling, result download, and reporting
+- The official Toolathlon service controls MCP environments, task containers, agent loop execution, and scoring
+- No Toolathlon, MCP application accounts, or Toolathlon Python package installation are required when using the
+  official public evaluation service
+- A local or intranet OpenAI-compatible endpoint is required for private mode
+- EvalScope represents one remote Toolathlon job as one local sample; the generated data statistics count wrapper
+  jobs, while `task_list` and `limit` control the Toolathlon tasks submitted inside that job
+- The bundled Toolathlon-Verified task list was inspected from official repository commit
+  `b7bbac3f9a1f381b095c878debe1a47dd164ad85`
+
+## Usage Guide
+
+See the Toolathlon usage guide for public-service limits, private-mode data flow, self-hosted service setup, and
+EvalScope configuration examples:
+
+- https://evalscope.readthedocs.io/en/latest/third_party/toolathlon.html
+
+Official sources:
+
+- https://github.com/hkust-nlp/Toolathlon
+- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `toolathlon` |
+| **Dataset ID** | [Toolathlon](https://github.com/hkust-nlp/Toolathlon) |
+| **Paper** | N/A |
+| **Tags** | `Agent`, `FunctionCalling`, `MultiTurn` |
+| **Metrics** | `acc` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 1 |
+| Prompt Length (Mean) | 50 chars |
+| Prompt Length (Min/Max) | 50 / 50 chars |
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "22a512d8",
+      "content": "Run Toolathlon official remote evaluation service."
+    }
+  ],
+  "target": "",
+  "id": 0,
+  "metadata": {
+    "task_list": [
+      "ab-testing",
+      "academic-pdf-report",
+      "academic-warning",
+      "add-bibtex",
+      "apply-phd-email",
+      "arrange-workspace",
+      "canvas-arrange-exam",
+      "canvas-art-manager",
+      "canvas-art-quiz",
+      "canvas-do-quiz",
+      "... [TRUNCATED 98 more items] ..."
+    ],
+    "mode": "private"
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{question}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mode` | `str` | `private` | Toolathlon service mode. EvalScope supports private mode for this wrapper. Choices: ['private'] |
+| `server_host` | `str` | `47.253.6.47` | Official Toolathlon evaluation service host. |
+| `server_port` | `int` | `8080` | Official Toolathlon HTTP service port. |
+| `ws_proxy_port` | `int` | `8081` | Official Toolathlon WebSocket proxy port for private mode. |
+| `workers` | `int` | `10` | Number of parallel Toolathlon workers requested from the official service. |
+| `provider` | `str` | `unified` | Toolathlon model provider type. Choices: ['unified', 'openai_stateful_responses'] |
+| `task_list` | `list` | `[]` | Optional Toolathlon task names to evaluate. Empty uses the bundled Toolathlon-Verified list. |
+| `task_list_file` | `str` | `` | Optional file containing one Toolathlon task name per line. |
+| `model_params` | `dict` | `{}` | Extra model parameters forwarded to Toolathlon, merged after TaskConfig.generation_config. |
+| `job_id` | `str` | `` | Optional Toolathlon job id. Reuse to resume an incomplete official-service job. |
+| `force_redownload` | `bool` | `False` | Force redownload of Toolathlon result archives. |
+| `override_output_dir` | `bool` | `False` | Clear the Toolathlon output directory when it already contains files. |
+| `skip_container_restart` | `bool` | `False` | Skip Toolathlon container restart. Use only for small debug task subsets. |
+| `trust_env_in_httpx` | `bool` | `False` | Allow httpx to use proxy environment variables. |
+| `timeout_seconds` | `int` | `14400` | Maximum time to wait for a Toolathlon official-service job. |
+| `poll_interval` | `int` | `5` | Polling interval in seconds for Toolathlon job status. |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets toolathlon \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/agent.md
+++ b/docs/en/get_started/supported_dataset/agent.md
@@ -27,6 +27,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 | `tau_bench` | [τ-bench](../../benchmarks/tau_bench.md) | `Agent`, `FunctionCalling`, `Reasoning` |
 | `terminal_bench_v2` | [Terminal-Bench-2.0](../../benchmarks/terminal_bench_v2.md) | `Coding` |
 | `terminal_bench_v2_1` | [Terminal-Bench-2.1](../../benchmarks/terminal_bench_v2_1.md) | `Coding` |
+| `toolathlon` | [Toolathlon Official Service Wrapper](../../benchmarks/toolathlon.md) | `Agent`, `FunctionCalling`, `MultiTurn` |
 
 :::{toctree}
 :hidden:
@@ -55,4 +56,5 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 ../../benchmarks/tau_bench.md
 ../../benchmarks/terminal_bench_v2.md
 ../../benchmarks/terminal_bench_v2_1.md
+../../benchmarks/toolathlon.md
 :::

--- a/docs/en/third_party/index.md
+++ b/docs/en/third_party/index.md
@@ -9,6 +9,7 @@ Before using these benchmarks, please follow the instructions in each benchmark'
 
 terminal_bench.md
 skillsbench.md
+toolathlon.md
 gaia.md
 swe_bench.md
 swe_bench_pro.md

--- a/docs/en/third_party/toolathlon.md
+++ b/docs/en/third_party/toolathlon.md
@@ -1,0 +1,139 @@
+# Toolathlon
+
+Toolathlon evaluates long-horizon agent tool use in realistic MCP-backed software environments. EvalScope integrates it as a wrapper around the official Toolathlon evaluation service. EvalScope does not reimplement the MCP environments, task containers, agent loop, or official scorer.
+
+## Install
+
+```bash
+pip install evalscope[toolathlon]
+```
+
+The EvalScope wrapper only needs the client-side dependencies `httpx` and `websockets`. You do not need to install the full Toolathlon repository when you use the official public service.
+
+## Service Modes
+
+EvalScope supports Toolathlon official service private mode.
+
+In private mode, the Toolathlon service runs the task containers, MCP environments, agent loop, and scoring. EvalScope starts a local WebSocket relay; when the service needs a model response, the request is relayed back to your local or intranet OpenAI-compatible endpoint. This allows `api_url=http://localhost:8000/v1` to work even when the Toolathlon service is remote.
+
+The official Toolathlon client also supports public mode, where the service directly calls a public model API with the submitted API key. The EvalScope wrapper intentionally uses private mode so the model endpoint and API key stay on the EvalScope side.
+
+## Official Public Service
+
+The default service is the official public service:
+
+- HTTP service: `47.253.6.47:8080`
+- WebSocket proxy: `47.253.6.47:8081`
+
+The public service is intended for quick trials and debugging. According to the official documentation, it applies IP-based limits over a 24-hour window:
+
+- 180 minutes cumulative execution time per IP per 24 hours
+- 3 evaluation requests per IP per 24 hours
+- While cumulative execution time is under 180 minutes, requests are not capped by the 3-request limit
+- After cumulative execution time exceeds 180 minutes, the 3-request-per-24-hour cap applies
+
+If submission returns `HTTP 503 Service Unavailable`, the service is usually busy because the official server runs one evaluation job at a time. If submission returns `HTTP 429`, the IP-based rate limit was reached.
+
+## Quick Debug Run
+
+Use a small `task_list` first:
+
+```python
+from evalscope import TaskConfig, run_task
+
+task_cfg = TaskConfig(
+    model='your-model-name',
+    api_url='http://localhost:8000/v1',
+    api_key='your-local-api-key',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            'extra_params': {
+                'task_list': ['find-alita-paper'],
+                'skip_container_restart': True,
+            }
+        }
+    },
+    limit=1,
+)
+
+run_task(task_cfg)
+```
+
+Use `skip_container_restart=True` only for small debugging subsets. For formal runs, remove it so the official service can restart task containers between jobs.
+
+## Self-hosted Official Service
+
+Self-hosting removes the public-service queue and public IP limits, but it is not a single `docker compose up` deployment. The official Docker image `docker.io/lockon0927/toolathlon-task-image:1016beta` is mainly the task/runtime image; it does not package every service, account, credential, and evaluator process required by the Toolathlon evaluation service.
+
+Before starting a self-hosted service, follow the official Toolathlon materials:
+
+- `README.md`: installation dependencies, Docker/Podman setup, `configs/global_configs.py`, app credential setup, local app deployment, and local smoke checks
+- `global_preparation/how2register_accounts.md`: accounts, tokens, and sessions required by MCP-backed tasks
+- `configs/global_configs_example.py`: copy to `configs/global_configs.py` and set `podman_or_docker`
+- `global_preparation/pull_toolathlon_image.sh`: pull the official task image
+- `global_preparation/deploy_containers.sh`: deploy local services such as Canvas, email, WooCommerce, and k8s/kind
+- `EVAL_SERVICE_README.md`: start the official `eval_server.py` HTTP service and private-mode WebSocket proxy
+
+After the full Toolathlon environment is ready, start the official service from the Toolathlon repository:
+
+```bash
+python eval_server.py 8080 8081 3 10 180
+```
+
+The arguments are:
+
+- `server_port`: HTTP service port
+- `ws_proxy_port`: WebSocket proxy port for private mode
+- `max_submissions_per_ip`: request limit per IP per 24 hours, or `-1` for unlimited
+- `max_workers`: maximum Toolathlon workers per job
+- `max_duration_minutes`: cumulative execution-time limit per IP per 24 hours, or `-1` for unlimited
+
+For an internal service without rate limiting:
+
+```bash
+python eval_server.py 8080 8081 -1 10 -1
+```
+
+## Use a Self-hosted Service from EvalScope
+
+Point EvalScope to the self-hosted service through `extra_params`:
+
+```python
+from evalscope import TaskConfig, run_task
+
+task_cfg = TaskConfig(
+    model='your-model-name',
+    api_url='http://localhost:8000/v1',
+    api_key='your-local-api-key',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            'extra_params': {
+                'server_host': 'your.toolathlon.server',
+                'server_port': 8080,
+                'ws_proxy_port': 8081,
+                'workers': 10,
+                'task_list': ['find-alita-paper'],
+            }
+        }
+    },
+    limit=1,
+)
+
+run_task(task_cfg)
+```
+
+For CLI usage, put the same values under `toolathlon.extra_params` in `--dataset-args`.
+
+## Operational Notes
+
+- The official server runs one evaluation job at a time. Increasing `workers` controls parallelism inside a job, not the number of concurrent submitted jobs.
+- The official service receives prompts, model responses, and tool context in order to drive the agent loop and scoring.
+- Keep `client_version` and WebSocket client protocol aligned with the official service version. This EvalScope wrapper follows Toolathlon service protocol `1.3`.
+- For sustained evaluation, prefer a dedicated official service or a self-hosted service over the shared public endpoint.
+
+Official sources:
+
+- [Toolathlon repository](https://github.com/hkust-nlp/Toolathlon)
+- [Toolathlon evaluation service README](https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md)

--- a/docs/zh/benchmarks/toolathlon.md
+++ b/docs/zh/benchmarks/toolathlon.md
@@ -1,0 +1,146 @@
+# Toolathlon Official Service Wrapper
+
+
+## 概述
+
+Toolathlon 是一个面向现实场景、长周期工具使用的智能体基准测试，覆盖多种基于 MCP 的软件环境。本 EvalScope 基准测试是对官方 Toolathlon 远程评估服务的封装，并非对 MCP 环境或官方评估器的本地重新实现。
+
+## 评估模式
+
+- 基准测试 ID：`toolathlon`
+- 支持模式：官方服务私有模式（official service private mode）
+- EvalScope 负责控制模型端点、任务选择、作业参数、轮询、结果下载和报告生成
+- 官方 Toolathlon 服务负责控制 MCP 环境、任务容器、智能体循环执行和评分
+- 使用官方公共评估服务时，无需安装 Toolathlon、MCP 应用账户或 Toolathlon Python 包
+- 私有模式下需要一个本地或内网的 OpenAI 兼容端点
+- EvalScope 将一个远程 Toolathlon 作业视为一个本地样本；生成的数据统计计数的是封装作业数量，而 `task_list` 和 `limit` 控制该作业内部提交的 Toolathlon 任务
+- 所附带的 Toolathlon-Verified 任务列表源自官方仓库提交记录 `b7bbac3f9a1f381b095c878debe1a47dd164ad85`
+
+## 使用指南
+
+有关公共服务限制、私有模式数据流、自托管服务设置以及 EvalScope 配置示例，请参阅 Toolathlon 使用指南：
+
+- https://evalscope.readthedocs.io/zh-cn/latest/third_party/toolathlon.html
+
+官方资源：
+
+- https://github.com/hkust-nlp/Toolathlon
+- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `toolathlon` |
+| **数据集ID** | [Toolathlon](https://github.com/hkust-nlp/Toolathlon) |
+| **论文** | N/A |
+| **标签** | `Agent`, `FunctionCalling`, `MultiTurn` |
+| **指标** | `acc` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 1 |
+| 提示词长度（平均） | 50 字符 |
+| 提示词长度（最小/最大） | 50 / 50 字符 |
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "22a512d8",
+      "content": "Run Toolathlon official remote evaluation service."
+    }
+  ],
+  "target": "",
+  "id": 0,
+  "metadata": {
+    "task_list": [
+      "ab-testing",
+      "academic-pdf-report",
+      "academic-warning",
+      "add-bibtex",
+      "apply-phd-email",
+      "arrange-workspace",
+      "canvas-arrange-exam",
+      "canvas-art-manager",
+      "canvas-art-quiz",
+      "canvas-do-quiz",
+      "... [TRUNCATED 98 more items] ..."
+    ],
+    "mode": "private"
+  }
+}
+```
+
+## 提示模板
+
+**提示模板:**
+```text
+{question}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `mode` | `str` | `private` | Toolathlon 服务模式。EvalScope 此封装仅支持私有模式。选项：['private'] |
+| `server_host` | `str` | `47.253.6.47` | 官方 Toolathlon 评估服务主机地址。 |
+| `server_port` | `int` | `8080` | 官方 Toolathlon HTTP 服务端口。 |
+| `ws_proxy_port` | `int` | `8081` | 私有模式下官方 Toolathlon WebSocket 代理端口。 |
+| `workers` | `int` | `10` | 向官方服务请求的并行 Toolathlon 工作进程数量。 |
+| `provider` | `str` | `unified` | Toolathlon 模型提供者类型。选项：['unified', 'openai_stateful_responses'] |
+| `task_list` | `list` | `[]` | 可选的待评估 Toolathlon 任务名称列表。留空则使用内置的 Toolathlon-Verified 列表。 |
+| `task_list_file` | `str` | `` | 可选文件路径，每行包含一个 Toolathlon 任务名称。 |
+| `model_params` | `dict` | `{}` | 额外模型参数，将转发给 Toolathlon，并在 TaskConfig.generation_config 之后合并。 |
+| `job_id` | `str` | `` | 可选的 Toolathlon 作业 ID。可用于恢复未完成的官方服务作业。 |
+| `force_redownload` | `bool` | `False` | 强制重新下载 Toolathlon 结果压缩包。 |
+| `override_output_dir` | `bool` | `False` | 当 Toolathlon 输出目录已存在文件时，是否清空目录。 |
+| `skip_container_restart` | `bool` | `False` | 跳过 Toolathlon 容器重启。仅用于小型调试任务子集。 |
+| `trust_env_in_httpx` | `bool` | `False` | 允许 httpx 使用代理环境变量。 |
+| `timeout_seconds` | `int` | `14400` | 等待 Toolathlon 官方服务作业的最大时间（秒）。 |
+| `poll_interval` | `int` | `5` | 轮询 Toolathlon 作业状态的时间间隔（秒）。 |
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets toolathlon \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/agent.md
+++ b/docs/zh/get_started/supported_dataset/agent.md
@@ -27,6 +27,7 @@
 | `tau_bench` | [τ-bench](../../benchmarks/tau_bench.md) | `Agent`, `FunctionCalling`, `Reasoning` |
 | `terminal_bench_v2` | [Terminal-Bench-2.0](../../benchmarks/terminal_bench_v2.md) | `Coding` |
 | `terminal_bench_v2_1` | [Terminal-Bench-2.1](../../benchmarks/terminal_bench_v2_1.md) | `Coding` |
+| `toolathlon` | [Toolathlon Official Service Wrapper](../../benchmarks/toolathlon.md) | `Agent`, `FunctionCalling`, `MultiTurn` |
 
 :::{toctree}
 :hidden:
@@ -55,4 +56,5 @@
 ../../benchmarks/tau_bench.md
 ../../benchmarks/terminal_bench_v2.md
 ../../benchmarks/terminal_bench_v2_1.md
+../../benchmarks/toolathlon.md
 :::

--- a/docs/zh/third_party/index.md
+++ b/docs/zh/third_party/index.md
@@ -9,6 +9,7 @@
 
 terminal_bench.md
 skillsbench.md
+toolathlon.md
 gaia.md
 swe_bench.md
 swe_bench_pro.md

--- a/docs/zh/third_party/toolathlon.md
+++ b/docs/zh/third_party/toolathlon.md
@@ -1,0 +1,139 @@
+# Toolathlon
+
+Toolathlon 用于评测智能体在真实 MCP 软件环境中的长程工具使用能力。EvalScope 的 `toolathlon` 集成是官方 Toolathlon evaluation service 的 wrapper，不重新实现 MCP 环境、任务容器、agent loop 或官方评分器。
+
+## 安装
+
+```bash
+pip install evalscope[toolathlon]
+```
+
+EvalScope wrapper 只需要客户端依赖 `httpx` 和 `websockets`。如果使用官方公共服务，不需要安装完整 Toolathlon 仓库。
+
+## 服务模式
+
+EvalScope 支持 Toolathlon 官方服务的 private mode。
+
+在 private mode 中，Toolathlon 服务负责运行任务容器、MCP 环境、agent loop 和评分。EvalScope 会启动本地 WebSocket relay；当服务端需要模型响应时，请求会通过 WebSocket 转回 EvalScope 所在机器，再调用你的本地或内网 OpenAI-compatible endpoint。因此即使 Toolathlon 服务在远端，也可以使用 `api_url=http://localhost:8000/v1`。
+
+官方 Toolathlon client 还支持 public mode，即服务端直接用提交的 API key 调用公共模型 API。EvalScope wrapper 目前固定使用 private mode，让模型 endpoint 和 API key 留在 EvalScope 侧。
+
+## 官方公共服务
+
+默认服务是官方公共服务：
+
+- HTTP service: `47.253.6.47:8080`
+- WebSocket proxy: `47.253.6.47:8081`
+
+官方公共服务主要用于快速试跑和调试。根据官方文档，它按 IP 在 24 小时窗口内限流：
+
+- 每个 IP 每 24 小时累计执行时长 180 分钟
+- 每个 IP 每 24 小时 3 次 evaluation request
+- 累计执行时长低于 180 分钟时，不受 3 次请求数限制
+- 累计执行时长超过 180 分钟后，开始应用 3 次请求数限制
+
+如果提交阶段返回 `HTTP 503 Service Unavailable`，通常表示官方服务忙，因为服务端一次只运行一个 evaluation job。如果返回 `HTTP 429`，则表示触发了 IP 限流。
+
+## 快速调试
+
+建议先用很小的 `task_list` 调试：
+
+```python
+from evalscope import TaskConfig, run_task
+
+task_cfg = TaskConfig(
+    model='your-model-name',
+    api_url='http://localhost:8000/v1',
+    api_key='your-local-api-key',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            'extra_params': {
+                'task_list': ['find-alita-paper'],
+                'skip_container_restart': True,
+            }
+        }
+    },
+    limit=1,
+)
+
+run_task(task_cfg)
+```
+
+`skip_container_restart=True` 只建议用于小规模调试。正式评测时应移除它，让官方服务在任务之间重启容器。
+
+## 自建官方服务
+
+自建服务可以避开公共服务排队和公共 IP 限流，但它不是一个 `docker compose up` 就能完成的部署。官方 Docker 镜像 `docker.io/lockon0927/toolathlon-task-image:1016beta` 主要是任务运行镜像，不包含 Toolathlon evaluation service 所需的所有服务、账号、凭据和评测进程。
+
+启动自建服务前，先按官方 Toolathlon 材料完成环境准备：
+
+- `README.md`：安装依赖、Docker/Podman、`configs/global_configs.py`、应用凭据、本地服务部署和 smoke check
+- `global_preparation/how2register_accounts.md`：MCP 任务需要的账号、token 和 session
+- `configs/global_configs_example.py`：复制为 `configs/global_configs.py`，并配置 `podman_or_docker`
+- `global_preparation/pull_toolathlon_image.sh`：拉取官方任务镜像
+- `global_preparation/deploy_containers.sh`：部署 Canvas、email、WooCommerce、k8s/kind 等本地服务
+- `EVAL_SERVICE_README.md`：启动官方 `eval_server.py` HTTP 服务和 private mode WebSocket proxy
+
+完整 Toolathlon 环境准备好后，在 Toolathlon 仓库中启动官方服务：
+
+```bash
+python eval_server.py 8080 8081 3 10 180
+```
+
+参数含义：
+
+- `server_port`：HTTP 服务端口
+- `ws_proxy_port`：private mode 的 WebSocket proxy 端口
+- `max_submissions_per_ip`：每个 IP 每 24 小时请求数限制，`-1` 表示不限
+- `max_workers`：每个 job 内部最大的 Toolathlon workers 数
+- `max_duration_minutes`：每个 IP 每 24 小时累计执行时长限制，`-1` 表示不限
+
+如果是内部自用服务，可以关闭限流：
+
+```bash
+python eval_server.py 8080 8081 -1 10 -1
+```
+
+## 在 EvalScope 中使用自建服务
+
+通过 `extra_params` 指向自建服务：
+
+```python
+from evalscope import TaskConfig, run_task
+
+task_cfg = TaskConfig(
+    model='your-model-name',
+    api_url='http://localhost:8000/v1',
+    api_key='your-local-api-key',
+    datasets=['toolathlon'],
+    dataset_args={
+        'toolathlon': {
+            'extra_params': {
+                'server_host': 'your.toolathlon.server',
+                'server_port': 8080,
+                'ws_proxy_port': 8081,
+                'workers': 10,
+                'task_list': ['find-alita-paper'],
+            }
+        }
+    },
+    limit=1,
+)
+
+run_task(task_cfg)
+```
+
+如果使用 CLI，把同样的配置放到 `--dataset-args` 的 `toolathlon.extra_params` 下即可。
+
+## 运维注意点
+
+- 官方服务一次只运行一个 evaluation job。`workers` 控制的是单个 job 内部并行度，不是提交 job 的并发数。
+- 官方服务为了驱动 agent loop 和评分，会接收 prompt、模型响应和工具上下文。
+- 需要保持 client protocol 和官方服务版本一致。当前 EvalScope wrapper 对齐 Toolathlon service protocol `1.3`。
+- 长期或正式评测建议使用 dedicated official service 或自建服务，不建议依赖共享公共服务。
+
+官方来源：
+
+- [Toolathlon repository](https://github.com/hkust-nlp/Toolathlon)
+- [Toolathlon evaluation service README](https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md)

--- a/evalscope/benchmarks/_meta/toolathlon.json
+++ b/evalscope/benchmarks/_meta/toolathlon.json
@@ -1,0 +1,177 @@
+{
+  "meta": {
+    "pretty_name": "Toolathlon Official Service Wrapper",
+    "dataset_id": "https://github.com/hkust-nlp/Toolathlon",
+    "paper_url": null,
+    "tags": [
+      "Agent",
+      "FunctionCalling",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "acc"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nToolathlon is an agent benchmark for realistic, long-horizon tool use across many MCP-backed software\nenvironments. This EvalScope benchmark is a wrapper around the official Toolathlon remote evaluation service,\nnot a local reimplementation of the MCP environments or official evaluator.\n\n## Evaluation Mode\n\n- Benchmark id: `toolathlon`\n- Supported mode: official service private mode\n- EvalScope controls model endpoint, task selection, job parameters, polling, result download, and reporting\n- The official Toolathlon service controls MCP environments, task containers, agent loop execution, and scoring\n- No Toolathlon, MCP application accounts, or Toolathlon Python package installation are required when using the\n  official public evaluation service\n- A local or intranet OpenAI-compatible endpoint is required for private mode\n- EvalScope represents one remote Toolathlon job as one local sample; the generated data statistics count wrapper\n  jobs, while `task_list` and `limit` control the Toolathlon tasks submitted inside that job\n- The bundled Toolathlon-Verified task list was inspected from official repository commit\n  `b7bbac3f9a1f381b095c878debe1a47dd164ad85`\n\n## Usage Guide\n\nSee the Toolathlon usage guide for public-service limits, private-mode data flow, self-hosted service setup, and\nEvalScope configuration examples:\n\n- https://evalscope.readthedocs.io/en/latest/third_party/toolathlon.html\n\nOfficial sources:\n\n- https://github.com/hkust-nlp/Toolathlon\n- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md\n",
+    "prompt_template": "{question}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "mode": {
+        "type": "str",
+        "description": "Toolathlon service mode. EvalScope supports private mode for this wrapper.",
+        "value": "private",
+        "choices": [
+          "private"
+        ]
+      },
+      "server_host": {
+        "type": "str",
+        "description": "Official Toolathlon evaluation service host.",
+        "value": "47.253.6.47"
+      },
+      "server_port": {
+        "type": "int",
+        "description": "Official Toolathlon HTTP service port.",
+        "value": 8080
+      },
+      "ws_proxy_port": {
+        "type": "int",
+        "description": "Official Toolathlon WebSocket proxy port for private mode.",
+        "value": 8081
+      },
+      "workers": {
+        "type": "int",
+        "description": "Number of parallel Toolathlon workers requested from the official service.",
+        "value": 10
+      },
+      "provider": {
+        "type": "str",
+        "description": "Toolathlon model provider type.",
+        "value": "unified",
+        "choices": [
+          "unified",
+          "openai_stateful_responses"
+        ]
+      },
+      "task_list": {
+        "type": "list",
+        "description": "Optional Toolathlon task names to evaluate. Empty uses the bundled Toolathlon-Verified list.",
+        "value": []
+      },
+      "task_list_file": {
+        "type": "str",
+        "description": "Optional file containing one Toolathlon task name per line.",
+        "value": ""
+      },
+      "model_params": {
+        "type": "dict",
+        "description": "Extra model parameters forwarded to Toolathlon, merged after TaskConfig.generation_config.",
+        "value": {}
+      },
+      "job_id": {
+        "type": "str",
+        "description": "Optional Toolathlon job id. Reuse to resume an incomplete official-service job.",
+        "value": ""
+      },
+      "force_redownload": {
+        "type": "bool",
+        "description": "Force redownload of Toolathlon result archives.",
+        "value": false
+      },
+      "override_output_dir": {
+        "type": "bool",
+        "description": "Clear the Toolathlon output directory when it already contains files.",
+        "value": false
+      },
+      "skip_container_restart": {
+        "type": "bool",
+        "description": "Skip Toolathlon container restart. Use only for small debug task subsets.",
+        "value": false
+      },
+      "trust_env_in_httpx": {
+        "type": "bool",
+        "description": "Allow httpx to use proxy environment variables.",
+        "value": false
+      },
+      "timeout_seconds": {
+        "type": "int",
+        "description": "Maximum time to wait for a Toolathlon official-service job.",
+        "value": 14400
+      },
+      "poll_interval": {
+        "type": "int",
+        "description": "Polling interval in seconds for Toolathlon job status.",
+        "value": 5
+      }
+    },
+    "sandbox_config": {},
+    "category": "agent"
+  },
+  "statistics": {
+    "total_samples": 1,
+    "subset_stats": [
+      {
+        "name": "default",
+        "sample_count": 1,
+        "prompt_length_mean": 50,
+        "prompt_length_min": 50,
+        "prompt_length_max": 50,
+        "prompt_length_std": null,
+        "target_length_mean": null
+      }
+    ],
+    "prompt_length": {
+      "mean": 50,
+      "min": 50,
+      "max": 50,
+      "std": null
+    },
+    "target_length_mean": null,
+    "computed_at": "2026-07-10T10:05:26.379976"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "22a512d8",
+          "content": "Run Toolathlon official remote evaluation service."
+        }
+      ],
+      "target": "",
+      "id": 0,
+      "metadata": {
+        "task_list": [
+          "ab-testing",
+          "academic-pdf-report",
+          "academic-warning",
+          "add-bibtex",
+          "apply-phd-email",
+          "arrange-workspace",
+          "canvas-arrange-exam",
+          "canvas-art-manager",
+          "canvas-art-quiz",
+          "canvas-do-quiz",
+          "... [TRUNCATED 98 more items] ..."
+        ],
+        "mode": "private"
+      }
+    },
+    "subset": "default",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# Toolathlon Official Service Wrapper\n\n\n## Overview\n\nToolathlon is an agent benchmark for realistic, long-horizon tool use across many MCP-backed software\nenvironments. This EvalScope benchmark is a wrapper around the official Toolathlon remote evaluation service,\nnot a local reimplementation of the MCP environments or official evaluator.\n\n## Evaluation Mode\n\n- Benchmark id: `toolathlon`\n- Supported mode: official service private mode\n- EvalScope controls model endpoint, task selection, job parameters, polling, result download, and reporting\n- The official Toolathlon service controls MCP environments, task containers, agent loop execution, and scoring\n- No Toolathlon, MCP application accounts, or Toolathlon Python package installation are required when using the\n  official public evaluation service\n- A local or intranet OpenAI-compatible endpoint is required for private mode\n- EvalScope represents one remote Toolathlon job as one local sample; the generated data statistics count wrapper\n  jobs, while `task_list` and `limit` control the Toolathlon tasks submitted inside that job\n- The bundled Toolathlon-Verified task list was inspected from official repository commit\n  `b7bbac3f9a1f381b095c878debe1a47dd164ad85`\n\n## Usage Guide\n\nSee the Toolathlon usage guide for public-service limits, private-mode data flow, self-hosted service setup, and\nEvalScope configuration examples:\n\n- https://evalscope.readthedocs.io/en/latest/third_party/toolathlon.html\n\nOfficial sources:\n\n- https://github.com/hkust-nlp/Toolathlon\n- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `toolathlon` |\n| **Dataset ID** | [Toolathlon](https://github.com/hkust-nlp/Toolathlon) |\n| **Paper** | N/A |\n| **Tags** | `Agent`, `FunctionCalling`, `MultiTurn` |\n| **Metrics** | `acc` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 1 |\n| Prompt Length (Mean) | 50 chars |\n| Prompt Length (Min/Max) | 50 / 50 chars |\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"22a512d8\",\n      \"content\": \"Run Toolathlon official remote evaluation service.\"\n    }\n  ],\n  \"target\": \"\",\n  \"id\": 0,\n  \"metadata\": {\n    \"task_list\": [\n      \"ab-testing\",\n      \"academic-pdf-report\",\n      \"academic-warning\",\n      \"add-bibtex\",\n      \"apply-phd-email\",\n      \"arrange-workspace\",\n      \"canvas-arrange-exam\",\n      \"canvas-art-manager\",\n      \"canvas-art-quiz\",\n      \"canvas-do-quiz\",\n      \"... [TRUNCATED 98 more items] ...\"\n    ],\n    \"mode\": \"private\"\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{question}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `mode` | `str` | `private` | Toolathlon service mode. EvalScope supports private mode for this wrapper. Choices: ['private'] |\n| `server_host` | `str` | `47.253.6.47` | Official Toolathlon evaluation service host. |\n| `server_port` | `int` | `8080` | Official Toolathlon HTTP service port. |\n| `ws_proxy_port` | `int` | `8081` | Official Toolathlon WebSocket proxy port for private mode. |\n| `workers` | `int` | `10` | Number of parallel Toolathlon workers requested from the official service. |\n| `provider` | `str` | `unified` | Toolathlon model provider type. Choices: ['unified', 'openai_stateful_responses'] |\n| `task_list` | `list` | `[]` | Optional Toolathlon task names to evaluate. Empty uses the bundled Toolathlon-Verified list. |\n| `task_list_file` | `str` | `` | Optional file containing one Toolathlon task name per line. |\n| `model_params` | `dict` | `{}` | Extra model parameters forwarded to Toolathlon, merged after TaskConfig.generation_config. |\n| `job_id` | `str` | `` | Optional Toolathlon job id. Reuse to resume an incomplete official-service job. |\n| `force_redownload` | `bool` | `False` | Force redownload of Toolathlon result archives. |\n| `override_output_dir` | `bool` | `False` | Clear the Toolathlon output directory when it already contains files. |\n| `skip_container_restart` | `bool` | `False` | Skip Toolathlon container restart. Use only for small debug task subsets. |\n| `trust_env_in_httpx` | `bool` | `False` | Allow httpx to use proxy environment variables. |\n| `timeout_seconds` | `int` | `14400` | Maximum time to wait for a Toolathlon official-service job. |\n| `poll_interval` | `int` | `5` | Polling interval in seconds for Toolathlon job status. |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets toolathlon \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['toolathlon'],\n    dataset_args={\n        'toolathlon': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# Toolathlon Official Service Wrapper\n\n\n## 概述\n\nToolathlon 是一个面向现实场景、长周期工具使用的智能体基准测试，覆盖多种基于 MCP 的软件环境。本 EvalScope 基准测试是对官方 Toolathlon 远程评估服务的封装，并非对 MCP 环境或官方评估器的本地重新实现。\n\n## 评估模式\n\n- 基准测试 ID：`toolathlon`\n- 支持模式：官方服务私有模式（official service private mode）\n- EvalScope 负责控制模型端点、任务选择、作业参数、轮询、结果下载和报告生成\n- 官方 Toolathlon 服务负责控制 MCP 环境、任务容器、智能体循环执行和评分\n- 使用官方公共评估服务时，无需安装 Toolathlon、MCP 应用账户或 Toolathlon Python 包\n- 私有模式下需要一个本地或内网的 OpenAI 兼容端点\n- EvalScope 将一个远程 Toolathlon 作业视为一个本地样本；生成的数据统计计数的是封装作业数量，而 `task_list` 和 `limit` 控制该作业内部提交的 Toolathlon 任务\n- 所附带的 Toolathlon-Verified 任务列表源自官方仓库提交记录 `b7bbac3f9a1f381b095c878debe1a47dd164ad85`\n\n## 使用指南\n\n有关公共服务限制、私有模式数据流、自托管服务设置以及 EvalScope 配置示例，请参阅 Toolathlon 使用指南：\n\n- https://evalscope.readthedocs.io/zh-cn/latest/third_party/toolathlon.html\n\n官方资源：\n\n- https://github.com/hkust-nlp/Toolathlon\n- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `toolathlon` |\n| **数据集ID** | [Toolathlon](https://github.com/hkust-nlp/Toolathlon) |\n| **论文** | N/A |\n| **标签** | `Agent`, `FunctionCalling`, `MultiTurn` |\n| **指标** | `acc` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 1 |\n| 提示词长度（平均） | 50 字符 |\n| 提示词长度（最小/最大） | 50 / 50 字符 |\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"22a512d8\",\n      \"content\": \"Run Toolathlon official remote evaluation service.\"\n    }\n  ],\n  \"target\": \"\",\n  \"id\": 0,\n  \"metadata\": {\n    \"task_list\": [\n      \"ab-testing\",\n      \"academic-pdf-report\",\n      \"academic-warning\",\n      \"add-bibtex\",\n      \"apply-phd-email\",\n      \"arrange-workspace\",\n      \"canvas-arrange-exam\",\n      \"canvas-art-manager\",\n      \"canvas-art-quiz\",\n      \"canvas-do-quiz\",\n      \"... [TRUNCATED 98 more items] ...\"\n    ],\n    \"mode\": \"private\"\n  }\n}\n```\n\n## 提示模板\n\n**提示模板:**\n```text\n{question}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `mode` | `str` | `private` | Toolathlon 服务模式。EvalScope 此封装仅支持私有模式。选项：['private'] |\n| `server_host` | `str` | `47.253.6.47` | 官方 Toolathlon 评估服务主机地址。 |\n| `server_port` | `int` | `8080` | 官方 Toolathlon HTTP 服务端口。 |\n| `ws_proxy_port` | `int` | `8081` | 私有模式下官方 Toolathlon WebSocket 代理端口。 |\n| `workers` | `int` | `10` | 向官方服务请求的并行 Toolathlon 工作进程数量。 |\n| `provider` | `str` | `unified` | Toolathlon 模型提供者类型。选项：['unified', 'openai_stateful_responses'] |\n| `task_list` | `list` | `[]` | 可选的待评估 Toolathlon 任务名称列表。留空则使用内置的 Toolathlon-Verified 列表。 |\n| `task_list_file` | `str` | `` | 可选文件路径，每行包含一个 Toolathlon 任务名称。 |\n| `model_params` | `dict` | `{}` | 额外模型参数，将转发给 Toolathlon，并在 TaskConfig.generation_config 之后合并。 |\n| `job_id` | `str` | `` | 可选的 Toolathlon 作业 ID。可用于恢复未完成的官方服务作业。 |\n| `force_redownload` | `bool` | `False` | 强制重新下载 Toolathlon 结果压缩包。 |\n| `override_output_dir` | `bool` | `False` | 当 Toolathlon 输出目录已存在文件时，是否清空目录。 |\n| `skip_container_restart` | `bool` | `False` | 跳过 Toolathlon 容器重启。仅用于小型调试任务子集。 |\n| `trust_env_in_httpx` | `bool` | `False` | 允许 httpx 使用代理环境变量。 |\n| `timeout_seconds` | `int` | `14400` | 等待 Toolathlon 官方服务作业的最大时间（秒）。 |\n| `poll_interval` | `int` | `5` | 轮询 Toolathlon 作业状态的时间间隔（秒）。 |\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets toolathlon \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['toolathlon'],\n    dataset_args={\n        'toolathlon': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "1bd327d70c75f087d1902656a5ddb66e",
+    "needs_translation": false
+  },
+  "updated_at": "2026-07-10T10:05:26.380342",
+  "translation_updated_at": "2026-07-10T10:05:29"
+}

--- a/evalscope/benchmarks/toolathlon/__init__.py
+++ b/evalscope/benchmarks/toolathlon/__init__.py
@@ -1,0 +1,3 @@
+from .toolathlon_adapter import ToolathlonAdapter
+
+__all__ = ['ToolathlonAdapter']

--- a/evalscope/benchmarks/toolathlon/client.py
+++ b/evalscope/benchmarks/toolathlon/client.py
@@ -67,8 +67,8 @@ class ToolathlonServiceClient:
         self.output_dir = Path(config.output_dir)
 
     def run_private(self) -> Dict[str, Any]:
-        check_import('httpx', raise_error=True, feature_name='Toolathlon')
-        check_import('websockets', raise_error=True, feature_name='Toolathlon')
+        check_import('httpx', extra='toolathlon', raise_error=True, feature_name='Toolathlon')
+        check_import('websockets', extra='toolathlon', raise_error=True, feature_name='Toolathlon')
 
         self._prepare_output_dir()
         job = self._submit_job()
@@ -79,7 +79,7 @@ class ToolathlonServiceClient:
 
         ws_process = self._start_ws_client(job_id)
         try:
-            self._poll_until_finished(job_id)
+            self._poll_until_finished(job_id, ws_process)
         finally:
             self._stop_process(ws_process)
 
@@ -144,11 +144,11 @@ class ToolathlonServiceClient:
         return data
 
     def _start_ws_client(self, job_id: str) -> subprocess.Popen:
-        script = Path(__file__).with_name('ws_client.py')
         log_file = self.output_dir / 'ws_client.log'
         command = [
             sys.executable,
-            str(script),
+            '-m',
+            'evalscope.benchmarks.toolathlon.ws_client',
             '--server-url',
             self.config.ws_server_url,
             '--llm-base-url',
@@ -161,14 +161,18 @@ class ToolathlonServiceClient:
         with open(log_file, 'w', encoding='utf-8') as log:
             return subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
 
-    def _poll_until_finished(self, job_id: str) -> None:
+    def _poll_until_finished(self, job_id: str, ws_process: subprocess.Popen) -> None:
         import httpx
 
-        start_time = time.time()
+        start_time = time.monotonic()
         downloaded_tasks = set()
         with httpx.Client(timeout=30.0, trust_env=self.config.trust_env_in_httpx) as client:
             while True:
-                if time.time() - start_time > self.config.timeout_seconds:
+                exit_code = ws_process.poll()
+                if exit_code is not None:
+                    self._cancel_job(job_id, 'WebSocket relay exited')
+                    raise RuntimeError(f'Toolathlon WebSocket relay exited unexpectedly with code {exit_code}.')
+                if time.monotonic() - start_time > self.config.timeout_seconds:
                     self._cancel_job(job_id, 'Timeout')
                     raise TimeoutError(f'Toolathlon job exceeded {self.config.timeout_seconds} seconds.')
 
@@ -225,7 +229,7 @@ class ToolathlonServiceClient:
         finalpool_dir = self.output_dir / 'finalpool'
         finalpool_dir.mkdir(parents=True, exist_ok=True)
         with tarfile.open(fileobj=_BytesIO(archive_bytes), mode='r:gz') as archive:
-            archive.extractall(finalpool_dir)
+            _extract_tar_safely(archive, finalpool_dir)
 
     def _download_static_files(self, client: Any, job_id: str) -> None:
         response = client.get(f'{self.config.server_url}/get_static_files', params={'job_id': job_id}, timeout=60.0)
@@ -235,7 +239,7 @@ class ToolathlonServiceClient:
         for filename, content in response.json().items():
             if content is None:
                 continue
-            target = self.output_dir / filename
+            target = _resolve_output_path(self.output_dir, filename)
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding='utf-8')
 
@@ -327,6 +331,26 @@ def _BytesIO(content: bytes) -> Any:
     return BytesIO(content)
 
 
+def _extract_tar_safely(archive: tarfile.TarFile, destination: Path) -> None:
+    destination = destination.resolve()
+    members = archive.getmembers()
+    for member in members:
+        if member.issym() or member.islnk() or not (member.isfile() or member.isdir()):
+            raise RuntimeError(f'Unsafe Toolathlon archive member type: {member.name}')
+        _resolve_output_path(destination, member.name)
+    archive.extractall(destination, members=members)
+
+
+def _resolve_output_path(base_dir: Path, relative_path: str) -> Path:
+    base = base_dir.resolve()
+    target = (base / relative_path).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise RuntimeError(f'Unsafe Toolathlon output path: {relative_path}') from exc
+    return target
+
+
 async def run_ws_proxy(server_url: str, llm_base_url: str, llm_api_key: str, job_id: str) -> None:
     import httpx
     from websockets import connect
@@ -354,7 +378,7 @@ async def run_ws_proxy(server_url: str, llm_base_url: str, llm_api_key: str, job
                 request = await request_queue.get()
                 task = asyncio.create_task(process_request(request))
                 active_tasks.add(task)
-                active_tasks = {item for item in active_tasks if not item.done()}
+                task.add_done_callback(active_tasks.discard)
 
         async def process_request(request: Dict[str, Any]) -> None:
             request_id = request['request_id']
@@ -364,7 +388,7 @@ async def run_ws_proxy(server_url: str, llm_base_url: str, llm_api_key: str, job
                 for key, value in request.items()
                 if key not in {'request_id', 'pushed', '_server_push_time'} and not key.startswith('_')
             }
-            headers = {'Authorization': f'Bearer {llm_api_key}'}
+            headers = {'Authorization': f'Bearer {llm_api_key}'} if llm_api_key else {}
             try:
                 async with httpx.AsyncClient(timeout=600.0) as client:
                     response = await client.post(f'{llm_base_url}{endpoint}', json=payload, headers=headers)

--- a/evalscope/benchmarks/toolathlon/client.py
+++ b/evalscope/benchmarks/toolathlon/client.py
@@ -1,0 +1,402 @@
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import time
+from dataclasses import dataclass, field
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from evalscope.utils.import_utils import check_import
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+CLIENT_VERSION = '1.3'
+WS_CLIENT_VERSION = '1.3'
+DEFAULT_SERVER_HOST = '47.253.6.47'
+DEFAULT_SERVER_PORT = 8080
+DEFAULT_WS_PROXY_PORT = 8081
+DEFAULT_TIMEOUT_SECONDS = 240 * 60
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+
+@dataclass
+class ToolathlonServiceConfig:
+    """Configuration for the official Toolathlon remote evaluation service."""
+
+    server_host: str = DEFAULT_SERVER_HOST
+    server_port: int = DEFAULT_SERVER_PORT
+    ws_proxy_port: int = DEFAULT_WS_PROXY_PORT
+    base_url: str = ''
+    model_name: str = ''
+    api_key: Optional[str] = None
+    workers: int = 10
+    provider: str = 'unified'
+    task_list: Optional[List[str]] = None
+    model_params: Optional[Dict[str, Any]] = None
+    job_id: Optional[str] = None
+    force_redownload: bool = False
+    override_output_dir: bool = False
+    skip_container_restart: bool = False
+    trust_env_in_httpx: bool = False
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    poll_interval: int = DEFAULT_POLL_INTERVAL_SECONDS
+    output_dir: Path = field(default_factory=lambda: Path('outputs/toolathlon'))
+
+    @property
+    def server_url(self) -> str:
+        return f'http://{self.server_host}:{self.server_port}'
+
+    @property
+    def ws_server_url(self) -> str:
+        parsed = urlparse(self.server_url)
+        return f'http://{parsed.hostname}:{self.ws_proxy_port}'
+
+
+class ToolathlonServiceClient:
+    """Minimal client for Toolathlon private-mode official service protocol."""
+
+    def __init__(self, config: ToolathlonServiceConfig) -> None:
+        self.config = config
+        self.output_dir = Path(config.output_dir)
+
+    def run_private(self) -> Dict[str, Any]:
+        check_import('httpx', raise_error=True, feature_name='Toolathlon')
+        check_import('websockets', raise_error=True, feature_name='Toolathlon')
+
+        self._prepare_output_dir()
+        job = self._submit_job()
+        job_id = job['job_id']
+        client_id = job.get('client_id')
+        if not client_id:
+            raise RuntimeError('Toolathlon private mode did not return client_id.')
+
+        ws_process = self._start_ws_client(job_id)
+        try:
+            self._poll_until_finished(job_id)
+        finally:
+            self._stop_process(ws_process)
+
+        return self.load_results()
+
+    def load_results(self) -> Dict[str, Any]:
+        stats = self._read_json_if_exists(self.output_dir / 'eval_stats.json')
+        task_results = self._read_jsonl_if_exists(self.output_dir / 'eval_res_all.jsonl')
+        if not task_results:
+            task_results = self._read_jsonl_if_exists(self.output_dir / 'traj_log_all.jsonl')
+
+        score = _extract_accuracy(stats, task_results)
+        return {
+            'job_id': self.config.job_id,
+            'output_dir': str(self.output_dir),
+            'eval_stats': stats,
+            'task_results': task_results,
+            'acc': score,
+        }
+
+    def _prepare_output_dir(self) -> None:
+        if self.output_dir.exists() and any(self.output_dir.iterdir()):
+            if not self.config.override_output_dir:
+                raise RuntimeError(
+                    f'Toolathlon output directory is not empty: {self.output_dir}. '
+                    'Set extra_params.override_output_dir=True to clear it.'
+                )
+            shutil.rmtree(self.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _submit_job(self) -> Dict[str, Any]:
+        import httpx
+
+        submit_data: Dict[str, Any] = {
+            'client_version': CLIENT_VERSION,
+            'ws_client_version': WS_CLIENT_VERSION,
+            'mode': 'private',
+            'base_url': self.config.base_url,
+            'api_key': 'dummy',
+            'model_name': self.config.model_name,
+            'workers': self.config.workers,
+            'custom_job_id': self.config.job_id,
+            'skip_container_restart': self.config.skip_container_restart,
+            'provider': self.config.provider,
+        }
+        if self.config.model_params:
+            submit_data['model_params'] = self.config.model_params
+        if self.config.task_list:
+            submit_data['task_list_content'] = '\n'.join(self.config.task_list) + '\n'
+
+        with httpx.Client(timeout=30.0, trust_env=self.config.trust_env_in_httpx) as client:
+            response = client.post(f'{self.config.server_url}/submit_evaluation', json=submit_data)
+            if response.status_code >= 400:
+                raise RuntimeError(_format_submit_error(response))
+            response.raise_for_status()
+            data = response.json()
+
+        job_id = data.get('job_id') or data.get('final_job_id')
+        if not job_id:
+            raise RuntimeError(f'Toolathlon service response missing job_id: {data}')
+        self.config.job_id = job_id
+        return data
+
+    def _start_ws_client(self, job_id: str) -> subprocess.Popen:
+        script = Path(__file__).with_name('ws_client.py')
+        log_file = self.output_dir / 'ws_client.log'
+        command = [
+            sys.executable,
+            str(script),
+            '--server-url',
+            self.config.ws_server_url,
+            '--llm-base-url',
+            self.config.base_url,
+            '--llm-api-key',
+            self.config.api_key or '',
+            '--job-id',
+            job_id,
+        ]
+        with open(log_file, 'w', encoding='utf-8') as log:
+            return subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+
+    def _poll_until_finished(self, job_id: str) -> None:
+        import httpx
+
+        start_time = time.time()
+        downloaded_tasks = set()
+        with httpx.Client(timeout=30.0, trust_env=self.config.trust_env_in_httpx) as client:
+            while True:
+                if time.time() - start_time > self.config.timeout_seconds:
+                    self._cancel_job(job_id, 'Timeout')
+                    raise TimeoutError(f'Toolathlon job exceeded {self.config.timeout_seconds} seconds.')
+
+                downloaded_tasks.update(self._download_completed_tasks(client, job_id, downloaded_tasks))
+                status = self._get_job_status(client, job_id)
+                state = str(status.get('status') or status.get('state') or '').lower()
+                if state in {'completed', 'finished', 'success', 'succeeded'}:
+                    self._download_completed_tasks(client, job_id, downloaded_tasks)
+                    self._download_static_files(client, job_id)
+                    return
+                if state in {'failed', 'error', 'cancelled', 'canceled'}:
+                    self._download_static_files(client, job_id)
+                    raise RuntimeError(f'Toolathlon job failed: {status}')
+
+                time.sleep(self.config.poll_interval)
+
+    def _get_job_status(self, client: Any, job_id: str) -> Dict[str, Any]:
+        for endpoint in ('poll_job_status', 'status'):
+            response = client.get(f'{self.config.server_url}/{endpoint}', params={'job_id': job_id})
+            if response.status_code == 404:
+                continue
+            response.raise_for_status()
+            return response.json()
+        raise RuntimeError('Toolathlon service does not expose a supported job status endpoint.')
+
+    def _download_completed_tasks(self, client: Any, job_id: str, downloaded_tasks: set) -> set:
+        response = client.get(f'{self.config.server_url}/get_completed_tasks', params={'job_id': job_id})
+        if response.status_code == 404:
+            return set()
+        response.raise_for_status()
+        data = response.json()
+        task_names = data.get('completed_tasks') or data.get('tasks') or []
+        new_tasks = {name for name in task_names if name not in downloaded_tasks}
+        for task_name in new_tasks:
+            self._download_task_archive(client, job_id, task_name)
+        return new_tasks
+
+    def _download_task_archive(self, client: Any, job_id: str, task_name: str) -> None:
+        response = client.get(
+            f'{self.config.server_url}/get_task_archive',
+            params={
+                'job_id': job_id,
+                'task_name': task_name
+            },
+            timeout=120.0,
+        )
+        response.raise_for_status()
+        expected_md5 = response.headers.get('X-Content-MD5')
+        archive_bytes = response.content
+        actual_md5 = md5(archive_bytes).hexdigest()
+        if expected_md5 and expected_md5 != actual_md5:
+            raise RuntimeError(f'Toolathlon archive MD5 mismatch for {task_name}: {actual_md5} != {expected_md5}')
+
+        finalpool_dir = self.output_dir / 'finalpool'
+        finalpool_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=_BytesIO(archive_bytes), mode='r:gz') as archive:
+            archive.extractall(finalpool_dir)
+
+    def _download_static_files(self, client: Any, job_id: str) -> None:
+        response = client.get(f'{self.config.server_url}/get_static_files', params={'job_id': job_id}, timeout=60.0)
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+        for filename, content in response.json().items():
+            if content is None:
+                continue
+            target = self.output_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding='utf-8')
+
+    def _cancel_job(self, job_id: str, reason: str) -> None:
+        try:
+            import httpx
+
+            with httpx.Client(timeout=10.0, trust_env=self.config.trust_env_in_httpx) as client:
+                client.post(f'{self.config.server_url}/cancel_job', params={'job_id': job_id})
+        except Exception as exc:
+            logger.warning(f'Failed to cancel Toolathlon job after {reason}: {exc}')
+
+    def _stop_process(self, process: subprocess.Popen) -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    def _read_json_if_exists(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return {}
+        return json.loads(path.read_text(encoding='utf-8'))
+
+    def _read_jsonl_if_exists(self, path: Path) -> List[Dict[str, Any]]:
+        if not path.exists():
+            return []
+        rows = []
+        for line in path.read_text(encoding='utf-8').splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+        return rows
+
+
+def _extract_accuracy(stats: Dict[str, Any], task_results: List[Dict[str, Any]]) -> float:
+    for key in ('acc', 'accuracy', 'pass_rate', 'success_rate', 'score'):
+        value = stats.get(key)
+        if isinstance(value, (int, float, bool)):
+            return float(value)
+
+    total = stats.get('total') or stats.get('num_tasks')
+    passed = stats.get('passed') or stats.get('num_passed') or stats.get('success')
+    if isinstance(total, int) and total > 0 and isinstance(passed, int):
+        return passed / total
+
+    pass_values = []
+    for row in task_results:
+        value = row.get('pass')
+        if isinstance(value, bool):
+            pass_values.append(float(value))
+        elif isinstance(value, (int, float)):
+            pass_values.append(float(value))
+    if pass_values:
+        return sum(pass_values) / len(pass_values)
+    return 0.0
+
+
+def _format_submit_error(response: Any) -> str:
+    detail = _response_detail(response)
+    status_code = response.status_code
+    prefix = f'Toolathlon official service rejected evaluation submission with HTTP {status_code}.'
+    if status_code == 503:
+        return (
+            f'{prefix} The public official service is currently busy and can run only one evaluation job at a time. '
+            f'Retry later, request a dedicated official service, or self-deploy Toolathlon. Response: {detail}'
+        )
+    if status_code == 429:
+        return (
+            f'{prefix} The official service rate limit was reached. The public service allows 180 minutes of '
+            f'cumulative execution time per IP per 24 hours; after that threshold, requests are capped at 3 per IP '
+            f'per 24 hours. Response: {detail}'
+        )
+    return f'{prefix} Response: {detail}'
+
+
+def _response_detail(response: Any) -> str:
+    try:
+        data = response.json()
+    except Exception:
+        data = getattr(response, 'text', '')
+    return str(data)[:1000] if data else '<empty>'
+
+
+def _BytesIO(content: bytes) -> Any:
+    from io import BytesIO
+
+    return BytesIO(content)
+
+
+async def run_ws_proxy(server_url: str, llm_base_url: str, llm_api_key: str, job_id: str) -> None:
+    import httpx
+    from websockets import connect
+
+    ws_url = server_url.replace('http://', 'ws://').replace('https://', 'wss://') + f'/ws?job_id={job_id}'
+    async with connect(ws_url, ping_interval=20, ping_timeout=120, max_size=32 * 1024 * 1024) as websocket:
+        request_queue: asyncio.Queue = asyncio.Queue()
+        last_heartbeat_ack = {'time': time.monotonic()}
+
+        async def receive_messages() -> None:
+            async for message in websocket:
+                data = json.loads(message)
+                msg_type = data.get('type')
+                if msg_type == 'heartbeat_ack':
+                    last_heartbeat_ack['time'] = time.monotonic()
+                elif msg_type == 'error':
+                    raise RuntimeError(data.get('message'))
+                elif msg_type == 'new_requests':
+                    for request in data.get('requests', []):
+                        await request_queue.put(request)
+
+        async def process_requests() -> None:
+            active_tasks = set()
+            while True:
+                request = await request_queue.get()
+                task = asyncio.create_task(process_request(request))
+                active_tasks.add(task)
+                active_tasks = {item for item in active_tasks if not item.done()}
+
+        async def process_request(request: Dict[str, Any]) -> None:
+            request_id = request['request_id']
+            endpoint = request.get('_endpoint', '/chat/completions')
+            payload = {
+                key: value
+                for key, value in request.items()
+                if key not in {'request_id', 'pushed', '_server_push_time'} and not key.startswith('_')
+            }
+            headers = {'Authorization': f'Bearer {llm_api_key}'}
+            try:
+                async with httpx.AsyncClient(timeout=600.0) as client:
+                    response = await client.post(f'{llm_base_url}{endpoint}', json=payload, headers=headers)
+                response_data = {'status_code': response.status_code, 'body': response.json()}
+            except Exception as exc:
+                response_data = {
+                    'status_code': 500,
+                    'body': {
+                        'error': {
+                            'message': f'{type(exc).__name__}: {exc}',
+                            'type': 'network_error',
+                            'code': 'client_error',
+                        }
+                    },
+                }
+            await websocket.send(json.dumps({'type': 'response', 'request_id': request_id, 'data': response_data}))
+            request_queue.task_done()
+
+        async def send_heartbeat() -> None:
+            while True:
+                await asyncio.sleep(30)
+                await websocket.send(json.dumps({'type': 'heartbeat'}))
+                if time.monotonic() - last_heartbeat_ack['time'] > 120:
+                    raise TimeoutError('Toolathlon WebSocket heartbeat timed out.')
+
+        tasks = [
+            asyncio.create_task(receive_messages()),
+            asyncio.create_task(process_requests()),
+            asyncio.create_task(send_heartbeat()),
+        ]
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+        for task in pending:
+            task.cancel()
+        for task in done:
+            task.result()

--- a/evalscope/benchmarks/toolathlon/requirements.txt
+++ b/evalscope/benchmarks/toolathlon/requirements.txt
@@ -1,0 +1,2 @@
+httpx
+websockets

--- a/evalscope/benchmarks/toolathlon/toolathlon_adapter.py
+++ b/evalscope/benchmarks/toolathlon/toolathlon_adapter.py
@@ -1,0 +1,401 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
+from evalscope.api.dataset import DatasetDict, MemoryDataset, Sample
+from evalscope.api.evaluator import InferenceResult
+from evalscope.api.metric import Score
+from evalscope.api.model import Model, ModelOutput
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from .client import (
+    DEFAULT_POLL_INTERVAL_SECONDS,
+    DEFAULT_SERVER_HOST,
+    DEFAULT_SERVER_PORT,
+    DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_WS_PROXY_PORT,
+    ToolathlonServiceClient,
+    ToolathlonServiceConfig,
+)
+
+DEFAULT_TASK_LIST = [
+    'ab-testing',
+    'academic-pdf-report',
+    'academic-warning',
+    'add-bibtex',
+    'apply-phd-email',
+    'arrange-workspace',
+    'canvas-arrange-exam',
+    'canvas-art-manager',
+    'canvas-art-quiz',
+    'canvas-do-quiz',
+    'canvas-homework-grader-python',
+    'canvas-list-test',
+    'canvas-new-students-notification',
+    'canvas-submit-late-work',
+    'cooking-guidance',
+    'course-assistant',
+    'course-schedule',
+    'courses-ta-hws',
+    'cvpr-research',
+    'dataset-license-issue',
+    'detect-revised-terms',
+    'dietary-health',
+    'email-paper-homepage',
+    'excel-data-transformation',
+    'excel-market-research',
+    'experiments-recordings',
+    'fillout-online-forms',
+    'filter-low-selling-products',
+    'find-alita-paper',
+    'flagged-transactions',
+    'game-statistics',
+    'gdp-cr5-analysis',
+    'git-bug-hunt',
+    'git-milestone',
+    'git-repo',
+    'hk-top-conf',
+    'huggingface-upload',
+    'identify-all-songs',
+    'imagenet',
+    'inter-final-performance-analysis',
+    'interview-report',
+    'inventory-sync',
+    'investment-decision-analysis',
+    'invoice-org',
+    'ipad-edu-price',
+    'k8s-deployment-cleanup',
+    'k8s-mysql',
+    'k8s-pr-preview-testing',
+    'k8s-redis-helm-upgrade',
+    'k8s-safety-audit',
+    'landing-task-reminder',
+    'language-school',
+    'latex-prompt-box',
+    'live-transactions',
+    'llm-training-dataset',
+    'logical-datasets-collection',
+    'machine-operating',
+    'meeting-assign',
+    'merge-hf-datasets',
+    'mrbeast-analysis',
+    'music-analysis',
+    'nhl-b2b-analysis',
+    'notion-find-job',
+    'notion-hr',
+    'notion-movies',
+    'notion-personal-website',
+    'nvidia-market',
+    'nvidia-stock-analysis',
+    'oil-price',
+    'paper-checker',
+    'payable-invoice-checker',
+    'personal-website-construct',
+    'ppt-analysis',
+    'price-comparison',
+    'privacy-desensitization',
+    'profile-update-online',
+    'quantitative-financial-analysis',
+    'reimbursement-form-filler',
+    'sales-accounting',
+    'search-ca-school',
+    'set-conf-cr-ddl',
+    'shopping-helper',
+    'sla-timeout-monitor',
+    'stock-build-position',
+    'student-interview',
+    'subway-planning',
+    'sync-todo-to-readme',
+    'task-tracker',
+    'train-ticket-plan',
+    'travel-exchange',
+    'travel-expense-reimbursement',
+    'trip-adviser',
+    'trip-itinerary-generator',
+    'university-course-selection',
+    'update-material-inventory',
+    'upenn-campus-route',
+    'verl-dataset',
+    'vlm-history-completer',
+    'wandb-best-score',
+    'wandb-shortest-length',
+    'woocommerce-customer-survey',
+    'woocommerce-new-product',
+    'woocommerce-new-welcome',
+    'woocommerce-product-recall',
+    'woocommerce-stock-alert',
+    'woocommerce-update-cover',
+    'yahoo-analysis',
+    'youtube-repo',
+]
+MODEL_PARAM_EXCLUDES = {
+    'model',
+    'messages',
+    'tools',
+    'tool_choice',
+    'stream',
+    'batch_size',
+    'retries',
+    'retry_interval',
+    'anthropic_cache_strategy',
+}
+
+DESCRIPTION = """
+## Overview
+
+Toolathlon is an agent benchmark for realistic, long-horizon tool use across many MCP-backed software
+environments. This EvalScope benchmark is a wrapper around the official Toolathlon remote evaluation service,
+not a local reimplementation of the MCP environments or official evaluator.
+
+## Evaluation Mode
+
+- Benchmark id: `toolathlon`
+- Supported mode: official service private mode
+- EvalScope controls model endpoint, task selection, job parameters, polling, result download, and reporting
+- The official Toolathlon service controls MCP environments, task containers, agent loop execution, and scoring
+- No Toolathlon, MCP application accounts, or Toolathlon Python package installation are required when using the
+  official public evaluation service
+- A local or intranet OpenAI-compatible endpoint is required for private mode
+- EvalScope represents one remote Toolathlon job as one local sample; the generated data statistics count wrapper
+  jobs, while `task_list` and `limit` control the Toolathlon tasks submitted inside that job
+- The bundled Toolathlon-Verified task list was inspected from official repository commit
+  `b7bbac3f9a1f381b095c878debe1a47dd164ad85`
+
+## Usage Guide
+
+See the Toolathlon usage guide for public-service limits, private-mode data flow, self-hosted service setup, and
+EvalScope configuration examples:
+
+- https://evalscope.readthedocs.io/en/latest/third_party/toolathlon.html
+
+Official sources:
+
+- https://github.com/hkust-nlp/Toolathlon
+- https://github.com/hkust-nlp/Toolathlon/blob/main/EVAL_SERVICE_README.md
+"""
+
+EXTRA_PARAMS = {
+    'mode': {
+        'type': 'str',
+        'description': 'Toolathlon service mode. EvalScope supports private mode for this wrapper.',
+        'value': 'private',
+        'choices': ['private'],
+    },
+    'server_host': {
+        'type': 'str',
+        'description': 'Official Toolathlon evaluation service host.',
+        'value': DEFAULT_SERVER_HOST,
+    },
+    'server_port': {
+        'type': 'int',
+        'description': 'Official Toolathlon HTTP service port.',
+        'value': DEFAULT_SERVER_PORT,
+    },
+    'ws_proxy_port': {
+        'type': 'int',
+        'description': 'Official Toolathlon WebSocket proxy port for private mode.',
+        'value': DEFAULT_WS_PROXY_PORT,
+    },
+    'workers': {
+        'type': 'int',
+        'description': 'Number of parallel Toolathlon workers requested from the official service.',
+        'value': 10,
+    },
+    'provider': {
+        'type': 'str',
+        'description': 'Toolathlon model provider type.',
+        'value': 'unified',
+        'choices': ['unified', 'openai_stateful_responses'],
+    },
+    'task_list': {
+        'type': 'list',
+        'description': 'Optional Toolathlon task names to evaluate. Empty uses the bundled Toolathlon-Verified list.',
+        'value': [],
+    },
+    'task_list_file': {
+        'type': 'str',
+        'description': 'Optional file containing one Toolathlon task name per line.',
+        'value': '',
+    },
+    'model_params': {
+        'type': 'dict',
+        'description': 'Extra model parameters forwarded to Toolathlon, merged after TaskConfig.generation_config.',
+        'value': {},
+    },
+    'job_id': {
+        'type': 'str',
+        'description': 'Optional Toolathlon job id. Reuse to resume an incomplete official-service job.',
+        'value': '',
+    },
+    'force_redownload': {
+        'type': 'bool',
+        'description': 'Force redownload of Toolathlon result archives.',
+        'value': False,
+    },
+    'override_output_dir': {
+        'type': 'bool',
+        'description': 'Clear the Toolathlon output directory when it already contains files.',
+        'value': False,
+    },
+    'skip_container_restart': {
+        'type': 'bool',
+        'description': 'Skip Toolathlon container restart. Use only for small debug task subsets.',
+        'value': False,
+    },
+    'trust_env_in_httpx': {
+        'type': 'bool',
+        'description': 'Allow httpx to use proxy environment variables.',
+        'value': False,
+    },
+    'timeout_seconds': {
+        'type': 'int',
+        'description': 'Maximum time to wait for a Toolathlon official-service job.',
+        'value': DEFAULT_TIMEOUT_SECONDS,
+    },
+    'poll_interval': {
+        'type': 'int',
+        'description': 'Polling interval in seconds for Toolathlon job status.',
+        'value': DEFAULT_POLL_INTERVAL_SECONDS,
+    },
+}
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='toolathlon',
+        pretty_name='Toolathlon Official Service Wrapper',
+        dataset_id='https://github.com/hkust-nlp/Toolathlon',
+        tags=[Tags.AGENT, Tags.FUNCTION_CALLING, Tags.MULTI_TURN],
+        description=DESCRIPTION,
+        metric_list=['acc'],
+        eval_split='test',
+        subset_list=['default'],
+        prompt_template='{question}',
+        extra_params=EXTRA_PARAMS,
+    )
+)
+class ToolathlonAdapter(AgentAdapter):
+    """EvalScope wrapper around the official Toolathlon private-mode service."""
+
+    client_cls = ToolathlonServiceClient
+
+    def load(self) -> tuple[DatasetDict, None]:
+        task_list = self._resolve_task_list()
+        sample = Sample(
+            input='Run Toolathlon official remote evaluation service.',
+            target='',
+            id=0,
+            metadata={
+                'task_list': task_list,
+                'mode': self.extra_params.get('mode', 'private'),
+            },
+        )
+        dataset = MemoryDataset([sample], name='toolathlon', location=self.dataset_id)
+        return DatasetDict({'default': dataset}), None
+
+    def _on_inference(self, model: Model, sample: Sample) -> InferenceResult:
+        config = self._build_service_config(model, sample)
+        result = self.client_cls(config).run_private()
+        sample.metadata['toolathlon_result'] = result
+
+        content = json.dumps(
+            {
+                'job_id': result.get('job_id'),
+                'output_dir': result.get('output_dir'),
+                'acc': result.get('acc', 0.0),
+            },
+            ensure_ascii=False,
+        )
+        output = ModelOutput.from_content(model=model.name, content=content)
+        output.metadata = result
+        return InferenceResult(output=output)
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: Any,
+    ) -> Score:
+        result = task_state.metadata.get('toolathlon_result', {})
+        acc = float(result.get('acc', 0.0))
+        return Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+            value={'acc': acc},
+            main_score_name='acc',
+            metadata=result,
+        )
+
+    def _build_service_config(self, model: Model, sample: Sample) -> ToolathlonServiceConfig:
+        mode = self.extra_params.get('mode', 'private')
+        if mode != 'private':
+            raise ValueError('The EvalScope Toolathlon wrapper supports only private mode.')
+
+        base_url = self._resolve_base_url(model)
+        if not base_url:
+            raise ValueError('Toolathlon private mode requires TaskConfig.api_url or model.api.base_url.')
+
+        output_dir = Path(self.output_dir) / 'toolathlon'
+        return ToolathlonServiceConfig(
+            server_host=str(self.extra_params.get('server_host', DEFAULT_SERVER_HOST)),
+            server_port=int(self.extra_params.get('server_port', DEFAULT_SERVER_PORT)),
+            ws_proxy_port=int(self.extra_params.get('ws_proxy_port', DEFAULT_WS_PROXY_PORT)),
+            base_url=base_url.rstrip('/'),
+            model_name=model.name,
+            api_key=self._resolve_api_key(model),
+            workers=int(self.extra_params.get('workers', 10)),
+            provider=str(self.extra_params.get('provider', 'unified')),
+            task_list=sample.metadata.get('task_list'),
+            model_params=self._resolve_model_params(model),
+            job_id=self._empty_to_none(self.extra_params.get('job_id')),
+            force_redownload=bool(self.extra_params.get('force_redownload', False)),
+            override_output_dir=bool(self.extra_params.get('override_output_dir', False)),
+            skip_container_restart=bool(self.extra_params.get('skip_container_restart', False)),
+            trust_env_in_httpx=bool(self.extra_params.get('trust_env_in_httpx', False)),
+            timeout_seconds=int(self.extra_params.get('timeout_seconds', DEFAULT_TIMEOUT_SECONDS)),
+            poll_interval=int(self.extra_params.get('poll_interval', DEFAULT_POLL_INTERVAL_SECONDS)),
+            output_dir=output_dir,
+        )
+
+    def _resolve_base_url(self, model: Model) -> str:
+        if self._task_config is not None and self._task_config.api_url:
+            return self._task_config.api_url
+        return getattr(model.api, 'base_url', '') or ''
+
+    def _resolve_api_key(self, model: Model) -> Optional[str]:
+        if self._task_config is not None and self._task_config.api_key:
+            return self._task_config.api_key
+        return getattr(model.api, 'api_key', None)
+
+    def _resolve_model_params(self, model: Model) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        generation_config = getattr(model, 'config', None)
+        if generation_config is not None:
+            if hasattr(generation_config, 'model_dump'):
+                params.update(generation_config.model_dump(exclude_none=True))
+            elif isinstance(generation_config, dict):
+                params.update(generation_config)
+        params = {key: value for key, value in params.items() if key not in MODEL_PARAM_EXCLUDES}
+        params.update(self.extra_params.get('model_params') or {})
+        return params
+
+    def _resolve_task_list(self) -> List[str]:
+        task_list = self.extra_params.get('task_list') or []
+        task_list_file = self.extra_params.get('task_list_file') or ''
+        if task_list_file:
+            task_path = Path(task_list_file)
+            task_list = [line.strip() for line in task_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+        task_list = [str(task).strip() for task in task_list if str(task).strip()]
+        if not task_list:
+            task_list = list(DEFAULT_TASK_LIST)
+        if isinstance(self.limit, int) and self.limit > 0:
+            task_list = task_list[:self.limit]
+        return task_list
+
+    def _empty_to_none(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value or None

--- a/evalscope/benchmarks/toolathlon/ws_client.py
+++ b/evalscope/benchmarks/toolathlon/ws_client.py
@@ -1,0 +1,18 @@
+import argparse
+import asyncio
+
+from evalscope.benchmarks.toolathlon.client import run_ws_proxy
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Toolathlon private-mode WebSocket relay.')
+    parser.add_argument('--server-url', required=True)
+    parser.add_argument('--llm-base-url', required=True)
+    parser.add_argument('--llm-api-key', default='')
+    parser.add_argument('--job-id', required=True)
+    args = parser.parse_args()
+    asyncio.run(run_ws_proxy(args.server_url, args.llm_base_url, args.llm_api_key, args.job_id))
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ wmt              = {file = ["evalscope/benchmarks/wmt/requirements.txt"]}
 torgo            = {file = ["evalscope/benchmarks/torgo/requirements.txt"]}
 terminal_bench   = {file = ["evalscope/benchmarks/terminal_bench/requirements.txt"]}
 deep_swe         = {file = ["evalscope/benchmarks/deep_swe/requirements.txt"]}
+toolathlon       = {file = ["evalscope/benchmarks/toolathlon/requirements.txt"]}
 bfcl             = {file = ["evalscope/benchmarks/bfcl/requirements.txt"]}
 all = {file = [
   "requirements/opencompass.txt",

--- a/tests/benchmark/test_agent.py
+++ b/tests/benchmark/test_agent.py
@@ -3,6 +3,7 @@ import json
 import tempfile
 from dotenv import dotenv_values, load_dotenv
 from pathlib import Path
+from unittest.mock import patch
 
 load_dotenv('.env')
 
@@ -10,6 +11,7 @@ env = dotenv_values('.env')
 
 import unittest
 
+from evalscope.benchmarks.toolathlon.toolathlon_adapter import ToolathlonAdapter
 from evalscope.config import SandboxTaskConfig
 from evalscope.constants import EvalType, JudgeStrategy, OutputType
 from evalscope.utils.logger import get_logger
@@ -212,6 +214,63 @@ class TestAgentBenchmark(TestBenchmark):
             },
         }
         self._run_dataset_test('terminal_bench_v2_1', dataset_args, limit=3, eval_batch_size=3)
+
+    def test_toolathlon(self):
+        """Test Toolathlon official-service wrapper with a mocked service client."""
+
+        class FakeToolathlonClient:
+            last_config = None
+
+            def __init__(self, config):
+                FakeToolathlonClient.last_config = config
+
+            def run_private(self):
+                return {
+                    'job_id': self.last_config.job_id or 'fake-toolathlon-job',
+                    'output_dir': str(self.last_config.output_dir),
+                    'acc': 1.0,
+                    'eval_stats': {
+                        'passed': 1,
+                        'total': 1
+                    },
+                    'task_results': [{
+                        'task': 'find-alita-paper',
+                        'pass': True
+                    }],
+                }
+
+        dataset_args = {
+            'extra_params': {
+                'task_list': ['find-alita-paper'],
+                'workers': 1,
+                'skip_container_restart': True,
+                'model_params': {
+                    'temperature': 0.0
+                },
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(ToolathlonAdapter, 'client_cls', FakeToolathlonClient):
+                self._run_dataset_test(
+                    'toolathlon',
+                    dataset_args,
+                    use_mock=True,
+                    limit=1,
+                    eval_batch_size=1,
+                    no_timestamp=True,
+                    work_dir=tmp_dir,
+                    api_url='http://localhost:8000/v1',
+                    api_key='local-key',
+                )
+
+            self.assertIsNotNone(FakeToolathlonClient.last_config)
+            self.assertEqual(FakeToolathlonClient.last_config.base_url, 'http://localhost:8000/v1')
+            self.assertEqual(FakeToolathlonClient.last_config.api_key, 'local-key')
+            self.assertEqual(FakeToolathlonClient.last_config.task_list, ['find-alita-paper'])
+            self.assertEqual(FakeToolathlonClient.last_config.model_params['temperature'], 0.0)
+            self.assertNotIn('retries', FakeToolathlonClient.last_config.model_params)
+            self.assertNotIn('batch_size', FakeToolathlonClient.last_config.model_params)
 
     def test_swe_bench_verified_agentic_backticks(self):
         """Test SWE-bench-verified agentic dataset with backticks protocol."""

--- a/tests/benchmark/test_toolathlon_client.py
+++ b/tests/benchmark/test_toolathlon_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import importlib.util
 import io
 import json
 import tarfile
@@ -7,7 +9,15 @@ from pathlib import Path
 from typing import Any, Optional
 from unittest.mock import patch
 
-from evalscope.benchmarks.toolathlon.client import ToolathlonServiceClient, ToolathlonServiceConfig, _extract_accuracy
+if importlib.util.find_spec('httpx') is None or importlib.util.find_spec('websockets') is None:
+    raise unittest.SkipTest('Toolathlon client tests require `evalscope[toolathlon]`.')
+
+from evalscope.benchmarks.toolathlon.client import (
+    ToolathlonServiceClient,
+    ToolathlonServiceConfig,
+    _extract_accuracy,
+    run_ws_proxy,
+)
 
 
 class TestToolathlonClient(unittest.TestCase):
@@ -139,6 +149,11 @@ class TestToolathlonClient(unittest.TestCase):
         calls = []
         archive_bytes = _make_task_archive()
 
+        class FakeProcess:
+
+            def poll(self) -> None:
+                return None
+
         class FakeResponse:
 
             def __init__(
@@ -210,7 +225,7 @@ class TestToolathlonClient(unittest.TestCase):
             )
 
             with patch('httpx.Client', FakeHttpxClient):
-                with patch.object(ToolathlonServiceClient, '_start_ws_client', return_value=object()) as start_ws:
+                with patch.object(ToolathlonServiceClient, '_start_ws_client', return_value=FakeProcess()) as start_ws:
                     with patch.object(ToolathlonServiceClient, '_stop_process') as stop_process:
                         result = ToolathlonServiceClient(config).run_private()
 
@@ -229,12 +244,141 @@ class TestToolathlonClient(unittest.TestCase):
         self.assertIn('http://toolathlon.example:8080/poll_job_status', called_urls)
         self.assertIn('http://toolathlon.example:8080/get_static_files', called_urls)
 
+    def test_rejects_unsafe_task_archive_path(self) -> None:
 
-def _make_task_archive() -> bytes:
+        class FakeResponse:
+            status_code = 200
+            headers = {}
+            content = _make_task_archive('../../escape.txt')
+
+            def raise_for_status(self) -> None:
+                pass
+
+        class FakeHttpxClient:
+
+            def get(self, url: str, params: Optional[dict] = None, timeout: Optional[float] = None) -> FakeResponse:
+                return FakeResponse()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = ToolathlonServiceConfig(output_dir=Path(tmp_dir) / 'toolathlon')
+            client = ToolathlonServiceClient(config)
+            with self.assertRaisesRegex(RuntimeError, 'Unsafe Toolathlon output path'):
+                client._download_task_archive(FakeHttpxClient(), 'job-1', 'find-alita-paper')
+
+    def test_rejects_unsafe_static_file_path(self) -> None:
+
+        class FakeResponse:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {'../../escape.txt': 'bad'}
+
+        class FakeHttpxClient:
+
+            def get(self, url: str, params: Optional[dict] = None, timeout: Optional[float] = None) -> FakeResponse:
+                return FakeResponse()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = ToolathlonServiceConfig(output_dir=Path(tmp_dir) / 'toolathlon')
+            client = ToolathlonServiceClient(config)
+            with self.assertRaisesRegex(RuntimeError, 'Unsafe Toolathlon output path'):
+                client._download_static_files(FakeHttpxClient(), 'job-1')
+
+    def test_poll_fails_when_ws_process_exits(self) -> None:
+
+        class FakeProcess:
+
+            def poll(self) -> int:
+                return 1
+
+        class FakeHttpxClient:
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def __enter__(self) -> 'FakeHttpxClient':
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+                return False
+
+            def post(self, url: str, params: Optional[dict] = None) -> None:
+                return None
+
+        config = ToolathlonServiceConfig(server_host='toolathlon.example', poll_interval=0)
+        client = ToolathlonServiceClient(config)
+        with patch('httpx.Client', FakeHttpxClient):
+            with self.assertRaisesRegex(RuntimeError, 'WebSocket relay exited unexpectedly'):
+                client._poll_until_finished('job-1', FakeProcess())
+
+    def test_ws_proxy_omits_empty_authorization_header(self) -> None:
+        headers_seen = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self) -> dict:
+                return {'id': 'chatcmpl-mock'}
+
+        class FakeAsyncClient:
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def __aenter__(self) -> 'FakeAsyncClient':
+                return self
+
+            async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+                return False
+
+            async def post(self, url: str, json: dict, headers: dict) -> FakeResponse:
+                headers_seen.update(headers)
+                return FakeResponse()
+
+        class FakeWebSocket:
+
+            def __init__(self) -> None:
+                self.sent_messages = []
+
+            async def __aiter__(self):
+                yield json.dumps({
+                    'type': 'new_requests',
+                    'requests': [{
+                        'request_id': 'request-1',
+                        'messages': [],
+                    }]
+                })
+                while not self.sent_messages:
+                    await asyncio.sleep(0)
+                yield json.dumps({'type': 'error', 'message': 'done'})
+
+            async def send(self, message: str) -> None:
+                self.sent_messages.append(message)
+
+        class FakeConnect:
+
+            async def __aenter__(self) -> FakeWebSocket:
+                return FakeWebSocket()
+
+            async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+                return False
+
+        with patch('websockets.connect', return_value=FakeConnect()):
+            with patch('httpx.AsyncClient', FakeAsyncClient):
+                with self.assertRaisesRegex(RuntimeError, 'done'):
+                    asyncio.run(run_ws_proxy('http://toolathlon.example:8081', 'http://localhost:8000/v1', '', 'job-1'))
+
+        self.assertNotIn('Authorization', headers_seen)
+
+
+def _make_task_archive(member_name: str = 'find-alita-paper/README.md') -> bytes:
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode='w:gz') as archive:
         content = b'mock task archive'
-        info = tarfile.TarInfo('find-alita-paper/README.md')
+        info = tarfile.TarInfo(member_name)
         info.size = len(content)
         archive.addfile(info, io.BytesIO(content))
     return buffer.getvalue()

--- a/tests/benchmark/test_toolathlon_client.py
+++ b/tests/benchmark/test_toolathlon_client.py
@@ -1,0 +1,244 @@
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import patch
+
+from evalscope.benchmarks.toolathlon.client import ToolathlonServiceClient, ToolathlonServiceConfig, _extract_accuracy
+
+
+class TestToolathlonClient(unittest.TestCase):
+
+    def test_extract_accuracy_from_stats(self):
+        self.assertEqual(_extract_accuracy({'passed': 3, 'total': 4}, []), 0.75)
+        self.assertEqual(_extract_accuracy({'pass_rate': 0.5}, []), 0.5)
+        self.assertEqual(_extract_accuracy({}, [{'pass': True}, {'pass': False}]), 0.5)
+
+    def test_submit_private_job_does_not_send_local_api_key(self):
+        captured = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'job_id': 'job-1', 'client_id': 'client-1'}
+
+        class FakeHttpxClient:
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def post(self, url, json):
+                captured['url'] = url
+                captured['json'] = json
+                return FakeResponse()
+
+        config = ToolathlonServiceConfig(
+            server_host='toolathlon.example',
+            server_port=8080,
+            base_url='http://localhost:8000/v1',
+            model_name='local-model',
+            api_key='secret-local-key',
+            task_list=['find-alita-paper', 'git-milestone'],
+            model_params={'temperature': 0.0},
+            output_dir=Path('/tmp/toolathlon-test'),
+        )
+
+        with patch('httpx.Client', FakeHttpxClient):
+            result = ToolathlonServiceClient(config)._submit_job()
+
+        self.assertEqual(result['job_id'], 'job-1')
+        self.assertEqual(captured['url'], 'http://toolathlon.example:8080/submit_evaluation')
+        self.assertEqual(captured['json']['mode'], 'private')
+        self.assertEqual(captured['json']['api_key'], 'dummy')
+        self.assertNotIn('secret-local-key', str(captured['json']))
+        self.assertEqual(captured['json']['task_list_content'], 'find-alita-paper\ngit-milestone\n')
+        self.assertEqual(captured['json']['model_params'], {'temperature': 0.0})
+
+    def test_submit_private_job_reports_busy_service(self):
+
+        class FakeResponse:
+            status_code = 503
+            text = 'Service Unavailable'
+
+            def json(self):
+                return {'detail': 'Server is busy'}
+
+        class FakeHttpxClient:
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def post(self, url, json):
+                return FakeResponse()
+
+        config = ToolathlonServiceConfig(
+            server_host='toolathlon.example',
+            server_port=8080,
+            base_url='http://localhost:8000/v1',
+            model_name='local-model',
+        )
+
+        with patch('httpx.Client', FakeHttpxClient):
+            with self.assertRaisesRegex(RuntimeError, 'currently busy.*one evaluation job'):
+                ToolathlonServiceClient(config)._submit_job()
+
+    def test_submit_private_job_reports_rate_limit(self):
+
+        class FakeResponse:
+            status_code = 429
+            text = 'Too Many Requests'
+
+            def json(self):
+                return {'detail': 'Rate limit exceeded'}
+
+        class FakeHttpxClient:
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def post(self, url, json):
+                return FakeResponse()
+
+        config = ToolathlonServiceConfig(
+            server_host='toolathlon.example',
+            server_port=8080,
+            base_url='http://localhost:8000/v1',
+            model_name='local-model',
+        )
+
+        with patch('httpx.Client', FakeHttpxClient):
+            with self.assertRaisesRegex(RuntimeError, '180 minutes.*3 per IP'):
+                ToolathlonServiceClient(config)._submit_job()
+
+    def test_run_private_with_mock_service_flow(self) -> None:
+        calls = []
+        archive_bytes = _make_task_archive()
+
+        class FakeResponse:
+
+            def __init__(
+                self,
+                payload: Any = None,
+                content: bytes = b'',
+                status_code: int = 200,
+                headers: Optional[dict] = None,
+            ) -> None:
+                self.payload = payload
+                self.content = content
+                self.status_code = status_code
+                self.headers = headers or {}
+                self.text = json.dumps(payload) if payload is not None else ''
+
+            def raise_for_status(self) -> None:
+                if self.status_code >= 400:
+                    raise RuntimeError(f'HTTP {self.status_code}')
+
+            def json(self) -> Any:
+                return self.payload
+
+        class FakeHttpxClient:
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def __enter__(self) -> 'FakeHttpxClient':
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+                return False
+
+            def post(self, url: str, json: dict) -> FakeResponse:
+                calls.append(('post', url, json))
+                return FakeResponse({'job_id': 'job-1', 'client_id': 'client-1'})
+
+            def get(self, url: str, params: Optional[dict] = None, timeout: Optional[float] = None) -> FakeResponse:
+                calls.append(('get', url, params))
+                if url.endswith('/get_completed_tasks'):
+                    return FakeResponse({'completed_tasks': ['find-alita-paper']})
+                if url.endswith('/get_task_archive'):
+                    return FakeResponse(content=archive_bytes)
+                if url.endswith('/poll_job_status'):
+                    return FakeResponse({'status': 'completed'})
+                if url.endswith('/get_static_files'):
+                    return FakeResponse({
+                        'eval_stats.json': json.dumps({
+                            'passed': 1,
+                            'total': 1
+                        }),
+                        'eval_res_all.jsonl': json.dumps({
+                            'task': 'find-alita-paper',
+                            'pass': True
+                        }) + '\n',
+                    })
+                return FakeResponse(status_code=404, payload={'detail': 'not found'})
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = ToolathlonServiceConfig(
+                server_host='toolathlon.example',
+                server_port=8080,
+                base_url='http://localhost:8000/v1',
+                model_name='local-model',
+                api_key='secret-local-key',
+                task_list=['find-alita-paper'],
+                output_dir=Path(tmp_dir) / 'toolathlon',
+                poll_interval=0,
+            )
+
+            with patch('httpx.Client', FakeHttpxClient):
+                with patch.object(ToolathlonServiceClient, '_start_ws_client', return_value=object()) as start_ws:
+                    with patch.object(ToolathlonServiceClient, '_stop_process') as stop_process:
+                        result = ToolathlonServiceClient(config).run_private()
+
+            self.assertEqual(result['job_id'], 'job-1')
+            self.assertEqual(result['acc'], 1.0)
+            self.assertEqual(result['eval_stats'], {'passed': 1, 'total': 1})
+            self.assertEqual(result['task_results'], [{'task': 'find-alita-paper', 'pass': True}])
+            self.assertTrue((Path(tmp_dir) / 'toolathlon/finalpool/find-alita-paper/README.md').exists())
+            start_ws.assert_called_once_with('job-1')
+            stop_process.assert_called_once()
+
+        called_urls = [item[1] for item in calls]
+        self.assertIn('http://toolathlon.example:8080/submit_evaluation', called_urls)
+        self.assertIn('http://toolathlon.example:8080/get_completed_tasks', called_urls)
+        self.assertIn('http://toolathlon.example:8080/get_task_archive', called_urls)
+        self.assertIn('http://toolathlon.example:8080/poll_job_status', called_urls)
+        self.assertIn('http://toolathlon.example:8080/get_static_files', called_urls)
+
+
+def _make_task_archive() -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode='w:gz') as archive:
+        content = b'mock task archive'
+        info = tarfile.TarInfo('find-alita-paper/README.md')
+        info.size = len(content)
+        archive.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/benchmark/test_toolathlon_remote.py
+++ b/tests/benchmark/test_toolathlon_remote.py
@@ -1,0 +1,45 @@
+import os
+import tempfile
+import unittest
+
+from evalscope.config import TaskConfig
+from evalscope.constants import EvalType, JudgeStrategy
+from evalscope.run import run_task
+
+
+@unittest.skipUnless(
+    os.getenv('RUN_TOOLATHLON_REMOTE_SMOKE') == '1',
+    'Set RUN_TOOLATHLON_REMOTE_SMOKE=1 to run the Toolathlon official-service smoke test.',
+)
+class TestToolathlonRemoteSmoke(unittest.TestCase):
+
+    def test_toolathlon_private_find_alita_paper(self):
+        """Run one Toolathlon private-mode task against the official remote service."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            task_cfg = TaskConfig(
+                model=os.getenv('TOOLATHLON_LOCAL_MODEL', 'local-model'),
+                api_url=os.getenv('TOOLATHLON_LOCAL_BASE_URL', 'http://localhost:8000/v1'),
+                api_key=os.getenv('TOOLATHLON_LOCAL_API_KEY', 'dummy'),
+                eval_type=EvalType.OPENAI_API,
+                datasets=['toolathlon'],
+                dataset_args={
+                    'toolathlon': {
+                        'extra_params': {
+                            'task_list': ['find-alita-paper'],
+                            'workers': 1,
+                            'skip_container_restart': True,
+                            'timeout_seconds': 3600,
+                        }
+                    }
+                },
+                judge_strategy=JudgeStrategy.RULE,
+                limit=1,
+                eval_batch_size=1,
+                work_dir=tmp_dir,
+                no_timestamp=True,
+            )
+            run_task(task_cfg=task_cfg)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a `toolathlon` benchmark adapter that wraps the official Toolathlon private-mode evaluation service.
- Add a minimal service client, WebSocket relay entrypoint, optional dependency extra, generated benchmark docs/meta, and third-party usage docs for public and self-hosted service usage.
- Add mocked client/service flow coverage, EvalScope adapter smoke coverage, and an opt-in real remote smoke test.

## Notes

This is an official service wrapper, not a local reimplementation of Toolathlon MCP environments or scoring. EvalScope controls task selection, model endpoint configuration, polling, downloads, and reporting; the official Toolathlon service controls task containers, agent loop execution, and scoring.

## Validation

- `make docs-pipeline BENCHMARK="toolathlon" FORCE=1`
- `make docs-generate`
- `/Users/yunlin/miniconda3/bin/conda run -n eval python -m pytest tests/benchmark/test_toolathlon_client.py tests/benchmark/test_toolathlon_remote.py tests/benchmark/test_agent.py::TestAgentBenchmark::test_toolathlon -v -s -p no:warnings`
- `/Users/yunlin/miniconda3/bin/conda run -n eval make lint`
- `git diff --check`

Remote smoke against the public official service is included but skipped by default unless `RUN_TOOLATHLON_REMOTE_SMOKE=1` is set. A prior real submission attempt reached the official service boundary and received `HTTP 503 Service Unavailable`, which matches the documented single-job public service behavior.
