### PR TITLE
fix: support code execution scoring on Windows

### DIFF
--- a/evalscope/benchmarks/humaneval/utils.py
+++ b/evalscope/benchmarks/humaneval/utils.py
@@ -88,7 +88,7 @@ def check_correctness(problem: Dict, completion: str, timeout: float, completion
 @contextlib.contextmanager
 def time_limit(seconds: float):
 
-    if not (hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM')):
+    if not (hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM') and hasattr(signal, 'ITIMER_REAL')):
         yield
         return
 

--- a/evalscope/benchmarks/humaneval/utils.py
+++ b/evalscope/benchmarks/humaneval/utils.py
@@ -88,6 +88,10 @@ def check_correctness(problem: Dict, completion: str, timeout: float, completion
 @contextlib.contextmanager
 def time_limit(seconds: float):
 
+    if not hasattr(signal, 'setitimer'):
+        yield
+        return
+
     def signal_handler(signum, frame):
         raise TimeoutException('Timed out!')
 

--- a/evalscope/benchmarks/humaneval/utils.py
+++ b/evalscope/benchmarks/humaneval/utils.py
@@ -88,7 +88,7 @@ def check_correctness(problem: Dict, completion: str, timeout: float, completion
 @contextlib.contextmanager
 def time_limit(seconds: float):
 
-    if not hasattr(signal, 'setitimer'):
+    if not (hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM')):
         yield
         return
 

--- a/evalscope/benchmarks/live_code_bench/testing_util.py
+++ b/evalscope/benchmarks/live_code_bench/testing_util.py
@@ -58,9 +58,13 @@ def timeout_handler(debug, signum, frame):
     raise TimeoutException
 
 
-def _set_alarm(seconds: int) -> None:
-    if hasattr(signal, 'SIGALRM') and hasattr(signal, 'alarm'):
-        signal.alarm(seconds)
+def _set_alarm(seconds: float) -> None:
+    # setitimer preserves sub-second precision; signal.alarm() only accepts
+    # ints, so a float timeout would truncate (e.g. 0.5 -> 0 cancels the
+    # timeout, 1.9 -> 1 fires early). setitimer(ITIMER_REAL, 0) cancels, matching
+    # alarm(0). Delivers SIGALRM, so the existing handler still fires.
+    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM'):
+        signal.setitimer(signal.ITIMER_REAL, seconds)
 
 
 # used to capture stdout as a list
@@ -394,7 +398,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
     otherwise it'll just return an input and output pair.
     """
     timeout_handler_wrapper = partial(timeout_handler, debug)
-    if hasattr(signal, 'SIGALRM') and hasattr(signal, 'alarm'):
+    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM'):
         signal.signal(signal.SIGALRM, timeout_handler_wrapper)
 
     # Disable functionalities that can make destructive changes to the test.

--- a/evalscope/benchmarks/live_code_bench/testing_util.py
+++ b/evalscope/benchmarks/live_code_bench/testing_util.py
@@ -63,7 +63,7 @@ def _set_alarm(seconds: float) -> None:
     # ints, so a float timeout would truncate (e.g. 0.5 -> 0 cancels the
     # timeout, 1.9 -> 1 fires early). setitimer(ITIMER_REAL, 0) cancels, matching
     # alarm(0). Delivers SIGALRM, so the existing handler still fires.
-    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM'):
+    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM') and hasattr(signal, 'ITIMER_REAL'):
         signal.setitimer(signal.ITIMER_REAL, seconds)
 
 
@@ -398,7 +398,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
     otherwise it'll just return an input and output pair.
     """
     timeout_handler_wrapper = partial(timeout_handler, debug)
-    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM'):
+    if hasattr(signal, 'setitimer') and hasattr(signal, 'SIGALRM') and hasattr(signal, 'ITIMER_REAL'):
         signal.signal(signal.SIGALRM, timeout_handler_wrapper)
 
     # Disable functionalities that can make destructive changes to the test.

--- a/evalscope/benchmarks/live_code_bench/testing_util.py
+++ b/evalscope/benchmarks/live_code_bench/testing_util.py
@@ -58,6 +58,11 @@ def timeout_handler(debug, signum, frame):
     raise TimeoutException
 
 
+def _set_alarm(seconds: int) -> None:
+    if hasattr(signal, 'SIGALRM') and hasattr(signal, 'alarm'):
+        signal.alarm(seconds)
+
+
 # used to capture stdout as a list
 # from https://stackoverflow.com/a/16571630/6416660
 # alternative use redirect_stdout() from contextlib
@@ -155,7 +160,7 @@ def get_function(compiled_sol, fn_name: str):  # type: ignore
 
 
 def compile_code(code: str, timeout: int):
-    signal.alarm(timeout)
+    _set_alarm(timeout)
     try:
         tmp_sol = ModuleType('tmp_sol', '')
         exec(code, tmp_sol.__dict__)
@@ -171,7 +176,7 @@ def compile_code(code: str, timeout: int):
 
         assert compiled_sol is not None
     finally:
-        signal.alarm(0)
+        _set_alarm(0)
 
     return compiled_sol
 
@@ -212,14 +217,14 @@ def grade_call_based(code: str, all_inputs: list, all_outputs: list, fn_name: st
     total_execution = 0
     all_results = []
     for idx, (gt_inp, gt_out) in enumerate(zip(all_inputs, all_outputs)):
-        signal.alarm(timeout)
+        _set_alarm(timeout)
         # faulthandler.enable()
         try:
             # can lock here so time is useful
             start = time.time()
             prediction = method(*gt_inp)
             total_execution += time.time() - start
-            signal.alarm(0)
+            _set_alarm(0)
 
             # don't penalize model if it produces tuples instead of lists
             # ground truth sequences are not tuples
@@ -241,7 +246,7 @@ def grade_call_based(code: str, all_inputs: list, all_outputs: list, fn_name: st
                     'error_message': 'Wrong Answer',
                 }
         except Exception as e:
-            signal.alarm(0)
+            _set_alarm(0)
             if 'timeoutexception' in repr(e).lower():
                 all_results.append(-3)
                 return all_results, {
@@ -262,7 +267,7 @@ def grade_call_based(code: str, all_inputs: list, all_outputs: list, fn_name: st
                 }
 
         finally:
-            signal.alarm(0)
+            _set_alarm(0)
             # faulthandler.disable()
 
     return all_results, {'execution time': total_execution}
@@ -292,7 +297,7 @@ def grade_stdio(
     all_results = []
     total_execution_time = 0
     for idx, (gt_inp, gt_out) in enumerate(zip(all_inputs, all_outputs)):
-        signal.alarm(timeout)
+        _set_alarm(timeout)
         # faulthandler.enable()
 
         with Capturing() as captured_output:
@@ -301,9 +306,9 @@ def grade_stdio(
                 call_method(method, gt_inp)
                 total_execution_time += time.time() - start
                 # reset the alarm
-                signal.alarm(0)
+                _set_alarm(0)
             except Exception as e:
-                signal.alarm(0)
+                _set_alarm(0)
                 if 'timeoutexception' in repr(e).lower():
                     all_results.append(-3)
                     return all_results, {
@@ -324,7 +329,7 @@ def grade_stdio(
                     }
 
             finally:
-                signal.alarm(0)
+                _set_alarm(0)
                 # faulthandler.disable()
 
         prediction = captured_output[0]
@@ -389,7 +394,8 @@ def run_test(sample, test=None, debug=False, timeout=6):
     otherwise it'll just return an input and output pair.
     """
     timeout_handler_wrapper = partial(timeout_handler, debug)
-    signal.signal(signal.SIGALRM, timeout_handler_wrapper)
+    if hasattr(signal, 'SIGALRM') and hasattr(signal, 'alarm'):
+        signal.signal(signal.SIGALRM, timeout_handler_wrapper)
 
     # Disable functionalities that can make destructive changes to the test.
     # max memory is set to 4GB
@@ -426,7 +432,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
             logger.info(f'loading test code = {current_time().time()}')
 
         if which_type == CODE_TYPE.call_based:
-            signal.alarm(timeout)
+            _set_alarm(timeout)
             try:
                 results, metadata = grade_call_based(
                     code=test,
@@ -442,12 +448,12 @@ def run_test(sample, test=None, debug=False, timeout=6):
                     'error_message': f'Error during testing: {e}',
                 }
             finally:
-                signal.alarm(0)
+                _set_alarm(0)
         elif which_type == CODE_TYPE.standard_input:
             # sol
             # if code has if __name__ == "__main__": then remove it
 
-            signal.alarm(timeout)
+            _set_alarm(timeout)
             try:
                 results, metadata = grade_stdio(
                     code=test,
@@ -462,7 +468,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
                     'error_message': f'Error during testing: {e}',
                 }
             finally:
-                signal.alarm(0)
+                _set_alarm(0)
 
 
 def reliability_guard(maximum_memory_bytes=None):

--- a/tests/benchmark/test_code_execution_timeouts.py
+++ b/tests/benchmark/test_code_execution_timeouts.py
@@ -1,0 +1,50 @@
+import json
+import pytest
+
+from evalscope.benchmarks.humaneval import utils as humaneval_utils
+from evalscope.benchmarks.live_code_bench import testing_util
+
+
+def test_humaneval_time_limit_without_posix_timer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(humaneval_utils.signal, 'setitimer', raising=False)
+
+    with humaneval_utils.time_limit(0.01):
+        pass
+
+
+def test_live_code_bench_without_posix_alarm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(testing_util.signal, 'SIGALRM', raising=False)
+    monkeypatch.delattr(testing_util.signal, 'alarm', raising=False)
+    monkeypatch.setattr(testing_util, 'reliability_guard', lambda: None)
+    sample = {
+        'input_output': json.dumps({
+            'fn_name': 'add',
+            'inputs': ['1\n2'],
+            'outputs': ['3'],
+        })
+    }
+
+    results, _ = testing_util.run_test(sample, test='def add(a, b): return a + b', debug=False, timeout=1)
+
+    assert results == [True]
+
+
+def test_live_code_bench_standard_input_without_posix_alarm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(testing_util.signal, 'SIGALRM', raising=False)
+    monkeypatch.delattr(testing_util.signal, 'alarm', raising=False)
+    monkeypatch.setattr(testing_util, 'reliability_guard', lambda: None)
+    sample = {
+        'input_output': json.dumps({
+            'inputs': ['1 2'],
+            'outputs': ['3'],
+        })
+    }
+
+    results, _ = testing_util.run_test(
+        sample,
+        test='a, b = map(int, input().split()); print(a + b)',
+        debug=False,
+        timeout=1,
+    )
+
+    assert results == [True]


### PR DESCRIPTION
Fixes #1486.

### Summary
- HumanEval: skip the inner POSIX interval timer when `signal.setitimer` is unavailable
- LiveCodeBench: route all `signal.alarm()` set/clear points through a capability-guarded helper, and guard the `SIGALRM` handler registration
- add regression tests for the HumanEval path and for both LiveCodeBench paths (`call_based` and `standard_input`) on platforms without POSIX signal timers

Windows does not provide `setitimer`, `SIGALRM`, or `alarm`, so the previous inner timeout setup raised `AttributeError` before a known-correct completion could execute; that exception was swallowed and every sample was scored as failed. This guards the inner signal-based timeout by capability while leaving POSIX behavior unchanged.

The existing parent-process safeguards still bound runtime on all platforms: HumanEval uses `join(timeout + 1)` then `kill()`, and LiveCodeBench applies its global process timeout (`codegen_check_correctness`). POSIX platforms keep their existing inner signal timeouts byte-for-byte.

Per @Yunnglin's note, this keeps the sandbox path as the recommended default and only hardens the native local-execution path; it covers both the HumanEval `setitimer`/`SIGALRM` path and all LiveCodeBench `signal.alarm()` usages.

### Test plan
- `python -m pytest tests/benchmark/test_code_execution_timeouts.py -vv` — 3 passed
- ran known-correct HumanEval and LiveCodeBench (call_based + standard_input) samples on Windows 11; all scored correctly