### PR TITLE
fix(perf): exclude non-stream requests from TTFT/TPOT/ITL metrics

### DIFF
--- a/evalscope/perf/core/http_client.py
+++ b/evalscope/perf/core/http_client.py
@@ -4,7 +4,7 @@ import time
 from typing import TYPE_CHECKING
 
 from evalscope.perf.arguments import Arguments
-from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.perf.utils.benchmark_util import BenchmarkData, is_stream_body
 from evalscope.utils.argument_utils import SECRET_HEADER_KEYS, get_secret_value
 from evalscope.utils.logger import get_logger
 
@@ -88,10 +88,10 @@ class AioHttpClient:
             logger.error(
                 f'TimeoutError: total_timeout: {self.total_timeout}, connect_timeout: {self.connect_timeout}, read_timeout: {self.read_timeout}. Please set longer timeout.'  # noqa: E501
             )
-            return BenchmarkData(success=False, error=str(e))
+            return BenchmarkData(success=False, error=str(e), is_stream=is_stream_body(body))
         except (aiohttp.ClientConnectorError, Exception) as e:
             logger.error(e)
-            return BenchmarkData(success=False, error=str(e))
+            return BenchmarkData(success=False, error=str(e), is_stream=is_stream_body(body))
 
     @staticmethod
     async def on_request_start(session, context, params: aiohttp.TraceRequestStartParams):

--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.api.base import ApiPluginBase
-from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.perf.utils.benchmark_util import BenchmarkData, is_stream_body
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -129,6 +129,7 @@ class DefaultApiPlugin(ApiPluginBase):
                 if response.status == 200:
                     # Handle streaming responses (SSE)
                     if 'text/event-stream' in content_type:
+                        output.is_stream = True
                         handler = StreamedResponseHandler()
                         async for chunk_bytes in response.content.iter_any():
 
@@ -258,5 +259,9 @@ class DefaultApiPlugin(ApiPluginBase):
             exc_info = sys.exc_info()
             output.error = ''.join(traceback.format_exception(*exc_info))
             logger.error(output.error)
+
+        # Fall back to request body — response may not have been SSE (or arrived at all).
+        if not output.success and not output.is_stream:
+            output.is_stream = is_stream_body(body)
 
         return output

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -13,7 +13,7 @@ from evalscope.perf.multi_turn_args import _sample_int_or_range
 from evalscope.perf.plugin.api.default_api import DefaultApiPlugin, StreamedResponseHandler
 from evalscope.perf.plugin.datasets.utils import load_tokenizer
 from evalscope.perf.plugin.registry import register_api
-from evalscope.perf.utils.benchmark_util import BenchmarkData
+from evalscope.perf.utils.benchmark_util import BenchmarkData, is_stream_body
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -92,9 +92,13 @@ class OpenAIResponsesPlugin(DefaultApiPlugin):
                     except Exception:
                         output.error = await response.text()
                     output.success = False
+                    # No SSE response; classify from request body.
+                    if not output.is_stream:
+                        output.is_stream = is_stream_body(body)
                     return output
 
                 if 'text/event-stream' in content_type:
+                    output.is_stream = True
                     handler = StreamedResponseHandler()
                     stream_failed = False
                     async for chunk_bytes in response.content.iter_any():
@@ -172,6 +176,9 @@ class OpenAIResponsesPlugin(DefaultApiPlugin):
             output.success = False
             output.error = ''.join(traceback.format_exception(*sys.exc_info()))
             logger.error(output.error)
+            # Response may not have arrived; classify from request body.
+            if not output.is_stream:
+                output.is_stream = is_stream_body(body)
             return output
 
     @staticmethod

--- a/evalscope/perf/utils/benchmark_util.py
+++ b/evalscope/perf/utils/benchmark_util.py
@@ -12,6 +12,14 @@ logger = get_logger()
 # ===========================================================================
 
 
+def is_stream_body(body: dict) -> bool:
+    """Best-effort stream classification from the request body.
+
+    Used only when no response is available (error/timeout paths).
+    """
+    return body.get('stream') is True
+
+
 @dataclass
 class BenchmarkData:
     """Data container for a single benchmark request/response cycle.
@@ -26,6 +34,7 @@ class BenchmarkData:
     completed_time: float = 0.0
     chunk_times: List[float] = field(default_factory=list)
     success: bool = False
+    is_stream: bool = False
     response_messages: List[Any] = field(default_factory=list)
 
     # --- Derived timing (populated by finalize) ---
@@ -161,6 +170,14 @@ class MetricsAccumulator:
     total_time_per_output_token: float = 0.0
     all_inter_token_latencies: List[float] = field(default_factory=list)
 
+    # --- Stream-only cumulative sums (stream requests only) ---
+    n_stream_success: int = 0
+    n_stream_total: int = 0
+    n_non_stream_total: int = 0
+    total_first_chunk_latency_stream: float = 0.0
+    total_time_per_output_token_stream: float = 0.0
+    all_inter_token_latencies_stream: List[float] = field(default_factory=list)
+
     # --- Multi-turn cumulative sums ---
     total_input_turns: int = 0
     # Token-level accumulators for unbiased global cache hit rate.
@@ -212,6 +229,10 @@ class MetricsAccumulator:
             return  # Warmup requests are excluded from all metrics
 
         self.n_total += 1
+        if data.is_stream:
+            self.n_stream_total += 1
+        else:
+            self.n_non_stream_total += 1
 
         if data.success:
             self.n_success += 1
@@ -223,6 +244,12 @@ class MetricsAccumulator:
             self.total_completion_tokens += data.completion_tokens
             self.total_time_per_output_token += data.time_per_output_token
             self.all_inter_token_latencies += data.inter_chunk_latency
+
+            if data.is_stream:
+                self.n_stream_success += 1
+                self.total_first_chunk_latency_stream += data.first_chunk_latency
+                self.total_time_per_output_token_stream += data.time_per_output_token
+                self.all_inter_token_latencies_stream += data.inter_chunk_latency
 
             # Multi-turn specific
             if data.input_num_turns > 0:
@@ -280,15 +307,24 @@ class MetricsAccumulator:
 
         try:
             avg_latency = _safe_div(self.total_latency, n)
-            avg_first_chunk_latency = _safe_div(self.total_first_chunk_latency, n)
+            # Streaming-specific metrics use stream-only denominators to avoid
+            # pollution from non-stream requests (whose first_chunk_latency equals
+            # the full query latency and whose TPOT is 0). Pure non-stream runs
+            # fall back to the all-request computation so their values are unchanged.
+            if self.n_stream_success > 0:
+                avg_first_chunk_latency = _safe_div(self.total_first_chunk_latency_stream, self.n_stream_success)
+                avg_time_per_output_token = _safe_div(self.total_time_per_output_token_stream, self.n_stream_success)
+            else:
+                avg_first_chunk_latency = _safe_div(self.total_first_chunk_latency, n)
+                avg_time_per_output_token = _safe_div(self.total_time_per_output_token, n)
             avg_prompt_tokens = _safe_div(self.total_prompt_tokens, n)
             avg_completion_tokens = _safe_div(self.total_completion_tokens, n)
-            avg_time_per_output_token = _safe_div(self.total_time_per_output_token, n)
             avg_inter_token_latency = (
-                sum(self.all_inter_token_latencies)
-                / len(self.all_inter_token_latencies) if self.all_inter_token_latencies else 0.0
+                sum(self.all_inter_token_latencies_stream)
+                / len(self.all_inter_token_latencies_stream) if self.all_inter_token_latencies_stream else 0.0
             )
             qps = _safe_div(n, t)
+            # Deliberately population-wide: only used by embedding/rerank APIs
             avg_input_token_throughput = _safe_div(self.total_prompt_tokens, self.total_first_chunk_latency)
             avg_output_token_throughput = _safe_div(self.total_completion_tokens, t)
             avg_total_token_throughput = _safe_div(self.total_prompt_tokens + self.total_completion_tokens, t)
@@ -333,6 +369,8 @@ class MetricsAccumulator:
             total_requests=self.n_total,
             succeed_requests=self.n_success,
             failed_requests=self.n_failed,
+            stream_requests=self.n_stream_total,
+            non_stream_requests=self.n_non_stream_total,
             total_time=t,
             avg_latency=avg_latency,
             avg_first_chunk_latency=avg_first_chunk_latency,
@@ -373,6 +411,8 @@ class BenchmarkMetrics:
     total_requests: int = 0
     succeed_requests: int = 0
     failed_requests: int = 0
+    stream_requests: int = 0
+    non_stream_requests: int = 0
     total_time: float = 0.0
 
     # --- Latency averages ---
@@ -431,6 +471,8 @@ class BenchmarkMetrics:
             Metrics.TOTAL_REQUESTS: int(self.total_requests),
             Metrics.SUCCEED_REQUESTS: self.succeed_requests,
             Metrics.FAILED_REQUESTS: self.failed_requests,
+            Metrics.STREAM_REQUESTS: self.stream_requests,
+            Metrics.NON_STREAM_REQUESTS: self.non_stream_requests,
             Metrics.REQUEST_THROUGHPUT: round(self.qps, r),
             Metrics.AVERAGE_LATENCY: round(self.avg_latency, r),
             Metrics.AVERAGE_INPUT_TOKENS_PER_REQUEST: round(self.avg_prompt_tokens, r),

--- a/evalscope/perf/utils/benchmark_util.py
+++ b/evalscope/perf/utils/benchmark_util.py
@@ -12,12 +12,15 @@ logger = get_logger()
 # ===========================================================================
 
 
-def is_stream_body(body: dict) -> bool:
+def is_stream_body(body: Any) -> bool:
     """Best-effort stream classification from the request body.
 
-    Used only when no response is available (error/timeout paths).
+    Used only when no response is available (error/timeout paths), where the
+    body may be ``None`` or a non-dict type.
     """
-    return body.get('stream') is True
+    if isinstance(body, dict):
+        return body.get('stream') is True
+    return False
 
 
 @dataclass
@@ -171,12 +174,14 @@ class MetricsAccumulator:
     all_inter_token_latencies: List[float] = field(default_factory=list)
 
     # --- Stream-only cumulative sums (stream requests only) ---
+    # ITL is intentionally *not* bucketed here: non-stream requests contribute an
+    # empty inter_chunk_latency list, so all_inter_token_latencies is already
+    # stream-only by construction and needs no separate accumulator.
     n_stream_success: int = 0
     n_stream_total: int = 0
     n_non_stream_total: int = 0
     total_first_chunk_latency_stream: float = 0.0
     total_time_per_output_token_stream: float = 0.0
-    all_inter_token_latencies_stream: List[float] = field(default_factory=list)
 
     # --- Multi-turn cumulative sums ---
     total_input_turns: int = 0
@@ -249,7 +254,6 @@ class MetricsAccumulator:
                 self.n_stream_success += 1
                 self.total_first_chunk_latency_stream += data.first_chunk_latency
                 self.total_time_per_output_token_stream += data.time_per_output_token
-                self.all_inter_token_latencies_stream += data.inter_chunk_latency
 
             # Multi-turn specific
             if data.input_num_turns > 0:
@@ -320,8 +324,8 @@ class MetricsAccumulator:
             avg_prompt_tokens = _safe_div(self.total_prompt_tokens, n)
             avg_completion_tokens = _safe_div(self.total_completion_tokens, n)
             avg_inter_token_latency = (
-                sum(self.all_inter_token_latencies_stream)
-                / len(self.all_inter_token_latencies_stream) if self.all_inter_token_latencies_stream else 0.0
+                sum(self.all_inter_token_latencies)
+                / len(self.all_inter_token_latencies) if self.all_inter_token_latencies else 0.0
             )
             qps = _safe_div(n, t)
             # Deliberately population-wide: only used by embedding/rerank APIs

--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -210,12 +210,13 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
         }
     else:
         # For LLM models, show all metrics
-        # Prepare data for each metric
-        inter_token_latencies_stream = []
-        for row in streaming_rows:
+        # Prepare data for each metric.
+        # ITL over all rows: non-stream rows carry empty ITL, so no bucketing needed.
+        inter_token_latencies_all = []
+        for row in rows:
             try:
                 itl = json.loads(row[col_indices[DatabaseColumns.INTER_TOKEN_LATENCIES]]) or []
-                inter_token_latencies_stream.extend(itl)
+                inter_token_latencies_all.extend(itl)
             except (json.JSONDecodeError, TypeError) as e:
                 logger.error(f'Error parsing inter token latencies: {e}')
 
@@ -224,7 +225,7 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
             PercentileMetrics.TTFT: [
                 row[col_indices[DatabaseColumns.FIRST_CHUNK_LATENCY]] * 1000 for row in streaming_rows
             ],
-            PercentileMetrics.ITL: [v * 1000 for v in inter_token_latencies_stream],
+            PercentileMetrics.ITL: [v * 1000 for v in inter_token_latencies_all],
             PercentileMetrics.TPOT: [
                 row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]] * 1000 for row in streaming_rows
             ],

--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -34,6 +34,7 @@ class DatabaseColumns:
     MAX_GPU_MEMORY_COST = 'max_gpu_memory_cost'
     TIME_PER_OUTPUT_TOKEN = 'time_per_output_token'
     REQUEST_ID = 'request_id'
+    IS_STREAM = 'is_stream'
 
 
 def load_prompt(prompt_path_or_text):
@@ -68,7 +69,8 @@ def create_result_table(cursor):
                       {DatabaseColumns.COMPLETION_TOKENS} INTEGER,
                       {DatabaseColumns.MAX_GPU_MEMORY_COST} REAL,
                       {DatabaseColumns.TIME_PER_OUTPUT_TOKEN} REAL,
-                      {DatabaseColumns.REQUEST_ID} TEXT
+                      {DatabaseColumns.REQUEST_ID} TEXT,
+                      {DatabaseColumns.IS_STREAM} INTEGER
                    )'''
     )
 
@@ -87,10 +89,10 @@ def insert_benchmark_data(cursor: sqlite3.Cursor, benchmark_data: BenchmarkData)
         response_messages,
         benchmark_data.completed_time,
         benchmark_data.request_id,
+        int(benchmark_data.is_stream),
     )
 
     if benchmark_data.success:
-        # Add additional columns for success case
         additional_columns = (
             benchmark_data.query_latency, benchmark_data.first_chunk_latency, benchmark_data.prompt_tokens,
             benchmark_data.completion_tokens, benchmark_data.max_gpu_memory_cost, benchmark_data.time_per_output_token
@@ -98,18 +100,18 @@ def insert_benchmark_data(cursor: sqlite3.Cursor, benchmark_data: BenchmarkData)
         query = f"""INSERT INTO result(
                       {DatabaseColumns.REQUEST}, {DatabaseColumns.START_TIME}, {DatabaseColumns.INTER_TOKEN_LATENCIES},
                       {DatabaseColumns.SUCCESS}, {DatabaseColumns.RESPONSE_MESSAGES}, {DatabaseColumns.COMPLETED_TIME},
-                      {DatabaseColumns.REQUEST_ID},
+                      {DatabaseColumns.REQUEST_ID}, {DatabaseColumns.IS_STREAM},
                       {DatabaseColumns.LATENCY}, {DatabaseColumns.FIRST_CHUNK_LATENCY}, {DatabaseColumns.PROMPT_TOKENS},
                       {DatabaseColumns.COMPLETION_TOKENS}, {DatabaseColumns.MAX_GPU_MEMORY_COST},
                       {DatabaseColumns.TIME_PER_OUTPUT_TOKEN}
-                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
         cursor.execute(query, common_columns + additional_columns)
     else:
         query = f"""INSERT INTO result(
                       {DatabaseColumns.REQUEST}, {DatabaseColumns.START_TIME}, {DatabaseColumns.INTER_TOKEN_LATENCIES},
                       {DatabaseColumns.SUCCESS}, {DatabaseColumns.RESPONSE_MESSAGES}, {DatabaseColumns.COMPLETED_TIME},
-                      {DatabaseColumns.REQUEST_ID}
-                   ) VALUES (?, ?, ?, ?, ?, ?, ?)"""
+                      {DatabaseColumns.REQUEST_ID}, {DatabaseColumns.IS_STREAM}
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
         cursor.execute(query, common_columns)
 
 
@@ -173,7 +175,8 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
     query_sql = f'''SELECT {DatabaseColumns.START_TIME}, {DatabaseColumns.INTER_TOKEN_LATENCIES}, {DatabaseColumns.SUCCESS},
                     {DatabaseColumns.COMPLETED_TIME}, {DatabaseColumns.LATENCY}, {DatabaseColumns.FIRST_CHUNK_LATENCY},
                     {DatabaseColumns.PROMPT_TOKENS},
-                    {DatabaseColumns.COMPLETION_TOKENS}, {DatabaseColumns.TIME_PER_OUTPUT_TOKEN}
+                    {DatabaseColumns.COMPLETION_TOKENS}, {DatabaseColumns.TIME_PER_OUTPUT_TOKEN},
+                    {DatabaseColumns.IS_STREAM}
                     FROM result WHERE {DatabaseColumns.SUCCESS}=1'''  # noqa: E501
 
     percentiles = [1, 5, 10, 25, 50, 75, 90, 95, 99]
@@ -186,6 +189,12 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
 
     # Create column index mapping
     col_indices = {col: idx for idx, col in enumerate(columns)}
+
+    # Stream-only subset for metrics that lack valid values on non-stream requests.
+    # Pure non-stream runs have no stream rows, so fall back to all rows to keep
+    # their percentile output unchanged (backward compatible).
+    stream_rows = [r for r in rows if r[col_indices[DatabaseColumns.IS_STREAM]]]
+    streaming_rows = stream_rows if stream_rows else rows
 
     is_embedding_rerank = Metrics.is_embedding_or_rerank(api_type)
 
@@ -202,18 +211,29 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
     else:
         # For LLM models, show all metrics
         # Prepare data for each metric
-        inter_token_latencies_all = []
-        for row in rows:
+        inter_token_latencies_stream = []
+        for row in streaming_rows:
             try:
                 itl = json.loads(row[col_indices[DatabaseColumns.INTER_TOKEN_LATENCIES]]) or []
-                inter_token_latencies_all.extend(itl)
+                inter_token_latencies_stream.extend(itl)
             except (json.JSONDecodeError, TypeError) as e:
                 logger.error(f'Error parsing inter token latencies: {e}')
 
         metrics = {
-            PercentileMetrics.TTFT: [row[col_indices[DatabaseColumns.FIRST_CHUNK_LATENCY]] * 1000 for row in rows],
-            PercentileMetrics.ITL: [v * 1000 for v in inter_token_latencies_all],
-            PercentileMetrics.TPOT: [row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]] * 1000 for row in rows],
+            # Stream-only; pure non-stream runs fall back to all rows (streaming_rows)
+            PercentileMetrics.TTFT: [
+                row[col_indices[DatabaseColumns.FIRST_CHUNK_LATENCY]] * 1000 for row in streaming_rows
+            ],
+            PercentileMetrics.ITL: [v * 1000 for v in inter_token_latencies_stream],
+            PercentileMetrics.TPOT: [
+                row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]] * 1000 for row in streaming_rows
+            ],
+            PercentileMetrics.DECODE_THROUGHPUT: [
+                (1.0 / row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]])
+                if row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]] > 0 else float('nan')
+                for row in streaming_rows
+            ],
+            # Generic (all success rows)
             PercentileMetrics.LATENCY: [row[col_indices[DatabaseColumns.LATENCY]] for row in rows],
             PercentileMetrics.INPUT_TOKENS: [row[col_indices[DatabaseColumns.PROMPT_TOKENS]] for row in rows],
             PercentileMetrics.OUTPUT_TOKENS: [row[col_indices[DatabaseColumns.COMPLETION_TOKENS]] for row in rows],
@@ -225,10 +245,6 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
                 (row[col_indices[DatabaseColumns.PROMPT_TOKENS]] + row[col_indices[DatabaseColumns.COMPLETION_TOKENS]])
                 / row[col_indices[DatabaseColumns.LATENCY]]
             ) if row[col_indices[DatabaseColumns.LATENCY]] > 0 else float('nan') for row in rows],
-            PercentileMetrics.DECODE_THROUGHPUT: [
-                (1.0 / row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]])
-                if row[col_indices[DatabaseColumns.TIME_PER_OUTPUT_TOKEN]] > 0 else float('nan') for row in rows
-            ]
         }
 
     # Calculate percentiles for each metric and build transposed dict

--- a/evalscope/perf/utils/perf_constants.py
+++ b/evalscope/perf/utils/perf_constants.py
@@ -30,6 +30,8 @@ class Metrics:
     TOTAL_REQUESTS = 'Total Requests'
     SUCCEED_REQUESTS = 'Success Requests'
     FAILED_REQUESTS = 'Failed Requests'
+    STREAM_REQUESTS = 'Stream Requests'
+    NON_STREAM_REQUESTS = 'Non-Stream Requests'
     REQUEST_THROUGHPUT = 'Req Throughput (req/s)'
     AVERAGE_LATENCY = 'Avg Latency (s)'
     AVERAGE_INPUT_TOKENS_PER_REQUEST = 'Avg Input Tokens'

--- a/evalscope/perf/utils/perf_models.py
+++ b/evalscope/perf/utils/perf_models.py
@@ -45,6 +45,8 @@ class BenchmarkSummary(BaseModel):
     total_requests: int = Field(0, alias=Metrics.TOTAL_REQUESTS)
     succeed_requests: int = Field(0, alias=Metrics.SUCCEED_REQUESTS)
     failed_requests: int = Field(0, alias=Metrics.FAILED_REQUESTS)
+    stream_requests: int = Field(0, alias=Metrics.STREAM_REQUESTS)
+    non_stream_requests: int = Field(0, alias=Metrics.NON_STREAM_REQUESTS)
     request_throughput: float = Field(0.0, alias=Metrics.REQUEST_THROUGHPUT)
     avg_latency: float = Field(0.0, alias=Metrics.AVERAGE_LATENCY)
     avg_input_tokens: float = Field(0.0, alias=Metrics.AVERAGE_INPUT_TOKENS_PER_REQUEST)
@@ -71,7 +73,15 @@ class BenchmarkSummary(BaseModel):
     approx_spec_acceptance_rate: Optional[float] = Field(None, alias=Metrics.APPROX_SPECULATIVE_ACCEPTANCE_RATE)
 
     # Multi-run averaging produces fractional ints; round before validation.
-    @field_validator('concurrency', 'total_requests', 'succeed_requests', 'failed_requests', mode='before')
+    @field_validator(
+        'concurrency',
+        'total_requests',
+        'succeed_requests',
+        'failed_requests',
+        'stream_requests',
+        'non_stream_requests',
+        mode='before'
+    )
     @classmethod
     def _round_to_int(cls, v):
         if isinstance(v, float):
@@ -123,6 +133,8 @@ class BenchmarkSummary(BaseModel):
         rows.append(
             ('Total / Success / Failed', f'{self.total_requests} / {self.succeed_requests} / {self.failed_requests}')
         )
+        if self.stream_requests > 0 and self.non_stream_requests > 0:
+            rows.append(('Stream / Non-Stream', f'{self.stream_requests} / {self.non_stream_requests}'))
         rows.append((Metrics.REQUEST_THROUGHPUT, _fmt(self.request_throughput)))
 
         # ── Latency ──

--- a/tests/perf/test_stream_metrics.py
+++ b/tests/perf/test_stream_metrics.py
@@ -1,0 +1,186 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+"""Unit tests for stream/non-stream metric bucketing.
+
+Covers the is_stream decide-once classification, MetricsAccumulator bucketing,
+and percentile path filtering — all as pure-logic tests with no model service
+dependency (a mock SQLite result table is used for the percentile path).
+"""
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from evalscope.perf.utils.benchmark_util import BenchmarkData, MetricsAccumulator, is_stream_body
+from evalscope.perf.utils.db_util import create_result_table, get_percentile_results, insert_benchmark_data
+
+
+def _make(**kwargs):
+    """Build a BenchmarkData with sensible streaming defaults."""
+    data = BenchmarkData()
+    data.success = kwargs.get('success', True)
+    data.start_time = 0.0
+    data.completed_time = 1.0
+    data.query_latency = kwargs.get('latency', 1.0)
+    data.first_chunk_latency = kwargs.get('fcl', 0.3)
+    data.time_per_output_token = kwargs.get('tpot', 0.02)
+    data.prompt_tokens = kwargs.get('prompt_tokens', 10)
+    data.completion_tokens = kwargs.get('completion_tokens', 50)
+    data.inter_chunk_latency = kwargs.get('itl', [0.02] * 49)
+    data.decoded_tokens_per_iter = kwargs.get('decoded', 4.0)
+    data.is_stream = kwargs.get('is_stream', True)
+    data.request = kwargs.get('request', '{}')
+    data.response_messages = []
+    return data
+
+
+class _DummyPlugin:
+    def __init__(self, prompt, completion):
+        self._p, self._c = prompt, completion
+
+    def parse_responses(self, responses, request=None, **kw):
+        return self._p, self._c
+
+
+class TestIsStreamClassification(unittest.TestCase):
+    """Tests for the is_stream_body() helper used on error/timeout paths."""
+
+    def test_absent_is_nonstream(self):
+        self.assertFalse(is_stream_body({}))
+
+    def test_truthy_non_bool_is_nonstream(self):
+        self.assertFalse(is_stream_body({'stream': 'true'}))
+        self.assertFalse(is_stream_body({'stream': 'True'}))
+        self.assertFalse(is_stream_body({'stream': 1}))
+
+
+class TestAccumulatorBucketing(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = _DummyPlugin(10, 50)
+
+    def test_stream_only_metrics_excludes_nonstream(self):
+        acc = MetricsAccumulator()
+        s1 = _make(fcl=0.3, latency=1.0, itl=[0.02] * 49, is_stream=True)
+        s2 = _make(fcl=0.4, latency=1.0, itl=[0.04] * 49, is_stream=True)
+        ns1 = _make(fcl=1.5, latency=1.5, itl=[], is_stream=False)
+        ns2 = _make(fcl=1.6, latency=1.6, itl=[], is_stream=False)
+        for d in (s1, s2, ns1, ns2):
+            acc.update(d, self.plugin)
+        result = acc.to_result()
+
+        self.assertAlmostEqual(result.avg_first_chunk_latency, (0.3 + 0.4) / 2)
+        # TPOT post-finalize: (1.0-0.3)/49, (1.0-0.4)/49
+        exp_tpot = ((1.0 - 0.3) / 49 + (1.0 - 0.4) / 49) / 2
+        self.assertAlmostEqual(result.avg_time_per_output_token, exp_tpot)
+        self.assertAlmostEqual(result.avg_inter_token_latency, (0.02 * 49 + 0.04 * 49) / (2 * 49))
+
+        # Generic latency averaged over all success (n=4)
+        self.assertAlmostEqual(result.avg_latency, (1.0 + 1.0 + 1.5 + 1.6) / 4)
+
+    def test_counts_include_failures(self):
+        acc = MetricsAccumulator()
+        acc.update(_make(is_stream=True), self.plugin)
+        acc.update(_make(is_stream=True, success=False), self.plugin)
+        acc.update(_make(is_stream=False), self.plugin)
+        acc.update(_make(is_stream=False, success=False), self.plugin)
+        result = acc.to_result()
+
+        self.assertEqual(result.total_requests, 4)
+        self.assertEqual(result.succeed_requests, 2)
+        self.assertEqual(result.failed_requests, 2)
+        self.assertEqual(result.stream_requests, 2)
+        self.assertEqual(result.non_stream_requests, 2)
+
+    def test_all_stream_no_regression(self):
+        acc = MetricsAccumulator()
+        acc.update(_make(fcl=0.3, latency=1.0, tpot=0.02, itl=[0.02] * 49, is_stream=True), self.plugin)
+        acc.update(_make(fcl=0.5, latency=1.0, tpot=0.03, itl=[0.04] * 49, is_stream=True), self.plugin)
+        result = acc.to_result()
+        self.assertEqual(result.stream_requests, 2)
+        self.assertEqual(result.non_stream_requests, 0)
+
+    def test_all_stream_failed_empty_subset(self):
+        acc = MetricsAccumulator()
+        acc.update(_make(is_stream=True, success=False), self.plugin)
+        acc.update(_make(is_stream=True, success=False), self.plugin)
+        result = acc.to_result()
+        self.assertEqual(result.stream_requests, 2)
+        self.assertEqual(result.succeed_requests, 0)
+        self.assertEqual(result.avg_first_chunk_latency, -1)
+        self.assertEqual(result.avg_time_per_output_token, -1)
+
+    def test_no_stream_falls_back_to_all_requests(self):
+        # Pure non-stream run: streaming metrics fall back to the all-request
+        # computation (backward compatible) rather than reporting -1.
+        acc = MetricsAccumulator()
+        acc.update(_make(fcl=1.5, latency=2.0, itl=[], is_stream=False), self.plugin)
+        result = acc.to_result()
+        self.assertEqual(result.avg_first_chunk_latency, 1.5)
+        # finalize derives TPOT = (latency - fcl) / (completion_tokens - 1)
+        self.assertAlmostEqual(result.avg_time_per_output_token, (2.0 - 1.5) / 49)
+        self.assertEqual(result.avg_inter_token_latency, 0.0)
+
+
+class TestPercentileBucketing(unittest.TestCase):
+
+    def setUp(self):
+        self.db = tempfile.mktemp(suffix='.db')
+        con = sqlite3.connect(self.db)
+        cur = con.cursor()
+        create_result_table(cur)
+        # 4 stream (real TPOT) + 4 non-stream (TPOT 0, no ITL)
+        for i in range(4):
+            bd = _make(
+                fcl=0.5, latency=2.0, tpot=0.03 * (i + 1), itl=[0.03] * 50,
+                completion_tokens=51, prompt_tokens=10, is_stream=True,
+            )
+            insert_benchmark_data(cur, bd)
+        for i in range(4):
+            bd = _make(
+                fcl=1.5, latency=1.5, tpot=0.0, itl=[], completion_tokens=51,
+                prompt_tokens=10, is_stream=False,
+            )
+            insert_benchmark_data(cur, bd)
+        con.commit()
+        con.close()
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.unlink(self.db)
+
+    def test_stream_only_columns_no_zero_tpot(self):
+        result = get_percentile_results(self.db, api_type='openai')
+        rows = result.to_list()
+        for p in ['1%', '50%', '75%', '99%']:
+            row = next(r for r in rows if r['Percentiles'] == p)
+            tpot = row['TPOT (ms)']
+            self.assertNotEqual(tpot, 0.0, f'TPOT at {p} must not be 0 (non-stream excluded)')
+            self.assertEqual(row['ITL (ms)'], 30.0, f'ITL at {p} must be 30ms (stream-only)')
+
+    def test_pure_non_stream_percentiles_fall_back_to_all_rows(self):
+        # Pure non-stream run: no stream rows, so streaming metrics fall back to
+        # all rows (backward compatible) instead of producing NaN.
+        db = tempfile.mktemp(suffix='.db')
+        con = sqlite3.connect(db)
+        cur = con.cursor()
+        create_result_table(cur)
+        for _ in range(3):
+            bd = _make(
+                fcl=1.5, latency=1.5, tpot=0.0, itl=[], completion_tokens=51,
+                prompt_tokens=10, is_stream=False,
+            )
+            insert_benchmark_data(cur, bd)
+        con.commit()
+        con.close()
+        try:
+            rows = get_percentile_results(db, api_type='openai').to_list()
+            p50 = next(r for r in rows if r['Percentiles'] == '50%')
+            self.assertEqual(p50['TTFT (ms)'], 1500.0)
+            self.assertEqual(p50['TPOT (ms)'], 0.0)
+        finally:
+            if os.path.exists(db):
+                os.unlink(db)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

## Summary

When a benchmark run mixes `stream: true` and `stream: false` requests, streaming-specific metrics (TTFT / TPOT / ITL) are now computed over **stream requests only**. Pure-stream and pure-non-stream runs are unchanged.

## Motivation

For non-stream requests, `first_chunk_latency = query_latency` (entire request time) and `time_per_output_token = 0`. When mixed with real stream requests this **inflates TTFT** and **deflates TPOT**.

Mixed runs are reachable via `workload_trace` (per-request `stream` from original trace) and `line_by_line` (JSONL body `stream` field overrides CLI flag).

### Example

8 streaming (TTFT ~50 ms) + 2 non-streaming (latency ~2.5 s):

| Metric   | Before                             | After (stream only) |
|----------|------------------------------------|---------------------|
| Avg TTFT | `(8×0.05 + 2×2.5) / 10 = 0.54 s`  | `0.05 s`            |
| Avg TPOT | deflated by two `0` contributions  | stream-only mean    |

## Changes

| File | What changed |
|------|--------------|
| `benchmark_util.py` | Add `is_stream` flag and `is_stream_body()` helper; stream-only accumulators for TTFT/TPOT/ITL with non-stream fallback; expose stream/non-stream counts. |
| `default_api.py` | Set `is_stream = True` in SSE branch; body-based fallback on failure. |
| `openai_responses_api.py` | Set `is_stream = True` in SSE branch; body-based fallback on failure. |
| `http_client.py` | Body-based `is_stream` on timeout/connection-error paths. |
| `db_util.py` | Persist `is_stream` column; percentile TTFT/TPOT/ITL/decode use stream rows only (fallback for pure non-stream). |
| `perf_constants.py` | `STREAM_REQUESTS` / `NON_STREAM_REQUESTS` constants. |
| `perf_models.py` | Count fields in `BenchmarkSummary`; conditional display when mixed. |

## Testing

```
$ pytest tests/perf/test_stream_metrics.py -q
9 passed
```
