### PR TITLE
Mask eval and perf secrets with SecretStr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ docs/zh/learn/
 examples/api_test/
 .qoder
 .claude
+.kiro
 
 # Frontend (evalscope/web)
 node_modules/

--- a/evalscope/api/mixin/llm_judge_mixin.py
+++ b/evalscope/api/mixin/llm_judge_mixin.py
@@ -4,6 +4,7 @@ from evalscope.api.evaluator import TaskState
 from evalscope.api.metric import Score
 from evalscope.constants import JudgeStrategy
 from evalscope.metrics import LLMJudge
+from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -78,7 +79,8 @@ class LLMJudgeMixin:
                     'LLM judge model arguments must be provided for LLM-based judge strategies. '
                     'Please check your task configuration.'
                 )
-            return LLMJudge(**self._task_config.judge_model_args)
+            judge_model_args = get_secret_value(self._task_config.judge_model_args)
+            return LLMJudge(**judge_model_args)
 
     def maybe_llm_match_score(
         self,

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -1,8 +1,9 @@
 # flake8: noqa: E501
 from copy import deepcopy
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Any, Dict, List, Literal, Optional
 
+from evalscope.utils.argument_utils import secretize_auth_headers
 from evalscope.utils.json_schema import JSONSchema
 
 
@@ -151,7 +152,7 @@ class GenerateConfig(BaseModel):
     extra_query: Optional[Dict[str, Any]] = Field(default=None)
     """Extra query parameters to be sent with requests to OpenAI compatible servers. OpenAI, vLLM, and SGLang only."""
 
-    extra_headers: Optional[Dict[str, str]] = Field(default=None)
+    extra_headers: Optional[Dict[str, Any]] = Field(default=None)
     """Extra headers to be sent with requests to OpenAI compatible servers. OpenAI, vLLM, and SGLang only."""
 
     height: Optional[int] = Field(default=None)
@@ -175,6 +176,11 @@ class GenerateConfig(BaseModel):
                 'Use `anthropic_cache_strategy` to choose breakpoint placement.'
             )
         return data
+
+    @field_validator('extra_headers', mode='after')
+    @classmethod
+    def _validate_extra_headers(cls, value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        return secretize_auth_headers(value)
 
     def merge(self, other: 'GenerateConfig') -> 'GenerateConfig':
         """Merge another model configuration into this one.

--- a/evalscope/api/model/model.py
+++ b/evalscope/api/model/model.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Literal, Optional,
 from evalscope.api.messages import ChatMessage, ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
 from evalscope.api.registry import get_model_api
 from evalscope.api.tool import ToolChoice, ToolFunction, ToolInfo
-from evalscope.utils import get_logger
+from evalscope.utils import get_logger, get_secret_value
 from evalscope.utils.function_utils import thread_safe
 from .generate_config import GenerateConfig
 from .model_output import ModelOutput
@@ -305,7 +305,7 @@ def get_model_with_task_config(task_config: 'TaskConfig') -> Model:
     model = task_config.model
     eval_type = task_config.eval_type
     base_url = task_config.api_url
-    api_key = task_config.api_key
+    api_key = get_secret_value(task_config.api_key)
     config = task_config.generation_config
     model_args = task_config.model_args or {}
 

--- a/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
+++ b/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
@@ -15,6 +15,7 @@ from evalscope.api.model import Model, ModelOutput
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
 from evalscope.report import Report
+from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.function_utils import thread_safe
 from evalscope.utils.import_utils import check_import
 from evalscope.utils.logger import get_logger
@@ -179,7 +180,7 @@ class BFCLV4Adapter(AgentAdapter):
 
         # Set env variables for OpenAI API
         base_url = _normalize_openai_base_url(self._task_config.api_url)
-        os.environ['OPENAI_API_KEY'] = self._task_config.api_key
+        os.environ['OPENAI_API_KEY'] = get_secret_value(self._task_config.api_key) or ''
         if base_url:
             os.environ['OPENAI_BASE_URL'] = base_url
         else:

--- a/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
+++ b/evalscope/benchmarks/claw_eval/claw_eval_adapter.py
@@ -16,6 +16,7 @@ from evalscope.api.metric import AggScore, SampleScore, Score
 from evalscope.api.model import Model, ModelOutput
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import DEFAULT_EVALSCOPE_CACHE_DIR, HubType, JudgeStrategy, Tags
+from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.import_utils import check_import
 from evalscope.utils.logger import get_logger
 from .utils import (
@@ -327,7 +328,7 @@ class ClawEvalAdapter(AgentAdapter):
                 'temperature': getattr(model.config, 'temperature', 0.0),
             },
             'judge': {
-                'api_key': judge_args.get('api_key') or api_key,
+                'api_key': get_secret_value(judge_args.get('api_key')) or api_key,
                 'base_url': judge_args.get('api_url') or judge_args.get('base_url') or base_url,
                 'model_id': judge_model or model.name,
                 'enabled': not no_judge,
@@ -370,7 +371,7 @@ class ClawEvalAdapter(AgentAdapter):
 
     def _resolve_api_key(self, model: Model) -> Optional[str]:
         if self._task_config is not None:
-            return self._task_config.api_key
+            return get_secret_value(self._task_config.api_key)
         return getattr(model.api, 'api_key', None)
 
     def _redact_official_config(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/evalscope/benchmarks/toolathlon/toolathlon_adapter.py
+++ b/evalscope/benchmarks/toolathlon/toolathlon_adapter.py
@@ -9,6 +9,7 @@ from evalscope.api.metric import Score
 from evalscope.api.model import Model, ModelOutput
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
+from evalscope.utils.argument_utils import get_secret_value
 from .client import (
     DEFAULT_POLL_INTERVAL_SECONDS,
     DEFAULT_SERVER_HOST,
@@ -366,7 +367,7 @@ class ToolathlonAdapter(AgentAdapter):
 
     def _resolve_api_key(self, model: Model) -> Optional[str]:
         if self._task_config is not None and self._task_config.api_key:
-            return self._task_config.api_key
+            return get_secret_value(self._task_config.api_key)
         return getattr(model.api, 'api_key', None)
 
     def _resolve_model_params(self, model: Model) -> Dict[str, Any]:

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -4,7 +4,7 @@ import copy
 import json
 import os
 from argparse import Namespace
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from typing import Annotated, Any, Dict, List, Optional, Union
 
 from evalscope.agent.external.config import ExternalAgentConfig
@@ -32,6 +32,24 @@ AgentConfigUnion = Annotated[
 ]
 
 logger = get_logger()
+
+
+def _secretize_api_keys(value: Any) -> Any:
+    if isinstance(value, SecretStr):
+        return value
+    if isinstance(value, list):
+        return [_secretize_api_keys(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    result = {}
+    for key, val in value.items():
+        if key == 'api_key' and isinstance(val, str):
+            result[key] = SecretStr(val)
+        else:
+            result[key] = _secretize_api_keys(val)
+    return result
+
 
 # Default configurations
 DEFAULT_IMAGE_GEN_CONFIG = {
@@ -189,7 +207,7 @@ class TaskConfig(BaseArgument):
     api_url: Optional[str] = None
     """API endpoint URL for server-based model evaluation."""
 
-    api_key: Optional[str] = 'EMPTY'
+    api_key: Optional[SecretStr] = SecretStr('EMPTY')
     """API key for authenticating with server-based models."""
 
     timeout: Optional[float] = None
@@ -311,6 +329,11 @@ class TaskConfig(BaseArgument):
             f'`agent_config` must be a dict, NativeAgentConfig, ExternalAgentConfig or None, '
             f'got {type(v).__name__}.'
         )
+
+    @field_validator('judge_model_args', mode='before')
+    @classmethod
+    def _validate_judge_model_args(cls, v):
+        return _secretize_api_keys(v)
 
     @field_validator('sandbox', mode='before')
     @classmethod
@@ -492,12 +515,33 @@ class TaskConfig(BaseArgument):
                 result[key] = copy.deepcopy(value)
         return result
 
-    def update(self, other: Union['TaskConfig', dict]):
+    def update(self, other: Union['TaskConfig', dict]) -> None:
         if isinstance(other, TaskConfig):
-            other = other.to_dict()
-        merged = self._deep_merge(self.to_dict(), other)
+            other = other._to_update_dict()
+        other = _secretize_api_keys(other)
+        merged = self._deep_merge(self._to_update_dict(), other)
+        if isinstance(merged.get('generation_config'), dict):
+            merged['generation_config'] = GenerateConfig.model_validate(merged['generation_config'])
+        if isinstance(merged.get('sandbox'), dict):
+            merged['sandbox'] = SandboxTaskConfig.model_validate(merged['sandbox'])
         for key, value in merged.items():
             setattr(self, key, value)
+
+    def _to_update_dict(self) -> dict:
+        result = self.model_dump(exclude={'model', 'generation_config', 'sandbox'})
+        result['model'] = self.model
+        result['generation_config'] = self._dump_generation_config()
+        result['sandbox'] = self.sandbox
+        return result
+
+    def _dump_generation_config(self, mode: Optional[str] = None) -> Union[dict, GenerateConfig, None]:
+        if not isinstance(self.generation_config, GenerateConfig):
+            return self.generation_config
+
+        kwargs = {'exclude_unset': True}
+        if mode is not None:
+            kwargs['mode'] = mode
+        return self.generation_config.model_dump(**kwargs)
 
     def dump_yaml(self, output_dir: str):
         """Dump the task configuration to a YAML file."""
@@ -509,23 +553,16 @@ class TaskConfig(BaseArgument):
             logger.warning(f'Failed to dump overall task config: {e}')
 
     def to_dict(self):
-        result = self.model_dump()
-
-        # Remove sensitive info
-        result.pop('api_key', None)
-
-        # Handle nested sensitive info in judge_model_args
-        if self.judge_model_args:
-            result['judge_model_args'] = copy.deepcopy(self.judge_model_args)
-            result['judge_model_args'].pop('api_key', None)
+        result = self.model_dump(mode='json', exclude={'model', 'generation_config'})
 
         # Serialize Model objects
         if isinstance(self.model, (Model, ModelAPI)):
             result['model'] = self.model.__class__.__name__
+        else:
+            result['model'] = self.model
 
         # Serialize GenerateConfig
-        if isinstance(self.generation_config, GenerateConfig):
-            result['generation_config'] = self.generation_config.model_dump(exclude_unset=True)
+        result['generation_config'] = self._dump_generation_config(mode='json')
 
         return result
 

--- a/evalscope/models/utils/openai.py
+++ b/evalscope/models/utils/openai.py
@@ -57,7 +57,7 @@ from evalscope.api.model import (
     as_stop_reason,
 )
 from evalscope.api.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo, parse_tool_call
-from evalscope.utils import get_logger
+from evalscope.utils import get_logger, get_secret_value
 from evalscope.utils.url_utils import (
     data_uri_to_base64,
     file_as_data_uri,
@@ -299,7 +299,7 @@ def openai_completion_params(model: str, config: GenerateConfig, tools: bool) ->
     if config.extra_query:
         params['extra_query'] = config.extra_query
     if config.extra_headers:
-        params['extra_headers'] = config.extra_headers
+        params['extra_headers'] = get_secret_value(config.extra_headers)
 
     return params
 

--- a/evalscope/models/utils/openai_responses.py
+++ b/evalscope/models/utils/openai_responses.py
@@ -12,6 +12,7 @@ from evalscope.api.messages import (
 )
 from evalscope.api.model import ChatCompletionChoice, GenerateConfig, ModelOutput, ModelUsage, StopReason
 from evalscope.api.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo, parse_tool_call
+from evalscope.utils import get_secret_value
 from evalscope.utils.url_utils import file_as_data_uri, is_data_uri, is_http_url
 from .openai import openai_assistant_content
 
@@ -149,7 +150,7 @@ def openai_response_params(model: str, config: GenerateConfig, tools: bool) -> D
     if config.extra_query:
         params['extra_query'] = config.extra_query
     if config.extra_headers:
-        params['extra_headers'] = config.extra_headers
+        params['extra_headers'] = get_secret_value(config.extra_headers)
     return params
 
 

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -2,12 +2,12 @@ import argparse
 import json
 import os
 from contextlib import contextmanager
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from typing import Any, Dict, List, Optional, Union
 
 from evalscope.constants import DEFAULT_WORK_DIR, VisualizerType
 from evalscope.perf.multi_turn_args import IntOrRange, MultiTurnArgs, _sample_int_or_range
-from evalscope.utils import BaseArgument
+from evalscope.utils import BaseArgument, get_secret_value, secretize_auth_headers
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -63,7 +63,7 @@ class Arguments(BaseArgument):
     total_timeout: Optional[int] = 6 * 60 * 60
     """Total timeout in seconds."""
 
-    api_key: Optional[str] = None
+    api_key: Optional[SecretStr] = None
     """The API key for authentication."""
 
     no_test_connection: bool = False
@@ -208,11 +208,11 @@ class Arguments(BaseArgument):
     visualizer: Optional[str] = None
     """Visualizer for logging, supports 'swanlab' or 'wandb'."""
 
-    wandb_api_key: Optional[str] = None
+    wandb_api_key: Optional[SecretStr] = None
     """API key for wandb visualizer. [Deprecated] Prefer the WANDB_API_KEY env var; this field
     will be removed in a future release."""
 
-    swanlab_api_key: Optional[str] = None
+    swanlab_api_key: Optional[SecretStr] = None
     """API key for swanlab visualizer. [Deprecated] Prefer the SWANLAB_API_KEY env var; this
     field will be removed in a future release."""
 
@@ -407,6 +407,11 @@ class Arguments(BaseArgument):
             return MultiTurnArgs(**v)
         return v
 
+    @field_validator('headers', mode='after')
+    @classmethod
+    def _validate_headers(cls, v: Dict[str, Any]) -> Dict[str, Any]:
+        return secretize_auth_headers(v) or {}
+
     @field_validator('rate', mode='before')
     @classmethod
     def _validate_rate(cls, v):
@@ -456,8 +461,9 @@ class Arguments(BaseArgument):
     def _post_init(self) -> 'Arguments':
         # Set the default headers
         self.headers = self.headers or {}
-        if self.api_key:
-            self.headers['Authorization'] = f'Bearer {self.api_key}'
+        api_key = get_secret_value(self.api_key)
+        if api_key:
+            self.headers['Authorization'] = SecretStr(f'Bearer {api_key}')
 
         # Set the model ID based on the model name
         self.model_id = os.path.basename(self.model)
@@ -561,6 +567,10 @@ class Arguments(BaseArgument):
             yield path
         finally:
             self.outputs_dir = original_path
+
+    def to_dict(self) -> dict:
+        """Convert the instance to a display-safe dictionary."""
+        return self.model_dump(mode='json')
 
 
 class ParseKVAction(argparse.Action):

--- a/evalscope/perf/core/http_client.py
+++ b/evalscope/perf/core/http_client.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.utils.argument_utils import SECRET_HEADER_KEYS, get_secret_value
 from evalscope.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ class AioHttpClient:
         api_plugin: 'ApiPluginBase',
     ):
         self.url = args.url
-        self.headers = {'user-agent': 'modelscope_bench', **(args.headers or {})}
+        self.headers = {'user-agent': 'modelscope_bench', **self._get_runtime_headers(args.headers or {})}
         self.total_timeout = args.total_timeout
         self.read_timeout = args.read_timeout
         self.connect_timeout = args.connect_timeout
@@ -50,6 +51,10 @@ class AioHttpClient:
             timeout=client_timeout,
             trace_configs=[self._create_trace_config()] if args.debug else []
         )
+
+    @staticmethod
+    def _get_runtime_headers(headers: dict) -> dict:
+        return {key: get_secret_value(value) for key, value in headers.items()}
 
     async def __aenter__(self):
         pass
@@ -87,7 +92,11 @@ class AioHttpClient:
 
     @staticmethod
     async def on_request_start(session, context, params: aiohttp.TraceRequestStartParams):
-        logger.debug(f'Starting request: <{params}>')
+        headers = {
+            key: '**********' if str(key).lower() in SECRET_HEADER_KEYS else value
+            for key, value in params.headers.items()
+        }
+        logger.debug(f'Starting request: <method={params.method}, url={params.url}, headers={headers}>')
 
     @staticmethod
     async def on_request_chunk_sent(session, context, params: aiohttp.TraceRequestChunkSentParams):

--- a/evalscope/perf/utils/log_utils.py
+++ b/evalscope/perf/utils/log_utils.py
@@ -2,6 +2,7 @@ import os
 
 from evalscope.constants import VisualizerType
 from evalscope.perf.arguments import Arguments
+from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.io_utils import current_time
 from evalscope.utils.logger import get_logger
 
@@ -83,8 +84,9 @@ def init_wandb(args: Arguments) -> None:
 
     logging_config = _get_sanitized_config(args)
 
-    if args.wandb_api_key is not None:
-        wandb.login(key=args.wandb_api_key)
+    wandb_api_key = get_secret_value(args.wandb_api_key)
+    if wandb_api_key is not None:
+        wandb.login(key=wandb_api_key)
     wandb.init(project='perf_benchmark', name=name, config=logging_config)
 
 
@@ -103,11 +105,12 @@ def init_swanlab(args: Arguments) -> None:
 
     logging_config = _get_sanitized_config(args)
 
+    swanlab_api_key = get_secret_value(args.swanlab_api_key)
     init_kwargs = {
         'project': os.getenv('SWANLAB_PROJ_NAME', 'perf_benchmark'),
         'name': name,
         'config': logging_config,
-        'mode': 'local' if args.swanlab_api_key == 'local' else None
+        'mode': 'local' if swanlab_api_key == 'local' else None
     }
 
     workspace = os.getenv('SWANLAB_WORKSPACE')
@@ -115,11 +118,11 @@ def init_swanlab(args: Arguments) -> None:
         init_kwargs['workspace'] = workspace
 
     swanlab_host = args.swanlab_host or os.getenv('SWANLAB_HOST')
-    is_local = args.swanlab_api_key == 'local'
-    if not is_local and (isinstance(args.swanlab_api_key, str) or swanlab_host):
+    is_local = swanlab_api_key == 'local'
+    if not is_local and (swanlab_api_key is not None or swanlab_host):
         login_kwargs = {}
-        if isinstance(args.swanlab_api_key, str):
-            login_kwargs['api_key'] = args.swanlab_api_key
+        if swanlab_api_key is not None:
+            login_kwargs['api_key'] = swanlab_api_key
         if swanlab_host:
             login_kwargs['host'] = swanlab_host
         swanlab.login(**login_kwargs)
@@ -164,8 +167,4 @@ def _get_sanitized_config(args: Arguments) -> dict:
     Returns:
         Dict with sensitive keys removed
     """
-    config = args.to_dict()
-    sensitive_keys = ['api_key', 'wandb_api_key', 'swanlab_api_key']
-    for key in sensitive_keys:
-        config.pop(key, None)
-    return config
+    return args.to_dict()

--- a/evalscope/report/report.py
+++ b/evalscope/report/report.py
@@ -8,6 +8,7 @@ from typing_extensions import Self
 
 from evalscope.metrics import macro_mean, micro_mean
 from evalscope.utils import get_logger
+from evalscope.utils.argument_utils import get_secret_value
 
 if TYPE_CHECKING:
     from evalscope.config import TaskConfig
@@ -269,10 +270,11 @@ class Report(BaseModel):
 
             # Use judge_model_args if configured; otherwise fall back to the task's own model settings
             if task_config.judge_model_args:
-                judge_llm = LLMJudge(**task_config.judge_model_args)
+                judge_model_args = get_secret_value(task_config.judge_model_args)
+                judge_llm = LLMJudge(**judge_model_args)
             else:
                 judge_llm = LLMJudge(
-                    api_key=task_config.api_key,
+                    api_key=get_secret_value(task_config.api_key),
                     api_url=task_config.api_url,
                     model_id=task_config.model,
                     eval_type=task_config.eval_type,

--- a/evalscope/utils/__init__.py
+++ b/evalscope/utils/__init__.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING
 from .import_utils import _LazyModule
 
 if TYPE_CHECKING:
-    from .argument_utils import BaseArgument, get_supported_params, parse_int_or_float
+    from .argument_utils import (
+        BaseArgument,
+        get_secret_value,
+        get_supported_params,
+        parse_int_or_float,
+        secretize_auth_headers,
+    )
     from .deprecation_utils import deprecated
     from .function_utils import async_retry_call, run_once, thread_safe
     from .import_utils import get_module_path, is_module_installed
@@ -30,7 +36,9 @@ else:
     _import_structure = {
         'argument_utils': [
             'BaseArgument',
+            'get_secret_value',
             'parse_int_or_float',
+            'secretize_auth_headers',
             'get_supported_params',
         ],
         'model_utils': [

--- a/evalscope/utils/argument_utils.py
+++ b/evalscope/utils/argument_utils.py
@@ -1,9 +1,12 @@
 import json
 from argparse import Namespace
 from inspect import signature
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, SecretStr
+from typing import Optional, Union
 
 from evalscope.utils.io_utils import json_to_dict, yaml_to_dict
+
+SECRET_HEADER_KEYS = {'authorization', 'proxy-authorization', 'x-api-key', 'x-auth-token'}
 
 
 class BaseArgument(BaseModel):
@@ -62,6 +65,27 @@ def parse_int_or_float(num):
     if number.is_integer():
         return int(number)
     return number
+
+
+def get_secret_value(value: Optional[Union[str, SecretStr, dict, list]]) -> Optional[Union[str, dict, list]]:
+    """Return the raw value for runtime use while keeping SecretStr masked for display."""
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    if isinstance(value, dict):
+        return {key: get_secret_value(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [get_secret_value(item) for item in value]
+    return value
+
+
+def secretize_auth_headers(headers: Optional[dict]) -> Optional[dict]:
+    """Wrap auth-style header values as SecretStr for display-safe serialization."""
+    if not headers:
+        return headers
+    return {
+        key: SecretStr(value) if str(key).lower() in SECRET_HEADER_KEYS and isinstance(value, str) else value
+        for key, value in headers.items()
+    }
 
 
 def get_supported_params(func):

--- a/tests/perf/test_arguments_secrets.py
+++ b/tests/perf/test_arguments_secrets.py
@@ -1,0 +1,163 @@
+from evalscope.api.mixin import llm_judge_mixin
+from evalscope.api.model import model as model_module
+from evalscope.api.model.generate_config import GenerateConfig
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeStrategy
+from evalscope.models.utils.openai import openai_completion_params
+from evalscope.models.utils.openai_responses import openai_response_params
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.core.http_client import AioHttpClient
+
+
+def test_perf_arguments_masks_api_key_and_authorization_header():
+    args = Arguments(
+        model='test-model',
+        url='http://localhost:8080/v1/chat/completions',
+        api_key='secret-token',
+        wandb_api_key='wandb-token',
+        swanlab_api_key='swanlab-token',
+    )
+
+    args_dict = args.to_dict()
+    args_text = str(args)
+
+    assert args_dict['api_key'] == '**********'
+    assert args_dict['wandb_api_key'] == '**********'
+    assert args_dict['swanlab_api_key'] == '**********'
+    assert args_dict['headers']['Authorization'] == '**********'
+    assert 'secret-token' not in args_text
+    assert 'Bearer secret-token' not in args_text
+    assert 'wandb-token' not in args_text
+    assert 'swanlab-token' not in args_text
+    assert '**********' in args_text
+
+
+def test_perf_runtime_headers_use_raw_secret_value():
+    args = Arguments(
+        model='test-model',
+        url='http://localhost:8080/v1/chat/completions',
+        api_key='secret-token',
+    )
+
+    runtime_headers = AioHttpClient._get_runtime_headers(args.headers)
+
+    assert runtime_headers['Authorization'] == 'Bearer secret-token'
+
+
+def test_task_config_string_omits_api_keys():
+    task_config = TaskConfig(
+        model='test-model',
+        api_url='http://localhost:8080/v1/chat/completions',
+        api_key='secret-token',
+        datasets=['gsm8k'],
+        judge_model_args={
+            'api_key': 'judge-secret-token',
+            'nested': {
+                'api_key': 'nested-judge-secret-token'
+            },
+        },
+    )
+
+    task_config_text = str(task_config)
+    task_config_dict = task_config.to_dict()
+
+    assert 'secret-token' not in task_config_text
+    assert 'judge-secret-token' not in task_config_text
+    assert 'nested-judge-secret-token' not in task_config_text
+    assert task_config_dict['api_key'] == '**********'
+    assert task_config_dict['judge_model_args']['api_key'] == '**********'
+    assert task_config_dict['judge_model_args']['nested']['api_key'] == '**********'
+
+
+def test_task_config_string_omits_extra_auth_headers():
+    task_config = TaskConfig(
+        model='test-model',
+        api_url='http://localhost:8080/v1/chat/completions',
+        datasets=['gsm8k'],
+        generation_config={'extra_headers': {
+            'Authorization': 'Bearer eval-secret-token'
+        }},
+    )
+
+    task_config_text = str(task_config)
+    task_config_dict = task_config.to_dict()
+
+    assert 'eval-secret-token' not in task_config_text
+    assert task_config_dict['generation_config']['extra_headers']['Authorization'] == '**********'
+
+
+def test_get_model_with_task_config_uses_raw_secret_value(monkeypatch):
+    captured = {}
+
+    def fake_get_model(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model_module, 'get_model', fake_get_model)
+    task_config = TaskConfig(
+        model='test-model',
+        api_url='http://localhost:8080/v1/chat/completions',
+        api_key='secret-token',
+        datasets=['gsm8k'],
+    )
+
+    model_module.get_model_with_task_config(task_config)
+
+    assert captured['api_key'] == 'secret-token'
+
+
+def test_llm_judge_mixin_uses_raw_nested_judge_model_args(monkeypatch):
+    captured = {}
+
+    class FakeLLMJudge:
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(llm_judge_mixin, 'LLMJudge', FakeLLMJudge)
+    task_config = TaskConfig(
+        model='test-model',
+        api_url='http://localhost:8080/v1/chat/completions',
+        datasets=['gsm8k'],
+        judge_strategy=JudgeStrategy.LLM,
+        judge_model_args={
+            'api_key': 'judge-secret-token',
+            'nested': {
+                'api_key': 'nested-judge-secret-token'
+            },
+        },
+    )
+
+    llm_judge_mixin.LLMJudgeMixin(benchmark_meta=object(), task_config=task_config).init_llm_judge()
+
+    assert captured['api_key'] == 'judge-secret-token'
+    assert captured['nested']['api_key'] == 'nested-judge-secret-token'
+
+
+def test_openai_params_use_raw_extra_auth_headers():
+    config = GenerateConfig(extra_headers={'Authorization': 'Bearer eval-secret-token'})
+
+    chat_params = openai_completion_params('test-model', config, tools=False)
+    response_params = openai_response_params('test-model', config, tools=False)
+
+    assert chat_params['extra_headers']['Authorization'] == 'Bearer eval-secret-token'
+    assert response_params['extra_headers']['Authorization'] == 'Bearer eval-secret-token'
+
+
+def test_task_config_update_revalidates_generation_config_headers():
+    task_config = TaskConfig(
+        model='test-model',
+        api_url='http://localhost:8080/v1/chat/completions',
+        datasets=['gsm8k'],
+    )
+
+    task_config.update({'generation_config': {'extra_headers': {'Authorization': 'Bearer update-secret-token'}}})
+
+    task_config_text = str(task_config)
+    task_config_dict = task_config.to_dict()
+    runtime_headers = openai_completion_params('test-model', task_config.generation_config,
+                                               tools=False)['extra_headers']
+
+    assert 'update-secret-token' not in task_config_text
+    assert task_config_dict['generation_config']['extra_headers']['Authorization'] == '**********'
+    assert runtime_headers['Authorization'] == 'Bearer update-secret-token'


### PR DESCRIPTION
## Summary
- Use Pydantic SecretStr for eval and perf API key fields so logs and serialized configs are masked.
- Secretize auth-style headers in perf args and eval generation_config.extra_headers while unwrapping them before runtime SDK/HTTP use.
- Update eval consumers that pass TaskConfig.api_key or judge_model_args.api_key into SDKs, adapters, reports, and environment variables.
- Add regression tests covering masked display and raw runtime values.

## Validation
- conda run -n eval pytest tests/perf/test_arguments_secrets.py -q
- conda run -n eval pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings
- conda run -n eval pytest tests/perf/test_perf_basic.py::TestPerfBasic::test_multi_parallel_sweep -v -s
- conda run -n eval pytest tests/benchmark/test_agent.py::TestAgentBenchmark::test_toolathlon tests/benchmark/test_agent.py::TestAgentBenchmark::test_claw_eval tests/benchmark/test_agent.py::TestAgentBenchmark::test_claw_eval_runner_uses_official_sandbox -q
- conda run -n eval isort --check-only <touched files>
- conda run -n eval yapf --diff <touched files>