### PR TITLE
Refine config and CLI cold-start imports

### DIFF
--- a/evalscope/benchmarks/locomo/utils.py
+++ b/evalscope/benchmarks/locomo/utils.py
@@ -3,8 +3,7 @@ import re
 import string
 import unicodedata
 from collections import Counter
-from nltk.stem import PorterStemmer
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 DATA_FILE = 'locomo10.json'
 CATEGORY_IDS = [4, 1, 2, 3, 5]
@@ -16,7 +15,7 @@ CATEGORY_NAMES = {
     5: 'adversarial',
 }
 PUNCTUATION_TABLE = str.maketrans('', '', string.punctuation)
-STEMMER = PorterStemmer()
+STEMMER: Optional[Any] = None
 
 CONV_START_PROMPT = (
     'Below is a conversation between two people: {} and {}. The conversation takes place over multiple days and '
@@ -131,7 +130,16 @@ def _normalize_answer(text: str) -> str:
 
 
 def _stem(word: str) -> str:
-    return STEMMER.stem(word)
+    return _get_stemmer().stem(word)
+
+
+def _get_stemmer() -> Any:
+    global STEMMER
+    if STEMMER is None:
+        from nltk.stem import PorterStemmer
+
+        STEMMER = PorterStemmer()
+    return STEMMER
 
 
 def _token_f1(prediction: str, reference: str) -> float:

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -283,7 +283,7 @@ class TaskConfig(BaseArgument):
 
     @field_validator('limit', mode='before')
     @classmethod
-    def _validate_limit(cls, v):
+    def _validate_limit(cls, v: Any) -> Any:
         if v is not None:
             v = parse_int_or_float(v)
             if v < 0:
@@ -294,7 +294,7 @@ class TaskConfig(BaseArgument):
 
     @field_validator('eval_config', mode='before')
     @classmethod
-    def _validate_eval_config(cls, v):
+    def _validate_eval_config(cls, v: Any) -> Any:
         if not v:
             return v
         if isinstance(v, dict):
@@ -315,7 +315,7 @@ class TaskConfig(BaseArgument):
 
     @field_validator('agent_config', mode='before')
     @classmethod
-    def _validate_agent_config(cls, v):
+    def _validate_agent_config(cls, v: Any) -> Any:
         if v is None or isinstance(v, (NativeAgentConfig, ExternalAgentConfig)):
             return v
         if isinstance(v, dict):
@@ -332,17 +332,13 @@ class TaskConfig(BaseArgument):
 
     @field_validator('judge_model_args', mode='before')
     @classmethod
-    def _validate_judge_model_args(cls, v):
+    def _validate_judge_model_args(cls, v: Any) -> Any:
         return _secretize_api_keys(v)
 
     @field_validator('sandbox', mode='before')
     @classmethod
-    def _validate_sandbox(cls, v):
-        if v is None or isinstance(v, SandboxTaskConfig):
-            return v
-        if isinstance(v, dict):
-            return SandboxTaskConfig.model_validate(v)
-        raise ValueError(f'`sandbox` must be a dict, SandboxTaskConfig or None, got {type(v).__name__}.')
+    def _validate_sandbox(cls, v: Any) -> Any:
+        return cls._coerce_sandbox_config(v)
 
     # --- Model validator (cross-field logic, replaces __post_init__) ---
 
@@ -363,7 +359,7 @@ class TaskConfig(BaseArgument):
 
         return self
 
-    def _parse_rag_eval_config(self):
+    def _parse_rag_eval_config(self) -> None:
         """Parse eval_config into typed Pydantic models for RAGEval backend."""
         if self.eval_backend != EvalBackend.RAG_EVAL or not isinstance(self.eval_config, dict):
             return
@@ -378,7 +374,7 @@ class TaskConfig(BaseArgument):
             from evalscope.backend.rag_eval.clip_benchmark.arguments import ClipBenchmarkToolConfig
             self.eval_config = ClipBenchmarkToolConfig(**self.eval_config)
 
-    def _init_model_and_id(self):
+    def _init_model_and_id(self) -> None:
         # Set model to DummyCustomModel if not provided
         if self.model is None:
             logger.info('No model is provided, using DummyCustomModel for testing.')
@@ -408,14 +404,13 @@ class TaskConfig(BaseArgument):
             return safe_filename(self.model.model_name)
         return 'dummy_model'
 
-    def _init_default_generation_config(self):
+    def _init_default_generation_config(self) -> None:
         # 1. Set defaults if empty
         if not self.generation_config:
             self.generation_config = self._get_default_generation_config()
 
         # 2. Validate/Convert to GenerateConfig object
-        if isinstance(self.generation_config, dict):
-            self.generation_config = GenerateConfig.model_validate(self.generation_config)
+        self.generation_config = self._coerce_generation_config(self.generation_config)
 
         # 3. Sync batch size
         self.generation_config.batch_size = self.eval_batch_size
@@ -435,7 +430,21 @@ class TaskConfig(BaseArgument):
 
         return {}
 
-    def _handle_generation_config_deprecations(self):
+    @staticmethod
+    def _coerce_generation_config(value: Union[Dict, GenerateConfig]) -> GenerateConfig:
+        if isinstance(value, GenerateConfig):
+            return value
+        return GenerateConfig.model_validate(value)
+
+    @staticmethod
+    def _coerce_sandbox_config(value: Any) -> Optional[SandboxTaskConfig]:
+        if value is None or isinstance(value, SandboxTaskConfig):
+            return value
+        if isinstance(value, dict):
+            return SandboxTaskConfig.model_validate(value)
+        raise ValueError(f'`sandbox` must be a dict, SandboxTaskConfig or None, got {type(value).__name__}.')
+
+    def _handle_generation_config_deprecations(self) -> None:
         assert isinstance(self.generation_config, GenerateConfig)
 
         if self.timeout is not None:
@@ -460,13 +469,13 @@ class TaskConfig(BaseArgument):
                 'The `n` parameter in generation_config is deprecated and will be removed in v2.0.0. Use `TaskConfig.repeats` instead.'
             )
 
-    def _init_default_model_args(self):
+    def _init_default_model_args(self) -> None:
         if self.model_args:
             return
         if self.model_task == ModelTask.TEXT_GENERATION and self.eval_type == EvalType.CHECKPOINT:
             self.model_args = DEFAULT_MODEL_ARGS_CHECKPOINT.copy()
 
-    def _init_default_sandbox_config(self):
+    def _init_default_sandbox_config(self) -> None:
         """Normalise sandbox configuration into ``self.sandbox``.
 
         After this method every consumer (``CodeExecutionSandboxMixin``, data adapters,
@@ -481,16 +490,11 @@ class TaskConfig(BaseArgument):
           * Otherwise ``sandbox`` is constructed from the legacy fields so
             historical task configs keep working.
         """
-        legacy_set = bool(self.use_sandbox) or (self.sandbox_type
-                                                not in (None, 'docker')) or bool(self.sandbox_manager_config)
+        legacy_set = self._legacy_sandbox_fields_set()
 
         if self.sandbox is None:
             # Build from legacy fields (possibly all defaults).
-            self.sandbox = SandboxTaskConfig(
-                enabled=bool(self.use_sandbox),
-                engine=self.sandbox_type or 'docker',
-                manager_config=dict(self.sandbox_manager_config or {}),
-            )
+            self.sandbox = self._build_sandbox_from_legacy_fields()
         elif legacy_set:
             deprecated_warning(
                 logger, 'Both `sandbox` and legacy sandbox fields '
@@ -503,6 +507,18 @@ class TaskConfig(BaseArgument):
             return
 
         check_import('ms_enclave', 'evalscope[sandbox]', raise_error=True)
+
+    def _legacy_sandbox_fields_set(self) -> bool:
+        return bool(self.use_sandbox) or (self.sandbox_type not in (None, 'docker')) or bool(
+            self.sandbox_manager_config
+        )
+
+    def _build_sandbox_from_legacy_fields(self) -> SandboxTaskConfig:
+        return SandboxTaskConfig(
+            enabled=bool(self.use_sandbox),
+            engine=self.sandbox_type or 'docker',
+            manager_config=dict(self.sandbox_manager_config or {}),
+        )
 
     @staticmethod
     def _deep_merge(base: dict, override: dict) -> dict:
@@ -521,9 +537,9 @@ class TaskConfig(BaseArgument):
         other = _secretize_api_keys(other)
         merged = self._deep_merge(self._to_update_dict(), other)
         if isinstance(merged.get('generation_config'), dict):
-            merged['generation_config'] = GenerateConfig.model_validate(merged['generation_config'])
+            merged['generation_config'] = self._coerce_generation_config(merged['generation_config'])
         if isinstance(merged.get('sandbox'), dict):
-            merged['sandbox'] = SandboxTaskConfig.model_validate(merged['sandbox'])
+            merged['sandbox'] = self._coerce_sandbox_config(merged['sandbox'])
         for key, value in merged.items():
             setattr(self, key, value)
 
@@ -543,7 +559,7 @@ class TaskConfig(BaseArgument):
             kwargs['mode'] = mode
         return self.generation_config.model_dump(**kwargs)
 
-    def dump_yaml(self, output_dir: str):
+    def dump_yaml(self, output_dir: str) -> None:
         """Dump the task configuration to a YAML file."""
         task_cfg_file = os.path.join(output_dir, f'task_config.yaml')
         try:
@@ -552,7 +568,7 @@ class TaskConfig(BaseArgument):
         except Exception as e:
             logger.warning(f'Failed to dump overall task config: {e}')
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         result = self.model_dump(mode='json', exclude={'model', 'generation_config'})
 
         # Serialize Model objects

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -509,9 +509,8 @@ class TaskConfig(BaseArgument):
         check_import('ms_enclave', 'evalscope[sandbox]', raise_error=True)
 
     def _legacy_sandbox_fields_set(self) -> bool:
-        return bool(self.use_sandbox) or (self.sandbox_type not in (None, 'docker')) or bool(
-            self.sandbox_manager_config
-        )
+        return bool(self.use_sandbox) or (self.sandbox_type
+                                          not in (None, 'docker')) or bool(self.sandbox_manager_config)
 
     def _build_sandbox_from_legacy_fields(self) -> SandboxTaskConfig:
         return SandboxTaskConfig(

--- a/evalscope/constants.py
+++ b/evalscope/constants.py
@@ -5,13 +5,15 @@ from datetime import timedelta, timezone
 
 os.environ['MODELSCOPE_LOG_LEVEL'] = '40'  # Set default log level to ERROR
 
-from modelscope.utils.constant import DEFAULT_REPOSITORY_REVISION
-from modelscope.utils.file_utils import get_dataset_cache_root, get_model_cache_root
+
+def _get_modelscope_cache_dir() -> str:
+    return os.path.expanduser(os.getenv('MODELSCOPE_CACHE', '~/.cache/modelscope/hub'))
+
 
 DEFAULT_WORK_DIR = './outputs'
-DEFAULT_MODEL_REVISION = DEFAULT_REPOSITORY_REVISION  # master
-DEFAULT_MODEL_CACHE_DIR = get_model_cache_root()  # ~/.cache/modelscope/hub/models
-DEFAULT_DATASET_CACHE_DIR = get_dataset_cache_root()  # ~/.cache/modelscope/hub/datasets
+DEFAULT_MODEL_REVISION = 'master'
+DEFAULT_MODEL_CACHE_DIR = os.path.join(_get_modelscope_cache_dir(), 'models')  # ~/.cache/modelscope/hub/models
+DEFAULT_DATASET_CACHE_DIR = os.path.join(_get_modelscope_cache_dir(), 'datasets')  # ~/.cache/modelscope/hub/datasets
 DEFAULT_ROOT_CACHE_DIR = DEFAULT_DATASET_CACHE_DIR  # compatible with old version
 DEFAULT_EVALSCOPE_CACHE_DIR = os.path.expanduser(
     os.getenv('EVALSCOPE_CACHE', '~/.cache/evalscope')

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -6,7 +6,7 @@ from pydantic import Field, SecretStr, field_validator, model_validator
 from typing import Any, Dict, List, Optional, Union
 
 from evalscope.constants import DEFAULT_WORK_DIR, VisualizerType
-from evalscope.perf.multi_turn_args import IntOrRange, MultiTurnArgs, _sample_int_or_range
+from evalscope.perf.multi_turn_args import IntOrRange, MultiTurnArgs
 from evalscope.utils import BaseArgument, get_secret_value, secretize_auth_headers
 from evalscope.utils.logger import get_logger
 
@@ -22,6 +22,19 @@ _OPENAI_API_ENDPOINT_MAP = {
     'openai_rerank': 'reranks',
     'rerank': 'reranks',
 }
+
+_OPENAI_RESPONSES_APIS = ('openai_responses', 'openai_response', 'responses')
+_KNOWN_OPENAI_ENDPOINTS = ('chat/completions', 'completions', 'responses', 'embeddings', 'reranks')
+
+
+def _as_list_if_scalar(value: Any, scalar_type: Any) -> Any:
+    if isinstance(value, scalar_type):
+        return [value]
+    return value
+
+
+def _at_least_one(value: int) -> int:
+    return max(value, 1) if value <= 0 else value
 
 
 class Arguments(BaseArgument):
@@ -98,10 +111,9 @@ class Arguments(BaseArgument):
         """
         if self.warmup_num <= 0:
             return 0
-        n = self.number if isinstance(self.number, int) else self.number[0]
         if self.warmup_num >= 1:
             return int(self.warmup_num)
-        return max(1, int(self.warmup_num * n))
+        return max(1, int(self.warmup_num * self._current_number()))
 
     @property
     def total_count(self) -> int:
@@ -110,8 +122,7 @@ class Arguments(BaseArgument):
         Equal to ``number + warmup_count``.  When ``number`` is a list
         (sweep mode), uses the first element.
         """
-        n = self.number if isinstance(self.number, int) else self.number[0]
-        return n + self.warmup_count
+        return self._current_number() + self.warmup_count
 
     open_loop: bool = False
     """Enable open-loop rate mode: dispatch requests at the scheduled rate without semaphore backpressure.
@@ -379,7 +390,7 @@ class Arguments(BaseArgument):
 
     @field_validator('max_tokens', mode='before')
     @classmethod
-    def _validate_max_tokens(cls, v):
+    def _validate_max_tokens(cls, v: Any) -> Any:
         if isinstance(v, list):
             if len(v) == 1:
                 return v[0]  # single value from nargs='+'
@@ -393,7 +404,7 @@ class Arguments(BaseArgument):
 
     @field_validator('multi_turn_args', mode='before')
     @classmethod
-    def _validate_multi_turn_args(cls, v):
+    def _validate_multi_turn_args(cls, v: Any) -> Any:
         if v is None:
             return v
         if isinstance(v, MultiTurnArgs):
@@ -414,39 +425,33 @@ class Arguments(BaseArgument):
 
     @field_validator('rate', mode='before')
     @classmethod
-    def _validate_rate(cls, v):
-        if isinstance(v, (int, float)):
-            return [float(v)]
-        return v
+    def _validate_rate(cls, v: Any) -> Any:
+        return _as_list_if_scalar(float(v), (int, float)) if isinstance(v, (int, float)) else v
 
     @field_validator('number', mode='before')
     @classmethod
-    def _validate_number(cls, v):
-        if isinstance(v, int):
-            return [v]
-        return v
+    def _validate_number(cls, v: Any) -> Any:
+        return _as_list_if_scalar(v, int)
 
     @field_validator('parallel', mode='before')
     @classmethod
-    def _validate_parallel(cls, v):
-        if isinstance(v, int):
-            return [v]
-        return v
+    def _validate_parallel(cls, v: Any) -> Any:
+        return _as_list_if_scalar(v, int)
 
     @field_validator('db_commit_interval', mode='after')
     @classmethod
-    def _validate_db_commit_interval(cls, v):
-        return max(v, 1) if v <= 0 else v
+    def _validate_db_commit_interval(cls, v: int) -> int:
+        return _at_least_one(v)
 
     @field_validator('queue_size_multiplier', mode='after')
     @classmethod
-    def _validate_queue_size_multiplier(cls, v):
-        return max(v, 1) if v <= 0 else v
+    def _validate_queue_size_multiplier(cls, v: int) -> int:
+        return _at_least_one(v)
 
     @field_validator('in_flight_task_multiplier', mode='after')
     @classmethod
-    def _validate_in_flight_task_multiplier(cls, v):
-        return max(v, 1) if v <= 0 else v
+    def _validate_in_flight_task_multiplier(cls, v: int) -> int:
+        return _at_least_one(v)
 
     @field_validator('num_workers', mode='after')
     @classmethod
@@ -487,68 +492,86 @@ class Arguments(BaseArgument):
 
         return self
 
-    def _resolve_url(self):
+    def _current_number(self) -> int:
+        return self.number if isinstance(self.number, int) else self.number[0]
+
+    def _resolve_url(self) -> None:
         """Resolve URL based on api, dataset, port, and tokenize_prompt settings."""
-        # Set the URL based on the dataset type
+        self._resolve_local_url()
+        self._resolve_openai_compatible_url()
+        self._resolve_tokenize_prompt_url()
+
+    def _resolve_local_url(self) -> None:
         if self.api.startswith('local'):
             if self.dataset.startswith('speed_benchmark'):
                 self.url = f'http://127.0.0.1:{self.port}/v1/completions'
             else:
                 self.url = f'http://127.0.0.1:{self.port}/v1/chat/completions'
 
-        # Auto-append endpoint path for openai-compatible APIs when URL has no known endpoint suffix
+    def _resolve_openai_compatible_url(self) -> None:
         if self.api in _OPENAI_API_ENDPOINT_MAP:
-            _stripped = self.url.rstrip('/')
-            _expected_suffix = _OPENAI_API_ENDPOINT_MAP[self.api]
-            _known_endpoints = ('chat/completions', 'completions', 'responses', 'embeddings', 'reranks')
-            if self.api in ('openai_responses', 'openai_response',
-                            'responses') and _stripped.endswith('/chat/completions'):
-                self.url = _stripped[:-len('chat/completions')] + 'responses'
-                logger.warning(f'OpenAI Responses API selected: URL auto-adjusted to responses endpoint: {self.url}')
-            elif not any(_stripped.endswith('/' + ep) for ep in _known_endpoints):
-                self.url = _stripped + '/' + _expected_suffix
+            stripped_url = self.url.rstrip('/')
+            expected_suffix = _OPENAI_API_ENDPOINT_MAP[self.api]
+            if self._redirect_responses_url(stripped_url):
+                return
+            if not any(stripped_url.endswith('/' + endpoint) for endpoint in _KNOWN_OPENAI_ENDPOINTS):
+                self.url = stripped_url + '/' + expected_suffix
                 logger.warning(
-                    f'URL "{_stripped}" has no endpoint path, auto-appended "/{_expected_suffix}". '
+                    f'URL "{stripped_url}" has no endpoint path, auto-appended "/{expected_suffix}". '
                     'If this is not intended, please specify the full URL explicitly.'
                 )
 
-        # When tokenize_prompt is enabled, redirect to the completions endpoint.
-        if self.tokenize_prompt:
-            if self.api in ('openai_responses', 'openai_response', 'responses'):
-                raise ValueError('--tokenize-prompt is not supported with the OpenAI Responses API.')
-            if not self.tokenizer_path:
-                raise ValueError('--tokenizer-path is required when --tokenize-prompt is set.')
-            _stripped = self.url.rstrip('/')
-            if _stripped.endswith('chat/completions'):
-                self.url = _stripped[:-len('chat/completions')] + 'completions'
-                logger.warning(
-                    f'--tokenize-prompt is set: URL auto-adjusted from chat/completions '
-                    f'to completions endpoint: {self.url}'
-                )
+    def _redirect_responses_url(self, stripped_url: str) -> bool:
+        if self.api in _OPENAI_RESPONSES_APIS and stripped_url.endswith('/chat/completions'):
+            self.url = stripped_url[:-len('chat/completions')] + 'responses'
+            logger.warning(f'OpenAI Responses API selected: URL auto-adjusted to responses endpoint: {self.url}')
+            return True
+        return False
 
-    def _validate_sweep_params(self):
+    def _resolve_tokenize_prompt_url(self) -> None:
+        if not self.tokenize_prompt:
+            return
+        if self.api in _OPENAI_RESPONSES_APIS:
+            raise ValueError('--tokenize-prompt is not supported with the OpenAI Responses API.')
+        if not self.tokenizer_path:
+            raise ValueError('--tokenizer-path is required when --tokenize-prompt is set.')
+        stripped_url = self.url.rstrip('/')
+        if stripped_url.endswith('chat/completions'):
+            self.url = stripped_url[:-len('chat/completions')] + 'completions'
+            logger.warning(
+                f'--tokenize-prompt is set: URL auto-adjusted from chat/completions '
+                f'to completions endpoint: {self.url}'
+            )
+
+    def _validate_sweep_params(self) -> None:
         """Validate number/parallel/rate consistency after normalization."""
         if self.open_loop:
-            if len(self.number) != len(self.rate):
-                raise ValueError(
-                    f'In open-loop mode the length of --number and --rate must match, '
-                    f'but got number: {self.number} and rate: {self.rate}'
-                )
-            if not all(r > 0 for r in self.rate):
-                raise ValueError(f'In open-loop mode all --rate values must be > 0, but got: {self.rate}')
-            # In open-loop mode concurrency is unbounded; set parallel=-1 so downstream
-            # display layers render it as INF instead of a numeric value.
-            self.parallel = [-1]
-            logger.info(
-                'open-loop mode enabled: concurrency is unbounded (parallel set to -1 / INF). '
-                f'Rate sweep: {self.rate}, number sweep: {self.number}.'
+            self._validate_open_loop_sweep_params()
+            return
+        self._validate_closed_loop_sweep_params()
+
+    def _validate_open_loop_sweep_params(self) -> None:
+        if len(self.number) != len(self.rate):
+            raise ValueError(
+                f'In open-loop mode the length of --number and --rate must match, '
+                f'but got number: {self.number} and rate: {self.rate}'
             )
-        else:
-            if len(self.number) != len(self.parallel):
-                raise ValueError(
-                    f'The length of number and parallel should be the same, '
-                    f'but got number: {self.number} and parallel: {self.parallel}'
-                )
+        if not all(r > 0 for r in self.rate):
+            raise ValueError(f'In open-loop mode all --rate values must be > 0, but got: {self.rate}')
+        # In open-loop mode concurrency is unbounded; set parallel=-1 so downstream
+        # display layers render it as INF instead of a numeric value.
+        self.parallel = [-1]
+        logger.info(
+            'open-loop mode enabled: concurrency is unbounded (parallel set to -1 / INF). '
+            f'Rate sweep: {self.rate}, number sweep: {self.number}.'
+        )
+
+    def _validate_closed_loop_sweep_params(self) -> None:
+        if len(self.number) != len(self.parallel):
+            raise ValueError(
+                f'The length of number and parallel should be the same, '
+                f'but got number: {self.number} and parallel: {self.parallel}'
+            )
 
     @contextmanager
     def output_context(self, path: str):
@@ -592,16 +615,16 @@ class ParseKVAction(argparse.Action):
                 parser.error(f'Error parsing key-value pairs: {e}')
 
 
-def add_argument(parser: argparse.ArgumentParser):
-    # yapf: disable
-    # Model and API
+# yapf: disable
+def _add_model_api_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--model', type=str, required=True, help='The test model name.')
-    parser.add_argument('--attn-implementation', required=False, default=None, help='Attention implementaion')
+    parser.add_argument('--attn-implementation', required=False, default=None, help='Attention implementation')
     parser.add_argument('--api', type=str, default='openai', help='Service API protocol: openai | openai_responses/responses | openai_embedding/embedding | openai_rerank/rerank | local/local_vllm. Determines the auto-appended endpoint path on --url.')  # noqa: E501
     parser.add_argument(
         '--tokenizer-path', type=str, required=False, default=None, help='Specify the tokenizer weight path')
 
-    # Connection settings
+
+def _add_connection_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--url', type=str, default='http://127.0.0.1:8877/v1/chat/completions')
     parser.add_argument('--port', type=int, default=8877, help='The port for local inference')
     parser.add_argument('--headers', nargs='+', dest='headers', action=ParseKVAction, help='Extra HTTP headers')
@@ -611,7 +634,8 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--total-timeout', type=int, default=6 * 60 * 60, help='The total timeout for each request')  # noqa: E501
     parser.add_argument('--no-test-connection', action='store_true', default=False, help='Do not test the connection before starting the benchmark')  # noqa: E501
 
-    # Performance and parallelism
+
+def _add_performance_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-n', '--number', type=int, default=1000, nargs='+', help='How many requests to be made')
     parser.add_argument('--parallel', type=int, default=1, nargs='+', help='Set number of concurrency requests, default 1')  # noqa: E501
     parser.add_argument('--rate', type=float, default=-1, nargs='+',
@@ -634,7 +658,8 @@ def add_argument(parser: argparse.ArgumentParser):
              'matching trie). Warmup ignores this. When both --number and --duration are set, '
              'whichever limit is reached first ends the run.')  # noqa: E501
 
-    # SLA Auto-tuning
+
+def _add_sla_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--sla-auto-tune', action='store_true', default=False, help='Enable SLA auto-tuning')
     parser.add_argument('--sla-variable', type=str, default='parallel', choices=['parallel', 'rate'], help='The variable to tune, can be parallel or rate')  # noqa: E501
     parser.add_argument('--sla-params', type=json.loads, default=None, help='SLA constraints in JSON format')
@@ -644,7 +669,8 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--sla-fixed-parallel', type=int, default=None, help='Fixed parallel workers used when --sla-variable=rate. Defaults to --sla-upper-bound for backward compatibility.')  # noqa: E501
     parser.add_argument('--sla-number-multiplier', type=float, default=None, help='Multiplier for number of requests relative to parallel/rate in SLA auto-tuning. number = round(val * N). Defaults to 2 if not set.')  # noqa: E501
 
-    # Tuning knobs
+
+def _add_tuning_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--db-commit-interval', type=int, default=1000, help='Rows buffered before SQLite commit')
     parser.add_argument('--queue-size-multiplier', type=int, default=5, help='Queue maxsize = parallel * multiplier')
     parser.add_argument('--in-flight-task-multiplier', type=int, default=2, help='Max scheduled tasks = parallel * multiplier')  # noqa: E501
@@ -658,7 +684,8 @@ def add_argument(parser: argparse.ArgumentParser):
         ),
     )
 
-    # Logging and debugging
+
+def _add_logging_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--log-every-n-query', type=int, default=100, help='Logging every n query')
     parser.add_argument('--debug', action='store_true', default=False, help='Debug request send')
     parser.add_argument('--visualizer', type=str, default=None,
@@ -673,14 +700,15 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--name', type=str, help='The wandb/swanlab/clearml result name and result db name')
     parser.add_argument('--enable-progress-tracker', action='store_true', default=False, help='Enable progress tracker')
 
-    # Prompt settings
+
+def _add_prompt_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--max-prompt-length', type=int, default=131072, help='Maximum input prompt length')
     parser.add_argument('--min-prompt-length', type=int, default=0, help='Minimum input prompt length')
     parser.add_argument('--prefix-length', type=int, default=0, help='The prefix length')
     parser.add_argument('--prompt', type=str, required=False, default=None, help='Specified the request prompt')
     parser.add_argument('--query-template', type=str, default=None, help='Specify the query template')
     parser.add_argument(
-        '--apply-chat-template', type=argparse.BooleanOptionalAction, default=None, help='Apply chat template to the prompt')  # noqa: E501
+        '--apply-chat-template', action=argparse.BooleanOptionalAction, default=None, help='Apply chat template to the prompt')  # noqa: E501
     # random vl settings
     parser.add_argument('--image-width', type=int, default=224, help='Width of the image for random VL dataset')
     parser.add_argument('--image-height', type=int, default=224, help='Height of the image for random VL dataset')
@@ -688,11 +716,13 @@ def add_argument(parser: argparse.ArgumentParser):
     parser.add_argument('--image-num', type=int, default=1, help='Number of images for random VL dataset')
     parser.add_argument('--image-patch-size', type=int, default=28, help='Patch size for image tokenizer, only for local image token calculation')  # noqa: E501
 
-    # Output settings
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--outputs-dir', help='Outputs dir.', default='outputs')
     parser.add_argument('--no-timestamp', action='store_true', default=False, help='Do not add timestamp to output directory')  # noqa: E501
 
-    # Dataset settings
+
+def _add_dataset_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--dataset', type=str, default='openqa', help='Specify the dataset')
     parser.add_argument('--dataset-path', type=str, required=False, help='Path to the dataset file or directory')
     parser.add_argument(
@@ -713,7 +743,8 @@ def add_argument(parser: argparse.ArgumentParser):
         ),
     )
 
-    # Response settings
+
+def _add_response_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--frequency-penalty', type=float, help='The frequency_penalty value', default=None)
     parser.add_argument('--repetition-penalty', type=float, help='The repetition_penalty value', default=None)
     parser.add_argument('--logprobs', action='store_true', help='The logprobs', default=None)
@@ -741,7 +772,9 @@ def add_argument(parser: argparse.ArgumentParser):
             'Requires --tokenizer-path to be set.'
         ),
     )
-    # Multi-turn settings
+
+
+def _add_multi_turn_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '--multi-turn',
         action='store_true',
@@ -786,7 +819,21 @@ def add_argument(parser: argparse.ArgumentParser):
             'use top-level --num-workers for live construction parallelism.'
         ),
     )
-    # yapf: enable
+
+
+def add_argument(parser: argparse.ArgumentParser) -> None:
+    _add_model_api_arguments(parser)
+    _add_connection_arguments(parser)
+    _add_performance_arguments(parser)
+    _add_sla_arguments(parser)
+    _add_tuning_arguments(parser)
+    _add_logging_arguments(parser)
+    _add_prompt_arguments(parser)
+    _add_output_arguments(parser)
+    _add_dataset_arguments(parser)
+    _add_response_arguments(parser)
+    _add_multi_turn_arguments(parser)
+# yapf: enable
 
 
 def parse_args():

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -475,12 +475,15 @@ class Arguments(BaseArgument):
         # Set the model ID based on the model name
         self.model_id = os.path.basename(self.model)
 
-        # Set the URL based on the dataset type
-        self._resolve_url()
+        # Set the URL based on the dataset type.
+        self._resolve_local_url()
+        self._resolve_openai_compatible_url()
 
-        # Resolve apply_chat_template from the *original* URL before any redirects.
+        # Resolve apply_chat_template before tokenize_prompt redirects chat/completions to completions.
         if self.apply_chat_template is None:
             self.apply_chat_template = self.url.strip('/').endswith('chat/completions')
+
+        self._resolve_tokenize_prompt_url()
 
         # Validate sweep params (number/parallel/rate consistency)
         self._validate_sweep_params()

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -27,10 +27,12 @@ _OPENAI_RESPONSES_APIS = ('openai_responses', 'openai_response', 'responses')
 _KNOWN_OPENAI_ENDPOINTS = ('chat/completions', 'completions', 'responses', 'embeddings', 'reranks')
 
 
-def _as_list_if_scalar(value: Any, scalar_type: Any) -> Any:
-    if isinstance(value, scalar_type):
-        return [value]
-    return value
+def _as_list_if_scalar(value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
 
 
 def _at_least_one(value: int) -> int:
@@ -426,17 +428,17 @@ class Arguments(BaseArgument):
     @field_validator('rate', mode='before')
     @classmethod
     def _validate_rate(cls, v: Any) -> Any:
-        return _as_list_if_scalar(float(v), (int, float)) if isinstance(v, (int, float)) else v
+        return _as_list_if_scalar(v)
 
     @field_validator('number', mode='before')
     @classmethod
     def _validate_number(cls, v: Any) -> Any:
-        return _as_list_if_scalar(v, int)
+        return _as_list_if_scalar(v)
 
     @field_validator('parallel', mode='before')
     @classmethod
     def _validate_parallel(cls, v: Any) -> Any:
-        return _as_list_if_scalar(v, int)
+        return _as_list_if_scalar(v)
 
     @field_validator('db_commit_interval', mode='after')
     @classmethod

--- a/evalscope/utils/logger.py
+++ b/evalscope/utils/logger.py
@@ -59,26 +59,17 @@ warning_set = set()
 
 
 def _get_loaded_torch_distributed() -> Optional[ModuleType]:
-    if 'torch' not in sys.modules:
-        return None
-
-    try:
-        import torch.distributed as dist
-    except Exception:
-        return None
-    return dist
+    return sys.modules.get('torch.distributed')
 
 
 def _is_torch_dist() -> bool:
     dist = _get_loaded_torch_distributed()
-    if dist is None:
-        return False
-    return dist.is_available() and dist.is_initialized()
+    return dist is not None and dist.is_available() and dist.is_initialized()
 
 
 def _is_torch_master() -> bool:
     dist = _get_loaded_torch_distributed()
-    if dist is None or not _is_torch_dist():
+    if dist is None or not (dist.is_available() and dist.is_initialized()):
         return True
     return dist.get_rank() == 0
 

--- a/evalscope/utils/logger.py
+++ b/evalscope/utils/logger.py
@@ -62,16 +62,45 @@ def _get_loaded_torch_distributed() -> Optional[ModuleType]:
     return sys.modules.get('torch.distributed')
 
 
+def _get_distributed_rank_from_env() -> Optional[int]:
+    for key in ('RANK', 'LOCAL_RANK'):
+        value = os.getenv(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _is_distributed_from_env() -> bool:
+    world_size = os.getenv('WORLD_SIZE')
+    if world_size is None:
+        return _get_distributed_rank_from_env() is not None
+    try:
+        return int(world_size) > 1
+    except ValueError:
+        return False
+
+
 def _is_torch_dist() -> bool:
     dist = _get_loaded_torch_distributed()
-    return dist is not None and dist.is_available() and dist.is_initialized()
+    if dist is not None:
+        return dist.is_available() and dist.is_initialized()
+    return _is_distributed_from_env()
 
 
 def _is_torch_master() -> bool:
     dist = _get_loaded_torch_distributed()
-    if dist is None or not (dist.is_available() and dist.is_initialized()):
-        return True
-    return dist.get_rank() == 0
+    if dist is not None and dist.is_available() and dist.is_initialized():
+        return dist.get_rank() == 0
+
+    rank = _get_distributed_rank_from_env()
+    if rank is not None:
+        return rank == 0
+
+    return True
 
 
 def info_once(self, msg, *args, **kwargs):

--- a/evalscope/utils/logger.py
+++ b/evalscope/utils/logger.py
@@ -1,9 +1,10 @@
 import colorlog
-import importlib.util as iutil
 import logging
 import os
+import sys
 from datetime import datetime
 from logging import Logger
+from types import ModuleType
 from typing import List, Optional
 
 from evalscope.constants import BEIJING_TZ, USE_OSS, LoggingConstants
@@ -55,6 +56,31 @@ logging.getLogger('transformers_modules').setLevel(logging.ERROR)
 
 info_set = set()
 warning_set = set()
+
+
+def _get_loaded_torch_distributed() -> Optional[ModuleType]:
+    if 'torch' not in sys.modules:
+        return None
+
+    try:
+        import torch.distributed as dist
+    except Exception:
+        return None
+    return dist
+
+
+def _is_torch_dist() -> bool:
+    dist = _get_loaded_torch_distributed()
+    if dist is None:
+        return False
+    return dist.is_available() and dist.is_initialized()
+
+
+def _is_torch_master() -> bool:
+    dist = _get_loaded_torch_distributed()
+    if dist is None or not _is_torch_dist():
+        return True
+    return dist.get_rank() == 0
 
 
 def info_once(self, msg, *args, **kwargs):
@@ -154,13 +180,8 @@ def get_logger(
         return logger
 
     # handle duplicate logs to the console
-    torch_dist = False
-    is_worker0 = True
-    if iutil.find_spec('torch') is not None:
-        from modelscope.utils.torch_utils import is_dist, is_master
-
-        torch_dist = is_dist()
-        is_worker0 = is_master()
+    torch_dist = _is_torch_dist()
+    is_worker0 = _is_torch_master()
 
     if torch_dist:
         for handler in logger.root.handlers:
@@ -214,14 +235,7 @@ def add_file_handler_if_needed(
     if log_file is None:
         return
 
-    # Only worker-0 writes files
-    if iutil.find_spec('torch') is not None:
-        from modelscope.utils.torch_utils import is_master
-        is_worker0 = is_master()
-    else:
-        is_worker0 = True
-
-    if not is_worker0:
+    if not _is_torch_master():
         return
 
     target_path = os.path.abspath(log_file)

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -173,6 +173,16 @@ def test_apply_chat_template_boolean_cli_flags() -> None:
     assert disabled_args.apply_chat_template is False
 
 
+def test_tokenize_prompt_preserves_chat_template_default_before_redirect() -> None:
+    args = _make_args(
+        tokenize_prompt=True,
+        tokenizer_path='dummy-tokenizer',
+    )
+
+    assert args.url == 'http://127.0.0.1:8000/v1/completions'
+    assert args.apply_chat_template is True
+
+
 def test_random_dataset_parallel_uses_spawn_context() -> None:
     assert _get_random_generation_context().get_start_method() == 'spawn'
 

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -1,5 +1,5 @@
-import asyncio
 import argparse
+import asyncio
 import numpy as np
 from pytest import MonkeyPatch
 from typing import Dict, Iterator, List, Optional, Tuple
@@ -68,6 +68,18 @@ def _parse_perf_args(argv: List[str]) -> Arguments:
     parser = argparse.ArgumentParser()
     add_argument(parser)
     return Arguments.from_args(parser.parse_args(argv))
+
+
+def test_sweep_scalar_strings_are_normalized_to_lists() -> None:
+    args = _make_args(number='10', parallel='2')
+
+    assert args.number == [10]
+    assert args.parallel == [2]
+
+    args = _make_args(number='10', rate='5.0', open_loop=True)
+
+    assert args.number == [10]
+    assert args.rate == [5.0]
 
 
 def test_parallel_dataset_generation_hook_preserves_order_and_warmup() -> None:

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -1,9 +1,10 @@
 import asyncio
+import argparse
 import numpy as np
 from pytest import MonkeyPatch
 from typing import Dict, Iterator, List, Optional, Tuple
 
-from evalscope.perf.arguments import Arguments
+from evalscope.perf.arguments import Arguments, add_argument
 from evalscope.perf.benchmark import get_requests
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
 from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin, _get_random_generation_context
@@ -61,6 +62,12 @@ def _make_args(**kwargs) -> Arguments:
     }
     params.update(kwargs)
     return Arguments(**params)
+
+
+def _parse_perf_args(argv: List[str]) -> Arguments:
+    parser = argparse.ArgumentParser()
+    add_argument(parser)
+    return Arguments.from_args(parser.parse_args(argv))
 
 
 def test_parallel_dataset_generation_hook_preserves_order_and_warmup() -> None:
@@ -130,6 +137,28 @@ def test_top_level_num_workers_takes_precedence_over_multi_turn_value() -> None:
     args = _make_args(num_workers=0, multi_turn_args={'num_workers': 3})
 
     assert args.num_workers == 0
+
+
+def test_apply_chat_template_boolean_cli_flags() -> None:
+    default_args = _parse_perf_args(['--model', 'test-model', '--url', 'http://127.0.0.1:8000/v1/completions'])
+    enabled_args = _parse_perf_args([
+        '--model',
+        'test-model',
+        '--url',
+        'http://127.0.0.1:8000/v1/completions',
+        '--apply-chat-template',
+    ])
+    disabled_args = _parse_perf_args([
+        '--model',
+        'test-model',
+        '--url',
+        'http://127.0.0.1:8000/v1/chat/completions',
+        '--no-apply-chat-template',
+    ])
+
+    assert default_args.apply_chat_template is False
+    assert enabled_args.apply_chat_template is True
+    assert disabled_args.apply_chat_template is False
 
 
 def test_random_dataset_parallel_uses_spawn_context() -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,17 @@
+import sys
+
+from evalscope.utils import logger
+
+
+def test_distributed_env_detection_does_not_import_torch_distributed(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, 'torch.distributed', raising=False)
+    monkeypatch.setenv('WORLD_SIZE', '2')
+    monkeypatch.setenv('RANK', '1')
+
+    assert logger._is_torch_dist() is True
+    assert logger._is_torch_master() is False
+    assert 'torch.distributed' not in sys.modules
+
+    monkeypatch.setenv('RANK', '0')
+
+    assert logger._is_torch_master() is True


### PR DESCRIPTION
## Summary

- Clean up `TaskConfig` and perf `Arguments` internals without changing public fields, CLI flags, defaults, or compatibility paths.
- Fix `--apply-chat-template` boolean CLI parsing.
- Remove cold-start ModelScope imports from `constants.py` and logger, and lazy-load LoCoMo's NLTK stemmer.

## Validation

- `python3 -m py_compile evalscope/perf/arguments.py tests/perf/test_request_generation.py`
- `conda run -n eval pytest tests/perf/test_request_generation.py tests/perf/test_arguments_secrets.py tests/perf/test_openai_api_parse_responses.py tests/agent/test_sandbox_service.py -q`
- `conda run -n eval pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`
- `conda run -n eval pytest tests/benchmark/test_eval.py::TestNativeBenchmark::test_locomo -q`
- `git diff --check`

## Notes

- Current editable install in the `eval` environment now points at `/Users/yunlin/Code/eval-scope`.
- `evalscope --help` median is about 1.4s after the cold-start cleanup on this machine.
