### PR TITLE
Add Claw-Eval benchmark adapter

### DIFF
--- a/docs/en/benchmarks/claw_eval.md
+++ b/docs/en/benchmarks/claw_eval.md
@@ -1,0 +1,141 @@
+# Claw-Eval
+
+
+## Overview
+
+Claw-Eval evaluates assistant agents on realistic personal-assistant workflows that require tool use, file and fixture
+access, multimodal inputs, and simulated user interactions. EvalScope runs the pinned official Claw-Eval Python runner,
+Docker sandbox, and graders while exposing each Claw-Eval task as a normal EvalScope sample for caching, repeats,
+parallel execution, reporting, and dashboard trace review.
+
+## Task Description
+
+- **Task Type**: Agentic personal-assistant tasks with tool use, sandbox files, multimodal fixtures, and optional
+  simulated user turns.
+- **Dataset**: `claw-eval/Claw-Eval` on ModelScope.
+- **Subsets**: `general`, `multimodal`, and `multi_turn`; the current ModelScope manifest contains 300 tasks
+  (161 general, 101 multimodal, and 38 multi_turn). Use `subset_list` to select subsets.
+- **Output**: Official Claw-Eval scores and JSONL traces, EvalScope sample-level reviews, grouped summary metrics, and
+  dashboard-rendered agent traces.
+
+## Evaluation Notes
+
+- Requires Python 3.11+ and the official package installed from the pinned source commit:
+  `pip install "claw-eval[sandbox,mock,web] @
+  git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0"`.
+- The installed package provides the Claw-Eval runner APIs. EvalScope also caches the same pinned source archive because
+  `tasks/` and `Dockerfile.agent` are runtime assets, then loads the task manifest and fixtures from ModelScope.
+- Full fixtures are downloaded from ModelScope (`data/fixtures.tar.gz`) and linked into the official task tree before
+  execution. The archive is large; use `limit` or `extra_params.task_ids` for smoke runs.
+- Each selected Claw-Eval task is one EvalScope sample. Official scoring runs once per sample; use EvalScope `repeats`
+  for repeated trials per task and `eval_batch_size` for task-level worker concurrency.
+- Claw-Eval runs with the official Docker sandbox image. If `claw-eval-agent:latest` is missing locally, EvalScope
+  builds it automatically from the cached official `Dockerfile.agent`. The first run can be slow.
+- EvalScope `use_cache` resumes completed task-level samples. Claw-Eval trace JSONL files are stored under
+  `outputs/.../claw_eval/<split>/traces` and converted to EvalScope agent traces for dashboard visualization.
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `claw_eval` |
+| **Dataset ID** | [claw-eval/Claw-Eval](https://modelscope.cn/datasets/claw-eval/Claw-Eval/summary) |
+| **Paper** | N/A |
+| **Tags** | `Agent`, `MultiModal`, `MultiTurn` |
+| **Metrics** | `avg_score`, `pass_at_k`, `pass_hat_k`, `error_rate` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 300 |
+| Prompt Length (Mean) | 47.36 chars |
+| Prompt Length (Min/Max) | 30 / 60 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `general` | 161 | 46.47 | 34 | 58 |
+| `multimodal` | 101 | 49.75 | 30 | 60 |
+| `multi_turn` | 38 | 44.79 | 35 | 51 |
+
+## Sample Example
+
+**Subset**: `general`
+
+```json
+{
+  "input": [
+    {
+      "id": "a34b7f6b",
+      "content": "Run Claw-Eval task T001zh_email_triage."
+    }
+  ],
+  "target": "",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "general",
+  "metadata": {
+    "task_id": "T001zh_email_triage",
+    "split": "general",
+    "task_name": "",
+    "difficulty": "",
+    "dataset_id": "claw-eval/Claw-Eval",
+    "dataset_hub": "modelscope"
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{question}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `task_ids` | `list` | `[]` | Optional exact Claw-Eval task ids to run after split filtering. |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets claw_eval \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['claw_eval'],
+    dataset_args={
+        'claw_eval': {
+            # subset_list: ['general', 'multimodal', 'multi_turn']  # optional, evaluate specific subsets
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/agent.md
+++ b/docs/en/get_started/supported_dataset/agent.md
@@ -7,6 +7,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 | `bfcl_v3` | [BFCL-v3](../../benchmarks/bfcl_v3.md) | `Agent`, `FunctionCalling` |
 | `bfcl_v4` | [BFCL-v4](../../benchmarks/bfcl_v4.md) | `Agent`, `FunctionCalling` |
 | `browsecomp` | [BrowseComp](../../benchmarks/browsecomp.md) | `Agent`, `Knowledge`, `QA` |
+| `claw_eval` | [Claw-Eval](../../benchmarks/claw_eval.md) | `Agent`, `MultiModal`, `MultiTurn` |
 | `deep_swe` | [DeepSWE](../../benchmarks/deep_swe.md) | `Agent`, `Coding`, `MultiTurn` |
 | `gaia` | [GAIA](../../benchmarks/gaia.md) | `Agent`, `MultiTurn`, `Reasoning` |
 | `gdpval` | [GDPval](../../benchmarks/gdpval.md) | `Agent`, `Knowledge`, `MultiTurn` |
@@ -38,6 +39,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 ../../benchmarks/bfcl_v3.md
 ../../benchmarks/bfcl_v4.md
 ../../benchmarks/browsecomp.md
+../../benchmarks/claw_eval.md
 ../../benchmarks/deep_swe.md
 ../../benchmarks/gaia.md
 ../../benchmarks/gdpval.md

--- a/docs/zh/benchmarks/claw_eval.md
+++ b/docs/zh/benchmarks/claw_eval.md
@@ -1,0 +1,128 @@
+# Claw-Eval
+
+
+## 概述
+
+Claw-Eval 用于评估助手代理在真实个人助理工作流中的表现，这些工作流需要使用工具、访问文件和固定资源（fixtures）、处理多模态输入，并支持模拟用户交互。EvalScope 运行官方指定版本的 Claw-Eval Python 执行器、Docker 沙箱和评分器，同时将每个 Claw-Eval 任务作为标准的 EvalScope 样本进行处理，以支持缓存、重复执行、并行运行、报告生成以及仪表盘轨迹审查。
+
+## 任务描述
+
+- **任务类型**：涉及工具调用、沙箱文件、多模态固定资源及可选模拟用户轮次的代理型个人助理任务。
+- **数据集**：ModelScope 上的 `claw-eval/Claw-Eval`。
+- **子集**：`general`、`multimodal` 和 `multi_turn`；当前 ModelScope 清单包含 300 个任务（161 个 general、101 个 multimodal、38 个 multi_turn）。可通过 `subset_list` 选择子集。
+- **输出**：官方 Claw-Eval 评分与 JSONL 轨迹、EvalScope 样本级评审结果、分组汇总指标，以及仪表盘渲染的代理轨迹。
+
+## 评估说明
+
+- 需要 Python 3.11+，并从指定源代码提交安装官方包：
+  `pip install "claw-eval[sandbox,mock,web] @ git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0"`。
+- 安装的包提供 Claw-Eval 执行器 API。EvalScope 同时缓存相同版本的源代码归档，因为 `tasks/` 和 `Dockerfile.agent` 是运行时资产，随后从 ModelScope 加载任务清单和固定资源。
+- 完整的固定资源从 ModelScope 下载（`data/fixtures.tar.gz`），并在执行前链接到官方任务目录中。该归档较大；建议在试运行时使用 `limit` 或 `extra_params.task_ids` 参数。
+- 每个选定的 Claw-Eval 任务对应一个 EvalScope 样本。官方评分对每个样本仅运行一次；如需对同一任务进行多次试验，请使用 EvalScope 的 `repeats` 参数；如需任务级并发执行，请使用 `eval_batch_size`。
+- Claw-Eval 使用官方 Docker 沙箱镜像运行。若本地缺少 `claw-eval-agent:latest` 镜像，EvalScope 会自动基于缓存的官方 `Dockerfile.agent` 构建。首次运行可能较慢。
+- EvalScope 的 `use_cache` 功能可恢复已完成的任务级样本。Claw-Eval 轨迹 JSONL 文件存储在 `outputs/.../claw_eval/<split>/traces` 目录下，并转换为 EvalScope 代理轨迹以供仪表盘可视化。
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `claw_eval` |
+| **数据集ID** | [claw-eval/Claw-Eval](https://modelscope.cn/datasets/claw-eval/Claw-Eval/summary) |
+| **论文** | 无 |
+| **标签** | `Agent`, `MultiModal`, `MultiTurn` |
+| **指标** | `avg_score`, `pass_at_k`, `pass_hat_k`, `error_rate` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 300 |
+| 提示词长度（平均） | 47.36 字符 |
+| 提示词长度（最小/最大） | 30 / 60 字符 |
+
+**各子集统计数据：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `general` | 161 | 46.47 | 34 | 58 |
+| `multimodal` | 101 | 49.75 | 30 | 60 |
+| `multi_turn` | 38 | 44.79 | 35 | 51 |
+
+## 样例示例
+
+**子集**: `general`
+
+```json
+{
+  "input": [
+    {
+      "id": "a34b7f6b",
+      "content": "Run Claw-Eval task T001zh_email_triage."
+    }
+  ],
+  "target": "",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "general",
+  "metadata": {
+    "task_id": "T001zh_email_triage",
+    "split": "general",
+    "task_name": "",
+    "difficulty": "",
+    "dataset_id": "claw-eval/Claw-Eval",
+    "dataset_hub": "modelscope"
+  }
+}
+```
+
+## 提示模板
+
+**提示模板：**
+```text
+{question}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `task_ids` | `list` | `[]` | 可选，在子集过滤后精确指定要运行的 Claw-Eval 任务 ID 列表。 |
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets claw_eval \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['claw_eval'],
+    dataset_args={
+        'claw_eval': {
+            # subset_list: ['general', 'multimodal', 'multi_turn']  # 可选，评估特定子集
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/agent.md
+++ b/docs/zh/get_started/supported_dataset/agent.md
@@ -7,6 +7,7 @@
 | `bfcl_v3` | [BFCL-v3](../../benchmarks/bfcl_v3.md) | `Agent`, `FunctionCalling` |
 | `bfcl_v4` | [BFCL-v4](../../benchmarks/bfcl_v4.md) | `Agent`, `FunctionCalling` |
 | `browsecomp` | [BrowseComp](../../benchmarks/browsecomp.md) | `Agent`, `Knowledge`, `QA` |
+| `claw_eval` | [Claw-Eval](../../benchmarks/claw_eval.md) | `Agent`, `MultiModal`, `MultiTurn` |
 | `deep_swe` | [DeepSWE](../../benchmarks/deep_swe.md) | `Agent`, `Coding`, `MultiTurn` |
 | `gaia` | [GAIA](../../benchmarks/gaia.md) | `Agent`, `MultiTurn`, `Reasoning` |
 | `gdpval` | [GDPval](../../benchmarks/gdpval.md) | `Agent`, `Knowledge`, `MultiTurn` |
@@ -38,6 +39,7 @@
 ../../benchmarks/bfcl_v3.md
 ../../benchmarks/bfcl_v4.md
 ../../benchmarks/browsecomp.md
+../../benchmarks/claw_eval.md
 ../../benchmarks/deep_swe.md
 ../../benchmarks/gaia.md
 ../../benchmarks/gdpval.md

--- a/evalscope/benchmarks/_meta/claw_eval.json
+++ b/evalscope/benchmarks/_meta/claw_eval.json
@@ -1,0 +1,112 @@
+{
+  "meta": {
+    "pretty_name": "Claw-Eval",
+    "dataset_id": "claw-eval/Claw-Eval",
+    "paper_url": null,
+    "tags": [
+      "Agent",
+      "MultiModal",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "avg_score",
+      "pass_at_k",
+      "pass_hat_k",
+      "error_rate"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "general",
+      "multimodal",
+      "multi_turn"
+    ],
+    "description": "\n## Overview\n\nClaw-Eval evaluates assistant agents on realistic personal-assistant workflows that require tool use, file and fixture\naccess, multimodal inputs, and simulated user interactions. EvalScope runs the pinned official Claw-Eval Python runner,\nDocker sandbox, and graders while exposing each Claw-Eval task as a normal EvalScope sample for caching, repeats,\nparallel execution, reporting, and dashboard trace review.\n\n## Task Description\n\n- **Task Type**: Agentic personal-assistant tasks with tool use, sandbox files, multimodal fixtures, and optional\n  simulated user turns.\n- **Dataset**: `claw-eval/Claw-Eval` on ModelScope.\n- **Subsets**: `general`, `multimodal`, and `multi_turn`; the current ModelScope manifest contains 300 tasks\n  (161 general, 101 multimodal, and 38 multi_turn). Use `subset_list` to select subsets.\n- **Output**: Official Claw-Eval scores and JSONL traces, EvalScope sample-level reviews, grouped summary metrics, and\n  dashboard-rendered agent traces.\n\n## Evaluation Notes\n\n- Requires Python 3.11+ and the official package installed from the pinned source commit:\n  `pip install \"claw-eval[sandbox,mock,web] @\n  git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0\"`.\n- The installed package provides the Claw-Eval runner APIs. EvalScope also caches the same pinned source archive because\n  `tasks/` and `Dockerfile.agent` are runtime assets, then loads the task manifest and fixtures from ModelScope.\n- Full fixtures are downloaded from ModelScope (`data/fixtures.tar.gz`) and linked into the official task tree before\n  execution. The archive is large; use `limit` or `extra_params.task_ids` for smoke runs.\n- Each selected Claw-Eval task is one EvalScope sample. Official scoring runs once per sample; use EvalScope `repeats`\n  for repeated trials per task and `eval_batch_size` for task-level worker concurrency.\n- Claw-Eval runs with the official Docker sandbox image. If `claw-eval-agent:latest` is missing locally, EvalScope\n  builds it automatically from the cached official `Dockerfile.agent`. The first run can be slow.\n- EvalScope `use_cache` resumes completed task-level samples. Claw-Eval trace JSONL files are stored under\n  `outputs/.../claw_eval/<split>/traces` and converted to EvalScope agent traces for dashboard visualization.\n",
+    "prompt_template": "{question}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "task_ids": {
+        "type": "list",
+        "description": "Optional exact Claw-Eval task ids to run after split filtering.",
+        "value": []
+      }
+    },
+    "sandbox_config": {},
+    "category": "agent"
+  },
+  "statistics": {
+    "total_samples": 300,
+    "subset_stats": [
+      {
+        "name": "general",
+        "sample_count": 161,
+        "prompt_length_mean": 46.47,
+        "prompt_length_min": 34,
+        "prompt_length_max": 58,
+        "prompt_length_std": 4.87,
+        "target_length_mean": null
+      },
+      {
+        "name": "multimodal",
+        "sample_count": 101,
+        "prompt_length_mean": 49.75,
+        "prompt_length_min": 30,
+        "prompt_length_max": 60,
+        "prompt_length_std": 5.97,
+        "target_length_mean": null
+      },
+      {
+        "name": "multi_turn",
+        "sample_count": 38,
+        "prompt_length_mean": 44.79,
+        "prompt_length_min": 35,
+        "prompt_length_max": 51,
+        "prompt_length_std": 3.68,
+        "target_length_mean": null
+      }
+    ],
+    "prompt_length": {
+      "mean": 47.36,
+      "min": 30,
+      "max": 60,
+      "std": 5.43
+    },
+    "target_length_mean": null,
+    "computed_at": "2026-07-14T16:59:09.900658"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "a34b7f6b",
+          "content": "Run Claw-Eval task T001zh_email_triage."
+        }
+      ],
+      "target": "",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "general",
+      "metadata": {
+        "task_id": "T001zh_email_triage",
+        "split": "general",
+        "task_name": "",
+        "difficulty": "",
+        "dataset_id": "claw-eval/Claw-Eval",
+        "dataset_hub": "modelscope"
+      }
+    },
+    "subset": "general",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# Claw-Eval\n\n\n## Overview\n\nClaw-Eval evaluates assistant agents on realistic personal-assistant workflows that require tool use, file and fixture\naccess, multimodal inputs, and simulated user interactions. EvalScope runs the pinned official Claw-Eval Python runner,\nDocker sandbox, and graders while exposing each Claw-Eval task as a normal EvalScope sample for caching, repeats,\nparallel execution, reporting, and dashboard trace review.\n\n## Task Description\n\n- **Task Type**: Agentic personal-assistant tasks with tool use, sandbox files, multimodal fixtures, and optional\n  simulated user turns.\n- **Dataset**: `claw-eval/Claw-Eval` on ModelScope.\n- **Subsets**: `general`, `multimodal`, and `multi_turn`; the current ModelScope manifest contains 300 tasks\n  (161 general, 101 multimodal, and 38 multi_turn). Use `subset_list` to select subsets.\n- **Output**: Official Claw-Eval scores and JSONL traces, EvalScope sample-level reviews, grouped summary metrics, and\n  dashboard-rendered agent traces.\n\n## Evaluation Notes\n\n- Requires Python 3.11+ and the official package installed from the pinned source commit:\n  `pip install \"claw-eval[sandbox,mock,web] @\n  git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0\"`.\n- The installed package provides the Claw-Eval runner APIs. EvalScope also caches the same pinned source archive because\n  `tasks/` and `Dockerfile.agent` are runtime assets, then loads the task manifest and fixtures from ModelScope.\n- Full fixtures are downloaded from ModelScope (`data/fixtures.tar.gz`) and linked into the official task tree before\n  execution. The archive is large; use `limit` or `extra_params.task_ids` for smoke runs.\n- Each selected Claw-Eval task is one EvalScope sample. Official scoring runs once per sample; use EvalScope `repeats`\n  for repeated trials per task and `eval_batch_size` for task-level worker concurrency.\n- Claw-Eval runs with the official Docker sandbox image. If `claw-eval-agent:latest` is missing locally, EvalScope\n  builds it automatically from the cached official `Dockerfile.agent`. The first run can be slow.\n- EvalScope `use_cache` resumes completed task-level samples. Claw-Eval trace JSONL files are stored under\n  `outputs/.../claw_eval/<split>/traces` and converted to EvalScope agent traces for dashboard visualization.\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `claw_eval` |\n| **Dataset ID** | [claw-eval/Claw-Eval](https://modelscope.cn/datasets/claw-eval/Claw-Eval/summary) |\n| **Paper** | N/A |\n| **Tags** | `Agent`, `MultiModal`, `MultiTurn` |\n| **Metrics** | `avg_score`, `pass_at_k`, `pass_hat_k`, `error_rate` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 300 |\n| Prompt Length (Mean) | 47.36 chars |\n| Prompt Length (Min/Max) | 30 / 60 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `general` | 161 | 46.47 | 34 | 58 |\n| `multimodal` | 101 | 49.75 | 30 | 60 |\n| `multi_turn` | 38 | 44.79 | 35 | 51 |\n\n## Sample Example\n\n**Subset**: `general`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"a34b7f6b\",\n      \"content\": \"Run Claw-Eval task T001zh_email_triage.\"\n    }\n  ],\n  \"target\": \"\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"general\",\n  \"metadata\": {\n    \"task_id\": \"T001zh_email_triage\",\n    \"split\": \"general\",\n    \"task_name\": \"\",\n    \"difficulty\": \"\",\n    \"dataset_id\": \"claw-eval/Claw-Eval\",\n    \"dataset_hub\": \"modelscope\"\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{question}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `task_ids` | `list` | `[]` | Optional exact Claw-Eval task ids to run after split filtering. |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets claw_eval \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['claw_eval'],\n    dataset_args={\n        'claw_eval': {\n            # subset_list: ['general', 'multimodal', 'multi_turn']  # optional, evaluate specific subsets\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# Claw-Eval\n\n\n## 概述\n\nClaw-Eval 用于评估助手代理在真实个人助理工作流中的表现，这些工作流需要使用工具、访问文件和固定资源（fixtures）、处理多模态输入，并支持模拟用户交互。EvalScope 运行官方指定版本的 Claw-Eval Python 执行器、Docker 沙箱和评分器，同时将每个 Claw-Eval 任务作为标准的 EvalScope 样本进行处理，以支持缓存、重复执行、并行运行、报告生成以及仪表盘轨迹审查。\n\n## 任务描述\n\n- **任务类型**：涉及工具调用、沙箱文件、多模态固定资源及可选模拟用户轮次的代理型个人助理任务。\n- **数据集**：ModelScope 上的 `claw-eval/Claw-Eval`。\n- **子集**：`general`、`multimodal` 和 `multi_turn`；当前 ModelScope 清单包含 300 个任务（161 个 general、101 个 multimodal、38 个 multi_turn）。可通过 `subset_list` 选择子集。\n- **输出**：官方 Claw-Eval 评分与 JSONL 轨迹、EvalScope 样本级评审结果、分组汇总指标，以及仪表盘渲染的代理轨迹。\n\n## 评估说明\n\n- 需要 Python 3.11+，并从指定源代码提交安装官方包：\n  `pip install \"claw-eval[sandbox,mock,web] @ git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0\"`。\n- 安装的包提供 Claw-Eval 执行器 API。EvalScope 同时缓存相同版本的源代码归档，因为 `tasks/` 和 `Dockerfile.agent` 是运行时资产，随后从 ModelScope 加载任务清单和固定资源。\n- 完整的固定资源从 ModelScope 下载（`data/fixtures.tar.gz`），并在执行前链接到官方任务目录中。该归档较大；建议在试运行时使用 `limit` 或 `extra_params.task_ids` 参数。\n- 每个选定的 Claw-Eval 任务对应一个 EvalScope 样本。官方评分对每个样本仅运行一次；如需对同一任务进行多次试验，请使用 EvalScope 的 `repeats` 参数；如需任务级并发执行，请使用 `eval_batch_size`。\n- Claw-Eval 使用官方 Docker 沙箱镜像运行。若本地缺少 `claw-eval-agent:latest` 镜像，EvalScope 会自动基于缓存的官方 `Dockerfile.agent` 构建。首次运行可能较慢。\n- EvalScope 的 `use_cache` 功能可恢复已完成的任务级样本。Claw-Eval 轨迹 JSONL 文件存储在 `outputs/.../claw_eval/<split>/traces` 目录下，并转换为 EvalScope 代理轨迹以供仪表盘可视化。\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `claw_eval` |\n| **数据集ID** | [claw-eval/Claw-Eval](https://modelscope.cn/datasets/claw-eval/Claw-Eval/summary) |\n| **论文** | 无 |\n| **标签** | `Agent`, `MultiModal`, `MultiTurn` |\n| **指标** | `avg_score`, `pass_at_k`, `pass_hat_k`, `error_rate` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 300 |\n| 提示词长度（平均） | 47.36 字符 |\n| 提示词长度（最小/最大） | 30 / 60 字符 |\n\n**各子集统计数据：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `general` | 161 | 46.47 | 34 | 58 |\n| `multimodal` | 101 | 49.75 | 30 | 60 |\n| `multi_turn` | 38 | 44.79 | 35 | 51 |\n\n## 样例示例\n\n**子集**: `general`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"a34b7f6b\",\n      \"content\": \"Run Claw-Eval task T001zh_email_triage.\"\n    }\n  ],\n  \"target\": \"\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"general\",\n  \"metadata\": {\n    \"task_id\": \"T001zh_email_triage\",\n    \"split\": \"general\",\n    \"task_name\": \"\",\n    \"difficulty\": \"\",\n    \"dataset_id\": \"claw-eval/Claw-Eval\",\n    \"dataset_hub\": \"modelscope\"\n  }\n}\n```\n\n## 提示模板\n\n**提示模板：**\n```text\n{question}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `task_ids` | `list` | `[]` | 可选，在子集过滤后精确指定要运行的 Claw-Eval 任务 ID 列表。 |\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets claw_eval \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['claw_eval'],\n    dataset_args={\n        'claw_eval': {\n            # subset_list: ['general', 'multimodal', 'multi_turn']  # 可选，评估特定子集\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "96fad09d5529737f9cd0025e2494c9cd",
+    "needs_translation": false
+  },
+  "updated_at": "2026-07-14T17:44:31.169240",
+  "translation_updated_at": "2026-07-14T17:44:38"
+}

--- a/evalscope/benchmarks/claw_eval/__init__.py
+++ b/evalscope/benchmarks/claw_eval/__init__.py
@@ -1,0 +1,3 @@
+from .claw_eval_adapter import ClawEvalAdapter
+
+__all__ = ['ClawEvalAdapter']

--- a/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
+++ b/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
@@ -4,11 +4,12 @@ import queue
 import sys
 import threading
 from collections import defaultdict
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
-from evalscope.api.dataset import DatasetDict, Sample, build_dataset_from_records
+from evalscope.api.dataset import DatasetDict, Sample, build_dataset_dict_from_record_map
 from evalscope.api.evaluator import InferenceResult
 from evalscope.api.messages.chat_message import ChatMessageUser
 from evalscope.api.metric import AggScore, SampleScore, Score
@@ -134,26 +135,19 @@ class ClawEvalAdapter(AgentAdapter):
                 normalized['split'] = split
                 records_by_split[split].append(normalized)
 
-        datasets: Dict[str, Any] = {}
-        for split, split_records in records_by_split.items():
-            if not split_records:
-                continue
-
-            datasets[split] = build_dataset_from_records(
-                records=split_records,
-                sample_fields=self.record_to_sample,
-                name=f'claw_eval_{split}',
-                location=self.dataset_id,
-                limit=self.limit,
-                repeats=self.repeats,
-                shuffle=self.shuffle,
-                seed=None,
-            )
-
-        if not datasets:
+        records_by_split = {split: split_records for split, split_records in records_by_split.items() if split_records}
+        if not records_by_split:
             raise ValueError('No Claw-Eval tasks selected. Check splits, task_ids, and limit.')
 
-        return DatasetDict(datasets), None
+        return build_dataset_dict_from_record_map(
+            record_map=records_by_split,
+            sample_fields=self.record_to_sample,
+            location=self.dataset_id,
+            limit=self.limit,
+            repeats=self.repeats,
+            shuffle=self.shuffle,
+            seed=None,
+        ), None
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
         task_id = str(record.get('task_id') or '').strip()
@@ -208,7 +202,7 @@ class ClawEvalAdapter(AgentAdapter):
         )
         write_claw_eval_config(config_path, official_config)
 
-        port_slot = self._acquire_port_slot()
+        port_slot = self._get_port_slots().get()
         try:
             result = run_claw_eval_task(
                 task_dir=tasks_dir / task_id,
@@ -224,7 +218,7 @@ class ClawEvalAdapter(AgentAdapter):
                 proxy=os.environ.get('CLAW_EVAL_PROXY') or None,
             )
         finally:
-            self._release_port_slot(port_slot)
+            self._get_port_slots().put(port_slot)
             write_claw_eval_config(config_path, self._redact_official_config(official_config))
         sample.metadata['claw_eval_result'] = result
 
@@ -380,7 +374,7 @@ class ClawEvalAdapter(AgentAdapter):
         return getattr(model.api, 'api_key', None)
 
     def _redact_official_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
-        redacted = json.loads(json.dumps(config))
+        redacted = deepcopy(config)
         for section in ('model', 'judge'):
             section_config = redacted.get(section)
             if isinstance(section_config, dict) and section_config.get('api_key'):
@@ -407,12 +401,6 @@ class ClawEvalAdapter(AgentAdapter):
                 ensure_claw_eval_sandbox_image(self._assets.repo_root)
                 self._image_prepared = True
             return self._assets
-
-    def _acquire_port_slot(self) -> int:
-        return self._get_port_slots().get()
-
-    def _release_port_slot(self, slot: int) -> None:
-        self._get_port_slots().put(slot)
 
     def _get_port_slots(self) -> queue.Queue[int]:
         with self._port_slots_lock:

--- a/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
+++ b/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
@@ -301,10 +301,7 @@ class ClawEvalAdapter(AgentAdapter):
                 num=num_groups
             ),
             AggScore(
-                score=sum(group_pass_at) / num_groups,
-                metric_name='pass_at_k',
-                aggregation_name='mean',
-                num=num_groups
+                score=sum(group_pass_at) / num_groups, metric_name='pass_at_k', aggregation_name='mean', num=num_groups
             ),
             AggScore(
                 score=sum(group_pass_hat) / num_groups,
@@ -313,10 +310,7 @@ class ClawEvalAdapter(AgentAdapter):
                 num=num_groups
             ),
             AggScore(
-                score=sample_errors / num_samples,
-                metric_name='error_rate',
-                aggregation_name='mean',
-                num=num_samples
+                score=sample_errors / num_samples, metric_name='error_rate', aggregation_name='mean', num=num_samples
             ),
         ]
 
@@ -388,9 +382,9 @@ class ClawEvalAdapter(AgentAdapter):
     def _redact_official_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
         redacted = json.loads(json.dumps(config))
         for section in ('model', 'judge'):
-            api_key = redacted.get(section, {}).get('api_key')
-            if api_key:
-                redacted[section]['api_key'] = '<redacted>'
+            section_config = redacted.get(section)
+            if isinstance(section_config, dict) and section_config.get('api_key'):
+                section_config['api_key'] = '<redacted>'
         return redacted
 
     def _selected_splits(self) -> List[str]:

--- a/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
+++ b/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
@@ -1,0 +1,430 @@
+import json
+import os
+import queue
+import sys
+import threading
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
+from evalscope.api.dataset import DatasetDict, Sample, build_dataset_from_records
+from evalscope.api.evaluator import InferenceResult
+from evalscope.api.messages.chat_message import ChatMessageUser
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.model import Model, ModelOutput
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import DEFAULT_EVALSCOPE_CACHE_DIR, HubType, JudgeStrategy, Tags
+from evalscope.utils.import_utils import check_import
+from evalscope.utils.logger import get_logger
+from .utils import (
+    DEFAULT_CLAW_EVAL_DATASET_ID,
+    DEFAULT_CLAW_EVAL_PACKAGE,
+    ClawEvalAssets,
+    ensure_claw_eval_sandbox_image,
+    load_claw_eval_trace,
+    load_task_manifest,
+    materialize_task_root,
+    prepare_claw_eval_assets,
+    run_claw_eval_task,
+    write_claw_eval_config,
+)
+
+logger = get_logger()
+
+_DEFAULT_SPLITS = ['general', 'multimodal', 'multi_turn']
+
+_EXTRA_PARAMS = {
+    'task_ids': {
+        'type': 'list',
+        'description': 'Optional exact Claw-Eval task ids to run after split filtering.',
+        'value': [],
+    },
+}
+
+_DESCRIPTION = """
+## Overview
+
+Claw-Eval evaluates assistant agents on realistic personal-assistant workflows that require tool use, file and fixture
+access, multimodal inputs, and simulated user interactions. EvalScope runs the pinned official Claw-Eval Python runner,
+Docker sandbox, and graders while exposing each Claw-Eval task as a normal EvalScope sample for caching, repeats,
+parallel execution, reporting, and dashboard trace review.
+
+## Task Description
+
+- **Task Type**: Agentic personal-assistant tasks with tool use, sandbox files, multimodal fixtures, and optional
+  simulated user turns.
+- **Dataset**: `claw-eval/Claw-Eval` on ModelScope.
+- **Subsets**: `general`, `multimodal`, and `multi_turn`; the current ModelScope manifest contains 300 tasks
+  (161 general, 101 multimodal, and 38 multi_turn). Use `subset_list` to select subsets.
+- **Output**: Official Claw-Eval scores and JSONL traces, EvalScope sample-level reviews, grouped summary metrics, and
+  dashboard-rendered agent traces.
+
+## Evaluation Notes
+
+- Requires Python 3.11+ and the official package installed from the pinned source commit:
+  `pip install "claw-eval[sandbox,mock,web] @
+  git+https://github.com/claw-eval/claw-eval.git@d3f02d4938ab0832377d90535013def2b1a2fdc0"`.
+- The installed package provides the Claw-Eval runner APIs. EvalScope also caches the same pinned source archive because
+  `tasks/` and `Dockerfile.agent` are runtime assets, then loads the task manifest and fixtures from ModelScope.
+- Full fixtures are downloaded from ModelScope (`data/fixtures.tar.gz`) and linked into the official task tree before
+  execution. The archive is large; use `limit` or `extra_params.task_ids` for smoke runs.
+- Each selected Claw-Eval task is one EvalScope sample. Official scoring runs once per sample; use EvalScope `repeats`
+  for repeated trials per task and `eval_batch_size` for task-level worker concurrency.
+- Claw-Eval runs with the official Docker sandbox image. If `claw-eval-agent:latest` is missing locally, EvalScope
+  builds it automatically from the cached official `Dockerfile.agent`. The first run can be slow.
+- EvalScope `use_cache` resumes completed task-level samples. Claw-Eval trace JSONL files are stored under
+  `outputs/.../claw_eval/<split>/traces` and converted to EvalScope agent traces for dashboard visualization.
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='claw_eval',
+        pretty_name='Claw-Eval',
+        dataset_id=DEFAULT_CLAW_EVAL_DATASET_ID,
+        tags=[Tags.AGENT, Tags.MULTI_MODAL, Tags.MULTI_TURN],
+        description=_DESCRIPTION,
+        metric_list=['avg_score', 'pass_at_k', 'pass_hat_k', 'error_rate'],
+        aggregation='mean',
+        eval_split='test',
+        subset_list=_DEFAULT_SPLITS,
+        default_subset='general',
+        prompt_template='{question}',
+        extra_params=_EXTRA_PARAMS,
+    )
+)
+class ClawEvalAdapter(AgentAdapter):
+    """EvalScope wrapper for the official Claw-Eval runner."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._check_runtime()
+        self._assets: Optional[ClawEvalAssets] = None
+        self._assets_lock = threading.Lock()
+        self._image_prepared = False
+        self._port_slots: Optional[queue.Queue[int]] = None
+        self._port_slots_lock = threading.Lock()
+
+    def load(self) -> tuple[DatasetDict, None]:
+        selected_splits = self._selected_splits()
+        task_ids = self.extra_params.get('task_ids') or []
+        if isinstance(task_ids, str):
+            task_ids_filter = {task_id.strip() for task_id in task_ids.split(',') if task_id.strip()}
+        else:
+            task_ids_filter = {str(task_id).strip() for task_id in task_ids if str(task_id).strip()}
+        records = load_task_manifest(
+            dataset_id=self.dataset_id,
+            data_source=self.dataset_hub or HubType.MODELSCOPE,
+            splits=selected_splits,
+            force_redownload=self.force_redownload,
+        )
+
+        records_by_split: Dict[str, List[Dict[str, Any]]] = {split: [] for split in selected_splits}
+        for record in records:
+            task_id = str(record.get('task_id') or '').strip()
+            if not task_id:
+                continue
+            if task_ids_filter and task_id not in task_ids_filter:
+                continue
+            split = str(record.get('split') or '').strip()
+            if split in records_by_split:
+                normalized = dict(record)
+                normalized['task_id'] = task_id
+                normalized['split'] = split
+                records_by_split[split].append(normalized)
+
+        datasets: Dict[str, Any] = {}
+        for split, split_records in records_by_split.items():
+            if not split_records:
+                continue
+
+            datasets[split] = build_dataset_from_records(
+                records=split_records,
+                sample_fields=self.record_to_sample,
+                name=f'claw_eval_{split}',
+                location=self.dataset_id,
+                limit=self.limit,
+                repeats=self.repeats,
+                shuffle=self.shuffle,
+                seed=None,
+            )
+
+        if not datasets:
+            raise ValueError('No Claw-Eval tasks selected. Check splits, task_ids, and limit.')
+
+        return DatasetDict(datasets), None
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        task_id = str(record.get('task_id') or '').strip()
+        split = str(record.get('split') or '').strip()
+        task_name = str(record.get('task_name') or record.get('name') or '')
+        return Sample(
+            input=[ChatMessageUser(content=f'Run Claw-Eval task {task_id}.')],
+            target='',
+            subset_key=split,
+            metadata={
+                'task_id': task_id,
+                'split': split,
+                'task_name': task_name,
+                'difficulty': record.get('difficulty') or '',
+                'dataset_id': self.dataset_id,
+                'dataset_hub': self.dataset_hub,
+            },
+        )
+
+    def _on_inference(self, model: Model, sample: Sample) -> InferenceResult:
+        selected_split = str(sample.metadata.get('split') or 'default')
+        task_id = str(sample.metadata.get('task_id') or '').strip()
+        if not task_id:
+            raise ValueError('Claw-Eval sample is missing task_id metadata.')
+
+        output_root = (Path(self.output_dir) / 'claw_eval' / selected_split).resolve()
+        output_root.mkdir(parents=True, exist_ok=True)
+
+        assets = self._prepare_assets_once()
+        runtime_root = output_root / 'runtime' / f'{sample.id}_{task_id}'
+        tasks_dir = materialize_task_root(
+            source_tasks_dir=assets.tasks_dir,
+            selected_task_ids=[task_id],
+            output_root=runtime_root,
+        )
+        config_path = runtime_root / 'config.yaml'
+        trace_root = output_root / 'traces'
+        api_key = self._resolve_api_key(model)
+        base_url = self._resolve_base_url(model)
+        judge_args = self._task_config.judge_model_args or {}
+        judge_model = judge_args.get('model_id')
+        no_judge = self._task_config.judge_strategy == JudgeStrategy.RULE
+        official_config = self._build_official_config(
+            model=model,
+            tasks_dir=tasks_dir,
+            trace_root=trace_root,
+            api_key=api_key,
+            base_url=base_url,
+            judge_args=judge_args,
+            judge_model=judge_model,
+            no_judge=no_judge,
+        )
+        write_claw_eval_config(config_path, official_config)
+
+        port_slot = self._acquire_port_slot()
+        try:
+            result = run_claw_eval_task(
+                task_dir=tasks_dir / task_id,
+                config_path=config_path,
+                trace_root=trace_root,
+                repo_root=assets.repo_root,
+                model_id=model.name,
+                api_key=api_key,
+                base_url=base_url,
+                port_offset=port_slot * 50,
+                judge_model=judge_model,
+                no_judge=no_judge,
+                proxy=os.environ.get('CLAW_EVAL_PROXY') or None,
+            )
+        finally:
+            self._release_port_slot(port_slot)
+            write_claw_eval_config(config_path, self._redact_official_config(official_config))
+        sample.metadata['claw_eval_result'] = result
+
+        content = json.dumps(
+            {
+                'task_id': result.get('task_id'),
+                'trace_path': result.get('trace_path'),
+                'metrics': result.get('metrics', {}),
+            },
+            ensure_ascii=False,
+        )
+        output = ModelOutput.from_content(model=model.name, content=content)
+        output.metadata = result
+        trace, messages = load_claw_eval_trace(result.get('trace_path'))
+        return InferenceResult(output=output, trace=trace, messages=messages)
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: Any,
+    ) -> Score:
+        result = task_state.metadata.get('claw_eval_result') or {}
+        metrics = dict(result.get('metrics') or {})
+        return Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+            value=metrics,
+            main_score_name='avg_score',
+            metadata={
+                'task_id': result.get('task_id'),
+                'task_name': result.get('task_name'),
+                'difficulty': result.get('difficulty'),
+                'trace_path': result.get('trace_path'),
+                'trace_root': result.get('trace_root'),
+                'error': result.get('error'),
+                'raw_result': result.get('raw_result'),
+            },
+        )
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        if not sample_scores:
+            return []
+
+        from claw_eval.models.scoring import compute_pass_at_k, compute_pass_hat_k
+
+        grouped: Dict[Any, List[SampleScore]] = defaultdict(list)
+        for sample_score in sample_scores:
+            group_id = sample_score.group_id if sample_score.group_id is not None else sample_score.sample_id
+            grouped[group_id].append(sample_score)
+
+        group_avg_scores = []
+        group_pass_at = []
+        group_pass_hat = []
+        sample_errors = 0
+        for group_scores in grouped.values():
+            trial_scores = [float(item.score.value.get('avg_score', 0.0)) for item in group_scores]
+            group_avg_scores.append(sum(trial_scores) / len(trial_scores) if trial_scores else 0.0)
+            k = len(trial_scores)
+            group_pass_at.append(compute_pass_at_k(trial_scores, k=k))
+            group_pass_hat.append(compute_pass_hat_k(trial_scores, k=k))
+            for item in group_scores:
+                if item.score.metadata and item.score.metadata.get('error'):
+                    sample_errors += 1
+
+        num_groups = len(grouped)
+        num_samples = len(sample_scores)
+        return [
+            AggScore(
+                score=sum(group_avg_scores) / num_groups,
+                metric_name='avg_score',
+                aggregation_name='mean',
+                num=num_groups
+            ),
+            AggScore(
+                score=sum(group_pass_at) / num_groups,
+                metric_name='pass_at_k',
+                aggregation_name='mean',
+                num=num_groups
+            ),
+            AggScore(
+                score=sum(group_pass_hat) / num_groups,
+                metric_name='pass_hat_k',
+                aggregation_name='mean',
+                num=num_groups
+            ),
+            AggScore(
+                score=sample_errors / num_samples,
+                metric_name='error_rate',
+                aggregation_name='mean',
+                num=num_samples
+            ),
+        ]
+
+    def _build_official_config(
+        self,
+        model: Model,
+        tasks_dir: Path,
+        trace_root: Path,
+        api_key: Optional[str],
+        base_url: Optional[str],
+        judge_args: Dict[str, Any],
+        judge_model: Optional[str],
+        no_judge: bool,
+    ) -> Dict[str, Any]:
+        config: Dict[str, Any] = {
+            'model': {
+                'api_key': api_key,
+                'base_url': base_url,
+                'model_id': model.name,
+                'temperature': getattr(model.config, 'temperature', 0.0),
+            },
+            'judge': {
+                'api_key': judge_args.get('api_key') or api_key,
+                'base_url': judge_args.get('api_url') or judge_args.get('base_url') or base_url,
+                'model_id': judge_model or model.name,
+                'enabled': not no_judge,
+            },
+            'defaults': {
+                'trace_dir': str(trace_root),
+                'tasks_dir': str(tasks_dir),
+            },
+            'sandbox': {
+                'enabled': True,
+            },
+        }
+        if getattr(model.config, 'extra_body', None):
+            config['model']['extra_body'] = model.config.extra_body
+        return config
+
+    def _check_runtime(self) -> None:
+        if sys.version_info < (3, 11):
+            raise RuntimeError(
+                'Claw-Eval official runner requires Python 3.11+. Run EvalScope with Python 3.11+ for claw_eval.'
+            )
+        check_import(
+            'claw_eval',
+            package=f'"{DEFAULT_CLAW_EVAL_PACKAGE}"',
+            raise_error=True,
+            feature_name=self.pretty_name,
+        )
+
+    def _cache_dir(self) -> str:
+        configured = (os.environ.get('CLAW_EVAL_CACHE_DIR') or '').strip()
+        return configured or str(Path(DEFAULT_EVALSCOPE_CACHE_DIR) / self.name)
+
+    def _official_repo_path(self) -> Optional[str]:
+        return (os.environ.get('CLAW_EVAL_REPO_PATH') or '').strip() or None
+
+    def _resolve_base_url(self, model: Model) -> Optional[str]:
+        if self._task_config is not None and self._task_config.api_url:
+            return self._task_config.api_url
+        return getattr(model.api, 'base_url', None)
+
+    def _resolve_api_key(self, model: Model) -> Optional[str]:
+        if self._task_config is not None:
+            return self._task_config.api_key
+        return getattr(model.api, 'api_key', None)
+
+    def _redact_official_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        redacted = json.loads(json.dumps(config))
+        for section in ('model', 'judge'):
+            api_key = redacted.get(section, {}).get('api_key')
+            if api_key:
+                redacted[section]['api_key'] = '<redacted>'
+        return redacted
+
+    def _selected_splits(self) -> List[str]:
+        unsupported = [split for split in self.subset_list if split not in _DEFAULT_SPLITS]
+        if unsupported:
+            raise ValueError(f'Unsupported Claw-Eval subset(s): {unsupported}. Supported subsets: {_DEFAULT_SPLITS}')
+        return list(self.subset_list)
+
+    def _prepare_assets_once(self) -> ClawEvalAssets:
+        with self._assets_lock:
+            if self._assets is None:
+                self._assets = prepare_claw_eval_assets(
+                    dataset_id=self.dataset_id,
+                    data_source=self.dataset_hub or HubType.MODELSCOPE,
+                    cache_dir=self._cache_dir(),
+                    force_redownload=self.force_redownload,
+                    official_repo_path=self._official_repo_path(),
+                )
+            if not self._image_prepared:
+                ensure_claw_eval_sandbox_image(self._assets.repo_root)
+                self._image_prepared = True
+            return self._assets
+
+    def _acquire_port_slot(self) -> int:
+        return self._get_port_slots().get()
+
+    def _release_port_slot(self, slot: int) -> None:
+        self._get_port_slots().put(slot)
+
+    def _get_port_slots(self) -> queue.Queue[int]:
+        with self._port_slots_lock:
+            if self._port_slots is None:
+                workers = max(int(self._task_config.eval_batch_size or 1), 1)
+                self._port_slots = queue.Queue(maxsize=workers)
+                for slot in range(workers):
+                    self._port_slots.put(slot)
+            return self._port_slots

--- a/evalscope/benchmarks/claw_eval/utils.py
+++ b/evalscope/benchmarks/claw_eval/utils.py
@@ -368,6 +368,16 @@ def load_claw_eval_trace(trace_path: Optional[str]) -> Tuple[Optional[AgentTrace
                     else:
                         msg_id = uuid.uuid4().hex[:8]
                         messages.append(ChatMessageUser(id=msg_id, content=_content_part_to_text(part)))
+                        trace.add(
+                            AgentTraceEvent(
+                                step=step,
+                                type=EventType.ENV_EXEC,
+                                message_id=msg_id,
+                                timestamp=timestamp,
+                                payload={'role': role},
+                            )
+                        )
+                        step += 1
 
             last_timestamp = timestamp or last_timestamp
             continue
@@ -436,13 +446,19 @@ def _prepare_official_repo(
     cache_root.mkdir(parents=True, exist_ok=True)
     archive_path = cache_root / 'claw_eval_official.zip'
     if force_redownload or not archive_path.is_file():
-        urllib.request.urlretrieve(DEFAULT_CLAW_EVAL_REPO_ARCHIVE, archive_path)
+        tmp_archive_path = archive_path.with_suffix(f'{archive_path.suffix}.tmp')
+        try:
+            urllib.request.urlretrieve(DEFAULT_CLAW_EVAL_REPO_ARCHIVE, tmp_archive_path)
+            tmp_archive_path.replace(archive_path)
+        except Exception:
+            tmp_archive_path.unlink(missing_ok=True)
+            raise
 
     if extract_root.exists():
         shutil.rmtree(extract_root)
     extract_root.mkdir(parents=True)
     with zipfile.ZipFile(archive_path) as zf:
-        zf.extractall(extract_root)
+        _safe_extract_zip(zf, extract_root)
 
     repo_root = _find_repo_root(extract_root)
     if repo_root is None:
@@ -594,9 +610,33 @@ def _safe_extract_tar(tf: tarfile.TarFile, target_dir: Path) -> None:
     target_root = target_dir.resolve()
     for member in tf.getmembers():
         member_path = (target_dir / member.name).resolve()
-        if os.path.commonpath([target_root, member_path]) != str(target_root):
+        if not _is_relative_to(member_path, target_root):
             raise ValueError(f'Unsafe tar member path: {member.name}')
+        if member.issym() or member.islnk():
+            link_path = Path(member.linkname)
+            if member.issym():
+                target_path = link_path if link_path.is_absolute() else member_path.parent / link_path
+            else:
+                target_path = link_path if link_path.is_absolute() else target_dir / link_path
+            if not _is_relative_to(target_path.resolve(), target_root):
+                raise ValueError(f'Unsafe tar link target: {member.name} -> {member.linkname}')
     tf.extractall(target_dir)
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: Path) -> None:
+    target_root = target_dir.resolve()
+    for member in zf.infolist():
+        member_path = (target_dir / member.filename).resolve()
+        if not _is_relative_to(member_path, target_root):
+            raise ValueError(f'Unsafe zip member path: {member.filename}')
+    zf.extractall(target_dir)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        return os.path.commonpath([str(root), str(path)]) == str(root)
+    except ValueError:
+        return False
 
 
 def _find_repo_root(extract_root: Path) -> Optional[Path]:
@@ -611,7 +651,11 @@ def _find_repo_root(extract_root: Path) -> Optional[Path]:
 
 
 def _symlink_or_copy(source: Path, dest: Path) -> None:
-    if dest.exists():
+    if dest.is_symlink():
+        if dest.exists():
+            return
+        dest.unlink()
+    elif dest.exists():
         return
     try:
         os.symlink(source, dest, target_is_directory=source.is_dir())

--- a/evalscope/benchmarks/claw_eval/utils.py
+++ b/evalscope/benchmarks/claw_eval/utils.py
@@ -1,0 +1,622 @@
+import json
+import os
+import shutil
+import tarfile
+import urllib.request
+import uuid
+import yaml
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime
+from inspect import signature
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from evalscope.api.agent import AgentTrace, AgentTraceEvent, EventType
+from evalscope.api.dataset import DatasetHub
+from evalscope.api.messages import ChatMessage, ChatMessageAssistant, ChatMessageTool, ChatMessageUser
+from evalscope.api.model import ModelUsage
+from evalscope.api.sandbox import build_docker_image, should_build_docker_image
+from evalscope.api.tool import ToolCall, ToolFunction
+from evalscope.constants import HubType
+from evalscope.utils.logger import get_logger
+
+DEFAULT_CLAW_EVAL_DATASET_ID = 'claw-eval/Claw-Eval'
+DEFAULT_CLAW_EVAL_COMMIT = 'd3f02d4938ab0832377d90535013def2b1a2fdc0'
+DEFAULT_CLAW_EVAL_PACKAGE = (
+    f'claw-eval[sandbox,mock,web] @ git+https://github.com/claw-eval/claw-eval.git@{DEFAULT_CLAW_EVAL_COMMIT}'
+)
+DEFAULT_CLAW_EVAL_REPO_ARCHIVE = f'https://github.com/claw-eval/claw-eval/archive/{DEFAULT_CLAW_EVAL_COMMIT}.zip'
+DEFAULT_CLAW_EVAL_SANDBOX_IMAGE = 'claw-eval-agent:latest'
+FIXTURES_FILE_PATH = 'data/fixtures.tar.gz'
+
+logger = get_logger()
+
+
+@dataclass(frozen=True)
+class ClawEvalAssets:
+    repo_root: Path
+    tasks_dir: Path
+    fixtures_archive: Path
+    fixtures_dir: Path
+
+
+def load_task_manifest(
+    dataset_id: str,
+    data_source: str,
+    splits: Iterable[str],
+    force_redownload: bool = False,
+) -> List[Dict[str, Any]]:
+    """Load Claw-Eval task rows through EvalScope's shared dataset hub."""
+    hub = DatasetHub(
+        data_id_or_path=dataset_id,
+        data_source=data_source,
+        force_redownload=force_redownload,
+    )
+    records: List[Dict[str, Any]] = []
+    for split in splits:
+        dataset = hub.load(split=split)
+        for row in dataset:
+            record = dict(row)
+            record['split'] = split
+            records.append(record)
+    return records
+
+
+def prepare_claw_eval_assets(
+    dataset_id: str = DEFAULT_CLAW_EVAL_DATASET_ID,
+    data_source: str = HubType.MODELSCOPE,
+    cache_dir: Optional[str] = None,
+    force_redownload: bool = False,
+    official_repo_path: Optional[str] = None,
+) -> ClawEvalAssets:
+    """Prepare official Claw-Eval task code and ModelScope fixtures."""
+    root = Path(cache_dir).expanduser() if cache_dir else Path.home() / '.cache' / 'evalscope' / 'claw_eval'
+    root.mkdir(parents=True, exist_ok=True)
+    repo_root = _prepare_official_repo(
+        cache_root=root / 'official_repo',
+        force_redownload=force_redownload,
+        official_repo_path=official_repo_path,
+    )
+
+    fixtures_archive = Path(
+        DatasetHub(
+            data_id_or_path=dataset_id,
+            data_source=data_source,
+            force_redownload=force_redownload,
+            cache_dir=str(root / 'modelscope'),
+        ).download_file(FIXTURES_FILE_PATH)
+    )
+    fixtures_dir = _extract_fixtures(fixtures_archive, root / 'fixtures', force_redownload=force_redownload)
+    _link_fixtures_into_tasks(fixtures_dir, repo_root / 'tasks')
+
+    tasks_dir = repo_root / 'tasks'
+    if not tasks_dir.is_dir():
+        raise FileNotFoundError(f'Claw-Eval official repo does not contain tasks/: {repo_root}')
+    return ClawEvalAssets(
+        repo_root=repo_root,
+        tasks_dir=tasks_dir,
+        fixtures_archive=fixtures_archive,
+        fixtures_dir=fixtures_dir,
+    )
+
+
+def ensure_claw_eval_sandbox_image(repo_root: Path) -> str:
+    """Build the official Claw-Eval sandbox image locally when it is missing."""
+    dockerfile = repo_root / 'Dockerfile.agent'
+    if not dockerfile.is_file():
+        raise FileNotFoundError(f'Claw-Eval official repo does not contain Dockerfile.agent: {repo_root}')
+    if should_build_docker_image(DEFAULT_CLAW_EVAL_SANDBOX_IMAGE):
+        logger.info(
+            f'Claw-Eval sandbox image {DEFAULT_CLAW_EVAL_SANDBOX_IMAGE!r} not found. '
+            f'Building from official Dockerfile: {dockerfile}'
+        )
+        build_docker_image(
+            image=DEFAULT_CLAW_EVAL_SANDBOX_IMAGE,
+            path=str(repo_root),
+            dockerfile='Dockerfile.agent',
+        )
+    return DEFAULT_CLAW_EVAL_SANDBOX_IMAGE
+
+
+def materialize_task_root(source_tasks_dir: Path, selected_task_ids: List[str], output_root: Path) -> Path:
+    """Create a runtime tasks/ root that runs selected tasks while keeping fixture-only cross refs."""
+    tasks_root = output_root / 'tasks'
+    if tasks_root.exists():
+        shutil.rmtree(tasks_root)
+    tasks_root.mkdir(parents=True)
+
+    selected = set(selected_task_ids)
+    for task_dir in source_tasks_dir.iterdir():
+        if not task_dir.is_dir():
+            continue
+        dest = tasks_root / task_dir.name
+        if task_dir.name in selected:
+            _symlink_or_copy(task_dir, dest)
+            continue
+        fixtures = task_dir / 'fixtures'
+        if fixtures.exists():
+            (dest).mkdir(parents=True, exist_ok=True)
+            _symlink_or_copy(fixtures, dest / 'fixtures')
+
+    missing = [task_id for task_id in selected_task_ids if not (tasks_root / task_id / 'task.yaml').is_file()]
+    if missing:
+        raise FileNotFoundError(f'Claw-Eval task ids not found in official tasks/: {missing[:10]}')
+
+    mock_services = source_tasks_dir.parent / 'mock_services'
+    if mock_services.is_dir():
+        runtime_mock_services = output_root / 'mock_services'
+        if runtime_mock_services.is_symlink() or runtime_mock_services.is_file():
+            runtime_mock_services.unlink()
+        elif runtime_mock_services.exists():
+            shutil.rmtree(runtime_mock_services)
+        _symlink_or_copy(mock_services, runtime_mock_services)
+    return tasks_root
+
+
+def write_claw_eval_config(path: Path, config: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding='utf-8')
+
+
+def run_claw_eval_task(
+    task_dir: Path,
+    config_path: Path,
+    trace_root: Path,
+    repo_root: Path,
+    model_id: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    port_offset: int = 0,
+    judge_model: Optional[str] = None,
+    no_judge: bool = False,
+    proxy: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run one Claw-Eval task through the pinned official private API."""
+    validate_claw_eval_private_api()
+    task_dir = task_dir.resolve()
+    trace_root = trace_root.resolve()
+    config_path = config_path.resolve()
+    if not config_path.is_file():
+        raise FileNotFoundError(f'Claw-Eval config file was not found: {config_path}')
+    if not (task_dir / 'task.yaml').is_file():
+        raise FileNotFoundError(f'Claw-Eval task.yaml was not found: {task_dir}')
+
+    from claw_eval.cli import _run_single_task
+
+    result = _run_single_task(
+        task_dir=str(task_dir),
+        config_path=str(config_path),
+        model=model_id,
+        api_key=api_key,
+        base_url=base_url,
+        trace_dir=str(trace_root),
+        port_offset=port_offset,
+        no_judge=no_judge,
+        judge_model=judge_model,
+        trials=1,
+        proxy=proxy,
+        sandbox=True,
+        sandbox_image=None,
+        sandbox_tools=False,
+    )
+    return parse_single_task_result(result, trace_root=trace_root, task_dir=task_dir, repo_root=repo_root)
+
+
+def validate_claw_eval_private_api() -> None:
+    """Fail fast when the installed Claw-Eval package is not the pinned private API shape."""
+    try:
+        from claw_eval.cli import _run_single_task
+    except ImportError as exc:
+        raise RuntimeError(
+            'Claw-Eval official runner is not installed. Install the pinned package with: '
+            f'pip install "{DEFAULT_CLAW_EVAL_PACKAGE}"'
+        ) from exc
+
+    expected_run_params = {
+        'task_dir',
+        'config_path',
+        'model',
+        'api_key',
+        'base_url',
+        'trace_dir',
+        'port_offset',
+        'no_judge',
+        'judge_model',
+        'trials',
+        'proxy',
+        'sandbox',
+        'sandbox_image',
+        'sandbox_tools',
+    }
+    actual_run_params = set(signature(_run_single_task).parameters)
+    if not expected_run_params.issubset(actual_run_params):
+        raise RuntimeError(
+            'Installed Claw-Eval private API is incompatible with EvalScope claw_eval. '
+            f'Expected _run_single_task parameters {sorted(expected_run_params)}, got {sorted(actual_run_params)}. '
+            f'Install the pinned package with: pip install "{DEFAULT_CLAW_EVAL_PACKAGE}"'
+        )
+
+
+def parse_single_task_result(
+    result: Dict[str, Any],
+    trace_root: Path,
+    task_dir: Path,
+    repo_root: Path,
+) -> Dict[str, Any]:
+    """Normalize official _run_single_task output into EvalScope metadata."""
+    trials = list(result.get('trials') or [])
+    first_trial = trials[0] if trials else {}
+    task_score = float(first_trial.get('task_score') or result.get('avg_score') or 0.0)
+    errored = bool(result.get('error') or first_trial.get('error'))
+    passed = bool(first_trial.get('passed') or result.get('avg_passed') or False)
+    trace_path = first_trial.get('trace')
+    metrics = {
+        'avg_score': task_score,
+        'task_score': task_score,
+        'passed': 1.0 if passed else 0.0,
+        'error_rate': 1.0 if errored else 0.0,
+    }
+    for key in (
+        'model_input_tokens',
+        'model_output_tokens',
+        'input_tokens',
+        'output_tokens',
+        'tokens',
+        'model_time_s',
+        'tool_time_s',
+        'other_time_s',
+        'wall_time_s',
+        'completion',
+        'robustness',
+        'communication',
+        'safety',
+    ):
+        if key in first_trial:
+            metrics[key] = float(first_trial[key])
+
+    return {
+        'task_id': result.get('task_id') or task_dir.name,
+        'task_name': result.get('task_name') or '',
+        'difficulty': result.get('difficulty') or '',
+        'trace_root': str(trace_root),
+        'trace_path': str(trace_path) if trace_path else None,
+        'task_dir': str(task_dir),
+        'repo_root': str(repo_root),
+        'raw_result': result,
+        'trials': trials,
+        'metrics': metrics,
+        'error': result.get('error') or first_trial.get('error'),
+    }
+
+
+def load_claw_eval_trace(trace_path: Optional[str]) -> Tuple[Optional[AgentTrace], Optional[List[ChatMessage]]]:
+    """Convert an official Claw-Eval trace JSONL file into EvalScope agent visualization data."""
+    if not trace_path:
+        return None, None
+    path = Path(trace_path)
+    if not path.is_file():
+        return None, None
+
+    trace = AgentTrace(framework='claw-eval', environment='docker')
+    messages: List[ChatMessage] = []
+    dispatches: Dict[str, Dict[str, Any]] = {}
+    step = 0
+    last_timestamp: Optional[float] = None
+
+    try:
+        rows = [json.loads(line) for line in path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    except (OSError, json.JSONDecodeError):
+        return None, None
+
+    for row in rows:
+        event_type = row.get('type')
+        timestamp = _parse_timestamp(row.get('timestamp'))
+        if event_type == 'trace_start':
+            trace.trial_id = row.get('trace_id')
+            continue
+
+        if event_type == 'tool_dispatch':
+            dispatches[str(row.get('tool_use_id') or '')] = row
+            continue
+
+        if event_type == 'message':
+            message = row.get('message') or {}
+            role = message.get('role')
+            content = message.get('content') or []
+            usage = row.get('usage') or {}
+
+            if role == 'assistant':
+                msg_id = uuid.uuid4().hex[:8]
+                text, tool_calls = _parse_assistant_content(content)
+                messages.append(
+                    ChatMessageAssistant(
+                        id=msg_id, content=text, tool_calls=tool_calls or None, model=row.get('model')
+                    )
+                )
+                trace.add(
+                    AgentTraceEvent(
+                        step=step,
+                        type=EventType.MODEL_GENERATE,
+                        message_id=msg_id,
+                        timestamp=timestamp,
+                        latency_ms=_latency_ms(last_timestamp, timestamp),
+                        token_usage=_token_usage_dict(usage),
+                    )
+                )
+                for tool_call in tool_calls:
+                    trace.add(
+                        AgentTraceEvent(
+                            step=step,
+                            type=EventType.TOOL_CALL,
+                            message_id=msg_id,
+                            timestamp=timestamp,
+                            payload={
+                                'tool_call_id': tool_call.id,
+                                'name': tool_call.function.name,
+                                'arguments': tool_call.function.arguments,
+                            },
+                        )
+                    )
+                step += 1
+            elif role == 'user':
+                for part in content if isinstance(content, list) else [{'type': 'text', 'text': str(content)}]:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get('type') == 'tool_result':
+                        _append_tool_result(trace, messages, part, dispatches, step, timestamp)
+                    else:
+                        msg_id = uuid.uuid4().hex[:8]
+                        messages.append(ChatMessageUser(id=msg_id, content=_content_part_to_text(part)))
+
+            last_timestamp = timestamp or last_timestamp
+            continue
+
+        if event_type == 'trace_end':
+            trace.total_usage = ModelUsage(
+                input_tokens=int(row.get('input_tokens') or row.get('model_input_tokens') or 0),
+                output_tokens=int(row.get('output_tokens') or row.get('model_output_tokens') or 0),
+                total_tokens=int(row.get('total_tokens') or 0),
+            )
+            trace.add(
+                AgentTraceEvent(
+                    step=step,
+                    type=EventType.RUN_END,
+                    timestamp=timestamp,
+                    token_usage={
+                        'input': trace.total_usage.input_tokens,
+                        'output': trace.total_usage.output_tokens,
+                        'total': trace.total_usage.total_tokens,
+                    },
+                    payload={
+                        'total_turns': row.get('total_turns'),
+                        'wall_time_s': row.get('wall_time_s'),
+                        'task_score': row.get('task_score'),
+                        'passed': row.get('passed'),
+                    },
+                )
+            )
+            continue
+
+        if event_type == 'grading_result':
+            trace.add(
+                AgentTraceEvent(
+                    step=step,
+                    type=EventType.SUBMIT,
+                    timestamp=timestamp,
+                    payload={
+                        'task_score': row.get('task_score'),
+                        'passed': row.get('passed'),
+                        'scores': row.get('scores') or {},
+                    },
+                )
+            )
+
+    return trace, messages or None
+
+
+def _prepare_official_repo(
+    cache_root: Path,
+    force_redownload: bool,
+    official_repo_path: Optional[str],
+) -> Path:
+    if official_repo_path:
+        repo_root = Path(official_repo_path).expanduser().resolve()
+        if not (repo_root / 'tasks').is_dir():
+            raise FileNotFoundError(f'Claw-Eval official_repo_path must contain tasks/: {repo_root}')
+        return repo_root
+
+    extract_root = cache_root / 'extracted'
+    if force_redownload and extract_root.exists():
+        shutil.rmtree(extract_root)
+    existing = _find_repo_root(extract_root)
+    if existing is not None:
+        return existing
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_root / 'claw_eval_official.zip'
+    if force_redownload or not archive_path.is_file():
+        urllib.request.urlretrieve(DEFAULT_CLAW_EVAL_REPO_ARCHIVE, archive_path)
+
+    if extract_root.exists():
+        shutil.rmtree(extract_root)
+    extract_root.mkdir(parents=True)
+    with zipfile.ZipFile(archive_path) as zf:
+        zf.extractall(extract_root)
+
+    repo_root = _find_repo_root(extract_root)
+    if repo_root is None:
+        raise FileNotFoundError(f'Could not find tasks/ after extracting {archive_path}')
+    return repo_root
+
+
+def _parse_timestamp(value: Any) -> float:
+    if not value:
+        return 0
+    try:
+        timestamp = str(value)
+        if timestamp.endswith('Z'):
+            timestamp = f'{timestamp[:-1]}+00:00'
+        return datetime.fromisoformat(timestamp).timestamp()
+    except (TypeError, ValueError):
+        return 0
+
+
+def _latency_ms(previous: Optional[float], current: float) -> Optional[float]:
+    if not previous or not current:
+        return None
+    return round((current - previous) * 1000, 2)
+
+
+def _token_usage_dict(usage: Dict[str, Any]) -> Optional[Dict[str, int]]:
+    if not usage:
+        return None
+    input_tokens = int(usage.get('input_tokens') or 0)
+    output_tokens = int(usage.get('output_tokens') or 0)
+    return {
+        'input': input_tokens,
+        'output': output_tokens,
+        'total': input_tokens + output_tokens,
+    }
+
+
+def _parse_assistant_content(content: Any) -> Tuple[str, List[ToolCall]]:
+    text_parts: List[str] = []
+    tool_calls: List[ToolCall] = []
+    parts = content if isinstance(content, list) else [{'type': 'text', 'text': str(content or '')}]
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get('type')
+        if part_type == 'tool_use':
+            tool_calls.append(
+                ToolCall(
+                    id=str(part.get('id') or uuid.uuid4().hex[:8]),
+                    function=ToolFunction(name=str(part.get('name') or ''), arguments=part.get('input') or {}),
+                )
+            )
+        elif part_type == 'text':
+            text_parts.append(str(part.get('text') or ''))
+    return ''.join(text_parts), tool_calls
+
+
+def _append_tool_result(
+    trace: AgentTrace,
+    messages: List[ChatMessage],
+    part: Dict[str, Any],
+    dispatches: Dict[str, Dict[str, Any]],
+    step: int,
+    timestamp: float,
+) -> None:
+    tool_call_id = str(part.get('tool_use_id') or '')
+    dispatch = dispatches.get(tool_call_id) or {}
+    msg_id = uuid.uuid4().hex[:8]
+    content = _content_part_to_text(part)
+    is_error = bool(part.get('is_error') or dispatch.get('response_status', 200) >= 400)
+    messages.append(
+        ChatMessageTool(
+            id=msg_id,
+            content=content,
+            tool_call_id=tool_call_id,
+            function=dispatch.get('tool_name'),
+        )
+    )
+    trace.add(
+        AgentTraceEvent(
+            step=step,
+            type=EventType.TOOL_RESULT if not is_error else EventType.ERROR,
+            message_id=msg_id,
+            timestamp=timestamp,
+            latency_ms=dispatch.get('latency_ms'),
+            payload={
+                'tool_call_id': tool_call_id,
+                'name': dispatch.get('tool_name'),
+                'arguments': dispatch.get('request_body') or {},
+                'status': dispatch.get('response_status'),
+                'endpoint_url': dispatch.get('endpoint_url'),
+            },
+        )
+    )
+
+
+def _content_part_to_text(part: Dict[str, Any]) -> str:
+    content = part.get('content')
+    if isinstance(content, list):
+        return ''.join(_content_part_to_text(item) for item in content if isinstance(item, dict))
+    if content is not None:
+        return str(content)
+    return str(part.get('text') or '')
+
+
+def _extract_fixtures(archive_path: Path, fixtures_dir: Path, force_redownload: bool) -> Path:
+    marker_path = fixtures_dir / '.extract_complete.json'
+    archive_sig = {
+        'archive': str(archive_path),
+        'size': archive_path.stat().st_size,
+        'mtime_ns': archive_path.stat().st_mtime_ns,
+    }
+    if marker_path.is_file() and not force_redownload:
+        try:
+            if json.loads(marker_path.read_text(encoding='utf-8')) == archive_sig:
+                return fixtures_dir
+        except json.JSONDecodeError:
+            pass
+
+    if fixtures_dir.exists():
+        shutil.rmtree(fixtures_dir)
+    fixtures_dir.mkdir(parents=True)
+    with tarfile.open(archive_path) as tf:
+        _safe_extract_tar(tf, fixtures_dir)
+    marker_path.write_text(json.dumps(archive_sig, indent=2), encoding='utf-8')
+    return fixtures_dir
+
+
+def _link_fixtures_into_tasks(fixtures_dir: Path, tasks_dir: Path) -> None:
+    for fixture_task_dir in fixtures_dir.iterdir():
+        if not fixture_task_dir.is_dir():
+            continue
+        source_fixtures = fixture_task_dir / 'fixtures'
+        target_fixtures = tasks_dir / fixture_task_dir.name / 'fixtures'
+        if not source_fixtures.is_dir() or not target_fixtures.parent.is_dir():
+            continue
+        for source_file in source_fixtures.rglob('*'):
+            if not source_file.is_file():
+                continue
+            rel_path = source_file.relative_to(source_fixtures)
+            target_file = target_fixtures / rel_path
+            if target_file.exists():
+                continue
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            _symlink_or_copy(source_file, target_file)
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, target_dir: Path) -> None:
+    target_root = target_dir.resolve()
+    for member in tf.getmembers():
+        member_path = (target_dir / member.name).resolve()
+        if os.path.commonpath([target_root, member_path]) != str(target_root):
+            raise ValueError(f'Unsafe tar member path: {member.name}')
+    tf.extractall(target_dir)
+
+
+def _find_repo_root(extract_root: Path) -> Optional[Path]:
+    if not extract_root.exists():
+        return None
+    if (extract_root / 'tasks').is_dir():
+        return extract_root
+    for child in extract_root.iterdir():
+        if child.is_dir() and (child / 'tasks').is_dir():
+            return child
+    return None
+
+
+def _symlink_or_copy(source: Path, dest: Path) -> None:
+    if dest.exists():
+        return
+    try:
+        os.symlink(source, dest, target_is_directory=source.is_dir())
+    except OSError:
+        if source.is_dir():
+            shutil.copytree(source, dest, symlinks=True)
+        else:
+            shutil.copy2(source, dest)

--- a/evalscope/benchmarks/claw_eval/utils.py
+++ b/evalscope/benchmarks/claw_eval/utils.py
@@ -8,6 +8,7 @@ import yaml
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from inspect import signature
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -203,6 +204,7 @@ def run_claw_eval_task(
     return parse_single_task_result(result, trace_root=trace_root, task_dir=task_dir, repo_root=repo_root)
 
 
+@lru_cache(maxsize=1)
 def validate_claw_eval_private_api() -> None:
     """Fail fast when the installed Claw-Eval package is not the pinned private API shape."""
     try:

--- a/tests/benchmark/test_agent.py
+++ b/tests/benchmark/test_agent.py
@@ -1,8 +1,10 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 import json
 import sys
+import tempfile
 from dotenv import dotenv_values, load_dotenv
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 load_dotenv('.env')
@@ -13,13 +15,38 @@ import unittest
 
 from evalscope.api.agent import NativeAgentConfig
 from evalscope.api.agent.mcp import MCPServerConfigStdio
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.claw_eval.claw_eval_adapter import ClawEvalAdapter
+from evalscope.benchmarks.claw_eval.utils import (
+    DEFAULT_CLAW_EVAL_SANDBOX_IMAGE,
+    ClawEvalAssets,
+    ensure_claw_eval_sandbox_image,
+    load_claw_eval_trace,
+    materialize_task_root,
+    run_claw_eval_task,
+    validate_claw_eval_private_api,
+)
 from evalscope.benchmarks.toolathlon.toolathlon_adapter import ToolathlonAdapter
-from evalscope.config import SandboxTaskConfig
+from evalscope.config import SandboxTaskConfig, TaskConfig
 from evalscope.constants import EvalType, JudgeStrategy, OutputType
 from evalscope.utils.logger import get_logger
 from tests.common import TestBenchmark
 
 logger = get_logger()
+
+
+def _fake_claw_eval_scoring_modules() -> dict[str, ModuleType]:
+    claw_eval = ModuleType('claw_eval')
+    models = ModuleType('claw_eval.models')
+    scoring = ModuleType('claw_eval.models.scoring')
+    scoring.compute_pass_at_k = lambda scores, k: 1.0 if scores else 0.0
+    scoring.compute_pass_hat_k = lambda scores, k: 1.0 if all(score >= 0.8 for score in scores) else 0.25
+    return {
+        'claw_eval': claw_eval,
+        'claw_eval.models': models,
+        'claw_eval.models.scoring': scoring,
+    }
 
 
 class TestAgentBenchmark(TestBenchmark):
@@ -300,6 +327,355 @@ class TestAgentBenchmark(TestBenchmark):
         self.assertNotIn('retries', FakeToolathlonClient.last_config.model_params)
         self.assertNotIn('batch_size', FakeToolathlonClient.last_config.model_params)
 
+    def test_claw_eval(self):
+        """Test Claw-Eval task-level wrapper with mocked assets and private API runner."""
+        run_calls = []
+
+        def fake_run_claw_eval_task(**kwargs):
+            run_calls.append(kwargs)
+            self.assertTrue((kwargs['task_dir'] / 'task.yaml').is_file())
+            self.assertEqual(kwargs['task_dir'].name, 'T002_task')
+            self.assertTrue(kwargs['config_path'].is_file())
+            return {
+                'task_id': 'T002_task',
+                'task_name': 'Task 2',
+                'difficulty': 'easy',
+                'trace_root': str(kwargs['trace_root']),
+                'trace_path': str(kwargs['trace_root'] / f'T002_task_{len(run_calls)}.jsonl'),
+                'raw_result': {
+                    'task_id': 'T002_task'
+                },
+                'trials': [],
+                'metrics': {
+                    'avg_score': 0.8,
+                    'task_score': 0.8,
+                    'passed': 1.0,
+                    'error_rate': 0.0,
+                    'tokens': 10,
+                    'model_input_tokens': 8,
+                    'model_output_tokens': 2,
+                    'wall_time_s': 1.5,
+                    'model_time_s': 1.0,
+                    'tool_time_s': 0.2,
+                    'completion': 0.8,
+                    'robustness': 0.8,
+                    'communication': 0.0,
+                    'safety': 1.0,
+                },
+            }
+
+        def fake_manifest_loader(dataset_id, data_source, splits, force_redownload=False):
+            self.assertEqual(dataset_id, 'claw-eval/Claw-Eval')
+            self.assertEqual(splits, ['general'])
+            return [
+                {
+                    'task_id': 'T001_task',
+                    'split': 'general'
+                },
+                {
+                    'task_id': 'T002_task',
+                    'split': 'general'
+                },
+            ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp) / 'repo'
+            tasks_dir = repo_root / 'tasks'
+            (tasks_dir / 'T001_task').mkdir(parents=True)
+            (tasks_dir / 'T002_task').mkdir(parents=True)
+            (tasks_dir / 'T001_task' / 'task.yaml').write_text('id: T001_task\n', encoding='utf-8')
+            (tasks_dir / 'T002_task' / 'task.yaml').write_text('id: T002_task\n', encoding='utf-8')
+            fixtures_archive = Path(tmp) / 'fixtures.tar.gz'
+            fixtures_archive.write_bytes(b'fixture')
+            fixtures_dir = Path(tmp) / 'fixtures'
+            fixtures_dir.mkdir()
+
+            def fake_assets_preparer(**kwargs):
+                self.assertNotIn('download_fixtures', kwargs)
+                return ClawEvalAssets(
+                    repo_root=repo_root,
+                    tasks_dir=tasks_dir,
+                    fixtures_archive=fixtures_archive,
+                    fixtures_dir=fixtures_dir,
+                )
+
+            prepared_images = []
+
+            def fake_image_preparer(repo_root_arg):
+                prepared_images.append(repo_root_arg)
+                return DEFAULT_CLAW_EVAL_SANDBOX_IMAGE
+
+            dataset_args = {
+                'subset_list': ['general'],
+                'extra_params': {
+                    'task_ids': ['T002_task'],
+                }
+            }
+
+            with patch('evalscope.benchmarks.claw_eval.claw_eval_adapter.run_claw_eval_task',
+                       side_effect=fake_run_claw_eval_task), \
+                    patch('evalscope.benchmarks.claw_eval.claw_eval_adapter.load_task_manifest',
+                          side_effect=fake_manifest_loader), \
+                    patch('evalscope.benchmarks.claw_eval.claw_eval_adapter.prepare_claw_eval_assets',
+                          side_effect=fake_assets_preparer), \
+                    patch('evalscope.benchmarks.claw_eval.claw_eval_adapter.ensure_claw_eval_sandbox_image',
+                          side_effect=fake_image_preparer), \
+                    patch.dict(sys.modules, _fake_claw_eval_scoring_modules()), \
+                    patch.object(ClawEvalAdapter, '_check_runtime', return_value=None):
+                self._run_dataset_test(
+                    'claw_eval',
+                    dataset_args,
+                    use_mock=True,
+                    limit=1,
+                    eval_batch_size=1,
+                    no_timestamp=True,
+                    work_dir='outputs/test_agent_claw_eval',
+                    api_url='http://localhost:8000/v1',
+                    api_key='local-key',
+                    repeats=3,
+                )
+
+        self.assertEqual(len(run_calls), 3)
+        self.assertEqual(run_calls[0]['model_id'], 'qwen3-max')
+        self.assertEqual(run_calls[0]['api_key'], 'local-key')
+        self.assertEqual(run_calls[0]['base_url'], 'http://localhost:8000/v1')
+        self.assertEqual([call['port_offset'] for call in run_calls], [0, 0, 0])
+        self.assertTrue(all(str(call['repo_root']).endswith('/repo') for call in run_calls))
+        self.assertEqual(prepared_images, [repo_root])
+        review_files = list(Path('outputs/test_agent_claw_eval').glob('reviews/*/claw_eval_general.jsonl'))
+        self.assertEqual(len(review_files), 1)
+        reviews = [json.loads(line) for line in review_files[0].read_text(encoding='utf-8').splitlines() if line]
+        self.assertEqual(len(reviews), 3)
+        review = reviews[0]
+        metadata = review['sample_score']['sample_metadata']
+        self.assertEqual(metadata['split'], 'general')
+        self.assertEqual(metadata['task_id'], 'T002_task')
+        self.assertEqual({row['sample_score']['group_id'] for row in reviews}, {0})
+        self.assertNotIn('selected_task_ids', metadata)
+        self.assertNotIn('selected_records', metadata)
+
+    def test_claw_eval_init_checks_runtime(self):
+        """Test Claw-Eval fails early when the official package is unavailable."""
+        with patch.object(ClawEvalAdapter, '_check_runtime') as check:
+            adapter = get_benchmark('claw_eval', TaskConfig(datasets=['claw_eval']))
+
+        self.assertIsInstance(adapter, ClawEvalAdapter)
+        check.assert_called_once_with()
+
+    def test_claw_eval_runner_uses_official_sandbox(self):
+        """Test the runner always invokes the official private API sandbox path."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            trace_root = root / 'traces'
+            config_path = root / 'config.yaml'
+            config_path.write_text('sandbox:\n  enabled: true\n', encoding='utf-8')
+            task_dir = root / 'tasks' / 'T001_task'
+            task_dir.mkdir(parents=True)
+            (task_dir / 'task.yaml').write_text('id: T001_task\n', encoding='utf-8')
+            with patch('evalscope.benchmarks.claw_eval.utils.validate_claw_eval_private_api', return_value=None), \
+                    patch('claw_eval.cli._run_single_task', return_value={
+                        'task_id': 'T001_task',
+                        'task_name': 'Task 1',
+                        'difficulty': 'easy',
+                        'trials': [{
+                            'trace': str(trace_root / 'T001_task_abc.jsonl'),
+                            'task_score': 1.0,
+                            'passed': True,
+                        }],
+                        'error': None,
+                    }) as run:
+                parsed = run_claw_eval_task(
+                    task_dir=task_dir,
+                    trace_root=trace_root,
+                    config_path=config_path,
+                    repo_root=root,
+                    model_id='qwen3-max',
+                    api_key='local-key',
+                    base_url='http://localhost:8000/v1',
+                    port_offset=50,
+                )
+
+        kwargs = run.call_args.kwargs
+        self.assertEqual(kwargs['task_dir'], str(task_dir.resolve()))
+        self.assertEqual(kwargs['trials'], 1)
+        self.assertEqual(kwargs['port_offset'], 50)
+        self.assertTrue(kwargs['sandbox'])
+        self.assertFalse(kwargs['sandbox_tools'])
+        self.assertIsNone(kwargs['sandbox_image'])
+        self.assertEqual(kwargs['api_key'], 'local-key')
+        self.assertEqual(parsed['metrics']['avg_score'], 1.0)
+
+    def test_claw_eval_private_api_signature_guard(self):
+        """Test incompatible Claw-Eval private API signatures fail fast."""
+
+        def incompatible_run_single_task(task_dir):
+            return {}
+
+        with patch('claw_eval.cli._run_single_task', incompatible_run_single_task):
+            with self.assertRaisesRegex(RuntimeError, 'private API is incompatible'):
+                validate_claw_eval_private_api()
+
+    def test_claw_eval_aggregate_scores_groups_repeats(self):
+        """Test grouped Claw-Eval repeat aggregation."""
+        adapter = object.__new__(ClawEvalAdapter)
+        scores = [
+            SampleScore(score=Score(value={'avg_score': 1.0}, metadata={}), sample_id=0, group_id=0),
+            SampleScore(score=Score(value={'avg_score': 0.0}, metadata={}), sample_id=1, group_id=0),
+            SampleScore(score=Score(value={'avg_score': 0.5}, metadata={'error': 'failed'}), sample_id=2, group_id=1),
+            SampleScore(score=Score(value={'avg_score': 1.0}, metadata={}), sample_id=3, group_id=1),
+        ]
+
+        with patch.dict(sys.modules, _fake_claw_eval_scoring_modules()):
+            aggregated = {(score.metric_name, score.aggregation_name): score.score
+                          for score in adapter.aggregate_scores(scores)}
+
+        self.assertAlmostEqual(aggregated[('avg_score', 'mean')], 0.625)
+        self.assertAlmostEqual(aggregated[('pass_at_k', 'mean')], 1.0)
+        self.assertAlmostEqual(aggregated[('pass_hat_k', 'mean')], 0.25)
+        self.assertAlmostEqual(aggregated[('error_rate', 'mean')], 0.25)
+
+    def test_claw_eval_trace_converts_to_agent_trace(self):
+        """Test official Claw-Eval JSONL traces are exposed as EvalScope agent traces."""
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / 'trace.jsonl'
+            rows = [
+                {
+                    'type': 'trace_start',
+                    'trace_id': 'trace-1',
+                    'timestamp': '2026-07-14T00:00:00+00:00',
+                },
+                {
+                    'type': 'message',
+                    'message': {
+                        'role': 'user',
+                        'content': [{
+                            'type': 'text',
+                            'text': 'Sort my inbox.'
+                        }],
+                    },
+                    'usage': {
+                        'input_tokens': 0,
+                        'output_tokens': 0
+                    },
+                    'timestamp': '2026-07-14T00:00:00+00:00',
+                },
+                {
+                    'type': 'message',
+                    'message': {
+                        'role': 'assistant',
+                        'content': [
+                            {
+                                'type': 'text',
+                                'text': 'Checking email.'
+                            },
+                            {
+                                'type': 'tool_use',
+                                'id': 'call-1',
+                                'name': 'gmail_list_messages',
+                                'input': {
+                                    'max_results': 5
+                                },
+                            },
+                        ],
+                    },
+                    'usage': {
+                        'input_tokens': 10,
+                        'output_tokens': 3
+                    },
+                    'timestamp': '2026-07-14T00:00:01+00:00',
+                },
+                {
+                    'type': 'tool_dispatch',
+                    'tool_use_id': 'call-1',
+                    'tool_name': 'gmail_list_messages',
+                    'request_body': {
+                        'max_results': 5
+                    },
+                    'response_status': 200,
+                    'latency_ms': 2.5,
+                    'timestamp': '2026-07-14T00:00:01+00:00',
+                },
+                {
+                    'type': 'message',
+                    'message': {
+                        'role': 'user',
+                        'content': [{
+                            'type': 'tool_result',
+                            'tool_use_id': 'call-1',
+                            'content': [{
+                                'type': 'text',
+                                'text': '{"messages": []}'
+                            }],
+                            'is_error': False,
+                        }],
+                    },
+                    'timestamp': '2026-07-14T00:00:02+00:00',
+                },
+                {
+                    'type': 'trace_end',
+                    'trace_id': 'trace-1',
+                    'input_tokens': 10,
+                    'output_tokens': 3,
+                    'total_tokens': 13,
+                    'wall_time_s': 2.0,
+                    'timestamp': '2026-07-14T00:00:03+00:00',
+                },
+            ]
+            trace_path.write_text('\n'.join(json.dumps(row) for row in rows), encoding='utf-8')
+
+            trace, messages = load_claw_eval_trace(str(trace_path))
+
+        self.assertIsNotNone(trace)
+        self.assertIsNotNone(messages)
+        self.assertEqual(trace.framework, 'claw-eval')
+        self.assertEqual(trace.trial_id, 'trace-1')
+        self.assertEqual(trace.total_usage.total_tokens, 13)
+        self.assertEqual([message.role for message in messages], ['user', 'assistant', 'tool'])
+        self.assertEqual(messages[1].tool_calls[0].function.name, 'gmail_list_messages')
+        self.assertIn('tool_result', {event.type.value for event in trace.events})
+
+    def test_claw_eval_image_auto_build(self):
+        """Test missing official sandbox image is built from the official repo."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            (repo_root / 'Dockerfile.agent').write_text('FROM scratch\n', encoding='utf-8')
+            with patch('evalscope.benchmarks.claw_eval.utils.should_build_docker_image', return_value=True), \
+                    patch('evalscope.benchmarks.claw_eval.utils.build_docker_image') as build:
+                image = ensure_claw_eval_sandbox_image(repo_root)
+
+        self.assertEqual(image, DEFAULT_CLAW_EVAL_SANDBOX_IMAGE)
+        build.assert_called_once_with(
+            image=DEFAULT_CLAW_EVAL_SANDBOX_IMAGE,
+            path=str(repo_root),
+            dockerfile='Dockerfile.agent',
+        )
+
+    def test_claw_eval_task_root_keeps_fixture_cross_refs(self):
+        """Test selected task roots keep non-selected fixture-only cross refs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            source_tasks = Path(tmp) / 'source' / 'tasks'
+            source_mock_services = source_tasks.parent / 'mock_services'
+            selected_task = source_tasks / 'T001_task'
+            fixture_only_task = source_tasks / 'T999_fixture_source'
+            selected_task.mkdir(parents=True)
+            source_mock_services.mkdir(parents=True)
+            (selected_task / 'task.yaml').write_text('id: T001_task\n', encoding='utf-8')
+            (source_mock_services / 'server.py').write_text('print("ok")\n', encoding='utf-8')
+            (fixture_only_task / 'fixtures').mkdir(parents=True)
+            (fixture_only_task / 'fixtures' / 'data.json').write_text('{}\n', encoding='utf-8')
+
+            runtime_tasks = materialize_task_root(
+                source_tasks_dir=source_tasks,
+                selected_task_ids=['T001_task'],
+                output_root=Path(tmp) / 'runtime',
+            )
+
+            self.assertTrue((runtime_tasks / 'T001_task' / 'task.yaml').is_file())
+            self.assertTrue((Path(tmp) / 'runtime' / 'mock_services' / 'server.py').is_file())
+            self.assertTrue((runtime_tasks / 'T999_fixture_source' / 'fixtures' / 'data.json').is_file())
+            self.assertFalse((runtime_tasks / 'T999_fixture_source' / 'task.yaml').exists())
+
     def test_swe_bench_verified_agentic_backticks(self):
         """Test SWE-bench-verified agentic dataset with backticks protocol."""
         dataset_args = {
@@ -315,6 +691,7 @@ class TestAgentBenchmark(TestBenchmark):
             limit=1,
             agent_config=NativeAgentConfig(strategy='swe_bench_backticks'),
         )
+
 
 if __name__ == '__main__':
     # Run specific test: python -m unittest test_agent.TestAgentBenchmark.test_swe_bench_verified_agentic

--- a/tests/benchmark/test_agent.py
+++ b/tests/benchmark/test_agent.py
@@ -5,7 +5,7 @@ import tempfile
 from dotenv import dotenv_values, load_dotenv
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 load_dotenv('.env')
 
@@ -38,14 +38,33 @@ logger = get_logger()
 
 def _fake_claw_eval_scoring_modules() -> dict[str, ModuleType]:
     claw_eval = ModuleType('claw_eval')
+    claw_eval.__path__ = []
     models = ModuleType('claw_eval.models')
     scoring = ModuleType('claw_eval.models.scoring')
-    scoring.compute_pass_at_k = lambda scores, k: 1.0 if scores else 0.0
-    scoring.compute_pass_hat_k = lambda scores, k: 1.0 if all(score >= 0.8 for score in scores) else 0.25
+
+    def compute_pass_at_k(scores, k):
+        return 1.0 if scores else 0.0
+
+    def compute_pass_hat_k(scores, k):
+        return 1.0 if all(score >= 0.8 for score in scores) else 0.25
+
+    scoring.compute_pass_at_k = compute_pass_at_k
+    scoring.compute_pass_hat_k = compute_pass_hat_k
     return {
         'claw_eval': claw_eval,
         'claw_eval.models': models,
         'claw_eval.models.scoring': scoring,
+    }
+
+
+def _fake_claw_eval_cli_modules(run_single_task) -> dict[str, ModuleType]:
+    claw_eval = ModuleType('claw_eval')
+    claw_eval.__path__ = []
+    cli = ModuleType('claw_eval.cli')
+    cli._run_single_task = run_single_task
+    return {
+        'claw_eval': claw_eval,
+        'claw_eval.cli': cli,
     }
 
 
@@ -473,18 +492,19 @@ class TestAgentBenchmark(TestBenchmark):
             task_dir = root / 'tasks' / 'T001_task'
             task_dir.mkdir(parents=True)
             (task_dir / 'task.yaml').write_text('id: T001_task\n', encoding='utf-8')
+            run = Mock(return_value={
+                'task_id': 'T001_task',
+                'task_name': 'Task 1',
+                'difficulty': 'easy',
+                'trials': [{
+                    'trace': str(trace_root / 'T001_task_abc.jsonl'),
+                    'task_score': 1.0,
+                    'passed': True,
+                }],
+                'error': None,
+            })
             with patch('evalscope.benchmarks.claw_eval.utils.validate_claw_eval_private_api', return_value=None), \
-                    patch('claw_eval.cli._run_single_task', return_value={
-                        'task_id': 'T001_task',
-                        'task_name': 'Task 1',
-                        'difficulty': 'easy',
-                        'trials': [{
-                            'trace': str(trace_root / 'T001_task_abc.jsonl'),
-                            'task_score': 1.0,
-                            'passed': True,
-                        }],
-                        'error': None,
-                    }) as run:
+                    patch.dict(sys.modules, _fake_claw_eval_cli_modules(run)):
                 parsed = run_claw_eval_task(
                     task_dir=task_dir,
                     trace_root=trace_root,
@@ -512,7 +532,7 @@ class TestAgentBenchmark(TestBenchmark):
         def incompatible_run_single_task(task_dir):
             return {}
 
-        with patch('claw_eval.cli._run_single_task', incompatible_run_single_task):
+        with patch.dict(sys.modules, _fake_claw_eval_cli_modules(incompatible_run_single_task)):
             with self.assertRaisesRegex(RuntimeError, 'private API is incompatible'):
                 validate_claw_eval_private_api()
 
@@ -633,7 +653,9 @@ class TestAgentBenchmark(TestBenchmark):
         self.assertEqual(trace.total_usage.total_tokens, 13)
         self.assertEqual([message.role for message in messages], ['user', 'assistant', 'tool'])
         self.assertEqual(messages[1].tool_calls[0].function.name, 'gmail_list_messages')
-        self.assertIn('tool_result', {event.type.value for event in trace.events})
+        event_types = {event.type.value for event in trace.events}
+        self.assertIn('env_exec', event_types)
+        self.assertIn('tool_result', event_types)
 
     def test_claw_eval_image_auto_build(self):
         """Test missing official sandbox image is built from the official repo."""


### PR DESCRIPTION
## Summary
- Add a Claw-Eval benchmark adapter backed by the pinned official runner API and Docker sandbox.
- Load task manifests and fixtures from ModelScope, expose each Claw-Eval task as an EvalScope sample, and map repeats/cache/dashboard traces into the native flow.
- Add generated benchmark docs/meta and targeted tests for loading, runner arguments, API guard, scoring, trace conversion, and sandbox image preparation.

## Validation
- PATH=/Users/yunlin/miniconda3/envs/eval/bin:$PATH make lint
- /Users/yunlin/miniconda3/envs/eval312/bin/python -m pytest tests/benchmark/test_agent.py -k claw_eval -q -p no:warnings

Note: the targeted pytest run passes but Python 3.12 still prints the known multiprocessing semaphore cleanup warning from tqdm's progress-lock setup at interpreter shutdown.