### PR TITLE
fix(evaluator): log resolved sample total and warn on per-subset --limit

### DIFF
--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -165,19 +165,34 @@ class DefaultEvaluator(Evaluator):
                 return {}
 
             subset_list = list(dataset_dict.keys())
-            logger.info(f'Start evaluating {len(dataset_dict)} subsets of {self.benchmark_name}: {subset_list}')
+
+            # Report the resolved sample total up front. `--limit` applies per subset,
+            # so on multi-subset datasets the total can be much larger than expected.
+            num_subsets = len(dataset_dict)
+            total_items = sum(len(v) for v in dataset_dict.values())
+            subset_word = 'subset' if num_subsets == 1 else 'subsets'
+            if self.benchmark.limit is not None:
+                logger.warning(
+                    f'{self.benchmark_name}: {total_items} samples to evaluate '
+                    f'({num_subsets} {subset_word}, --limit={self.benchmark.limit} per subset). '
+                    f'Remove `--limit` for a formal evaluation.'
+                )
+            else:
+                logger.info(f'{self.benchmark_name}: {total_items} samples to evaluate ({num_subsets} {subset_word})')
+            logger.info(f'Subsets of {self.benchmark_name}: {subset_list}')
 
             # Phase 1 – build unified work pool from all subsets
             context = self._collect_work_items(dataset_dict)
-            logger.info(
-                f'Unified pool: {len(context.work_items)} items to process, '
-                f'{context.total_cached} already fully cached '
-                f'({context.grand_total} total across all subsets).'
-            )
+            # Only report the cache split when resuming; otherwise the total above already covers it.
+            if context.total_cached > 0:
+                logger.info(
+                    f'{self.benchmark_name}: resuming from cache — {context.total_cached} cached, '
+                    f'{len(context.work_items)} to run ({context.grand_total} total).'
+                )
 
             # Phase 2 – execute unified thread pool (single progress bar)
             results_by_subset = self._run_pool(context)
-            logger.info(f'Unified pool finished for {self.benchmark_name}.')
+            logger.info(f'{self.benchmark_name}: predictions complete, aggregating scores...')
 
             # Phase 3 – aggregate scores per subset (batch review happens here too)
             agg_score_dict = self._aggregate_scores(dataset_dict, context, results_by_subset)

--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -184,11 +184,9 @@ class DefaultEvaluator(Evaluator):
 
             # Phase 1 – build unified work pool from all subsets
             context = self._collect_work_items(dataset_dict)
-            # Report the cache split when resuming. Count items that still need prediction;
-            # everything else was loaded from the prediction cache (fully cached or review
-            # pending). Deriving both from `total_items` keeps this consistent with the total
-            # logged above, including batch-scoring benchmarks whose review-pending items are
-            # tracked separately from the work pool (and thus excluded from `grand_total`).
+            # Report the cache split when resuming: items still needing prediction vs. the
+            # rest loaded from cache. Derived from `total_items` so it stays accurate for
+            # batch-scoring benchmarks too (their review-pending items skip `grand_total`).
             to_run = sum(1 for item in context.work_items if item.needs_predict)
             if to_run < total_items:
                 logger.info(

--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -171,10 +171,11 @@ class DefaultEvaluator(Evaluator):
             num_subsets = len(dataset_dict)
             total_items = sum(len(v) for v in dataset_dict.values())
             subset_word = 'subset' if num_subsets == 1 else 'subsets'
-            if self.benchmark.limit is not None:
+            limit = self.task_config.limit
+            if limit is not None:
                 logger.warning(
                     f'{self.benchmark_name}: {total_items} samples to evaluate '
-                    f'({num_subsets} {subset_word}, --limit={self.benchmark.limit} per subset). '
+                    f'({num_subsets} {subset_word}, --limit={limit} per subset). '
                     f'Remove `--limit` for a formal evaluation.'
                 )
             else:
@@ -183,11 +184,16 @@ class DefaultEvaluator(Evaluator):
 
             # Phase 1 – build unified work pool from all subsets
             context = self._collect_work_items(dataset_dict)
-            # Only report the cache split when resuming; otherwise the total above already covers it.
-            if context.total_cached > 0:
+            # Report the cache split when resuming. Count items that still need prediction;
+            # everything else was loaded from the prediction cache (fully cached or review
+            # pending). Deriving both from `total_items` keeps this consistent with the total
+            # logged above, including batch-scoring benchmarks whose review-pending items are
+            # tracked separately from the work pool (and thus excluded from `grand_total`).
+            to_run = sum(1 for item in context.work_items if item.needs_predict)
+            if to_run < total_items:
                 logger.info(
-                    f'{self.benchmark_name}: resuming from cache — {context.total_cached} cached, '
-                    f'{len(context.work_items)} to run ({context.grand_total} total).'
+                    f'{self.benchmark_name}: resuming from cache — {total_items - to_run} cached, '
+                    f'{to_run} to run ({total_items} total).'
                 )
 
             # Phase 2 – execute unified thread pool (single progress bar)


### PR DESCRIPTION
## Summary

Fixes #1496.

`--limit` is applied **per subset**, so on multi-subset datasets the run size is silently multiplied. For example `mmlu_redux --limit 300` (57 subsets × 100 items) is a no-op and runs 5700 items/model — the user in #1496 only caught it from item-count telemetry mid-run, after a ~2h plan had already become ~65h.

The total *is* present in the tqdm bar's denominator, but that only appears once the pool starts, is easy to skim past as a progress denominator, and doesn't render as a bar under non-TTY/redirected output (the common case for long evals).

## Changes

- **Log the resolved sample total up front**, right after loading and before any work starts:
  - `mmlu: 849 samples to evaluate (3 subsets)` (INFO, no limit)
  - `mmlu: 12 samples to evaluate (3 subsets, --limit=4 per subset). Remove `--limit` for a formal evaluation.` (**WARNING** when `--limit` is set)
- The total is computed from the already-limited `dataset_dict`, so it is always accurate (including the no-op case where `limit` exceeds a subset's size).
- **Log-flow cleanup** in `DefaultEvaluator.eval()`:
  - Drop the internal `Unified pool` jargon.
  - Only log the cache split when resuming (`total_cached > 0`); otherwise it just duplicated the total.
  - Replace the redundant second `... finished` line with a phase marker (`predictions complete, aggregating scores...`).

## Testing

Ran `mock_llm` on `mmlu` (multi-subset) verifying all branches:

```
# fresh, no limit
mmlu: 849 samples to evaluate (3 subsets)
# fresh, with limit -> WARNING
mmlu: 12 samples to evaluate (3 subsets, --limit=4 per subset). Remove `--limit` for a formal evaluation.
# resume (total_cached>0)
mmlu: resuming from cache — 5 cached, 0 to run (5 total).
```

`make lint` passes.