### PR TITLE
feat(perf): unified --dataset-args with fixed-length input (#1483)

### DIFF
--- a/docs/en/user_guides/stress_test/multi_turn.md
+++ b/docs/en/user_guides/stress_test/multi_turn.md
@@ -22,7 +22,11 @@ The multi-turn conversation benchmark allows you to test a model service in real
 
 ### `multi_turn_args` (swe_smith-specific parameters)
 
-The `swe_smith` dataset's live construction mode supports fine-grained control of conversation structure and token-length targets via a `MultiTurnArgs` object.
+```{note}
+`--multi-turn-args` is **deprecated**; pass the same parameters via the unified `--dataset-args` instead. The old flag still works and its content is automatically folded into `--dataset-args` (on a key conflict, `--dataset-args` takes precedence). The parameter key names below are unchanged.
+```
+
+The `swe_smith` dataset's live construction mode supports fine-grained control of conversation structure and token-length targets via `--dataset-args`.
 
 The number of turns per conversation is sampled from `[--min-turns, --max-turns]`; the amount of content filled per turn is controlled by the token-length parameters below.
 
@@ -384,7 +388,7 @@ evalscope perf \
   --max-tokens 512 \
   --min-tokens 512 \
   --multi-turn \
-  --multi-turn-args '{
+  --dataset-args '{
       "first_turn_length": 8192,
       "subsequent_turn_length": 1024
   }' \

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -89,6 +89,7 @@ For details on using the SLA auto-tuning feature, see the [Auto-tuning Guide](./
 | `--dataset` | `str` | Dataset mode, see table below for details | - |
 | `--dataset-path` | `str` | Dataset file or directory path<br>Points to a file: read directly; points to a directory: looks for the corresponding data file inside (for offline use with pre-downloaded dataset cache) | - |
 | `--data-source` | `str` | Data source for dataset loading: `modelscope`, `huggingface`, or `local`<br>Defaults to `modelscope` when not specified; automatically treated as `local` when `--dataset-path` is a local directory | `modelscope` |
+| `--dataset-args` | `str` | Per-dataset arguments (JSON string), validated against the schema of the selected `--dataset` (unknown keys raise an error). Carries the fixed-length input args `target_input_len` / `input_len_mode` for real-text datasets, and supersedes the deprecated `--multi-turn-args`. See the "dataset-args: Per-dataset Arguments" section below | - |
 
 ### Dataset Mode Description
 
@@ -136,6 +137,41 @@ Must be used with `--multi-turn`. See the [Multi-turn Benchmark Guide](./multi_t
 | `share_gpt_zh_multi_turn` | Automatically downloads the Chinese [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) dataset (~70k conversations) from ModelScope, preserving full multi-turn conversations<br>[Usage example](./multi_turn.md#share_gpt_multi_turn) | ✓ |
 | `share_gpt_en_multi_turn` | Automatically downloads the English [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) dataset (~70k conversations) from ModelScope, preserving full multi-turn conversations | ✓ |
 | `custom_multi_turn` | Uses a local JSONL file as a custom multi-turn dataset<br>Each line must be a JSON array of OpenAI message dicts; ideal for benchmarking with your own conversation data<br>**Requires `--dataset-path`**<br>[Usage example](./multi_turn.md#custom_multi_turn) | ✓ (Required) |
+
+### dataset-args: Per-dataset Arguments
+
+`--dataset-args` passes per-dataset arguments as a JSON string (a mistyped key raises an error, making mistakes easy to spot). Two common use cases:
+
+**Case 1: Truncate real data to a fixed input length**
+
+Use it when you want to benchmark a **fixed input length** with real data (instead of `random`). Supported on `openqa`, `longalpaca`, `line_by_line`, and single-turn ShareGPT (`share_gpt_zh` / `share_gpt_en`). **Requires `--tokenizer-path`**.
+
+```bash
+# Truncate every input to 2048 tokens
+evalscope perf \
+  --model qwen2.5 --url http://127.0.0.1:8000/v1/completions \
+  --dataset share_gpt_zh --tokenizer-path /path/to/tokenizer \
+  --dataset-args '{"target_input_len": 2048}'
+```
+
+| Key | Description | Default |
+|-----|-------------|--------|
+| `target_input_len` | Target input length in tokens. When set, every prompt is truncated to this length | disabled |
+| `input_len_mode` | What to do with prompts **shorter than** the target: `cap` (keep as-is; that prompt may be shorter than the target); `drop` (discard it, so every emitted prompt is exactly the target) | `cap` |
+
+How it differs from `--max/min-prompt-length`:
+- `--max/min-prompt-length` only **filters** and never changes content — samples outside the range are dropped, so you get real samples of varying lengths;
+- `target_input_len` **rewrites content** — it truncates every prompt to the given length, ideal for controlled fixed-length benchmarking.
+
+> To get "every prompt exactly N tokens", you must use `target_input_len`; setting `--min-prompt-length` equal to `--max-prompt-length` cannot achieve it (real data almost never has prompts of exactly N tokens, so they get filtered out). The `random` dataset is the exception — it is generated on the fly, so min=max already yields a fixed length and this arg is not needed.
+
+**Case 2: Length arguments for multi-turn datasets**
+
+Token-length arguments for multi-turn datasets such as `swe_smith` are also passed via `--dataset-args`; see the [Multi-turn Benchmark Guide](./multi_turn.md).
+
+```{note}
+`--multi-turn-args` is deprecated; use `--dataset-args` instead (the key names are unchanged). The old flag still works and is automatically merged into `--dataset-args` (on a key conflict, `--dataset-args` takes precedence).
+```
 
 ## Model Settings
 

--- a/docs/zh/user_guides/stress_test/multi_turn.md
+++ b/docs/zh/user_guides/stress_test/multi_turn.md
@@ -22,7 +22,11 @@
 
 ### `multi_turn_args`（`swe_smith` 专属参数）
 
-`swe_smith` 数据集的 live 构建模式支持通过 `MultiTurnArgs` 对象精细控制对话 token 长度目标。
+```{note}
+`--multi-turn-args` 已**废弃**，请改用统一的 `--dataset-args` 传入同名参数。旧参数仍可用，其内容会自动折叠进 `--dataset-args`（同名键以 `--dataset-args` 为准）。下表参数键名不变。
+```
+
+`swe_smith` 数据集的 live 构建模式支持通过 `--dataset-args` 精细控制对话 token 长度目标。
 
 每条对话的轮次数量从 `[--min-turns, --max-turns]` 中随机采样，每轮按以下 token 长度参数填充消息。
 
@@ -384,7 +388,7 @@ evalscope perf \
   --max-tokens 512 1024 \
   --min-tokens 512 \
   --multi-turn \
-  --multi-turn-args '{
+  --dataset-args '{
       "first_turn_length": [4096, 8192],
       "subsequent_turn_length": [512, 1024]
   }' \

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -90,6 +90,7 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 | `--dataset` | `str` | 数据集模式，详见下表 | - |
 | `--dataset-path` | `str` | 数据集文件或目录路径<br>指向文件时直接读取；指向目录时在目录内查找对应数据文件（适用于离线环境使用已下载的数据集缓存） | - |
 | `--data-source` | `str` | 数据集加载源，可选值：`modelscope`、`huggingface`、`local`<br>未指定时默认使用 `modelscope`；当 `--dataset-path` 为本地目录时自动视为 `local` | `modelscope` |
+| `--dataset-args` | `str` | 数据集专属参数（JSON 字符串），按 `--dataset` 所选数据集的 schema 校验（传入未知键会直接报错）。承载真实文本数据集的定长输入参数 `target_input_len` / `input_len_mode`，并取代已废弃的 `--multi-turn-args`。详见下方「dataset-args：数据集专属参数」小节 | - |
 
 ### dataset 模式说明
 
@@ -137,6 +138,41 @@ SLA自动调优功能使用详见[自动调优指南](./sla_auto_tune.md)。
 | `share_gpt_zh_multi_turn` | 从 ModelScope 自动下载中文 [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) 数据集（约 70k 条），保留完整多轮对话<br>[使用示例](./multi_turn.md#share_gpt_multi_turn) | ✓ |
 | `share_gpt_en_multi_turn` | 从 ModelScope 自动下载英文 [ShareGPT](https://www.modelscope.cn/datasets/swift/sharegpt) 数据集（约 70k 条），保留完整多轮对话 | ✓ |
 | `custom_multi_turn` | 使用本地 JSONL 文件作为自定义多轮对话数据集<br>每行为 OpenAI messages 格式的 JSON 数组，适合已有对话数据直接压测<br>**必需提供`dataset_path`**<br>[使用示例](./multi_turn.md#custom_multi_turn) | ✓（必需） |
+
+### dataset-args：数据集专属参数
+
+`--dataset-args` 用一个 JSON 字符串为不同数据集传入专属参数（键名写错会直接报错，便于排查）。常见两个场景：
+
+**场景一：把真实数据的输入截断到固定长度**
+
+想用真实数据（而非 `random`）压测某个**固定输入长度**时用它。支持 `openqa`、`longalpaca`、`line_by_line`、单轮 ShareGPT（`share_gpt_zh` / `share_gpt_en`），**需配合 `--tokenizer-path`**。
+
+```bash
+# 把每条输入截断到 2048 token
+evalscope perf \
+  --model qwen2.5 --url http://127.0.0.1:8000/v1/completions \
+  --dataset share_gpt_zh --tokenizer-path /path/to/tokenizer \
+  --dataset-args '{"target_input_len": 2048}'
+```
+
+| 键 | 说明 | 默认值 |
+|------|------|--------|
+| `target_input_len` | 目标输入 token 数。设置后每条 prompt 都会被截断到该长度 | 不启用 |
+| `input_len_mode` | 对**短于目标**的 prompt 怎么处理：`cap`（原样保留，该条长度可能小于目标）；`drop`（丢弃，保证产出的每条都恰好等于目标） | `cap` |
+
+它和 `--max/min-prompt-length` 的区别：
+- `--max/min-prompt-length` 只**筛选**、不改内容——长度不在区间内的样本被丢弃，你得到的是长短不一的真实样本；
+- `target_input_len` 会**改写内容**——把每条 prompt 截到指定长度，适合“固定输入长度”的对照压测。
+
+> 想让“每条恰好 N token”，只能用 `target_input_len`；把 `--min-prompt-length` 和 `--max-prompt-length` 设成相等是做不到的（真实数据几乎没有恰好等于 N 的，会被筛空）。`random` 数据集除外——它是现场生成的，min=max 即可定长，无需本参数。
+
+**场景二：多轮对话数据集的长度参数**
+
+`swe_smith` 等多轮数据集的 token 长度参数也通过 `--dataset-args` 传入，详见[多轮对话压测指南](./multi_turn.md)。
+
+```{note}
+`--multi-turn-args` 已废弃，请改用 `--dataset-args`（键名不变）。旧参数仍可用，会自动并入 `--dataset-args`（同名键以 `--dataset-args` 为准）。
+```
 
 ## 模型设置
 

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -514,20 +514,27 @@ class Arguments(BaseArgument):
         # schema), so the config layer stays free of any plugin dependency.
         self._normalize_legacy_dataset_args()
 
-        # Promote deprecated num_workers (from --dataset-args / --multi-turn-args) to top-level.
-        if 'num_workers' not in self.model_fields_set:
-            legacy_num_workers = (self.dataset_args or {}).get('num_workers')
-            if (
-                legacy_num_workers is None and self.multi_turn_args is not None
-                and 'num_workers' in self.multi_turn_args.model_fields_set
-            ):
-                legacy_num_workers = self.multi_turn_args.num_workers
-            if legacy_num_workers is not None:
-                logger.warning(
-                    '`num_workers` in dataset/multi-turn args is deprecated. '
-                    'Please use top-level `--num-workers` instead.'
-                )
-                self.num_workers = legacy_num_workers
+        # Promote deprecated num_workers to top-level. It must be removed from
+        # dataset_args regardless, otherwise non-multi-turn schemas (extra='forbid')
+        # would reject it during plugin construction.
+        legacy_num_workers = None
+        if self.dataset_args and 'num_workers' in self.dataset_args:
+            legacy_num_workers = self.dataset_args.pop('num_workers')
+        elif self.multi_turn_args is not None and 'num_workers' in self.multi_turn_args.model_fields_set:
+            legacy_num_workers = self.multi_turn_args.num_workers
+        if legacy_num_workers is not None:
+            logger.warning(
+                '`num_workers` in dataset/multi-turn args is deprecated. '
+                'Please use top-level `--num-workers` instead.'
+            )
+            if 'num_workers' not in self.model_fields_set:
+                try:
+                    coerced = int(legacy_num_workers)
+                except (TypeError, ValueError) as e:
+                    raise ValueError(f'`num_workers` must be an integer, got {legacy_num_workers!r}') from e
+                if coerced < 0:
+                    raise ValueError(f'`num_workers` must be >= 0, got {coerced}')
+                self.num_workers = coerced
 
         return self
 

--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -303,6 +303,14 @@ class Arguments(BaseArgument):
     A non-zero initial value shifts the starting position of the first run.
     """
 
+    dataset_args: Optional[Dict[str, Any]] = None
+    """Per-dataset arguments as a dict (parsed from a JSON string on the CLI).
+
+    Validated against the schema declared by the selected ``--dataset`` plugin
+    (``args_schema``), giving strongly-typed, fail-fast per-dataset options.
+    The deprecated ``--multi-turn-args`` is folded into this field.
+    """
+
     # Response settings
     frequency_penalty: Optional[float] = None
     """Frequency penalty for the response."""
@@ -420,6 +428,18 @@ class Arguments(BaseArgument):
             return MultiTurnArgs(**v)
         return v
 
+    @field_validator('dataset_args', mode='before')
+    @classmethod
+    def _validate_dataset_args(cls, v: Any) -> Any:
+        if v is None or isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except Exception as e:
+                raise ValueError(f'Failed to parse --dataset-args JSON: {e}') from e
+        return v
+
     @field_validator('headers', mode='after')
     @classmethod
     def _validate_headers(cls, v: Dict[str, Any]) -> Dict[str, Any]:
@@ -488,14 +508,61 @@ class Arguments(BaseArgument):
         # Validate sweep params (number/parallel/rate consistency)
         self._validate_sweep_params()
 
-        if (
-            'num_workers' not in self.model_fields_set and self.multi_turn_args is not None
-            and 'num_workers' in self.multi_turn_args.model_fields_set
-        ):
-            logger.warning('`multi_turn_args.num_workers` is deprecated. Please use top-level `--num-workers` instead.')
-            self.num_workers = self.multi_turn_args.num_workers
+        # Fold deprecated --multi-turn-args into --dataset-args (pure dict merge).
+        # NOTE: dataset_args is kept as a raw dict here; validation against the
+        # dataset's typed schema happens in the plugin layer (which owns the
+        # schema), so the config layer stays free of any plugin dependency.
+        self._normalize_legacy_dataset_args()
+
+        # Promote deprecated num_workers (from --dataset-args / --multi-turn-args) to top-level.
+        if 'num_workers' not in self.model_fields_set:
+            legacy_num_workers = (self.dataset_args or {}).get('num_workers')
+            if (
+                legacy_num_workers is None and self.multi_turn_args is not None
+                and 'num_workers' in self.multi_turn_args.model_fields_set
+            ):
+                legacy_num_workers = self.multi_turn_args.num_workers
+            if legacy_num_workers is not None:
+                logger.warning(
+                    '`num_workers` in dataset/multi-turn args is deprecated. '
+                    'Please use top-level `--num-workers` instead.'
+                )
+                self.num_workers = legacy_num_workers
 
         return self
+
+    def _normalize_legacy_dataset_args(self) -> None:
+        """Fold the deprecated ``--multi-turn-args`` into ``--dataset-args``.
+
+        Only user-set keys are folded (``setdefault`` semantics): on a key
+        conflict, ``--dataset-args`` takes precedence and a warning is emitted
+        (never an error).  Other legacy top-level flags (``prefix_length``,
+        ``image_*``, ``min/max_turns``, ``min/max_prompt_length``) are left
+        untouched and are still read directly by the plugins.
+        """
+        if self.multi_turn_args is None:
+            return
+        legacy = self.multi_turn_args.model_dump(exclude_unset=True)
+        # ``num_workers`` is a cross-cutting deprecated alias for top-level
+        # ``--num-workers`` (promoted separately); never fold it into dataset_args,
+        # which would otherwise be rejected by non-multi-turn dataset schemas.
+        legacy.pop('num_workers', None)
+        if not legacy:
+            return
+        merged = dict(self.dataset_args) if self.dataset_args else {}
+        conflicts = [k for k in legacy if k in merged]
+        for k, v in legacy.items():
+            merged.setdefault(k, v)
+        self.dataset_args = merged
+        logger.warning(
+            '`--multi-turn-args` is deprecated; its values were folded into `--dataset-args`. '
+            'Please migrate to `--dataset-args`.'
+        )
+        if conflicts:
+            logger.warning(
+                f'Keys {conflicts} were set in both --multi-turn-args and --dataset-args; '
+                '--dataset-args takes precedence.'
+            )
 
     def _current_number(self) -> int:
         return self.number if isinstance(self.number, int) else self.number[0]
@@ -745,6 +812,17 @@ def _add_dataset_arguments(parser: argparse.ArgumentParser) -> None:
             'Global token-sequence offset for random datasets. '
             'Automatically incremented between runs to avoid KV-cache hits. '
             'Default 0.'
+        ),
+    )
+    parser.add_argument(
+        '--dataset-args',
+        type=json.loads,
+        default=None,
+        dest='dataset_args',
+        help=(
+            'Per-dataset arguments as a JSON string, validated against the selected dataset schema. '
+            'Example: \'{"target_input_len": 2048, "input_len_mode": "cap"}\'. '
+            'Supersedes the deprecated --multi-turn-args.'
         ),
     )
 

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -178,7 +178,7 @@ class DatasetPluginBase:
         to the existing ``min/max_prompt_length`` filter and returns the prompt
         unchanged when valid (``None`` when out of range).  When it is set, the
         prompt is fit to the target length per ``input_len_mode`` (``cap`` /
-        ``drop`` / ``pad``); ``None`` means the caller should skip this item.
+        ``drop``); ``None`` means the caller should skip this item.
 
         Args:
             prompt (str): The raw prompt text.

--- a/evalscope/perf/plugin/datasets/base.py
+++ b/evalscope/perf/plugin/datasets/base.py
@@ -2,12 +2,13 @@ import json
 import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 from evalscope.api.dataset.hub import download_dataset_file, load_dataset_from_hub
 from evalscope.constants import HubType
 from evalscope.perf.arguments import Arguments
-from evalscope.perf.plugin.datasets.utils import load_tokenizer, tokenize_chat_messages
+from evalscope.perf.plugin.datasets.dataset_args import BaseDatasetArgs, TextLengthArgs
+from evalscope.perf.plugin.datasets.utils import fit_text_to_token_len, load_tokenizer, tokenize_chat_messages
 
 Message = Dict[str, Any]  # single OpenAI message: {"role": ..., "content": ...}
 Messages = List[Message]  # delta messages for one turn
@@ -36,6 +37,13 @@ Conversation = List[Turn]
 
 class DatasetPluginBase:
 
+    args_schema: ClassVar[Type[BaseDatasetArgs]] = BaseDatasetArgs
+    """Pydantic schema for this dataset's ``--dataset-args``.
+
+    Subclasses override this to declare their own typed argument model.  The
+    default empty schema rejects any ``--dataset-args`` keys (fail-fast).
+    """
+
     def __init__(self, query_parameters: Arguments):
         """Build data set plugin
 
@@ -43,10 +51,19 @@ class DatasetPluginBase:
             dataset_path (str, optional): The input dataset path. Defaults to None.
         """
         self.query_parameters = query_parameters
+        # Validate the raw --dataset-args against this plugin's own schema.  The
+        # plugin owns the schema, so no registry lookup (and no import cycle with
+        # the config layer) is needed.
+        self.dataset_args = self.args_schema(**(query_parameters.dataset_args or {}))
         if query_parameters.tokenizer_path:
             self.tokenizer = load_tokenizer(query_parameters.tokenizer_path)
         else:
             self.tokenizer = None
+        if (
+            isinstance(self.dataset_args, TextLengthArgs) and self.dataset_args.target_input_len is not None
+            and self.tokenizer is None
+        ):
+            raise ValueError('`target_input_len` requires a tokenizer; please set --tokenizer-path.')
 
     def __next__(self):
         for item in self.build_messages():
@@ -134,19 +151,48 @@ class DatasetPluginBase:
         return message
 
     def get_sampled_multi_turn_params(self) -> dict:
-        """Return multi-turn parameters if ``multi_turn_args`` is set.
+        """Return multi-turn parameters if configured.
 
-        Provides a common entry-point for all dataset plugins to obtain
-        concrete multi-turn parameter values from
-        :class:`~evalscope.perf.multi_turn_args.MultiTurnArgs`.
+        Reads from the resolved ``dataset_args`` when it is a
+        :class:`~evalscope.perf.multi_turn_args.MultiTurnArgs` (the new
+        ``--dataset-args`` path), otherwise falls back to the deprecated
+        ``--multi-turn-args`` field.
 
         Returns:
-            Dict with field values, or an empty dict when ``multi_turn_args``
-            is not configured.
+            Dict with field values, or an empty dict when neither is set.
         """
-        if self.query_parameters.multi_turn_args:
-            return self.query_parameters.multi_turn_args.sample_params()
-        return {}
+        mt_args = self._get_multi_turn_args()
+        return mt_args.sample_params() if mt_args else {}
+
+    def _get_multi_turn_args(self):
+        """Resolve the effective MultiTurnArgs (new dataset_args or legacy field)."""
+        from evalscope.perf.multi_turn_args import MultiTurnArgs
+        if isinstance(self.dataset_args, MultiTurnArgs):
+            return self.dataset_args
+        return self.query_parameters.multi_turn_args
+
+    def prepare_prompt(self, prompt: str) -> Optional[str]:
+        """Apply the input-length policy to a single-turn text prompt.
+
+        When ``target_input_len`` is not set (via ``--dataset-args``), falls back
+        to the existing ``min/max_prompt_length`` filter and returns the prompt
+        unchanged when valid (``None`` when out of range).  When it is set, the
+        prompt is fit to the target length per ``input_len_mode`` (``cap`` /
+        ``drop`` / ``pad``); ``None`` means the caller should skip this item.
+
+        Args:
+            prompt (str): The raw prompt text.
+
+        Returns:
+            Optional[str]: The adjusted prompt, or ``None`` to skip.
+        """
+        args = self.dataset_args
+        if not isinstance(args, TextLengthArgs) or args.target_input_len is None:
+            is_valid, _ = self.check_prompt_length(prompt)
+            return prompt if is_valid else None
+        if self.tokenizer is None:
+            raise ValueError('`target_input_len` requires a tokenizer; please set --tokenizer-path.')
+        return fit_text_to_token_len(prompt, args.target_input_len, args.input_len_mode, self.tokenizer)
 
     def check_prompt_length(self, prompt: str) -> Tuple[bool, int]:
         """Check if the prompt length is within the specified range.

--- a/evalscope/perf/plugin/datasets/dataset_args.py
+++ b/evalscope/perf/plugin/datasets/dataset_args.py
@@ -2,8 +2,8 @@
 
 Each dataset plugin declares an ``args_schema`` (a subclass of
 :class:`BaseDatasetArgs`).  The raw ``--dataset-args`` JSON is validated against
-the schema selected by ``--dataset`` (see
-:meth:`evalscope.perf.arguments.Arguments.resolve_dataset_args`), giving plugins
+the plugin's own ``args_schema`` at plugin construction time (see
+:class:`~evalscope.perf.plugin.datasets.base.DatasetPluginBase`), giving plugins
 a strongly-typed, fail-fast accessor instead of scattered ``query_parameters.*``
 reads.
 

--- a/evalscope/perf/plugin/datasets/dataset_args.py
+++ b/evalscope/perf/plugin/datasets/dataset_args.py
@@ -1,0 +1,77 @@
+"""Typed per-dataset argument schemas for the perf ``--dataset-args`` mechanism.
+
+Each dataset plugin declares an ``args_schema`` (a subclass of
+:class:`BaseDatasetArgs`).  The raw ``--dataset-args`` JSON is validated against
+the schema selected by ``--dataset`` (see
+:meth:`evalscope.perf.arguments.Arguments.resolve_dataset_args`), giving plugins
+a strongly-typed, fail-fast accessor instead of scattered ``query_parameters.*``
+reads.
+
+This module must NOT import any dataset plugin module (they import
+``Arguments``), to avoid an import cycle.  Importing :mod:`multi_turn_args` is
+safe because it has no such dependency.
+"""
+
+from pydantic import BaseModel, ConfigDict, field_validator
+from typing import Literal, Optional
+
+from evalscope.perf.multi_turn_args import MultiTurnArgs
+
+
+class BaseDatasetArgs(BaseModel):
+    """Base schema for ``--dataset-args``.
+
+    Rejects unknown keys so a mistyped argument fails fast at parse time rather
+    than being silently ignored.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+
+class TextLengthArgs(BaseDatasetArgs):
+    """Input-length controls for real-text datasets (issue #1483)."""
+
+    target_input_len: Optional[int] = None
+    """Target input length in tokens.
+
+    When set, prompts are actively fit to this length (see ``input_len_mode``)
+    instead of being filtered by ``min/max_prompt_length``.  Requires a
+    tokenizer (``--tokenizer-path``).  ``None`` (default) keeps the legacy
+    length-filter behavior.
+    """
+
+    input_len_mode: Literal['cap', 'drop'] = 'cap'
+    """Policy applied when a prompt is shorter than ``target_input_len``.
+
+    - ``cap`` (default): truncate over-length prompts to the target; keep
+      shorter prompts as-is (result <= target, preserves real semantics).
+    - ``drop``: truncate over-length prompts; skip shorter ones so every
+      yielded prompt is exactly ``target_input_len`` (drops data).
+    """
+
+    @field_validator('target_input_len')
+    @classmethod
+    def _validate_target_input_len(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v <= 0:
+            raise ValueError(f'target_input_len must be > 0, got {v}')
+        return v
+
+
+class TextDatasetArgs(TextLengthArgs):
+    """Args schema for single-turn real-text datasets.
+
+    Used by ``openqa`` / ``longalpaca`` / ``share_gpt_*`` (single-turn) /
+    ``line_by_line`` (plain-text path).
+    """
+
+
+class MultiTurnDatasetArgs(MultiTurnArgs, BaseDatasetArgs):
+    """Args schema for multi-turn datasets.
+
+    Inherits every :class:`~evalscope.perf.multi_turn_args.MultiTurnArgs` field
+    and ``sample_params()`` while adding fail-fast unknown-key rejection.  Note
+    ``min_turns`` / ``max_turns`` remain top-level ``Arguments`` fields and are
+    intentionally not folded here.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra='forbid')

--- a/evalscope/perf/plugin/datasets/line_by_line.py
+++ b/evalscope/perf/plugin/datasets/line_by_line.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterator, List, Union
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import TextDatasetArgs
 from evalscope.perf.plugin.registry import register_dataset
 
 
@@ -38,6 +39,8 @@ class LineByLineDatasetPlugin(DatasetPluginBase):
        defaults do not silently overwrite a user-supplied body.
     """
 
+    args_schema = TextDatasetArgs
+
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
 
@@ -64,13 +67,11 @@ class LineByLineDatasetPlugin(DatasetPluginBase):
             parsed = self._try_parse_json(line)
 
             if isinstance(parsed, str):
-                prompt = parsed
-                is_valid, _ = self.check_prompt_length(prompt)
-                if not is_valid:
+                prompt = self.prepare_prompt(parsed)
+                if prompt is None:
                     continue
                 if self.query_parameters.apply_chat_template:
-                    message = self.create_message(prompt)
-                    result = [message]
+                    result = [self.create_message(prompt)]
                 else:
                     result = prompt
             else:

--- a/evalscope/perf/plugin/datasets/longalpaca.py
+++ b/evalscope/perf/plugin/datasets/longalpaca.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterator, List
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import TextDatasetArgs
 from evalscope.perf.plugin.registry import register_dataset
 
 
@@ -11,6 +12,8 @@ class LongAlpacaDatasetPlugin(DatasetPluginBase):
     """Read data from file which is list of requests.
            Sample: https://www.modelscope.cn/datasets/AI-ModelScope/LongAlpaca-12k/files
     """
+
+    args_schema = TextDatasetArgs
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
@@ -22,10 +25,10 @@ class LongAlpacaDatasetPlugin(DatasetPluginBase):
             ds = self.load_hub_dataset(dataset_id='AI-ModelScope/LongAlpaca-12k', split='train')
         for item in ds:
             prompt = item['instruction'].strip()
-            is_valid, _ = self.check_prompt_length(prompt)
-            if is_valid:
-                if self.query_parameters.apply_chat_template:
-                    message = self.create_message(prompt)
-                    yield [message]
-                else:
-                    yield prompt
+            prompt = self.prepare_prompt(prompt)
+            if prompt is None:
+                continue
+            if self.query_parameters.apply_chat_template:
+                yield [self.create_message(prompt)]
+            else:
+                yield prompt

--- a/evalscope/perf/plugin/datasets/multi_turn.py
+++ b/evalscope/perf/plugin/datasets/multi_turn.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, Iterator, List
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import Conversation, Turn
+from evalscope.perf.plugin.datasets.dataset_args import MultiTurnDatasetArgs
 from evalscope.perf.plugin.datasets.random_dataset import RandomDatasetPlugin
 from evalscope.perf.plugin.datasets.share_gpt import ShareGPTDatasetPluginBase
 from evalscope.perf.plugin.registry import register_dataset
@@ -59,6 +60,8 @@ class RandomMultiTurnDatasetPlugin(RandomDatasetPlugin):
     Produces ``args.number`` conversations upfront (worst-case one turn each
     guarantees enough turn budget for the benchmark runner).
     """
+
+    args_schema = MultiTurnDatasetArgs
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
@@ -149,6 +152,8 @@ class RandomMultiTurnDatasetPlugin(RandomDatasetPlugin):
 
 class ShareGPTMultiTurnBase(ShareGPTDatasetPluginBase):
     """ShareGPT plugin that preserves the full user+assistant alternation."""
+
+    args_schema = MultiTurnDatasetArgs
 
     def _convert_to_openai_messages_full(self, conversation: List[Dict]) -> Conversation:
         """Convert swift/sharegpt format to a ``Conversation`` (``List[Turn]``).

--- a/evalscope/perf/plugin/datasets/openqa.py
+++ b/evalscope/perf/plugin/datasets/openqa.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterator, List
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import TextDatasetArgs
 from evalscope.perf.plugin.registry import register_dataset
 
 
@@ -12,6 +13,8 @@ class OpenqaDatasetPlugin(DatasetPluginBase):
     """Read dataset and return prompt.
     Datasets: https://www.modelscope.cn/datasets/AI-ModelScope/HC3-Chinese/resolve/master/open_qa.jsonl
     """
+
+    args_schema = TextDatasetArgs
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
@@ -25,10 +28,10 @@ class OpenqaDatasetPlugin(DatasetPluginBase):
         for item in self.dataset_line_by_line(self.query_parameters.dataset_path):
             item = json.loads(item)
             prompt = item['question'].strip()
-            is_valid, _ = self.check_prompt_length(prompt)
-            if is_valid:
-                if self.query_parameters.apply_chat_template:
-                    message = self.create_message(prompt)
-                    yield [message]
-                else:
-                    yield prompt
+            prompt = self.prepare_prompt(prompt)
+            if prompt is None:
+                continue
+            if self.query_parameters.apply_chat_template:
+                yield [self.create_message(prompt)]
+            else:
+                yield prompt

--- a/evalscope/perf/plugin/datasets/share_gpt.py
+++ b/evalscope/perf/plugin/datasets/share_gpt.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterator, List
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import TextDatasetArgs
 from evalscope.perf.plugin.registry import register_dataset
 
 
@@ -33,6 +34,8 @@ class ShareGPTDatasetPluginBase(DatasetPluginBase):
 
     # Subclasses must set this
     FILE_NAME: str = None
+
+    args_schema = TextDatasetArgs
 
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
@@ -76,11 +79,13 @@ class ShareGPTDatasetPluginBase(DatasetPluginBase):
             if not messages:
                 continue
 
-            # Check prompt length using the last user turn content
+            # Fit / filter using the last user turn content.
             last_user_content = messages[-1]['content']
-            is_valid, _ = self.check_prompt_length(last_user_content)
-            if is_valid:
-                yield messages
+            prepared = self.prepare_prompt(last_user_content)
+            if prepared is None:
+                continue
+            messages[-1]['content'] = prepared
+            yield messages
 
 
 @register_dataset('share_gpt_zh')

--- a/evalscope/perf/plugin/datasets/swe_smith.py
+++ b/evalscope/perf/plugin/datasets/swe_smith.py
@@ -28,8 +28,10 @@ from tqdm import tqdm
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from evalscope.perf.arguments import Arguments
+from evalscope.perf.multi_turn_args import _get_range_upper
 from evalscope.perf.plugin.datasets.base import Conversation, DatasetPluginBase, Message, Messages, Turn
-from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
+from evalscope.perf.plugin.datasets.dataset_args import MultiTurnDatasetArgs
+from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages, truncate_text_to_token_len
 from evalscope.perf.plugin.registry import register_dataset
 from evalscope.perf.utils.worker_util import resolve_dataset_generation_workers
 from evalscope.utils.logger import get_logger
@@ -78,14 +80,9 @@ def _count_tokens_for_messages(messages: List[Dict[str, str]], tokenizer) -> int
     return len(tokenize_chat_messages(tokenizer, messages))
 
 
-def _bare_encode(text: str, tokenizer) -> List[int]:
-    """Encode text to token ids without special tokens."""
-    return tokenizer.encode(text, add_special_tokens=False)
-
-
 def _encode_len(text: str, tokenizer) -> int:
-    """Fast bare-text token count (no chat template overhead)."""
-    return len(_bare_encode(text, tokenizer))
+    """Fast bare-text token count (no chat template overhead, no special tokens)."""
+    return len(tokenizer.encode(text, add_special_tokens=False))
 
 
 def _truncate_message_content(
@@ -94,8 +91,7 @@ def _truncate_message_content(
     tokenizer,
 ) -> Dict[str, str]:
     """Truncate a message's content so it occupies at most tokens_needed bare tokens."""
-    content_tokens = _bare_encode(message['content'], tokenizer)
-    truncated_content = tokenizer.decode(content_tokens[:tokens_needed], skip_special_tokens=True)
+    truncated_content = truncate_text_to_token_len(message['content'], tokens_needed, tokenizer)
     return {'role': message['role'], 'content': truncated_content}
 
 
@@ -219,6 +215,18 @@ def _build_conversation(
     return turns
 
 
+def _to_turns(conversation: List[Dict]) -> Optional[Conversation]:
+    """Convert a list of turn dicts (each carrying a ``messages`` delta) into a
+    :data:`Conversation`, marking the last turn as final.
+
+    Returns ``None`` when the conversation has no turns.
+    """
+    messages_per_turn: List[Messages] = [turn.get('messages', []) for turn in conversation]
+    if not messages_per_turn:
+        return None
+    return [Turn(messages=m, is_final=(i == len(messages_per_turn) - 1)) for i, m in enumerate(messages_per_turn)]
+
+
 # ---------------------------------------------------------------------------
 # Dataset plugin
 # ---------------------------------------------------------------------------
@@ -264,6 +272,8 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
     * Top-level ``--num-workers`` – multiprocessing pool size
     """
 
+    args_schema = MultiTurnDatasetArgs
+
     def __init__(self, query_parameters: Arguments):
         super().__init__(query_parameters)
 
@@ -308,13 +318,9 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
 
         for conversation in conversations:
             # Each turn's "messages" list is already the delta (non-assistant).
-            messages_per_turn: List[Messages] = [turn.get('messages', []) for turn in conversation]
-            if not messages_per_turn:
-                continue
-
-            yield [
-                Turn(messages=m, is_final=(i == len(messages_per_turn) - 1)) for i, m in enumerate(messages_per_turn)
-            ]
+            turns = _to_turns(conversation)
+            if turns is not None:
+                yield turns
 
     # ------------------------------------------------------------------
     # Live construction mode
@@ -329,8 +335,8 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
                 '--dataset-path.'
             )
 
-        mt_args = self.query_parameters.multi_turn_args
-        chars_per_token = mt_args.chars_per_token if mt_args else 3.0
+        mt_args = self._get_multi_turn_args()
+        chars_per_token = mt_args.chars_per_token
         offset = self.query_parameters.dataset_offset
         min_turns = self.query_parameters.min_turns
         max_turns = self.query_parameters.max_turns if self.query_parameters.max_turns is not None else min_turns
@@ -340,13 +346,10 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
 
         # For pre-filtering, use the upper-bound of first_turn_length as the minimum
         # char threshold (conservative: trajectories need at least that many tokens).
-        if mt_args is not None:
-            from evalscope.perf.multi_turn_args import _get_range_upper
-            first_upper = _get_range_upper(mt_args.first_turn_length)
-            subsequent_upper = _get_range_upper(mt_args.subsequent_turn_length)
-        else:
-            first_upper = 65000
-            subsequent_upper = 500
+        # ``args_schema`` guarantees ``dataset_args`` is a MultiTurnDatasetArgs, so
+        # ``mt_args`` (with schema defaults) is always available here.
+        first_upper = _get_range_upper(mt_args.first_turn_length)
+        subsequent_upper = _get_range_upper(mt_args.subsequent_turn_length)
 
         min_tokens_estimate = first_upper + subsequent_upper * (max_turns - 1)
         min_chars = int(min_tokens_estimate * chars_per_token)
@@ -459,9 +462,6 @@ class SweSmithDatasetPlugin(DatasetPluginBase):
             )
 
         for conversation in conversations:
-            messages_per_turn: List[Messages] = [turn.get('messages', []) for turn in conversation]
-            if not messages_per_turn:
-                continue
-            yield [
-                Turn(messages=m, is_final=(i == len(messages_per_turn) - 1)) for i, m in enumerate(messages_per_turn)
-            ]
+            turns = _to_turns(conversation)
+            if turns is not None:
+                yield turns

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from evalscope.utils.logger import get_logger
 
@@ -137,3 +137,60 @@ def gen_prompt_decode_to_target_len(
         remain_num_try -= 1
 
     return prompt, token_sequence, token_mismatch
+
+
+def truncate_text_to_token_len(text: str, target_len: int, tokenizer, add_special_tokens: bool = False) -> str:
+    """Truncate ``text`` so it occupies at most ``target_len`` tokens.
+
+    Encodes with ``add_special_tokens=False`` by default (bare content tokens),
+    keeps the first ``target_len`` ids and decodes back to text.
+
+    Args:
+        text: The input text to truncate.
+        target_len: Maximum number of tokens to keep.
+        tokenizer: A HuggingFace / ModelScope tokenizer instance.
+        add_special_tokens: Whether to add special tokens when encoding.
+
+    Returns:
+        The truncated text.
+    """
+    ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+    return tokenizer.decode(ids[:target_len], skip_special_tokens=True)
+
+
+def fit_text_to_token_len(
+    text: str,
+    target_len: int,
+    mode: str,
+    tokenizer,
+    add_special_tokens: bool = False,
+) -> Optional[str]:
+    """Fit ``text`` to ``target_len`` tokens according to ``mode``.
+
+    Over-length text is always truncated to ``target_len``.  The handling of
+    text shorter than ``target_len`` depends on ``mode``:
+
+    - ``cap``: keep the shorter text as-is (result <= target).
+    - ``drop``: return ``None`` so the caller skips it (exact length only).
+
+    Args:
+        text: The input text.
+        target_len: Target token length.
+        mode: One of ``'cap'``, ``'drop'``.
+        tokenizer: A HuggingFace / ModelScope tokenizer instance.
+        add_special_tokens: Whether to add special tokens when encoding.
+
+    Returns:
+        The adjusted text, or ``None`` when the prompt should be skipped.
+
+    Raises:
+        ValueError: If ``mode`` is not one of the supported values.
+    """
+    ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+    if len(ids) >= target_len:
+        return tokenizer.decode(ids[:target_len], skip_special_tokens=True)
+    if mode == 'cap':
+        return text
+    if mode == 'drop':
+        return None
+    raise ValueError(f"Unknown input_len_mode: {mode!r}. Expected one of 'cap', 'drop'.")

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -142,8 +142,9 @@ def gen_prompt_decode_to_target_len(
 def truncate_text_to_token_len(text: str, target_len: int, tokenizer, add_special_tokens: bool = False) -> str:
     """Truncate ``text`` so it occupies at most ``target_len`` tokens.
 
-    Encodes with ``add_special_tokens=False`` by default (bare content tokens),
-    keeps the first ``target_len`` ids and decodes back to text.
+    Encodes with ``add_special_tokens=False`` by default (bare content tokens).
+    Text that already fits within ``target_len`` is returned unchanged; longer
+    text is truncated to the first ``target_len`` ids and decoded back.
 
     Args:
         text: The input text to truncate.
@@ -155,6 +156,8 @@ def truncate_text_to_token_len(text: str, target_len: int, tokenizer, add_specia
         The truncated text.
     """
     ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+    if len(ids) <= target_len:
+        return text
     return tokenizer.decode(ids[:target_len], skip_special_tokens=True)
 
 
@@ -187,9 +190,11 @@ def fit_text_to_token_len(
         ValueError: If ``mode`` is not one of the supported values.
     """
     ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
-    if len(ids) >= target_len:
+    if len(ids) > target_len:
         return tokenizer.decode(ids[:target_len], skip_special_tokens=True)
-    if mode == 'cap':
+    # Already at or below the target: avoid a redundant decode/re-encode round-trip
+    # (which could otherwise alter the token count).
+    if mode == 'cap' or len(ids) == target_len:
         return text
     if mode == 'drop':
         return None

--- a/tests/perf/test_dataset_args.py
+++ b/tests/perf/test_dataset_args.py
@@ -124,6 +124,15 @@ class TestMultiTurnArgsFolding:
         args = _args(dataset='swe_smith', multi_turn_args='{"num_workers": 3}')
         assert args.num_workers == 3
 
+    def test_num_workers_in_dataset_args_promoted_and_popped(self):
+        # num_workers passed directly in --dataset-args must be promoted to top-level
+        # and removed, so non-multi-turn schemas (extra='forbid') do not reject it.
+        args = _args(dataset='openqa', dataset_args='{"num_workers": 4, "target_input_len": 100}')
+        assert args.num_workers == 4
+        assert 'num_workers' not in args.dataset_args
+        # remaining keys still validate against the dataset schema
+        assert _resolve(args).target_input_len == 100
+
     def test_no_multi_turn_args_leaves_dataset_args_none(self):
         args = _args(dataset='swe_smith')
         assert args.dataset_args is None

--- a/tests/perf/test_dataset_args.py
+++ b/tests/perf/test_dataset_args.py
@@ -1,0 +1,129 @@
+"""Tests for the unified ``--dataset-args`` framework.
+
+Covers:
+- Per-dataset ``args_schema`` selection via the dataset registry.
+- ``extra='forbid'`` fail-fast rejection of unknown keys (at the plugin/schema
+  layer, which owns the schema).
+- Backward-compatible folding of the deprecated ``--multi-turn-args`` into
+  the raw ``--dataset-args`` dict on ``Arguments`` (config layer, no plugin dep).
+"""
+
+import pytest
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.multi_turn_args import MultiTurnArgs
+from evalscope.perf.plugin.datasets.dataset_args import BaseDatasetArgs, MultiTurnDatasetArgs, TextDatasetArgs
+from evalscope.perf.plugin.datasets.openqa import OpenqaDatasetPlugin
+from evalscope.perf.plugin.registry import DatasetRegistry
+
+
+def _args(**kwargs) -> Arguments:
+    return Arguments(model='test-model', url='http://localhost:8080/v1/chat/completions', **kwargs)
+
+
+def _resolve(args: Arguments):
+    """Resolve raw ``dataset_args`` against the selected plugin's schema.
+
+    Mirrors the plugin-layer resolution (``self.args_schema(**raw)``) so tests
+    can validate the mapping without constructing a full plugin.
+    """
+    schema = DatasetRegistry.get_class(args.dataset).args_schema
+    return schema(**(args.dataset_args or {}))
+
+
+# ---------------------------------------------------------------------------
+# Schema selection
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaSelection:
+
+    def test_text_datasets_use_text_schema(self):
+        for name in ('openqa', 'longalpaca', 'line_by_line', 'share_gpt_zh', 'share_gpt_en'):
+            assert DatasetRegistry.get_class(name).args_schema is TextDatasetArgs
+
+    def test_multi_turn_datasets_use_multi_turn_schema(self):
+        for name in ('swe_smith', 'random_multi_turn', 'share_gpt_zh_multi_turn', 'share_gpt_en_multi_turn'):
+            assert DatasetRegistry.get_class(name).args_schema is MultiTurnDatasetArgs
+
+    def test_default_schema_is_base(self):
+        assert DatasetRegistry.get_class('random').args_schema is BaseDatasetArgs
+
+    def test_multi_turn_schema_subclasses_multi_turn_args(self):
+        assert issubclass(MultiTurnDatasetArgs, MultiTurnArgs)
+
+
+# ---------------------------------------------------------------------------
+# Schema resolution + fail-fast validation (plugin/schema layer)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDatasetArgs:
+
+    def test_none_resolves_to_empty_schema(self):
+        resolved = _resolve(_args(dataset='openqa'))
+        assert isinstance(resolved, TextDatasetArgs)
+        assert resolved.target_input_len is None
+        assert resolved.input_len_mode == 'cap'
+
+    def test_valid_keys_parsed(self):
+        args = _args(dataset='openqa', dataset_args={'target_input_len': 256, 'input_len_mode': 'drop'})
+        resolved = _resolve(args)
+        assert resolved.target_input_len == 256
+        assert resolved.input_len_mode == 'drop'
+
+    def test_unknown_key_fails_fast(self):
+        with pytest.raises(Exception):
+            _resolve(_args(dataset='openqa', dataset_args={'not_a_real_key': 1}))
+
+    def test_json_string_is_parsed(self):
+        args = _args(dataset='openqa', dataset_args='{"target_input_len": 64}')
+        assert _resolve(args).target_input_len == 64
+
+    def test_invalid_input_len_mode_rejected(self):
+        with pytest.raises(Exception):
+            _resolve(_args(dataset='openqa', dataset_args={'target_input_len': 8, 'input_len_mode': 'nope'}))
+
+    def test_non_positive_target_input_len_rejected(self):
+        with pytest.raises(Exception):
+            _resolve(_args(dataset='openqa', dataset_args={'target_input_len': 0}))
+
+    def test_target_input_len_requires_tokenizer(self):
+        # The tokenizer requirement is enforced at plugin construction (base layer).
+        args = _args(dataset='openqa', dataset_args={'target_input_len': 128})
+        with pytest.raises(ValueError, match='requires a tokenizer'):
+            OpenqaDatasetPlugin(args)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: --multi-turn-args folding (config layer, raw dict only)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTurnArgsFolding:
+
+    def test_folds_into_dataset_args(self):
+        args = _args(dataset='swe_smith', multi_turn_args='{"first_turn_length": 100}')
+        assert args.dataset_args['first_turn_length'] == 100
+        assert _resolve(args).first_turn_length == 100
+
+    def test_only_user_set_keys_are_folded(self):
+        args = _args(dataset='swe_smith', multi_turn_args='{"first_turn_length": 100}')
+        # subsequent_turn_length was not set by the user -> not injected
+        assert 'subsequent_turn_length' not in args.dataset_args
+
+    def test_dataset_args_wins_on_conflict(self):
+        args = _args(
+            dataset='swe_smith',
+            dataset_args={'first_turn_length': 999},
+            multi_turn_args='{"first_turn_length": 100}',
+        )
+        assert _resolve(args).first_turn_length == 999
+
+    def test_num_workers_promoted_to_top_level(self):
+        args = _args(dataset='swe_smith', multi_turn_args='{"num_workers": 3}')
+        assert args.num_workers == 3
+
+    def test_no_multi_turn_args_leaves_dataset_args_none(self):
+        args = _args(dataset='swe_smith')
+        assert args.dataset_args is None

--- a/tests/perf/test_target_input_len.py
+++ b/tests/perf/test_target_input_len.py
@@ -1,0 +1,136 @@
+"""Tests for target-input-length construction / truncation (issue #1483).
+
+Unit-tests the ``truncate_text_to_token_len`` / ``fit_text_to_token_len``
+helpers and their integration through ``DatasetPluginBase.prepare_prompt`` on a
+real dataset plugin, using a lightweight char-based fake tokenizer (no network).
+"""
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.datasets import base as base_mod
+from evalscope.perf.plugin.datasets.line_by_line import LineByLineDatasetPlugin
+from evalscope.perf.plugin.datasets.utils import fit_text_to_token_len, truncate_text_to_token_len
+
+
+class FakeTokenizer:
+    """One token per character; fully reversible so token lengths are exact."""
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) for c in text]
+
+    def decode(self, ids, skip_special_tokens=True):
+        return ''.join(chr(i) for i in ids)
+
+    def __len__(self):
+        return 256
+
+    @property
+    def all_special_ids(self):
+        return []
+
+
+TOK = FakeTokenizer()
+
+
+def _tok_len(text: str) -> int:
+    return len(TOK.encode(text))
+
+
+# ---------------------------------------------------------------------------
+# Unit: truncate / fit helpers
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateHelper:
+
+    def test_truncates_over_length(self):
+        assert truncate_text_to_token_len('abcdefghij', 5, TOK) == 'abcde'
+
+    def test_keeps_when_shorter(self):
+        assert truncate_text_to_token_len('abc', 5, TOK) == 'abc'
+
+
+class TestFitCapMode:
+
+    def test_over_length_is_truncated(self):
+        assert fit_text_to_token_len('abcdefghij', 5, 'cap', TOK) == 'abcde'
+
+    def test_shorter_is_kept(self):
+        assert fit_text_to_token_len('abc', 5, 'cap', TOK) == 'abc'
+
+
+class TestFitDropMode:
+
+    def test_over_length_is_truncated(self):
+        out = fit_text_to_token_len('abcdefghij', 5, 'drop', TOK)
+        assert out == 'abcde'
+        assert _tok_len(out) == 5
+
+    def test_shorter_is_dropped(self):
+        assert fit_text_to_token_len('abc', 5, 'drop', TOK) is None
+
+
+class TestFitInvalidMode:
+
+    def test_unknown_mode_raises(self):
+        try:
+            fit_text_to_token_len('abc', 5, 'bogus', TOK)
+            assert False, 'expected ValueError'
+        except ValueError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Integration: prepare_prompt through line_by_line
+# ---------------------------------------------------------------------------
+
+
+def _build_plugin(tmp_path, monkeypatch, lines, **dataset_args):
+    monkeypatch.setattr(base_mod, 'load_tokenizer', lambda path: FakeTokenizer())
+    path = tmp_path / 'lines.txt'
+    path.write_text('\n'.join(lines), encoding='utf-8')
+    args = Arguments(
+        model='test-model',
+        url='http://localhost:8080/v1/completions',
+        dataset='line_by_line',
+        dataset_path=str(path),
+        tokenizer_path='fake',
+        apply_chat_template=False,
+        dataset_args=dataset_args or None,
+    )
+    return LineByLineDatasetPlugin(args)
+
+
+class TestPreparePromptIntegration:
+
+    def test_cap_truncates_and_keeps_short(self, tmp_path, monkeypatch):
+        plugin = _build_plugin(
+            tmp_path,
+            monkeypatch,
+            lines=['abcdefghij', 'abc'],
+            target_input_len=5,
+            input_len_mode='cap',
+        )
+        out = list(plugin.build_messages())
+        assert out == ['abcde', 'abc']
+
+    def test_drop_yields_only_exact_length(self, tmp_path, monkeypatch):
+        plugin = _build_plugin(
+            tmp_path,
+            monkeypatch,
+            lines=['abcdefghij', 'abc'],
+            target_input_len=5,
+            input_len_mode='drop',
+        )
+        out = list(plugin.build_messages())
+        assert out == ['abcde']
+        assert all(_tok_len(p) == 5 for p in out)
+
+    def test_no_target_falls_back_to_length_filter(self, tmp_path, monkeypatch):
+        # Without target_input_len, prompts pass through the min/max filter unchanged.
+        plugin = _build_plugin(
+            tmp_path,
+            monkeypatch,
+            lines=['abcdefghij', 'abc'],
+        )
+        out = list(plugin.build_messages())
+        assert out == ['abcdefghij', 'abc']


### PR DESCRIPTION
## Summary

Closes #1483. Adds a unified, typed `--dataset-args` mechanism for the `perf` module and implements fixed-length input construction for real-text datasets on top of it.

## What's new

**1. Typed per-dataset args framework**
- Each dataset plugin declares an `args_schema` (Pydantic, `extra='forbid'`). `--dataset-args` (JSON) is validated against the selected dataset's schema **at plugin construction** — unknown keys fail fast.
- New module `evalscope/perf/plugin/datasets/dataset_args.py`: `BaseDatasetArgs` / `TextLengthArgs` / `TextDatasetArgs` / `MultiTurnDatasetArgs`.

**2. Fixed-length input for real datasets (#1483)**
- `--dataset-args '{"target_input_len": N, "input_len_mode": "cap"|"drop"}'` actively truncates real-text prompts to an exact token length (requires `--tokenizer-path`).
- `cap` (default): truncate over-length, keep shorter as-is. `drop`: truncate over-length, drop shorter ones (every prompt exactly `N`).
- Applies to `openqa` / `longalpaca` / `line_by_line` / single-turn ShareGPT. Truncation primitive is shared in `datasets/utils.py` (also reused by `swe_smith`).
- This is distinct from `--max/min-prompt-length` (which only **filters**, never mutates); `min==max` filtering cannot produce fixed-length inputs from real data.

**3. Backward compatibility**
- `--multi-turn-args` is deprecated and automatically folded into `--dataset-args` (on key conflict, `--dataset-args` wins; `num_workers` still promoted to top-level `--num-workers`). Existing scripts keep working.

**4. Architecture**
- The config layer (`Arguments`) holds `dataset_args` as a raw dict only and has **no dependency on the plugin layer** — the plugin resolves it via its own `args_schema`, eliminating the import cycle (no scattered lazy imports).

## Scope notes
- `input_len_mode` intentionally supports only `cap`/`drop` (no padding — padding real prompts with synthetic tokens would defeat the realism the feature is for).
- Output-side `ignore_eos` was already supported via `--extra-args '{"ignore_eos": true}'`; not re-added.
- `#1489` (workload_trace) is out of scope; the framework leaves an `args_schema` extension point for it.

## Testing
- Unit: `tests/perf/test_dataset_args.py` (schema selection, fail-fast validation, `--multi-turn-args` folding), `tests/perf/test_target_input_len.py` (cap/drop, tokenizer requirement).
- Regression: existing perf tests (`test_request_generation.py`, `test_line_by_line_body.py`) pass; CI smoke `test_ci_lite` passes.
- e2e (real): `longalpaca` + Qwen2.5 tokenizer truncated to exactly 512 tokens; `swe_smith` live construction from ModelScope; **real API** run against DashScope `qwen-turbo` confirmed server-side Input Tokens ≈ 524 (512 + chat-template overhead) with 100% success.

## Docs
- Updated `docs/{zh,en}/user_guides/stress_test/parameters.md` and `multi_turn.md`.