### PR TITLE
feat(perf): add workload_trace dataset plugin for production traffic replay

### DIFF
--- a/docs/en/user_guides/stress_test/examples.md
+++ b/docs/en/user_guides/stress_test/examples.md
@@ -312,6 +312,59 @@ evalscope perf \
 - Core difference from closed-loop (default) mode: closed-loop workers wait for a response before sending the next request (backpressure protection); open-loop fires requests on schedule without waiting (closer to real traffic).
 ```
 
+## Production Traffic Replay (workload_trace)
+
+The `workload_trace` dataset replays recorded production traffic verbatim following its **original arrival timing**, closely matching real-world load — bursty arrivals, heterogeneous request shapes, and multi-model routing that synthetic datasets (`random`, `openqa`, etc.) cannot reproduce. It builds on open-loop scheduling, but arrival times come from the trace's `timestamp` field, so **no `--rate` is needed**.
+
+Prepare a JSONL trace file (one request record per line); field reference is in [Parameters · Case 3](./parameters.md#dataset-args-per-dataset-arguments):
+
+```jsonl
+{"body": {"model": "qwen-plus", "messages": [{"role": "user", "content": "hello"}]}, "timestamp": 1700000000.0}
+{"body": {"model": "qwen-max", "messages": [{"role": "user", "content": "write a poem"}]}, "timestamp": 1700000001.5, "request_id": "req-42"}
+```
+
+**Basic replay**: replay the whole trace verbatim following the original timestamps.
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop
+```
+
+**Speed-up + model mapping**: replay at 2× rate, map `gpt-4` in the trace to a local `qwen-max`, and match the recorded output lengths (requires `ignore_eos` support, e.g. vLLM).
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop \
+  --dataset-args '{"speed": 2.0, "model_mapping": {"gpt-4": "qwen-max"}, "match_output_length": true}'
+```
+
+**Replay only the first 500 records**: truncate with `--number`.
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop \
+  --number 500
+```
+
+```{note}
+**Important Notes**
+
+- **Open-loop only**: `--open-loop` is required, otherwise it raises an error.
+- **`--model` is optional and does not rewrite the body**: each request keeps its own `model` (multi-model routing is preserved). To rewrite models, use `model_override` (replace all) or `model_mapping` (remap by name) via `--dataset-args`.
+- **`--number` is optional**: omit to replay all records, or pass it to truncate to the first N.
+- **Timestamps must be monotonically non-decreasing**: epoch numbers or ISO-8601 strings are accepted; out-of-order records trigger a warning and are sorted by timestamp.
+- Use `--name` to set a meaningful output directory name (without `--model`, the directory name defaults to the dataset name).
+```
+
 ## Debugging Requests
 Use the `--debug` option to output the requests and responses.
 

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -138,6 +138,14 @@ Must be used with `--multi-turn`. See the [Multi-turn Benchmark Guide](./multi_t
 | `share_gpt_en_multi_turn` | Automatically downloads the English [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) dataset (~70k conversations) from ModelScope, preserving full multi-turn conversations | ✓ |
 | `custom_multi_turn` | Uses a local JSONL file as a custom multi-turn dataset<br>Each line must be a JSON array of OpenAI message dicts; ideal for benchmarking with your own conversation data<br>**Requires `--dataset-path`**<br>[Usage example](./multi_turn.md#custom_multi_turn) | ✓ (Required) |
 
+**Production Traffic Replay**
+
+Must be used with `--open-loop`; replays recorded requests verbatim following their **original arrival timing**. See [Usage example](./examples.md#production-traffic-replay-workload_trace).
+
+| Mode | Description | Supports dataset-path |
+|------|-------------|----------------------|
+| `workload_trace` | Replays a recorded production-traffic JSONL verbatim — original timestamps, request bodies, and headers — for benchmarking against real-world load (bursty arrivals, heterogeneous requests, multi-model routing)<br>Each request carries its own `model`, preserving multi-model routing<br>**Requires `--open-loop` and `--dataset-path`**; `--model`/`--number` are optional (the trace carries its own model and count) | ✓ (Required) |
+
 ### dataset-args: Per-dataset Arguments
 
 `--dataset-args` passes per-dataset arguments as a JSON string (a mistyped key raises an error, making mistakes easy to spot). Two common use cases:
@@ -168,6 +176,36 @@ How it differs from `--max/min-prompt-length`:
 **Case 2: Length arguments for multi-turn datasets**
 
 Token-length arguments for multi-turn datasets such as `swe_smith` are also passed via `--dataset-args`; see the [Multi-turn Benchmark Guide](./multi_turn.md).
+
+**Case 3: Replay real production traffic**
+
+Use `workload_trace` to replay recorded production traffic verbatim following its **original arrival timing**, closely matching real-world load. **Requires `--open-loop`**; no `--rate` is needed (arrival times come from the trace timestamps). See the full example at [Production Traffic Replay (workload_trace)](./examples.md#production-traffic-replay-workload_trace).
+
+The trace file is JSONL, one request record per line:
+
+```jsonl
+{"body": {"model": "qwen-plus", "messages": [{"role": "user", "content": "hi"}]}, "timestamp": 1700000000.0}
+{"body": {"model": "qwen-max", "messages": [...]}, "timestamp": 1700000001.5, "headers": {"X-Tag": "exp"}, "request_id": "req-42", "completion_tokens": 256}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `body` | ✓ | Complete request body (dict or JSON string), sent as-is |
+| `timestamp` | ✓ | Arrival time (number or ISO-8601 string); only relative deltas matter; must be monotonically non-decreasing |
+| `headers` | | Per-request HTTP headers (merged with CLI headers, CLI wins; hop-by-hop headers are stripped) |
+| `request_id` | | Propagated to results for correlation with the original request |
+| `completion_tokens` | | Used together with `match_output_length` |
+
+| Key | Type | Description | Default |
+|-----|------|-------------|--------|
+| `speed` | float | Replay speed multiplier (2.0 = 2× faster, 0.5 = 2× slower) | `1.0` |
+| `model_override` | str | Replace the `model` of every request with this value | disabled |
+| `model_mapping` | dict | Remap `model` by name (a match takes priority; unmatched keeps the original) | disabled |
+| `match_output_length` | bool | Set `max_tokens` from the recorded `completion_tokens` and enable `ignore_eos` (requires vLLM or compatible; `ignore_eos` is auto-skipped for constrained-decoding requests) | `false` |
+
+```{note}
+`--model` **does not rewrite** the trace body for `workload_trace` — each request keeps its own `model`, preserving multi-model routing. To rewrite models, use `model_override` / `model_mapping`.
+```
 
 ```{note}
 `--multi-turn-args` is deprecated; use `--dataset-args` instead (the key names are unchanged). The old flag still works and is automatically merged into `--dataset-args` (on a key conflict, `--dataset-args` takes precedence).

--- a/docs/zh/user_guides/stress_test/examples.md
+++ b/docs/zh/user_guides/stress_test/examples.md
@@ -264,6 +264,59 @@ evalscope perf \
 - 本模式与 closed-loop（默认）模式的核心区别：closed-loop 每个 worker 等待响应后再发下一条（背压保护），open-loop 不等待、按调度直接发出（更接近真实流量）。
 ```
 
+## 生产流量回放（workload_trace）
+
+`workload_trace` 数据集把录制的生产流量按**原始到达节奏**逐字回放，贴近真实负载——突发到达、异构请求形状、多模型混合路由，这些是合成数据集（`random`、`openqa` 等）难以复现的。它基于 open-loop 调度，但到达时刻由 trace 里的 `timestamp` 决定，**无需 `--rate`**。
+
+准备一个 JSONL trace 文件（每行一条请求），字段说明见[参数说明 · 场景三](./parameters.md#dataset-args数据集专属参数)：
+
+```jsonl
+{"body": {"model": "qwen-plus", "messages": [{"role": "user", "content": "你好"}]}, "timestamp": 1700000000.0}
+{"body": {"model": "qwen-max", "messages": [{"role": "user", "content": "写一首诗"}]}, "timestamp": 1700000001.5, "request_id": "req-42"}
+```
+
+**基础回放**：按原始时间戳逐字重放整个 trace。
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop
+```
+
+**倍速 + 模型映射**：2× 速率回放，把 trace 里的 `gpt-4` 映射到本地 `qwen-max`，并按记录的输出长度对齐（需 vLLM 等支持 `ignore_eos`）。
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop \
+  --dataset-args '{"speed": 2.0, "model_mapping": {"gpt-4": "qwen-max"}, "match_output_length": true}'
+```
+
+**只回放前 500 条**：用 `--number` 截断。
+
+```bash
+evalscope perf \
+  --dataset workload_trace \
+  --dataset-path trace.jsonl \
+  --url http://127.0.0.1:8000/v1/chat/completions \
+  --open-loop \
+  --number 500
+```
+
+```{note}
+**注意事项**
+
+- **仅支持 open-loop**：必须加 `--open-loop`，否则报错。
+- **`--model` 可选且不改写 body**：每条请求保留自己的 `model`（多模型路由得以保留）。需要改模型请用 `--dataset-args` 的 `model_override`（全量替换）或 `model_mapping`（按名映射）。
+- **`--number` 可选**：不传则回放全部记录，传入则截断到前 N 条。
+- **时间戳须单调不减**：支持 epoch 数字或 ISO-8601 字符串；乱序会告警并按时间戳排序。
+- 建议用 `--name` 指定有意义的输出目录名（不传 `--model` 时目录名默认取数据集名）。
+```
+
 ## Warmup 预热压测
 
 在正式压测前发送一批预热请求，消除冷启动影响（如 KV-cache 填充、JIT 编译、连接池初始化等），使性能指标更准确。

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -139,6 +139,14 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 | `share_gpt_en_multi_turn` | 从 ModelScope 自动下载英文 [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) 数据集（约 70k 条），保留完整多轮对话 | ✓ |
 | `custom_multi_turn` | 使用本地 JSONL 文件作为自定义多轮对话数据集<br>每行为 OpenAI messages 格式的 JSON 数组，适合已有对话数据直接压测<br>**必需提供`dataset_path`**<br>[使用示例](./multi_turn.md#custom_multi_turn) | ✓（必需） |
 
+**生产流量回放类**
+
+需配合 `--open-loop` 使用，按录制的**原始到达节奏**逐字回放真实请求。详见[使用示例](./examples.md#生产流量回放workload_trace)。
+
+| 模式 | 说明 | 支持dataset-path |
+|------|------|------------------|
+| `workload_trace` | 回放录制的生产流量 JSONL：按原始时间戳、请求体、headers 逐字重放，贴近真实负载（突发流量、异构请求、多模型路由）<br>每条请求自带 `model`，保留多模型混合路由<br>**必需 `--open-loop` 和 `--dataset-path`**；`--model`/`--number` 可选（trace 自带模型与条数） | ✓（必需） |
+
 ### dataset-args：数据集专属参数
 
 `--dataset-args` 用一个 JSON 字符串为不同数据集传入专属参数（键名写错会直接报错，便于排查）。常见两个场景：
@@ -169,6 +177,36 @@ evalscope perf \
 **场景二：多轮对话数据集的长度参数**
 
 `swe_smith` 等多轮数据集的 token 长度参数也通过 `--dataset-args` 传入，详见[多轮对话压测指南](./multi_turn.md)。
+
+**场景三：回放真实生产流量**
+
+用 `workload_trace` 把录制的生产流量按**原始到达节奏**逐字回放，贴近真实负载。**必需 `--open-loop`**，无需 `--rate`（到达时刻由 trace 时间戳决定）。完整示例见[生产流量回放（workload_trace）](./examples.md#生产流量回放workload_trace)。
+
+trace 文件为 JSONL，每行一条请求记录：
+
+```jsonl
+{"body": {"model": "qwen-plus", "messages": [{"role": "user", "content": "hi"}]}, "timestamp": 1700000000.0}
+{"body": {"model": "qwen-max", "messages": [...]}, "timestamp": 1700000001.5, "headers": {"X-Tag": "exp"}, "request_id": "req-42", "completion_tokens": 256}
+```
+
+| 字段 | 必需 | 说明 |
+|------|------|------|
+| `body` | ✓ | 完整请求体（dict 或 JSON 字符串），原样发送 |
+| `timestamp` | ✓ | 到达时刻（数字或 ISO-8601 字符串），仅相对间隔有意义，须单调不减 |
+| `headers` | | 该请求专属 HTTP 头（与 CLI headers 合并，CLI 优先；hop-by-hop 头会被剔除） |
+| `request_id` | | 透传到结果，用于与原始请求关联 |
+| `completion_tokens` | | 配合 `match_output_length` 使用 |
+
+| 键 | 类型 | 说明 | 默认值 |
+|----|------|------|--------|
+| `speed` | float | 回放倍速（2.0 = 2× 快，0.5 = 2× 慢） | `1.0` |
+| `model_override` | str | 把所有请求的 `model` 全量替换为该值 | 不启用 |
+| `model_mapping` | dict | 按名映射 `model`（命中优先；未命中保留原值） | 不启用 |
+| `match_output_length` | bool | 用记录的 `completion_tokens` 设 `max_tokens` 并启用 `ignore_eos`（需 vLLM 等支持；对约束解码请求自动跳过 `ignore_eos`） | `false` |
+
+```{note}
+`--model` 对 `workload_trace` **不会改写** trace body——每条请求保留自己的 `model`，从而保留多模型混合路由。需要改模型请用 `model_override` / `model_mapping`。
+```
 
 ```{note}
 `--multi-turn-args` 已废弃，请改用 `--dataset-args`（键名不变）。旧参数仍可用，会自动并入 `--dataset-args`（同名键以 `--dataset-args` 为准）。

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -41,7 +41,7 @@ def _at_least_one(value: int) -> int:
 
 class Arguments(BaseArgument):
     # Model and API
-    model: str
+    model: Optional[str] = None
     """Model name or path."""
 
     model_id: Optional[str] = None
@@ -493,7 +493,12 @@ class Arguments(BaseArgument):
             self.headers['Authorization'] = SecretStr(f'Bearer {api_key}')
 
         # Set the model ID based on the model name
-        self.model_id = os.path.basename(self.model)
+        self.model_id = os.path.basename(self.model) if self.model else (self.dataset or 'unknown')
+
+        if self.model is None:
+            from evalscope.perf.plugin.registry import DatasetRegistry
+            if not self.dataset or DatasetRegistry.get_class(self.dataset).requires_model:
+                raise ValueError('--model is required.')
 
         # Set the URL based on the dataset type.
         self._resolve_local_url()
@@ -636,7 +641,10 @@ class Arguments(BaseArgument):
                 f'but got number: {self.number} and rate: {self.rate}'
             )
         if not all(r > 0 for r in self.rate):
-            raise ValueError(f'In open-loop mode all --rate values must be > 0, but got: {self.rate}')
+            from evalscope.perf.plugin.registry import DatasetRegistry
+            dataset_cls = DatasetRegistry.get_class(self.dataset)
+            if not dataset_cls.provides_arrival_schedule:
+                raise ValueError(f'In open-loop mode all --rate values must be > 0, but got: {self.rate}')
         # In open-loop mode concurrency is unbounded; set parallel=-1 so downstream
         # display layers render it as INF instead of a numeric value.
         self.parallel = [-1]
@@ -696,7 +704,7 @@ class ParseKVAction(argparse.Action):
 
 # yapf: disable
 def _add_model_api_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('--model', type=str, required=True, help='The test model name.')
+    parser.add_argument('--model', type=str, default=None, help='The test model name.')
     parser.add_argument('--attn-implementation', required=False, default=None, help='Attention implementation')
     parser.add_argument('--api', type=str, default='openai', help='Service API protocol: openai | openai_responses/responses | openai_embedding/embedding | openai_rerank/rerank | local/local_vllm. Determines the auto-appended endpoint path on --url.')  # noqa: E501
     parser.add_argument(
@@ -715,7 +723,7 @@ def _add_connection_arguments(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_performance_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('-n', '--number', type=int, default=1000, nargs='+', help='How many requests to be made')
+    parser.add_argument('-n', '--number', type=int, default=None, nargs='+', help='How many requests to be made')
     parser.add_argument('--parallel', type=int, default=1, nargs='+', help='Set number of concurrency requests, default 1')  # noqa: E501
     parser.add_argument('--rate', type=float, default=-1, nargs='+',
                         help='Number of requests per second. default -1 means no rate limit. '

--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -1,5 +1,4 @@
 import asyncio
-import numpy as np
 from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, Tuple
 
 from evalscope.perf.arguments import Arguments
@@ -50,6 +49,9 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
     async def _generate_from_dataset():
         """Generate requests by cycling through a dataset."""
         message_generator = DatasetRegistry.get_class(args.dataset)(args)
+        # Re-read: dataset plugins may adjust args.number / args.warmup_num.
+        total_count = args.total_count
+        warmup_count = args.warmup_count
         supports_parallel_generation = message_generator.supports_parallel_message_generation(total_count)
         dataset_generation_workers = resolve_dataset_generation_workers(
             args=args,

--- a/evalscope/perf/core/http_client.py
+++ b/evalscope/perf/core/http_client.py
@@ -82,7 +82,7 @@ class AioHttpClient:
             # Delegate the request processing to the API plugin
             output = await self.api_plugin.process_request(self.client, self.url, headers, body)
             if request_id:
-                output.trace_id = request_id
+                output.request_id = request_id
             return output
         except asyncio.TimeoutError as e:
             logger.error(

--- a/evalscope/perf/core/http_client.py
+++ b/evalscope/perf/core/http_client.py
@@ -78,8 +78,11 @@ class AioHttpClient:
             BenchmarkData: The benchmark data object containing request and response information.
         """
         try:
+            headers, request_id = self.api_plugin.extract_body_meta(body, self.headers)
             # Delegate the request processing to the API plugin
-            output = await self.api_plugin.process_request(self.client, self.url, self.headers, body)
+            output = await self.api_plugin.process_request(self.client, self.url, headers, body)
+            if request_id:
+                output.trace_id = request_id
             return output
         except asyncio.TimeoutError as e:
             logger.error(

--- a/evalscope/perf/core/strategies/base.py
+++ b/evalscope/perf/core/strategies/base.py
@@ -39,6 +39,12 @@ class BenchmarkStrategy(ABC):
         self.api_plugin = api_plugin
         self.client = client
         self.queue = queue
+        # GPU-memory accounting is only meaningful when the model runs in this
+        # process (``--api local`` in-process inference).  For remote APIs and
+        # ``local_vllm`` (subprocess) the client process holds no CUDA memory,
+        # so the measurement would be 0 and the per-request first-time
+        # ``import torch`` would only block the event loop.  Skip it there.
+        self.track_gpu_memory = args.api == 'local'
 
     @abstractmethod
     async def run(self) -> None:

--- a/evalscope/perf/core/strategies/closed_loop.py
+++ b/evalscope/perf/core/strategies/closed_loop.py
@@ -20,11 +20,13 @@ async def _send_request(
     is_warmup: bool,
     queue: asyncio.Queue,
     client: 'AioHttpClient',
+    track_gpu_memory: bool = False,
 ) -> None:
     async with semaphore:
         benchmark_data = await client.post(request)
     benchmark_data.is_warmup = is_warmup
-    benchmark_data.update_gpu_usage()
+    if track_gpu_memory:
+        benchmark_data.update_gpu_usage()
     await queue.put(benchmark_data)
 
 
@@ -119,7 +121,9 @@ class ClosedLoopStrategy(BenchmarkStrategy):
                 done, pending = await asyncio.wait(in_flight, return_when=asyncio.FIRST_COMPLETED)
                 in_flight = pending
 
-            task = asyncio.create_task(_send_request(semaphore, request, is_warmup, self.queue, self.client))
+            task = asyncio.create_task(
+                _send_request(semaphore, request, is_warmup, self.queue, self.client, self.track_gpu_memory)
+            )
             in_flight.add(task)
             dispatched += 1
 

--- a/evalscope/perf/core/strategies/open_loop.py
+++ b/evalscope/perf/core/strategies/open_loop.py
@@ -20,11 +20,13 @@ async def _send_request_open_loop(
     is_warmup: bool,
     queue: asyncio.Queue,
     client: 'AioHttpClient',
+    track_gpu_memory: bool = False,
 ) -> None:
     """Open-loop send: fires immediately regardless of in-flight count."""
     benchmark_data = await client.post(request)
     benchmark_data.is_warmup = is_warmup
-    benchmark_data.update_gpu_usage()
+    if track_gpu_memory:
+        benchmark_data.update_gpu_usage()
     await queue.put(benchmark_data)
 
 
@@ -120,7 +122,9 @@ class OpenLoopStrategy(BenchmarkStrategy):
                 if sleep_s > 0:
                     await asyncio.sleep(sleep_s)
                 task = asyncio.create_task(
-                    _send_request_open_loop(request, is_warmup or is_warmup_req, self.queue, self.client)
+                    _send_request_open_loop(
+                        request, is_warmup or is_warmup_req, self.queue, self.client, self.track_gpu_memory
+                    )
                 )
                 in_flight.add(task)
         elif rate == -1 or n == 0:
@@ -129,7 +133,9 @@ class OpenLoopStrategy(BenchmarkStrategy):
                 if deadline is not None and time.perf_counter() >= deadline:
                     logger.info('Duration deadline reached; stopping further dispatches.')
                     break
-                task = asyncio.create_task(_send_request_open_loop(request, is_warmup, self.queue, self.client))
+                task = asyncio.create_task(
+                    _send_request_open_loop(request, is_warmup, self.queue, self.client, self.track_gpu_memory)
+                )
                 in_flight.add(task)
         else:
             # 1) Sample n Poisson inter-arrival intervals (mean = 1/rate).
@@ -168,7 +174,9 @@ class OpenLoopStrategy(BenchmarkStrategy):
                     await asyncio.sleep(sleep_s)
                 # If sleep_s <= 0 we are behind schedule; dispatch immediately
                 # to absorb the drift.
-                task = asyncio.create_task(_send_request_open_loop(request, is_warmup, self.queue, self.client))
+                task = asyncio.create_task(
+                    _send_request_open_loop(request, is_warmup, self.queue, self.client, self.track_gpu_memory)
+                )
                 in_flight.add(task)
 
         # Phase barrier: let already-fired requests finish even past the

--- a/evalscope/perf/core/strategies/open_loop.py
+++ b/evalscope/perf/core/strategies/open_loop.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.core.strategies.base import BenchmarkStrategy
+from evalscope.perf.utils.body_meta import BODY_META_ARRIVAL_OFFSET, BODY_META_IS_WARMUP
 from evalscope.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -89,7 +90,40 @@ class OpenLoopStrategy(BenchmarkStrategy):
         n = len(requests)
         rate = self.args.rate
 
-        if rate == -1 or n == 0:
+        # Check for pre-computed arrival offsets.
+        has_trace_offsets = n > 0 and BODY_META_ARRIVAL_OFFSET in requests[0]
+
+        if has_trace_offsets:
+            delay_ts = np.array([r.pop(BODY_META_ARRIVAL_OFFSET) for r in requests])
+            target_times = delay_ts + time.perf_counter()
+            # Find the index of the first non-warmup request to anchor the deadline.
+            first_bench = next((j for j, r in enumerate(requests) if BODY_META_IS_WARMUP not in r), 0)
+            actual_deadline = None
+            for i, request in enumerate(requests):
+                is_warmup_req = request.pop(BODY_META_IS_WARMUP, False)
+                if is_warmup_req:
+                    # Warmup bypasses deadline.
+                    sleep_s = target_times[i] - time.perf_counter()
+                else:
+                    # Deadline anchored to first non-warmup request's dispatch time.
+                    if i == first_bench:
+                        actual_deadline = self._compute_deadline(self.args.duration)
+                    if actual_deadline is not None and time.perf_counter() >= actual_deadline:
+                        logger.info(
+                            f'Duration deadline reached after dispatching {i}/{n} requests; '
+                            'stopping further dispatches.'
+                        )
+                        break
+                    sleep_s = target_times[i] - time.perf_counter()
+                    if actual_deadline is not None:
+                        sleep_s = min(sleep_s, actual_deadline - time.perf_counter())
+                if sleep_s > 0:
+                    await asyncio.sleep(sleep_s)
+                task = asyncio.create_task(
+                    _send_request_open_loop(request, is_warmup or is_warmup_req, self.queue, self.client)
+                )
+                in_flight.add(task)
+        elif rate == -1 or n == 0:
             # Unlimited rate: fire all requests as fast as the loop allows.
             for request in requests:
                 if deadline is not None and time.perf_counter() >= deadline:

--- a/evalscope/perf/plugin/api/base.py
+++ b/evalscope/perf/plugin/api/base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.perf.utils.body_meta import BODY_META_HEADERS, BODY_META_PREFIX, BODY_META_REQUEST_ID
 
 
 class ApiPluginBase:
@@ -11,6 +12,28 @@ class ApiPluginBase:
     def __init__(self, param: Arguments) -> None:
         self.param = param
         self.model_path = param.tokenizer_path
+
+    @staticmethod
+    def extract_body_meta(body: Dict, headers: Dict) -> Tuple[Dict, Optional[str]]:
+        """Pop body-meta keys and return updated headers and trace id.
+
+        Must be called before ``process_request`` so that plugins receive a
+        clean body dict regardless of whether they handle body-meta keys.
+
+        Per-request headers from trace data are merged with CLI headers using
+        fill semantics: CLI-set headers (e.g. Authorization from --api-key)
+        take precedence; trace headers only fill in keys not already present.
+
+        Returns:
+            (headers, request_id)
+        """
+        extra_headers = body.pop(BODY_META_HEADERS, None)
+        request_id = body.pop(BODY_META_REQUEST_ID, None)
+        if extra_headers:
+            headers = {**extra_headers, **headers}
+        for k in [k for k in body if k.startswith(BODY_META_PREFIX)]:
+            body.pop(k)
+        return headers, request_id
 
     @abstractmethod
     def build_request(self, messages: Union[List[Dict], str], param: Optional[Arguments] = None) -> Dict:

--- a/evalscope/perf/plugin/api/base.py
+++ b/evalscope/perf/plugin/api/base.py
@@ -6,6 +6,20 @@ from evalscope.perf.arguments import Arguments
 from evalscope.perf.utils.benchmark_util import BenchmarkData
 from evalscope.perf.utils.body_meta import BODY_META_HEADERS, BODY_META_PREFIX, BODY_META_REQUEST_ID
 
+# Hop-by-hop headers that must not be forwarded from trace data.
+_HOP_BY_HOP_HEADERS = frozenset({
+    'host',
+    'connection',
+    'content-length',
+    'transfer-encoding',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailers',
+    'upgrade',
+})
+
 
 class ApiPluginBase:
 
@@ -15,7 +29,7 @@ class ApiPluginBase:
 
     @staticmethod
     def extract_body_meta(body: Dict, headers: Dict) -> Tuple[Dict, Optional[str]]:
-        """Pop body-meta keys and return updated headers and trace id.
+        """Pop body-meta keys and return updated headers and request id.
 
         Must be called before ``process_request`` so that plugins receive a
         clean body dict regardless of whether they handle body-meta keys.
@@ -23,6 +37,7 @@ class ApiPluginBase:
         Per-request headers from trace data are merged with CLI headers using
         fill semantics: CLI-set headers (e.g. Authorization from --api-key)
         take precedence; trace headers only fill in keys not already present.
+        Hop-by-hop headers from trace data are stripped.
 
         Returns:
             (headers, request_id)
@@ -30,6 +45,7 @@ class ApiPluginBase:
         extra_headers = body.pop(BODY_META_HEADERS, None)
         request_id = body.pop(BODY_META_REQUEST_ID, None)
         if extra_headers:
+            extra_headers = {k: v for k, v in extra_headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
             headers = {**extra_headers, **headers}
         for k in [k for k in body if k.startswith(BODY_META_PREFIX)]:
             body.pop(k)

--- a/evalscope/perf/plugin/api/custom_api.py
+++ b/evalscope/perf/plugin/api/custom_api.py
@@ -79,7 +79,8 @@ class CustomPlugin(ApiPluginBase):
             Dict: The request payload with added parameters.
         """
         # Add the model name
-        payload['model'] = param.model
+        if param.model is not None:
+            payload['model'] = param.model
 
         # Add various parameters if they are provided
         if param.max_tokens is not None:

--- a/evalscope/perf/plugin/api/dashscope_api.py
+++ b/evalscope/perf/plugin/api/dashscope_api.py
@@ -53,7 +53,8 @@ class DashScopeApiPlugin(ApiPluginBase):
             return None
 
     def __compose_query_from_parameter(self, payload: Dict, param: Arguments):
-        payload['model'] = param.model
+        if param.model is not None:
+            payload['model'] = param.model
         if 'parameters' not in payload:
             payload['parameters'] = {}
         if param.max_tokens is not None:

--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -123,7 +123,8 @@ class OpenaiPlugin(DefaultApiPlugin):
             else:
                 payload[key] = value
 
-        _set('model', param.model)
+        if param.model is not None:
+            _set('model', param.model)
         if param.max_tokens is not None:
             _set('max_tokens', _sample_int_or_range(param.max_tokens))
         if param.min_tokens is not None:

--- a/evalscope/perf/plugin/api/openai_embedding_api.py
+++ b/evalscope/perf/plugin/api/openai_embedding_api.py
@@ -88,8 +88,9 @@ class OpenaiEmbeddingPlugin(ApiPluginBase):
             # Build the embedding request
             payload = {
                 'input': input_text,
-                'model': param.model,
             }
+            if param.model is not None:
+                payload['model'] = param.model
 
             # Add optional parameters if specified
             if param.extra_args:

--- a/evalscope/perf/plugin/api/openai_rerank_api.py
+++ b/evalscope/perf/plugin/api/openai_rerank_api.py
@@ -96,8 +96,9 @@ class OpenaiRerankPlugin(ApiPluginBase):
             payload = {
                 'query': query,
                 'documents': documents,
-                'model': param.model,
             }
+            if param.model is not None:
+                payload['model'] = param.model
 
             # Add optional top_n parameter
             if param.extra_args:

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -191,7 +191,8 @@ class OpenAIResponsesPlugin(DefaultApiPlugin):
                 output.real_cached_tokens = cached
 
     def _compose_query_from_parameter(self, payload: Dict, param: Arguments) -> Dict:
-        payload['model'] = param.model
+        if param.model is not None:
+            payload['model'] = param.model
         if param.max_tokens is not None:
             payload['max_output_tokens'] = _sample_int_or_range(param.max_tokens)
         if param.stream is not None:

--- a/evalscope/perf/plugin/datasets/__init__.py
+++ b/evalscope/perf/plugin/datasets/__init__.py
@@ -19,3 +19,4 @@ from .share_gpt import ShareGPTEnDatasetPlugin, ShareGPTZhDatasetPlugin
 from .speed_benchmark import SpeedBenchmarkDatasetPlugin, SpeedBenchmarkLongDatasetPlugin
 from .swe_smith import SweSmithDatasetPlugin  # noqa: F401
 from .trie import TrieAgenticCodingPlugin, TrieCodeQaPlugin, TrieOfficeWorkPlugin  # noqa: F401
+from .workload_trace import WorkloadTraceDatasetPlugin  # noqa: F401

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -44,6 +44,12 @@ class DatasetPluginBase:
     default empty schema rejects any ``--dataset-args`` keys (fail-fast).
     """
 
+    provides_arrival_schedule: bool = False
+    """True if the dataset embeds per-request arrival times, bypassing ``--rate``."""
+
+    requires_model: bool = True
+    """False if the dataset carries model info in each request body, making ``--model`` optional."""
+
     def __init__(self, query_parameters: Arguments):
         """Build data set plugin
 

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -196,13 +196,9 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
         if not self._records:
             raise ValueError('workload_trace: dataset is empty')
 
-        for i in range(1, len(self._records)):
-            if self._records[i].timestamp < self._records[i - 1].timestamp:
-                raise ValueError(
-                    f'Timestamps must be monotonically non-decreasing: '
-                    f'record {i + 1} (t={self._records[i].timestamp}) < '
-                    f'record {i} (t={self._records[i - 1].timestamp})'
-                )
+        if any(self._records[i].timestamp < self._records[i - 1].timestamp for i in range(1, len(self._records))):
+            logger.warning('workload_trace: timestamps not monotonic, sorting by timestamp')
+        self._records.sort(key=lambda r: r.timestamp)
 
     def _compute_schedule(self) -> np.ndarray:
         if not self._records:

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -19,6 +19,18 @@ logger = get_logger()
 
 RESERVED_BODY_KEYS = frozenset({BODY_META_HEADERS, BODY_META_REQUEST_ID, BODY_META_ARRIVAL_OFFSET, BODY_META_IS_WARMUP})
 
+# When match_output_length is enabled, ignore_eos=true is injected into the
+# request body.  This is unsafe for requests that use constrained decoding
+# (grammar / FSM) — the grammar terminates generation independently of EOS,
+# and forcing past that point causes crashes (see vLLM#37506).
+#
+# _has_constrained_decoding() currently checks OpenAI-standard fields only
+# (response_format, tools + tool_choice).  Engine-specific keys that also
+# trigger constrained decoding are listed below for future reference:
+#   vLLM legacy:  guided_json, guided_regex, guided_choice, guided_grammar
+#   vLLM new:     structured_outputs
+#   SGLang:       json_schema, regex, ebnf, structural_tag
+
 
 class WorkloadTraceArgs(BaseDatasetArgs):
 
@@ -216,15 +228,49 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
         elif override is not None:
             body['model'] = override
 
+    @staticmethod
+    def _has_constrained_decoding(body: Dict[str, Any]) -> bool:
+        """Return True if *body* contains OpenAI fields that trigger constrained
+        decoding (grammar / FSM), making ``ignore_eos`` unsafe.
+
+        Checked fields (OpenAI standard only):
+
+        - ``response_format`` with ``type`` in {``json_object``, ``json_schema``}.
+          ``type=text`` does not trigger constrained decoding.
+        - ``tools`` with ``tool_choice`` in {``required``, or a named function
+          dict}.  ``tool_choice="auto"`` does **not** activate grammar
+          constraints in vLLM or SGLang — the model freely decides whether to
+          emit content or a tool call.
+
+        Returns False for plain text generation and ``tool_choice="auto"``
+        requests, where ``ignore_eos`` is safe to use.
+        """
+        # response_format with constrained type
+        rf = body.get('response_format')
+        if isinstance(rf, dict) and rf.get('type') in ('json_object', 'json_schema'):
+            return True
+        # tools + forced tool_choice ("required" or named function)
+        # "auto" / "none" / absent → no grammar constraint
+        tc = body.get('tool_choice')
+        if body.get('tools') and tc not in (None, 'none', 'auto'):
+            return True
+        return False
+
     def build_messages(self) -> Iterator[Dict[str, Any]]:
         match_output = self.dataset_args.match_output_length
+        skipped = 0
         for i, record in enumerate(self._records):
             body = dict(record.body)
             self._rewrite_model(body)
 
             if match_output and record.completion_tokens is not None:
                 body['max_tokens'] = record.completion_tokens
-                body['ignore_eos'] = True
+                if self._has_constrained_decoding(body):
+                    # Skip ignore_eos to avoid crashing constrained-decoding
+                    # requests; max_tokens still serves as an upper bound.
+                    skipped += 1
+                else:
+                    body['ignore_eos'] = True
 
             body[BODY_META_ARRIVAL_OFFSET] = float(self._schedule[i])
             if i < self._warmup_count:
@@ -235,3 +281,11 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
                 body[BODY_META_REQUEST_ID] = record.request_id
 
             yield body
+
+        if skipped:
+            logger.warning(
+                'workload_trace: %d request(s) use constrained decoding '
+                '(response_format / tools); ignore_eos skipped for these '
+                '(max_tokens still set)',
+                skipped,
+            )

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -1,0 +1,233 @@
+import json
+import numpy as np
+from pydantic import BaseModel, ConfigDict, field_validator
+from typing import Any, Dict, Iterator, List, Optional
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.registry import register_dataset
+from evalscope.perf.utils.body_meta import (
+    BODY_META_ARRIVAL_OFFSET,
+    BODY_META_HEADERS,
+    BODY_META_IS_WARMUP,
+    BODY_META_REQUEST_ID,
+)
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+RESERVED_BODY_KEYS = frozenset({BODY_META_HEADERS, BODY_META_REQUEST_ID, BODY_META_ARRIVAL_OFFSET, BODY_META_IS_WARMUP})
+
+
+class WorkloadTraceArgs(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    speed: float = 1.0
+    model_override: Optional[str] = None
+    model_mapping: Optional[Dict[str, str]] = None
+
+    @field_validator('speed')
+    @classmethod
+    def _speed_must_be_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(f'speed must be > 0, got {v}')
+        return v
+
+
+def _normalise_timestamp(v: Any) -> float:
+    if isinstance(v, (int, float)):
+        return float(v)
+    if isinstance(v, str):
+        from datetime import datetime, timezone
+        s = v.strip()
+        if s.endswith('Z') or s.endswith('z'):
+            s = s[:-1] + '+00:00'
+        try:
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except Exception as e:
+            raise ValueError(f'cannot parse timestamp: {v!r}') from e
+    raise TypeError(f'timestamp must be a number or ISO-8601 string, got {type(v).__name__}')
+
+
+class TraceRecord(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    body: Dict[str, Any]
+    timestamp: float
+    headers: Optional[Dict[str, str]] = None
+    request_id: Optional[str] = None
+
+    @field_validator('timestamp', mode='before')
+    @classmethod
+    def _parse_timestamp(cls, v: Any) -> float:
+        return _normalise_timestamp(v)
+
+    @field_validator('body', mode='before')
+    @classmethod
+    def _parse_body(cls, v: Any) -> Dict[str, Any]:
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except json.JSONDecodeError as e:
+                raise ValueError(f'body is a string but not valid JSON: {e}')
+            if not isinstance(parsed, dict):
+                raise ValueError(f'body JSON string must decode to a dict, got {type(parsed).__name__}')
+            return parsed
+        return v
+
+
+@register_dataset('workload_trace')
+class WorkloadTraceDatasetPlugin(DatasetPluginBase):
+    """Replay recorded production traffic traces with original arrival pattern.
+
+    Each line in the JSONL dataset file must be a JSON object with:
+
+    - ``body`` (dict or JSON string, required): Complete request body.
+    - ``timestamp`` (number or ISO-8601 string, required): Arrival time.
+    - ``headers`` (dict, optional): Per-request HTTP headers.
+    - ``request_id`` (str, optional): ID for result correlation.
+
+    Requires open-loop mode (``--open-loop``).
+    """
+
+    provides_arrival_schedule = True
+    requires_model = False
+
+    def __init__(self, query_parameters: Arguments):
+        super().__init__(query_parameters)
+
+        if not query_parameters.open_loop:
+            raise ValueError('workload_trace requires open-loop mode. '
+                             'Add --open-loop to your command.')
+
+        if not query_parameters.dataset_path:
+            raise ValueError('workload_trace requires --dataset-path pointing to a JSONL trace file.')
+
+        raw_args = query_parameters.dataset_args or {}
+        self._config = WorkloadTraceArgs(**raw_args)
+        self._records: List[TraceRecord] = []
+        self._load_and_validate()
+        self._schedule = self._compute_schedule()
+
+        n = len(self._records)
+
+        # --number: if user didn't pass it, use all records; if passed, truncate.
+        if 'number' in query_parameters.model_fields_set:
+            n = min(query_parameters._current_number(), n)
+            self._records = self._records[:n]
+            self._schedule = self._schedule[:n]
+        query_parameters.number = n
+
+        # --model: if user explicitly passed it, treat as model_override fallback.
+        if 'model' in query_parameters.model_fields_set:
+            if not self._config.model_override and not self._config.model_mapping:
+                self._config.model_override = query_parameters.model
+
+        self._warmup_count = min(query_parameters.warmup_count, n)
+
+        query_parameters.warmup_num = 0
+
+        warmup_msg = f', warmup={self._warmup_count}' if self._warmup_count else ''
+        logger.info(f'workload_trace: loaded {n} records, '
+                    f'speed={self._config.speed}x{warmup_msg}')
+
+    def _load_and_validate(self) -> None:
+        errors: List[str] = []
+        path = self.query_parameters.dataset_path
+
+        with open(path, 'r', encoding='utf-8') as f:
+            for line_num, raw_line in enumerate(f, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError as e:
+                    errors.append(f'line {line_num}: invalid JSON: {e}')
+                    continue
+
+                if not isinstance(data, dict):
+                    errors.append(f'line {line_num}: expected JSON object, got {type(data).__name__}')
+                    continue
+
+                if 'body' not in data:
+                    errors.append(f'line {line_num}: missing required field "body"')
+                    continue
+                if not isinstance(data['body'], (dict, str)):
+                    errors.append(f'line {line_num}: "body" must be a dict or JSON string')
+                    continue
+                if 'timestamp' not in data:
+                    errors.append(f'line {line_num}: missing required field "timestamp"')
+                    continue
+                if not isinstance(data['timestamp'], (int, float, str)):
+                    errors.append(f'line {line_num}: "timestamp" must be a number or ISO-8601 string')
+                    continue
+
+                body_for_check = data['body']
+                if isinstance(body_for_check, str):
+                    try:
+                        body_for_check = json.loads(body_for_check)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                if isinstance(body_for_check, dict):
+                    collisions = RESERVED_BODY_KEYS & body_for_check.keys()
+                    if collisions:
+                        errors.append(
+                            f'line {line_num}: body contains reserved key(s) {collisions}; '
+                            f'remove them from the trace body'
+                        )
+                        continue
+
+                try:
+                    self._records.append(TraceRecord(**data))
+                except Exception as e:
+                    errors.append(f'line {line_num}: {e}')
+
+        if errors:
+            raise ValueError(f'workload_trace validation failed ({len(errors)} error(s)):\n' + '\n'.join(errors))
+
+        if not self._records:
+            raise ValueError('workload_trace: dataset is empty')
+
+        for i in range(1, len(self._records)):
+            if self._records[i].timestamp < self._records[i - 1].timestamp:
+                raise ValueError(
+                    f'Timestamps must be monotonically non-decreasing: '
+                    f'record {i + 1} (t={self._records[i].timestamp}) < '
+                    f'record {i} (t={self._records[i - 1].timestamp})'
+                )
+
+    def _compute_schedule(self) -> np.ndarray:
+        if not self._records:
+            return np.array([])
+        t0 = self._records[0].timestamp
+        return np.array([(r.timestamp - t0) / self._config.speed for r in self._records])
+
+    def _rewrite_model(self, body: Dict[str, Any]) -> None:
+        original = body.get('model')
+        mapping = self._config.model_mapping
+        override = self._config.model_override
+
+        if mapping and original in mapping:
+            body['model'] = mapping[original]
+        elif override is not None:
+            body['model'] = override
+
+    def build_messages(self) -> Iterator[Dict[str, Any]]:
+        for i, record in enumerate(self._records):
+            body = dict(record.body)
+            self._rewrite_model(body)
+
+            body[BODY_META_ARRIVAL_OFFSET] = float(self._schedule[i])
+            if i < self._warmup_count:
+                body[BODY_META_IS_WARMUP] = True
+            if record.headers:
+                body[BODY_META_HEADERS] = dict(record.headers)
+            if record.request_id:
+                body[BODY_META_REQUEST_ID] = record.request_id
+
+            yield body

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import BaseDatasetArgs
 from evalscope.perf.plugin.registry import register_dataset
 from evalscope.perf.utils.body_meta import (
     BODY_META_ARRIVAL_OFFSET,
@@ -19,12 +20,14 @@ logger = get_logger()
 RESERVED_BODY_KEYS = frozenset({BODY_META_HEADERS, BODY_META_REQUEST_ID, BODY_META_ARRIVAL_OFFSET, BODY_META_IS_WARMUP})
 
 
-class WorkloadTraceArgs(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+class WorkloadTraceArgs(BaseDatasetArgs):
 
     speed: float = 1.0
     model_override: Optional[str] = None
     model_mapping: Optional[Dict[str, str]] = None
+    match_output_length: bool = False
+    """Set max_tokens from recorded completion_tokens and enable ignore_eos.
+    Requires an endpoint that supports ignore_eos (e.g. vLLM)."""
 
     @field_validator('speed')
     @classmethod
@@ -40,6 +43,10 @@ def _normalise_timestamp(v: Any) -> float:
     if isinstance(v, str):
         from datetime import datetime, timezone
         s = v.strip()
+        try:
+            return float(s)
+        except ValueError:
+            pass
         if s.endswith('Z') or s.endswith('z'):
             s = s[:-1] + '+00:00'
         try:
@@ -59,6 +66,14 @@ class TraceRecord(BaseModel):
     timestamp: float
     headers: Optional[Dict[str, str]] = None
     request_id: Optional[str] = None
+    completion_tokens: Optional[int] = None
+
+    @field_validator('completion_tokens')
+    @classmethod
+    def _completion_tokens_must_be_positive(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v <= 0:
+            raise ValueError(f'completion_tokens must be > 0, got {v}')
+        return v
 
     @field_validator('timestamp', mode='before')
     @classmethod
@@ -75,7 +90,11 @@ class TraceRecord(BaseModel):
                 raise ValueError(f'body is a string but not valid JSON: {e}')
             if not isinstance(parsed, dict):
                 raise ValueError(f'body JSON string must decode to a dict, got {type(parsed).__name__}')
-            return parsed
+            v = parsed
+        if isinstance(v, dict):
+            collisions = RESERVED_BODY_KEYS & v.keys()
+            if collisions:
+                raise ValueError(f'body contains reserved key(s) {collisions}; remove them from the trace body')
         return v
 
 
@@ -95,6 +114,7 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
 
     provides_arrival_schedule = True
     requires_model = False
+    args_schema = WorkloadTraceArgs
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
@@ -106,8 +126,6 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
         if not query_parameters.dataset_path:
             raise ValueError('workload_trace requires --dataset-path pointing to a JSONL trace file.')
 
-        raw_args = query_parameters.dataset_args or {}
-        self._config = WorkloadTraceArgs(**raw_args)
         self._records: List[TraceRecord] = []
         self._load_and_validate()
         self._schedule = self._compute_schedule()
@@ -123,8 +141,8 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
 
         # --model: if user explicitly passed it, treat as model_override fallback.
         if 'model' in query_parameters.model_fields_set:
-            if not self._config.model_override and not self._config.model_mapping:
-                self._config.model_override = query_parameters.model
+            if not self.dataset_args.model_override and not self.dataset_args.model_mapping:
+                self.dataset_args.model_override = query_parameters.model
 
         self._warmup_count = min(query_parameters.warmup_count, n)
 
@@ -132,7 +150,14 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
 
         warmup_msg = f', warmup={self._warmup_count}' if self._warmup_count else ''
         logger.info(f'workload_trace: loaded {n} records, '
-                    f'speed={self._config.speed}x{warmup_msg}')
+                    f'speed={self.dataset_args.speed}x{warmup_msg}')
+        if self.dataset_args.match_output_length:
+            logger.info(
+                'workload_trace: match_output_length enabled — '
+                'setting max_tokens from completion_tokens (requires ignore_eos support, e.g. vLLM)'
+            )
+        if not query_parameters.name:
+            logger.info('Tip: use --name to set a meaningful output directory name.')
 
     def _load_and_validate(self) -> None:
         errors: List[str] = []
@@ -153,34 +178,6 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
                 if not isinstance(data, dict):
                     errors.append(f'line {line_num}: expected JSON object, got {type(data).__name__}')
                     continue
-
-                if 'body' not in data:
-                    errors.append(f'line {line_num}: missing required field "body"')
-                    continue
-                if not isinstance(data['body'], (dict, str)):
-                    errors.append(f'line {line_num}: "body" must be a dict or JSON string')
-                    continue
-                if 'timestamp' not in data:
-                    errors.append(f'line {line_num}: missing required field "timestamp"')
-                    continue
-                if not isinstance(data['timestamp'], (int, float, str)):
-                    errors.append(f'line {line_num}: "timestamp" must be a number or ISO-8601 string')
-                    continue
-
-                body_for_check = data['body']
-                if isinstance(body_for_check, str):
-                    try:
-                        body_for_check = json.loads(body_for_check)
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-                if isinstance(body_for_check, dict):
-                    collisions = RESERVED_BODY_KEYS & body_for_check.keys()
-                    if collisions:
-                        errors.append(
-                            f'line {line_num}: body contains reserved key(s) {collisions}; '
-                            f'remove them from the trace body'
-                        )
-                        continue
 
                 try:
                     self._records.append(TraceRecord(**data))
@@ -205,12 +202,12 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
         if not self._records:
             return np.array([])
         t0 = self._records[0].timestamp
-        return np.array([(r.timestamp - t0) / self._config.speed for r in self._records])
+        return np.array([(r.timestamp - t0) / self.dataset_args.speed for r in self._records])
 
     def _rewrite_model(self, body: Dict[str, Any]) -> None:
         original = body.get('model')
-        mapping = self._config.model_mapping
-        override = self._config.model_override
+        mapping = self.dataset_args.model_mapping
+        override = self.dataset_args.model_override
 
         if mapping and original in mapping:
             body['model'] = mapping[original]
@@ -218,9 +215,14 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
             body['model'] = override
 
     def build_messages(self) -> Iterator[Dict[str, Any]]:
+        match_output = self.dataset_args.match_output_length
         for i, record in enumerate(self._records):
             body = dict(record.body)
             self._rewrite_model(body)
+
+            if match_output and record.completion_tokens is not None:
+                body['max_tokens'] = record.completion_tokens
+                body['ignore_eos'] = True
 
             body[BODY_META_ARRIVAL_OFFSET] = float(self._schedule[i])
             if i < self._warmup_count:

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -139,10 +139,16 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
             self._schedule = self._schedule[:n]
         query_parameters.number = n
 
-        # --model: if user explicitly passed it, treat as model_override fallback.
+        # --model: if user explicitly passed it and no dataset-args model
+        # rewriting is configured, treat as model_override fallback.
+        # For explicit control, prefer --dataset-args '{"model_override": "..."}' or model_mapping.
         if 'model' in query_parameters.model_fields_set:
             if not self.dataset_args.model_override and not self.dataset_args.model_mapping:
                 self.dataset_args.model_override = query_parameters.model
+                logger.info(
+                    f'workload_trace: using --model {query_parameters.model!r} as model_override. '
+                    'Use --dataset-args model_override/model_mapping for explicit control.'
+                )
 
         self._warmup_count = min(query_parameters.warmup_count, n)
 

--- a/evalscope/perf/plugin/datasets/workload_trace.py
+++ b/evalscope/perf/plugin/datasets/workload_trace.py
@@ -151,16 +151,18 @@ class WorkloadTraceDatasetPlugin(DatasetPluginBase):
             self._schedule = self._schedule[:n]
         query_parameters.number = n
 
-        # --model: if user explicitly passed it and no dataset-args model
-        # rewriting is configured, treat as model_override fallback.
-        # For explicit control, prefer --dataset-args '{"model_override": "..."}' or model_mapping.
-        if 'model' in query_parameters.model_fields_set:
-            if not self.dataset_args.model_override and not self.dataset_args.model_mapping:
-                self.dataset_args.model_override = query_parameters.model
-                logger.info(
-                    f'workload_trace: using --model {query_parameters.model!r} as model_override. '
-                    'Use --dataset-args model_override/model_mapping for explicit control.'
-                )
+        # --model does NOT rewrite trace bodies (issue #1489): each record
+        # carries its own model, preserving the trace's multi-model routing.
+        # Use --dataset-args model_override / model_mapping for explicit rewriting.
+        if (
+            'model' in query_parameters.model_fields_set and not self.dataset_args.model_override
+            and not self.dataset_args.model_mapping
+        ):
+            logger.warning(
+                f'workload_trace: --model {query_parameters.model!r} does not rewrite trace bodies; '
+                'each request keeps its own model. Use --dataset-args '
+                "'{\"model_override\": ...}' or model_mapping to rewrite."
+            )
 
         self._warmup_count = min(query_parameters.warmup_count, n)
 

--- a/evalscope/perf/utils/benchmark_util.py
+++ b/evalscope/perf/utils/benchmark_util.py
@@ -69,6 +69,10 @@ class BenchmarkData:
     for trace-level aggregation in multi-turn benchmarks.  None for single-turn
     runs.  Format is opaque (e.g. ``trace-42`` from MultiTurnStrategy)."""
 
+    request_id: Optional[str] = None
+    """Optional identifier from trace data for correlating benchmark results
+    with original production requests.  None for non-trace benchmarks."""
+
     # --- Warmup ---
     is_warmup: bool = False
     """True when this request is a warmup request, excluded from final metrics."""

--- a/evalscope/perf/utils/body_meta.py
+++ b/evalscope/perf/utils/body_meta.py
@@ -1,0 +1,5 @@
+BODY_META_PREFIX = '__evalscope_'
+BODY_META_HEADERS = '__evalscope_headers'
+BODY_META_REQUEST_ID = '__evalscope_request_id'
+BODY_META_ARRIVAL_OFFSET = '__evalscope_arrival_offset'
+BODY_META_IS_WARMUP = '__evalscope_is_warmup'

--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -33,6 +33,7 @@ class DatabaseColumns:
     COMPLETION_TOKENS = 'completion_tokens'
     MAX_GPU_MEMORY_COST = 'max_gpu_memory_cost'
     TIME_PER_OUTPUT_TOKEN = 'time_per_output_token'
+    REQUEST_ID = 'request_id'
 
 
 def load_prompt(prompt_path_or_text):
@@ -66,7 +67,8 @@ def create_result_table(cursor):
                       {DatabaseColumns.PROMPT_TOKENS} INTEGER,
                       {DatabaseColumns.COMPLETION_TOKENS} INTEGER,
                       {DatabaseColumns.MAX_GPU_MEMORY_COST} REAL,
-                      {DatabaseColumns.TIME_PER_OUTPUT_TOKEN} REAL
+                      {DatabaseColumns.TIME_PER_OUTPUT_TOKEN} REAL,
+                      {DatabaseColumns.REQUEST_ID} TEXT
                    )'''
     )
 
@@ -84,6 +86,7 @@ def insert_benchmark_data(cursor: sqlite3.Cursor, benchmark_data: BenchmarkData)
         benchmark_data.success,
         response_messages,
         benchmark_data.completed_time,
+        benchmark_data.request_id,
     )
 
     if benchmark_data.success:
@@ -95,16 +98,18 @@ def insert_benchmark_data(cursor: sqlite3.Cursor, benchmark_data: BenchmarkData)
         query = f"""INSERT INTO result(
                       {DatabaseColumns.REQUEST}, {DatabaseColumns.START_TIME}, {DatabaseColumns.INTER_TOKEN_LATENCIES},
                       {DatabaseColumns.SUCCESS}, {DatabaseColumns.RESPONSE_MESSAGES}, {DatabaseColumns.COMPLETED_TIME},
+                      {DatabaseColumns.REQUEST_ID},
                       {DatabaseColumns.LATENCY}, {DatabaseColumns.FIRST_CHUNK_LATENCY}, {DatabaseColumns.PROMPT_TOKENS},
                       {DatabaseColumns.COMPLETION_TOKENS}, {DatabaseColumns.MAX_GPU_MEMORY_COST},
                       {DatabaseColumns.TIME_PER_OUTPUT_TOKEN}
-                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
         cursor.execute(query, common_columns + additional_columns)
     else:
         query = f"""INSERT INTO result(
                       {DatabaseColumns.REQUEST}, {DatabaseColumns.START_TIME}, {DatabaseColumns.INTER_TOKEN_LATENCIES},
-                      {DatabaseColumns.SUCCESS}, {DatabaseColumns.RESPONSE_MESSAGES}, {DatabaseColumns.COMPLETED_TIME}
-                   ) VALUES (?, ?, ?, ?, ?, ?)"""
+                      {DatabaseColumns.SUCCESS}, {DatabaseColumns.RESPONSE_MESSAGES}, {DatabaseColumns.COMPLETED_TIME},
+                      {DatabaseColumns.REQUEST_ID}
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?)"""
         cursor.execute(query, common_columns)
 
 

--- a/tests/perf/test_workload_trace.py
+++ b/tests/perf/test_workload_trace.py
@@ -515,3 +515,119 @@ class TestMatchOutputLength:
         path = _make_trace_file([_record(completion_tokens=bad_value, timestamp=0.0)], tmp_path)
         with pytest.raises(ValueError, match='completion_tokens must be > 0'):
             WorkloadTraceDatasetPlugin(_make_args(path))
+
+    # -- constrained-decoding guard: ignore_eos must be skipped ----------------
+
+    @pytest.mark.parametrize(
+        'rf_type',
+        ['json_object', 'json_schema'],
+    )
+    def test_skips_ignore_eos_for_response_format(self, tmp_path, rf_type, caplog):
+        """response_format with json_object/json_schema triggers constrained
+        decoding — ignore_eos must NOT be injected."""
+        body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'response_format': {'type': rf_type},
+        }
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+        assert 'ignore_eos' not in msg
+        assert 'constrained decoding' in caplog.text
+
+    def test_allows_ignore_eos_for_response_format_text(self, tmp_path):
+        """response_format with type=text does NOT trigger constrained decoding."""
+        body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'response_format': {'type': 'text'},
+        }
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+        assert msg['ignore_eos'] is True
+
+    @pytest.mark.parametrize(
+        'tool_choice',
+        ['required', {'type': 'function', 'function': {'name': 'get_weather'}}],
+    )
+    def test_skips_ignore_eos_for_forced_tool_choice(self, tmp_path, tool_choice, caplog):
+        """tools + tool_choice=required or named function → constrained decoding."""
+        body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'tools': [{'type': 'function', 'function': {'name': 'get_weather'}}],
+            'tool_choice': tool_choice,
+        }
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+        assert 'ignore_eos' not in msg
+        assert 'constrained decoding' in caplog.text
+
+    @pytest.mark.parametrize('tool_choice', ['auto', 'none'])
+    def test_allows_ignore_eos_for_auto_none_tool_choice(self, tmp_path, tool_choice):
+        """tools + tool_choice=auto/none → no grammar constraint, ignore_eos safe."""
+        body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'tools': [{'type': 'function', 'function': {'name': 'get_weather'}}],
+            'tool_choice': tool_choice,
+        }
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+        assert msg['ignore_eos'] is True
+
+    def test_allows_ignore_eos_for_tools_without_tool_choice(self, tmp_path):
+        """tools present but no tool_choice key → defaults to auto, safe."""
+        body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'tools': [{'type': 'function', 'function': {'name': 'get_weather'}}],
+        }
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+        assert msg['ignore_eos'] is True
+
+    def test_mixed_constrained_and_plain(self, tmp_path, caplog):
+        """Only constrained requests skip ignore_eos; plain ones still get it."""
+        constrained_body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'json'}],
+            'response_format': {'type': 'json_object'},
+        }
+        plain_body = {
+            'model': 'qwen',
+            'messages': [{'role': 'user', 'content': 'text'}],
+        }
+        records = [
+            _record(body=constrained_body, completion_tokens=30, timestamp=0.0),
+            _record(body=plain_body, completion_tokens=60, timestamp=1.0),
+        ]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msgs = list(plugin.build_messages())
+
+        # constrained → max_tokens set, no ignore_eos
+        assert msgs[0]['max_tokens'] == 30
+        assert 'ignore_eos' not in msgs[0]
+
+        # plain → both set
+        assert msgs[1]['max_tokens'] == 60
+        assert msgs[1]['ignore_eos'] is True
+
+        assert '1 request(s) use constrained decoding' in caplog.text

--- a/tests/perf/test_workload_trace.py
+++ b/tests/perf/test_workload_trace.py
@@ -266,11 +266,14 @@ class TestValidation:
         with pytest.raises(ValueError, match=r'(?s)line 1.*timestamp.*(?:missing|required)'):
             WorkloadTraceDatasetPlugin(_make_args(path))
 
-    def test_non_monotonic_timestamps(self, tmp_path):
+    def test_non_monotonic_timestamps_sorted(self, tmp_path, caplog):
         records = [_record(timestamp=5.0), _record(timestamp=3.0)]
         path = _make_trace_file(records, tmp_path)
-        with pytest.raises(ValueError, match='monotonically non-decreasing'):
-            WorkloadTraceDatasetPlugin(_make_args(path))
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        # Should sort rather than reject
+        assert plugin._records[0].timestamp == 3.0
+        assert plugin._records[1].timestamp == 5.0
+        assert 'not monotonic' in caplog.text
 
     def test_body_meta_key_collision(self, tmp_path):
         body = {'model': 'm', 'messages': [], BODY_META_HEADERS: {}}

--- a/tests/perf/test_workload_trace.py
+++ b/tests/perf/test_workload_trace.py
@@ -145,6 +145,18 @@ class TestModelRewriting:
         msg = list(plugin.build_messages())[0]
         assert msg['model'] == 'mapped'
 
+    def test_cli_model_does_not_rewrite_body(self, tmp_path):
+        """--model must not rewrite trace bodies (issue #1489); the trace's own
+        model is preserved so multi-model routing stays intact."""
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = Arguments(
+            model='cli-model', url='http://localhost:8080/v1/chat/completions',
+            dataset='workload_trace', dataset_path=path, open_loop=True, rate=1,
+        )
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'qwen-72b'
+
 
 # ---------------------------------------------------------------------------
 # Arrival schedule

--- a/tests/perf/test_workload_trace.py
+++ b/tests/perf/test_workload_trace.py
@@ -30,7 +30,7 @@ def _make_args(trace_path, **kwargs):
     )
 
 
-def _record(body=None, timestamp=0.0, headers=None, request_id=None):
+def _record(body=None, timestamp=0.0, headers=None, request_id=None, completion_tokens=None):
     r = {
         'body': body or {'model': 'qwen-72b', 'messages': [{'role': 'user', 'content': 'hi'}], 'temperature': 0.5},
         'timestamp': timestamp,
@@ -39,6 +39,8 @@ def _record(body=None, timestamp=0.0, headers=None, request_id=None):
         r['headers'] = headers
     if request_id is not None:
         r['request_id'] = request_id
+    if completion_tokens is not None:
+        r['completion_tokens'] = completion_tokens
     return r
 
 
@@ -256,12 +258,12 @@ class TestValidation:
 
     def test_missing_body(self, tmp_path):
         path = _make_trace_file([{'timestamp': 0.0}], tmp_path)
-        with pytest.raises(ValueError, match='line 1.*missing.*body'):
+        with pytest.raises(ValueError, match=r'(?s)line 1.*body.*(?:missing|required)'):
             WorkloadTraceDatasetPlugin(_make_args(path))
 
     def test_missing_timestamp(self, tmp_path):
         path = _make_trace_file([{'body': {'model': 'm', 'messages': []}}], tmp_path)
-        with pytest.raises(ValueError, match='line 1.*missing.*timestamp'):
+        with pytest.raises(ValueError, match=r'(?s)line 1.*timestamp.*(?:missing|required)'):
             WorkloadTraceDatasetPlugin(_make_args(path))
 
     def test_non_monotonic_timestamps(self, tmp_path):
@@ -464,3 +466,49 @@ class TestRateValidation:
         )
         plugin = WorkloadTraceDatasetPlugin(args)
         assert len(list(plugin.build_messages())) == 1
+
+
+# ---------------------------------------------------------------------------
+# Match output length
+# ---------------------------------------------------------------------------
+
+
+class TestMatchOutputLength:
+
+    def test_sets_max_tokens_and_ignore_eos(self, tmp_path):
+        path = _make_trace_file([_record(completion_tokens=42, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 42
+        assert msg['ignore_eos'] is True
+
+    def test_no_effect_when_disabled(self, tmp_path):
+        path = _make_trace_file([_record(completion_tokens=42, timestamp=0.0)], tmp_path)
+        args = _make_args(path)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert 'ignore_eos' not in msg
+        assert msg.get('max_tokens') is None  # original body has no max_tokens
+
+    def test_skips_when_completion_tokens_missing(self, tmp_path):
+        """Records without completion_tokens are left untouched."""
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert 'ignore_eos' not in msg
+
+    def test_overwrites_existing_max_tokens(self, tmp_path):
+        body = {'model': 'qwen', 'messages': [{'role': 'user', 'content': 'hi'}], 'max_tokens': 999}
+        path = _make_trace_file([_record(body=body, completion_tokens=50, timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'match_output_length': True})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['max_tokens'] == 50
+
+    @pytest.mark.parametrize('bad_value', [0, -1, -100])
+    def test_rejects_non_positive_completion_tokens(self, tmp_path, bad_value):
+        path = _make_trace_file([_record(completion_tokens=bad_value, timestamp=0.0)], tmp_path)
+        with pytest.raises(ValueError, match='completion_tokens must be > 0'):
+            WorkloadTraceDatasetPlugin(_make_args(path))

--- a/tests/perf/test_workload_trace.py
+++ b/tests/perf/test_workload_trace.py
@@ -1,0 +1,466 @@
+"""Tests for workload_trace dataset plugin."""
+
+import json
+import numpy as np
+import os
+import pytest
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.api.openai_api import OpenaiPlugin
+from evalscope.perf.plugin.datasets.workload_trace import WorkloadTraceDatasetPlugin
+from evalscope.perf.utils.body_meta import BODY_META_ARRIVAL_OFFSET, BODY_META_HEADERS, BODY_META_REQUEST_ID
+
+
+def _make_trace_file(records, tmp_path):
+    path = os.path.join(tmp_path, 'trace.jsonl')
+    with open(path, 'w') as f:
+        for r in records:
+            f.write(json.dumps(r) + '\n')
+    return path
+
+
+def _make_args(trace_path, **kwargs):
+    return Arguments(
+        url='http://localhost:8080/v1/chat/completions',
+        dataset='workload_trace',
+        dataset_path=trace_path,
+        open_loop=True,
+        rate=1,
+        **kwargs,
+    )
+
+
+def _record(body=None, timestamp=0.0, headers=None, request_id=None):
+    r = {
+        'body': body or {'model': 'qwen-72b', 'messages': [{'role': 'user', 'content': 'hi'}], 'temperature': 0.5},
+        'timestamp': timestamp,
+    }
+    if headers is not None:
+        r['headers'] = headers
+    if request_id is not None:
+        r['request_id'] = request_id
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Loading and basic passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestBasicLoading:
+
+    def test_loads_records(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=1.0), _record(timestamp=2.0)], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        assert len(messages) == 2
+
+    def test_body_fields_preserved(self, tmp_path):
+        body = {'model': 'qwen-72b', 'messages': [{'role': 'user', 'content': 'hello'}], 'temperature': 0.9, 'max_tokens': 100}
+        path = _make_trace_file([_record(body=body, timestamp=0.0)], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        result = list(plugin.build_messages())[0]
+        assert result['temperature'] == 0.9
+        assert result['max_tokens'] == 100
+
+    def test_body_survives_build_request(self, tmp_path):
+        """Body fields should survive through OpenaiPlugin.build_request (setdefault)."""
+        body = {'model': 'qwen-72b', 'messages': [{'role': 'user', 'content': 'hi'}], 'temperature': 0.9, 'max_tokens': 100}
+        path = _make_trace_file([_record(body=body, timestamp=0.0)], tmp_path)
+        args = _make_args(path)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        api = OpenaiPlugin(args)
+        messages = list(plugin.build_messages())[0]
+        request = api.build_request(messages)
+        assert request['temperature'] == 0.9
+        assert request['max_tokens'] == 100
+        assert request['model'] == 'qwen-72b'
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = os.path.join(tmp_path, 'trace.jsonl')
+        with open(path, 'w') as f:
+            f.write(json.dumps(_record(timestamp=0.0)) + '\n')
+            f.write('\n')
+            f.write('   \n')
+            f.write(json.dumps(_record(timestamp=1.0)) + '\n')
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        assert len(list(plugin.build_messages())) == 2
+
+    def test_sets_number_to_record_count(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(5)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path)
+        WorkloadTraceDatasetPlugin(args)
+        assert args.number == 5
+
+    def test_missing_optional_fields(self, tmp_path):
+        path = _make_trace_file([{'body': {'model': 'm', 'messages': []}, 'timestamp': 0.0}], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        msg = list(plugin.build_messages())[0]
+        assert BODY_META_HEADERS not in msg
+        assert BODY_META_REQUEST_ID not in msg
+
+
+# ---------------------------------------------------------------------------
+# Model rewriting
+# ---------------------------------------------------------------------------
+
+
+class TestModelRewriting:
+
+    def test_model_override(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'model_override': 'new-model'})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'new-model'
+
+    def test_model_mapping_match(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'model_mapping': {'qwen-72b': 'qwen-72b-v2'}})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'qwen-72b-v2'
+
+    def test_model_mapping_no_match_falls_back_to_override(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'model_mapping': {'other': 'x'}, 'model_override': 'fallback'})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'fallback'
+
+    def test_model_mapping_no_match_no_override_keeps_original(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'model_mapping': {'other': 'x'}})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'qwen-72b'
+
+    def test_model_mapping_takes_priority_over_override(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = _make_args(path, dataset_args={'model_mapping': {'qwen-72b': 'mapped'}, 'model_override': 'overridden'})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'mapped'
+
+
+# ---------------------------------------------------------------------------
+# Arrival schedule
+# ---------------------------------------------------------------------------
+
+
+class TestArrivalSchedule:
+
+    def test_offsets_at_speed_1(self, tmp_path):
+        records = [_record(timestamp=10.0), _record(timestamp=12.0), _record(timestamp=15.0)]
+        path = _make_trace_file(records, tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 2.0, 5.0])
+
+    def test_offsets_at_speed_2(self, tmp_path):
+        records = [_record(timestamp=10.0), _record(timestamp=14.0)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, dataset_args={'speed': 2.0})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 2.0])
+
+    def test_offsets_at_speed_half(self, tmp_path):
+        records = [_record(timestamp=0.0), _record(timestamp=1.0)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, dataset_args={'speed': 0.5})
+        plugin = WorkloadTraceDatasetPlugin(args)
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# Body meta keys
+# ---------------------------------------------------------------------------
+
+
+class TestBodyMetaKeys:
+
+    def test_headers_injected(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0, headers={'X-Route': 'canary'})], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        msg = list(plugin.build_messages())[0]
+        assert msg[BODY_META_HEADERS] == {'X-Route': 'canary'}
+
+    def test_request_id_injected(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0, request_id='req-123')], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        msg = list(plugin.build_messages())[0]
+        assert msg[BODY_META_REQUEST_ID] == 'req-123'
+
+    def test_arrival_offset_injected(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=5.0)], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        msg = list(plugin.build_messages())[0]
+        assert BODY_META_ARRIVAL_OFFSET in msg
+
+    def test_body_meta_keys_survive_build_request(self, tmp_path):
+        """Body meta keys should survive build_request (they're not OpenAI params)."""
+        path = _make_trace_file([_record(timestamp=0.0, headers={'X-A': '1'}, request_id='r1')], tmp_path)
+        args = _make_args(path)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        api = OpenaiPlugin(args)
+        msg = list(plugin.build_messages())[0]
+        request = api.build_request(msg)
+        # Body meta keys pass through build_request (stripped later in process_request).
+        assert BODY_META_HEADERS in request
+        assert BODY_META_REQUEST_ID in request
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+
+    def test_requires_open_loop(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = Arguments(
+            model='m', url='http://localhost:8080/v1/chat/completions',
+            dataset='workload_trace', dataset_path=path, open_loop=False, rate=1,
+        )
+        with pytest.raises(ValueError, match='open-loop'):
+            WorkloadTraceDatasetPlugin(args)
+
+    def test_requires_dataset_path(self, tmp_path):
+        args = Arguments(
+            model='m', url='http://localhost:8080/v1/chat/completions',
+            dataset='workload_trace', open_loop=True, rate=1,
+        )
+        with pytest.raises(ValueError, match='dataset-path'):
+            WorkloadTraceDatasetPlugin(args)
+
+    def test_empty_file(self, tmp_path):
+        path = os.path.join(tmp_path, 'empty.jsonl')
+        with open(path, 'w') as f:
+            f.write('')
+        with pytest.raises(ValueError, match='empty'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_invalid_json(self, tmp_path):
+        path = os.path.join(tmp_path, 'bad.jsonl')
+        with open(path, 'w') as f:
+            f.write('not json\n')
+        with pytest.raises(ValueError, match='line 1.*invalid JSON'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_missing_body(self, tmp_path):
+        path = _make_trace_file([{'timestamp': 0.0}], tmp_path)
+        with pytest.raises(ValueError, match='line 1.*missing.*body'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_missing_timestamp(self, tmp_path):
+        path = _make_trace_file([{'body': {'model': 'm', 'messages': []}}], tmp_path)
+        with pytest.raises(ValueError, match='line 1.*missing.*timestamp'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_non_monotonic_timestamps(self, tmp_path):
+        records = [_record(timestamp=5.0), _record(timestamp=3.0)]
+        path = _make_trace_file(records, tmp_path)
+        with pytest.raises(ValueError, match='monotonically non-decreasing'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_body_meta_key_collision(self, tmp_path):
+        body = {'model': 'm', 'messages': [], BODY_META_HEADERS: {}}
+        path = _make_trace_file([{'body': body, 'timestamp': 0.0}], tmp_path)
+        with pytest.raises(ValueError, match='reserved'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_invalid_speed(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        with pytest.raises(Exception, match='speed'):
+            WorkloadTraceDatasetPlugin(_make_args(path, dataset_args={'speed': -1.0}))
+
+    def test_unknown_dataset_arg_rejected(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        with pytest.raises(Exception):
+            WorkloadTraceDatasetPlugin(_make_args(path, dataset_args={'bogus': True}))
+
+    def test_error_reports_line_number(self, tmp_path):
+        path = os.path.join(tmp_path, 'trace.jsonl')
+        with open(path, 'w') as f:
+            f.write(json.dumps(_record(timestamp=0.0)) + '\n')
+            f.write('bad line\n')
+        with pytest.raises(ValueError, match='line 2'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+
+# ---------------------------------------------------------------------------
+# ISO-8601 timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampFormats:
+
+    def test_iso8601_utc_z(self, tmp_path):
+        path = _make_trace_file([
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': '2025-01-15T10:00:00Z'},
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': '2025-01-15T10:00:05Z'},
+        ], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 5.0])
+
+    def test_iso8601_with_offset(self, tmp_path):
+        path = _make_trace_file([
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': '2025-01-15T18:00:00+08:00'},
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': '2025-01-15T18:00:03+08:00'},
+        ], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 3.0])
+
+    def test_integer_timestamp(self, tmp_path):
+        path = _make_trace_file([
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': 1000},
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': 1002},
+        ], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        offsets = [m[BODY_META_ARRIVAL_OFFSET] for m in messages]
+        np.testing.assert_allclose(offsets, [0.0, 2.0])
+
+    def test_mixed_numeric_and_iso_accepted(self, tmp_path):
+        """Pydantic converts both to float, so mixed formats work if monotonic."""
+        path = _make_trace_file([
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': 1000.0},
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': '2025-01-15T10:00:00Z'},
+        ], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        assert len(list(plugin.build_messages())) == 2
+
+    def test_unparseable_timestamp_rejected(self, tmp_path):
+        path = _make_trace_file([
+            {'body': {'model': 'm', 'messages': []}, 'timestamp': 'not-a-date'},
+        ], tmp_path)
+        with pytest.raises(ValueError, match='cannot parse timestamp'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+
+# ---------------------------------------------------------------------------
+# Body as JSON string
+# ---------------------------------------------------------------------------
+
+
+class TestBodyAsString:
+
+    def test_json_string_body_parsed(self, tmp_path):
+        body_dict = {'model': 'qwen', 'messages': [{'role': 'user', 'content': 'hi'}], 'temperature': 0.7}
+        path = _make_trace_file([
+            {'body': json.dumps(body_dict), 'timestamp': 0.0},
+        ], tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        msg = list(plugin.build_messages())[0]
+        assert msg['model'] == 'qwen'
+        assert msg['temperature'] == 0.7
+
+    def test_invalid_json_string_body_rejected(self, tmp_path):
+        path = _make_trace_file([
+            {'body': 'not valid json', 'timestamp': 0.0},
+        ], tmp_path)
+        with pytest.raises(ValueError, match='not valid JSON'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+    def test_json_string_body_non_dict_rejected(self, tmp_path):
+        path = _make_trace_file([
+            {'body': json.dumps([1, 2, 3]), 'timestamp': 0.0},
+        ], tmp_path)
+        with pytest.raises(ValueError, match='must.*dict'):
+            WorkloadTraceDatasetPlugin(_make_args(path))
+
+
+# ---------------------------------------------------------------------------
+# Warmup sideband key
+# ---------------------------------------------------------------------------
+
+
+class TestWarmup:
+
+    def test_warmup_absolute(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(5)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, warmup_num=2)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        messages = list(plugin.build_messages())
+        warmup_flags = ['__evalscope_is_warmup' in m for m in messages]
+        assert warmup_flags == [True, True, False, False, False]
+
+    def test_warmup_ratio(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(10)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, warmup_num=0.2)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        messages = list(plugin.build_messages())
+        warmup_flags = ['__evalscope_is_warmup' in m for m in messages]
+        assert sum(warmup_flags) == 2
+        assert warmup_flags[:2] == [True, True]
+        assert all(not f for f in warmup_flags[2:])
+
+    def test_warmup_capped_at_record_count(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(5)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, warmup_num=100)
+        plugin = WorkloadTraceDatasetPlugin(args)
+        messages = list(plugin.build_messages())
+        assert all('__evalscope_is_warmup' in m for m in messages)
+        assert len(messages) == 5
+
+    def test_warmup_disables_framework_split(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(5)]
+        path = _make_trace_file(records, tmp_path)
+        args = _make_args(path, warmup_num=2)
+        WorkloadTraceDatasetPlugin(args)
+        assert args.warmup_num == 0
+
+    def test_no_warmup_by_default(self, tmp_path):
+        records = [_record(timestamp=float(i)) for i in range(3)]
+        path = _make_trace_file(records, tmp_path)
+        plugin = WorkloadTraceDatasetPlugin(_make_args(path))
+        messages = list(plugin.build_messages())
+        assert all('__evalscope_is_warmup' not in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Rate validation bypass
+# ---------------------------------------------------------------------------
+
+
+class TestRateValidation:
+
+    def test_no_rate_required(self, tmp_path):
+        """workload_trace with --open-loop should not require --rate."""
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = Arguments(
+            model='m',
+            url='http://localhost:8080/v1/chat/completions',
+            dataset='workload_trace',
+            dataset_path=path,
+            open_loop=True,
+        )
+        plugin = WorkloadTraceDatasetPlugin(args)
+        assert len(list(plugin.build_messages())) == 1
+
+    def test_explicit_rate_still_works(self, tmp_path):
+        path = _make_trace_file([_record(timestamp=0.0)], tmp_path)
+        args = Arguments(
+            model='m',
+            url='http://localhost:8080/v1/chat/completions',
+            dataset='workload_trace',
+            dataset_path=path,
+            open_loop=True,
+            rate=5,
+        )
+        plugin = WorkloadTraceDatasetPlugin(args)
+        assert len(list(plugin.build_messages())) == 1

--- a/tests/perf/test_workload_trace_e2e.py
+++ b/tests/perf/test_workload_trace_e2e.py
@@ -1,0 +1,272 @@
+"""End-to-end tests for workload_trace: real HTTP server + full dispatch pipeline."""
+
+import asyncio
+import json
+import os
+import time
+from aiohttp import web
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.core.http_client import AioHttpClient
+from evalscope.perf.core.strategies.open_loop import OpenLoopStrategy
+from evalscope.perf.plugin.api.openai_api import OpenaiPlugin
+from evalscope.perf.plugin.datasets.workload_trace import WorkloadTraceDatasetPlugin
+from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.perf.utils.body_meta import BODY_META_PREFIX
+
+
+class EchoServer:
+    """In-process aiohttp server that records arrival times and request bodies."""
+
+    def __init__(self):
+        self.arrivals: list[float] = []
+        self.bodies: list[dict] = []
+        self.headers_log: list[dict] = []
+        self._runner = None
+        self.port = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.arrivals.append(time.perf_counter())
+        body = await request.json()
+        self.bodies.append(body)
+        self.headers_log.append(dict(request.headers))
+        return web.json_response({
+            'id': 'chatcmpl-1',
+            'object': 'chat.completion',
+            'choices': [{
+                'index': 0,
+                'message': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+            }],
+            'usage': {'prompt_tokens': 5, 'completion_tokens': 1, 'total_tokens': 6},
+        })
+
+    async def start(self) -> int:
+        app = web.Application()
+        app.router.add_post('/v1/chat/completions', self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, 'localhost', 0)
+        await site.start()
+        self.port = site._server.sockets[0].getsockname()[1]
+        return self.port
+
+    async def stop(self):
+        if self._runner:
+            await self._runner.cleanup()
+
+
+def _make_trace_file(records, tmp_path):
+    path = os.path.join(tmp_path, 'trace.jsonl')
+    with open(path, 'w') as f:
+        for r in records:
+            f.write(json.dumps(r) + '\n')
+    return path
+
+
+def _make_args(trace_path, port, **kwargs):
+    return Arguments(
+        url=f'http://localhost:{port}/v1/chat/completions',
+        dataset='workload_trace',
+        dataset_path=trace_path,
+        open_loop=True,
+        rate=1,
+        **kwargs,
+    )
+
+
+async def _run_e2e(records, tmp_path, dataset_args=None, warmup_num=0):
+    """Spin up echo server, run full pipeline, return (server, results)."""
+    server = EchoServer()
+    await server.start()
+    try:
+        path = _make_trace_file(records, tmp_path)
+        extra = {}
+        if dataset_args:
+            extra['dataset_args'] = dataset_args
+        if warmup_num:
+            extra['warmup_num'] = warmup_num
+        args = _make_args(path, server.port, **extra)
+        for attr in ('parallel', 'number', 'rate'):
+            v = getattr(args, attr)
+            if isinstance(v, list):
+                setattr(args, attr, v[0])
+
+        api_plugin = OpenaiPlugin(args)
+        dataset_plugin = WorkloadTraceDatasetPlugin(args)
+
+        requests = []
+        for messages in dataset_plugin.build_messages():
+            request = api_plugin.build_request(messages)
+            requests.append(request)
+
+        async def request_gen():
+            for r in requests:
+                yield r, False
+
+        queue = asyncio.Queue()
+        results: list[BenchmarkData] = []
+
+        client = AioHttpClient(args, api_plugin)
+        try:
+            strategy = OpenLoopStrategy(args, api_plugin, client, queue, request_gen())
+            await strategy.run()
+
+            while not queue.empty():
+                results.append(await queue.get())
+        finally:
+            await client.__aexit__(None, None, None)
+
+        return server, results
+    except Exception:
+        await server.stop()
+        raise
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# E2E Tests
+# ---------------------------------------------------------------------------
+
+
+class TestE2EArrivalTiming:
+
+    def test_arrival_intervals_match_trace(self, tmp_path):
+        """Requests arrive at intervals matching the trace timestamps (±80ms)."""
+        records = [
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'a'}]}, 'timestamp': 100.0},
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'b'}]}, 'timestamp': 100.3},
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'c'}]}, 'timestamp': 100.8},
+        ]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path)
+            await server.stop()
+            return server
+
+        server = _run(go())
+        assert len(server.arrivals) == 3
+        intervals = [server.arrivals[i + 1] - server.arrivals[i] for i in range(2)]
+        assert abs(intervals[0] - 0.3) < 0.08, f'interval[0]={intervals[0]:.3f}, expected ~0.3'
+        assert abs(intervals[1] - 0.5) < 0.08, f'interval[1]={intervals[1]:.3f}, expected ~0.5'
+
+    def test_speed_scaling_compresses_intervals(self, tmp_path):
+        """speed=2.0 halves the inter-arrival gaps."""
+        records = [
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'a'}]}, 'timestamp': 0.0},
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'b'}]}, 'timestamp': 0.6},
+        ]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path, dataset_args={'speed': 2.0})
+            await server.stop()
+            return server
+
+        server = _run(go())
+        assert len(server.arrivals) == 2
+        interval = server.arrivals[1] - server.arrivals[0]
+        assert abs(interval - 0.3) < 0.08, f'interval={interval:.3f}, expected ~0.3'
+
+
+class TestE2EBodyPassthrough:
+
+    def test_body_arrives_verbatim(self, tmp_path):
+        """All body fields reach the server unchanged; no body meta keys leak."""
+        body = {
+            'model': 'qwen-72b',
+            'messages': [{'role': 'user', 'content': 'hello'}],
+            'temperature': 0.9,
+            'max_tokens': 100,
+            'top_p': 0.95,
+            'seed': 42,
+        }
+        records = [{'body': body, 'timestamp': 0.0}]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path)
+            await server.stop()
+            return server
+
+        server = _run(go())
+        received = server.bodies[0]
+        assert received['temperature'] == 0.9
+        assert received['max_tokens'] == 100
+        assert received['top_p'] == 0.95
+        assert received['seed'] == 42
+        assert received['model'] == 'qwen-72b'
+        for key in received:
+            assert not key.startswith(BODY_META_PREFIX), f'body meta key leaked: {key}'
+
+    def test_body_meta_headers_applied(self, tmp_path):
+        """Per-request headers from trace are merged into HTTP request headers."""
+        records = [{
+            'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'hi'}]},
+            'timestamp': 0.0,
+            'headers': {'X-Canary': 'true'},
+        }]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path)
+            await server.stop()
+            return server
+
+        server = _run(go())
+        assert server.headers_log[0].get('X-Canary') == 'true'
+
+    def test_request_id_propagated(self, tmp_path):
+        """request_id flows through to BenchmarkData.trace_id."""
+        records = [{
+            'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'hi'}]},
+            'timestamp': 0.0,
+            'request_id': 'req-abc-123',
+        }]
+
+        async def go():
+            server, results = await _run_e2e(records, tmp_path)
+            await server.stop()
+            return results
+
+        results = _run(go())
+        assert len(results) == 1
+        assert results[0].trace_id == 'req-abc-123'
+
+
+class TestE2EWarmup:
+
+    def test_warmup_excluded_from_results(self, tmp_path):
+        """Warmup requests have is_warmup=True; non-warmup have is_warmup=False."""
+        records = [
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': str(i)}]}, 'timestamp': float(i) * 0.1}
+            for i in range(5)
+        ]
+
+        async def go():
+            server, results = await _run_e2e(records, tmp_path, warmup_num=2)
+            await server.stop()
+            return results
+
+        results = _run(go())
+        assert len(results) == 5
+        warmup_flags = [r.is_warmup for r in results]
+        assert sum(warmup_flags) == 2
+
+    def test_warmup_continuous_timing(self, tmp_path):
+        """Warmup and benchmark requests share a single continuous arrival schedule."""
+        records = [
+            {'body': {'model': 'm', 'messages': [{'role': 'user', 'content': str(i)}]}, 'timestamp': float(i) * 0.2}
+            for i in range(4)
+        ]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path, warmup_num=2)
+            await server.stop()
+            return server
+
+        server = _run(go())
+        assert len(server.arrivals) == 4
+        intervals = [server.arrivals[i + 1] - server.arrivals[i] for i in range(3)]
+        for idx, interval in enumerate(intervals):
+            assert abs(interval - 0.2) < 0.08, f'interval[{idx}]={interval:.3f}, expected ~0.2'

--- a/tests/perf/test_workload_trace_e2e.py
+++ b/tests/perf/test_workload_trace_e2e.py
@@ -216,8 +216,27 @@ class TestE2EBodyPassthrough:
         server = _run(go())
         assert server.headers_log[0].get('X-Canary') == 'true'
 
+    def test_hop_by_hop_headers_stripped(self, tmp_path):
+        """Hop-by-hop headers from trace data are stripped before sending."""
+        records = [{
+            'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'hi'}]},
+            'timestamp': 0.0,
+            'headers': {'X-Custom': 'keep', 'Host': 'evil.com', 'Connection': 'close'},
+        }]
+
+        async def go():
+            server, _ = await _run_e2e(records, tmp_path)
+            await server.stop()
+            return server
+
+        server = _run(go())
+        sent_headers = server.headers_log[0]
+        assert sent_headers.get('X-Custom') == 'keep'
+        # Host should be set by aiohttp to the actual target, not the trace value
+        assert sent_headers.get('Host') != 'evil.com'
+
     def test_request_id_propagated(self, tmp_path):
-        """request_id flows through to BenchmarkData.trace_id."""
+        """request_id flows through to BenchmarkData.request_id (not trace_id)."""
         records = [{
             'body': {'model': 'm', 'messages': [{'role': 'user', 'content': 'hi'}]},
             'timestamp': 0.0,
@@ -231,7 +250,8 @@ class TestE2EBodyPassthrough:
 
         results = _run(go())
         assert len(results) == 1
-        assert results[0].trace_id == 'req-abc-123'
+        assert results[0].request_id == 'req-abc-123'
+        assert results[0].trace_id is None
 
 
 class TestE2EWarmup:


### PR DESCRIPTION
## Summary

Add a `workload_trace` dataset plugin that replays recorded production traffic with original timing, headers, and request bodies — enabling performance benchmarking against real-world workload patterns.

Closes #1489

## Motivation

Existing perf datasets (`openqa`, `share_gpt`, `random`, etc.) generate synthetic traffic that may not reflect production load characteristics. Real production workloads have bursty arrival patterns, heterogeneous request shapes, and model-specific routing. This plugin bridges that gap by replaying captured JSONL traces verbatim.

## Changes

### New files

| File | Description |
|------|-------------|
| `evalscope/perf/plugin/datasets/workload_trace.py` | Core plugin (249 lines) |
| `evalscope/perf/utils/body_meta.py` | Sideband key constants for per-request metadata |
| `tests/perf/test_workload_trace.py` | 48 unit tests |
| `tests/perf/test_workload_trace_e2e.py` | 7 E2E tests (mock HTTP server) |

### Modified files

| File | What changed |
|------|-------------|
| `arguments.py` | `--dataset-args` CLI arg; `--model` / `--number` optional for trace datasets; `requires_model` validation |
| `benchmark.py` | Re-read `total_count` / `warmup_count` after plugin construction (plugins may adjust them); remove unused `import numpy` |
| `plugin/api/base.py` | `extract_body_meta()` — pops sideband keys before `process_request`; merges per-request headers with fill semantics (CLI headers win) |
| `plugin/api/openai_api.py` | Guard `model=None` when dataset carries model in body |
| `plugin/datasets/base.py` | `provides_arrival_schedule` / `requires_model` class attributes |
| `plugin/datasets/__init__.py` | Register import |
| `core/strategies/open_loop.py` | Trace-offset dispatch branch with deferred duration deadline for warmup |
| `core/http_client.py` | Call `extract_body_meta` before delegating to API plugin |

## Trace format

Each line in the JSONL file:

```jsonl
{"body": {"model": "qwen-plus", "messages": [...]}, "timestamp": 1700000000.0}
{"body": {"model": "qwen-max", "messages": [...]}, "timestamp": 1700000001.5, "headers": {"X-Tag": "exp"}, "request_id": "req-42", "completion_tokens": 256}
```

- **`body`** (dict or JSON string): complete request body, sent as-is.
- **`timestamp`** (number or ISO-8601): arrival time; only relative deltas matter.
- **`headers`** (optional): per-request HTTP headers (merged with fill semantics — CLI headers take precedence).
- **`request_id`** (optional): propagated to results for correlation.
- **`completion_tokens`** (optional): used by `match_output_length`.

## Usage

```bash
# Basic replay
evalscope perf \
  --dataset workload_trace \
  --dataset-path trace.jsonl \
  --url http://localhost:8000/v1/chat/completions \
  --open-loop

# 2× speed, remap models, match recorded output lengths
evalscope perf \
  --dataset workload_trace \
  --dataset-path trace.jsonl \
  --url http://localhost:8000/v1/chat/completions \
  --open-loop \
  --dataset-args '{"speed": 2.0, "model_mapping": {"gpt-4": "qwen-max"}, "match_output_length": true}'

# Limit to first 500 requests
evalscope perf \
  --dataset workload_trace \
  --dataset-path trace.jsonl \
  --url http://localhost:8000/v1/chat/completions \
  --open-loop \
  --number 500
```

### Dataset args (`--dataset-args`)

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `speed` | float | `1.0` | Replay speed multiplier (2.0 = 2× faster) |
| `model_override` | str | `None` | Replace all models with this value |
| `model_mapping` | dict | `None` | Selectively remap model names |
| `match_output_length` | bool | `false` | Set `max_tokens` from `completion_tokens` and enable `ignore_eos` (requires vLLM or compatible) |

## Design decisions

- **Sideband keys**: per-request metadata (`__evalscope_*` prefixed) is embedded in the body dict and stripped by `extract_body_meta` before reaching API plugins. This avoids changing the plugin interface.
- **Fill semantics for headers**: `{**trace_headers, **cli_headers}` — CLI-set headers (e.g. `Authorization` from `--api-key`) always take precedence over trace headers, so explicit CLI configuration is never silently overridden by trace data.
- **`--model` / `--number` optional**: Trace data carries its own model and count. New `requires_model` class attribute on `DatasetPluginBase` controls validation.
- **Deferred deadline**: `--duration` countdown starts after warmup completes, so warmup doesn't consume benchmark time.

## Testing

```
$ pytest tests/perf/test_workload_trace.py tests/perf/test_workload_trace_e2e.py -q
55 passed
```

Coverage includes: loading/validation, timestamp parsing (epoch + ISO-8601), body-as-string, model rewriting, speed scaling, warmup, `--number` truncation, `match_output_length`, header fill semantics, reserved key rejection, E2E body passthrough, and E2E warmup exclusion.
