### PR TITLE
fix(perf): stop open-loop dispatch at duration deadline

### DIFF
--- a/evalscope/perf/core/strategies/open_loop.py
+++ b/evalscope/perf/core/strategies/open_loop.py
@@ -110,12 +110,6 @@ class OpenLoopStrategy(BenchmarkStrategy):
                     # Deadline anchored to first non-warmup request's dispatch time.
                     if i == first_bench:
                         actual_deadline = self._compute_deadline(self.args.duration)
-                    if actual_deadline is not None and time.perf_counter() >= actual_deadline:
-                        logger.info(
-                            f'Duration deadline reached after dispatching {i}/{n} requests; '
-                            'stopping further dispatches.'
-                        )
-                        break
                     sleep_s = target_times[i] - time.perf_counter()
                     if actual_deadline is not None:
                         sleep_s = min(sleep_s, actual_deadline - time.perf_counter())
@@ -165,12 +159,6 @@ class OpenLoopStrategy(BenchmarkStrategy):
             #    loop, otherwise the anchor will skew.
             target_times = delay_ts + time.perf_counter()
             for i, request in enumerate(requests):
-                if deadline is not None and time.perf_counter() >= deadline:
-                    logger.info(
-                        f'Duration deadline reached after dispatching {i}/{n} requests; '
-                        'stopping further dispatches.'
-                    )
-                    break
                 sleep_s = target_times[i] - time.perf_counter()
                 # Cap the sleep at the remaining time-to-deadline so we don't
                 # sleep past the cancellation point.

--- a/evalscope/perf/core/strategies/open_loop.py
+++ b/evalscope/perf/core/strategies/open_loop.py
@@ -121,6 +121,12 @@ class OpenLoopStrategy(BenchmarkStrategy):
                         sleep_s = min(sleep_s, actual_deadline - time.perf_counter())
                 if sleep_s > 0:
                     await asyncio.sleep(sleep_s)
+                if not is_warmup_req and actual_deadline is not None and time.perf_counter() >= actual_deadline:
+                    logger.info(
+                        f'Duration deadline reached after dispatching {i}/{n} requests; '
+                        'stopping further dispatches.'
+                    )
+                    break
                 task = asyncio.create_task(
                     _send_request_open_loop(
                         request, is_warmup or is_warmup_req, self.queue, self.client, self.track_gpu_memory
@@ -172,6 +178,12 @@ class OpenLoopStrategy(BenchmarkStrategy):
                     sleep_s = min(sleep_s, deadline - time.perf_counter())
                 if sleep_s > 0:
                     await asyncio.sleep(sleep_s)
+                if deadline is not None and time.perf_counter() >= deadline:
+                    logger.info(
+                        f'Duration deadline reached after dispatching {i}/{n} requests; '
+                        'stopping further dispatches.'
+                    )
+                    break
                 # If sleep_s <= 0 we are behind schedule; dispatch immediately
                 # to absorb the drift.
                 task = asyncio.create_task(

--- a/tests/perf/test_open_loop_strategy.py
+++ b/tests/perf/test_open_loop_strategy.py
@@ -1,0 +1,60 @@
+import asyncio
+import pytest
+from types import SimpleNamespace
+from typing import AsyncIterator, Dict, List, Tuple
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.core.strategies import open_loop
+from evalscope.perf.core.strategies.open_loop import OpenLoopStrategy
+from evalscope.perf.utils.body_meta import BODY_META_ARRIVAL_OFFSET
+
+
+class FakeClient:
+
+    def __init__(self) -> None:
+        self.request_ids: List[int] = []
+
+    async def post(self, request: Dict[str, int]) -> SimpleNamespace:
+        self.request_ids.append(request['id'])
+        return SimpleNamespace(is_warmup=False)
+
+
+@pytest.mark.parametrize('use_trace_offsets', [True, False], ids=['trace', 'poisson'])
+def test_schedule_stops_dispatching_at_duration_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    use_trace_offsets: bool,
+) -> None:
+    current_time = 0.0
+
+    def perf_counter() -> float:
+        return current_time
+
+    async def sleep(seconds: float) -> None:
+        nonlocal current_time
+        current_time += seconds
+
+    async def request_generator(requests: List[dict]) -> AsyncIterator[Tuple[dict, bool]]:
+        for request in requests:
+            yield request, False
+
+    async def run() -> List[int]:
+        requests = [{'id': 1}, {'id': 2}]
+        if use_trace_offsets:
+            requests[0][BODY_META_ARRIVAL_OFFSET] = 0.0
+            requests[1][BODY_META_ARRIVAL_OFFSET] = 1.0
+        else:
+            monkeypatch.setattr(
+                open_loop.np.random, 'exponential', lambda *args, **kwargs: open_loop.np.array([0.0, 1.0])
+            )
+        args = Arguments(model='m', api='openai', open_loop=True, rate=1.0, number=2, duration=0.5)
+        args.rate = 1.0
+        args.number = 2
+        client = FakeClient()
+        strategy = OpenLoopStrategy(args, None, client, asyncio.Queue(), request_generator(requests))
+        await strategy.run()
+        return client.request_ids
+
+    monkeypatch.setattr(open_loop.time, 'perf_counter', perf_counter)
+    monkeypatch.setattr(open_loop.asyncio, 'sleep', sleep)
+
+    assert asyncio.run(run()) == [1]


### PR DESCRIPTION
## Summary

Fix open-loop scheduling so no new request is dispatched after the `--duration` deadline.

The fix covers both:

- regular Poisson open-loop scheduling
- `workload_trace` arrival-offset scheduling

## Problem

The scheduler caps its sleep to the remaining time before the deadline. However, after the sleep returns, it previously created the request task without checking the deadline again.

As a result, a request scheduled beyond the duration limit could still be dispatched exactly when the deadline was reached.

This conflicts with the documented soft-exit behavior: new requests should stop at the deadline, while requests already in flight are allowed to finish.

## Changes

- Re-check the deadline after the scheduling sleep and before creating a request task.
- Preserve the existing warmup and in-flight request behavior.
- Add parameterized regression coverage for both trace-based and Poisson scheduling.

## Scope

This is intentionally a narrow scheduler fix.

It does not change:

- CLI arguments or configuration
- arrival schedule calculation
- warmup behavior
- completion of already in-flight requests

## Testing

- `pytest tests/perf/test_open_loop_strategy.py -q`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`
- `pre-commit run --all-files`

All checks passed.

## Related Issues

Fixes #1500.

Related to #1494.