### PR TITLE
fix(perf): generate HTML report for open-loop runs with no fixed rate (rate=-1.0)

### DIFF
--- a/evalscope/perf/utils/perf_models.py
+++ b/evalscope/perf/utils/perf_models.py
@@ -434,14 +434,15 @@ class RunData(BaseModel):
     def name(self) -> str:
         """Human-readable run label.
 
-        * ``parallel_<N>_number_<M>`` directories  → "Parallel N / Number M"
-        * ``rate_<R>_number_<M>`` directories       → "Rate R rps / Number M"
+        * closed-loop (``parallel_<N>_number_<M>``) → "Parallel N / Number M"
+        * open-loop with a fixed rate               → "Rate R rps / Number M"
+        * open-loop with no fixed rate (rate=-1)    → "Open-loop / Number M"
         """
-        import re
-        m = re.match(r'^rate_([\d.]+)_number_(\d+)$', self.dir_name)
-        if m:
-            return f'Rate {m.group(1)} rps / Number {m.group(2)}'
-        return f'Parallel {self.parallel} / Number {self.number}'
+        if not self.is_open_loop:
+            return f'Parallel {self.parallel} / Number {self.number}'
+        if self.rate is not None and self.rate < 0:
+            return f'Open-loop / Number {self.number}'
+        return f'Rate {self.rate} rps / Number {self.number}'
 
     @property
     def success_rate(self) -> float:

--- a/evalscope/perf/utils/report/perf_charts.py
+++ b/evalscope/perf/utils/report/perf_charts.py
@@ -180,8 +180,6 @@ class ChartBuilder:
 # X-axis helper: adapts to open-loop (rate) vs closed-loop (concurrency)
 # ---------------------------------------------------------------------------
 
-_RATE_DIR_RE = re.compile(r'^rate_[\d.]+_number_\d+$')
-
 
 def _x_axis(runs: 'List[RunData]'):
     """Return *(xs, x_title)* appropriate for the run mode.
@@ -191,7 +189,7 @@ def _x_axis(runs: 'List[RunData]'):
     * closed-loop (``parallel_*_number_*`` dirs) → xs = concurrency integers,
       x_title = ``'Concurrency'``
     """
-    is_open = any(_RATE_DIR_RE.match(r.dir_name) for r in runs)
+    is_open = any(r.is_open_loop for r in runs)
     if is_open:
         return [r.summary.request_rate for r in runs], 'Rate (req/s)'
     return [r.parallel for r in runs], 'Concurrency'

--- a/evalscope/perf/utils/report/perf_data.py
+++ b/evalscope/perf/utils/report/perf_data.py
@@ -36,7 +36,7 @@ logger = get_logger()
 
 # Patterns for recognized run directory names
 _PARALLEL_RE = re.compile(r'^parallel_(\d+)_number_(\d+)$')
-_RATE_RE = re.compile(r'^rate_([\d.]+)_number_(\d+)$')
+_RATE_RE = re.compile(r'^rate_(-?[\d.]+)_number_(\d+)$')
 
 
 class RunLoader:

--- a/tests/perf/test_perf_report_loader.py
+++ b/tests/perf/test_perf_report_loader.py
@@ -1,0 +1,80 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+"""Unit tests for perf HTML-report run discovery and labeling.
+
+Network-free: builds minimal fake run sub-directories on disk and exercises
+``RunLoader.load_all`` plus the ``RunData``/chart helpers directly.
+
+Regression for open-loop runs with no fixed rate (``rate_-1.0_number_<M>``),
+which were previously dropped by the loader regex so no HTML report was
+generated.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+
+def _write_json(path: str, obj: object) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(obj, f)
+
+
+def _make_run(base: str, dir_name: str, *, request_rate: float) -> None:
+    """Create a minimal run sub-directory recognized by ``RunLoader``."""
+    sub = os.path.join(base, dir_name)
+    _write_json(os.path.join(sub, 'benchmark_summary.json'), {'Request rate': request_rate})
+    _write_json(os.path.join(sub, 'benchmark_percentile.json'), [])
+    _write_json(os.path.join(sub, 'benchmark_args.json'), {'api': 'openai'})
+
+
+class TestPerfReportLoader(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        _make_run(self.tmp, 'parallel_2_number_5', request_rate=-1.0)
+        _make_run(self.tmp, 'rate_1.5_number_4', request_rate=1.5)
+        _make_run(self.tmp, 'rate_-1.0_number_30', request_rate=-1.0)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _by_dir(self):
+        from evalscope.perf.utils.report.perf_data import RunLoader
+        runs = RunLoader.load_all(self.tmp, with_requests=False)
+        return {r.dir_name: r for r in runs}
+
+    def test_open_loop_no_fixed_rate_is_discovered(self):
+        """rate_-1.0_number_30 must be loaded (previously silently dropped)."""
+        runs = self._by_dir()
+        self.assertIn('rate_-1.0_number_30', runs)
+        run = runs['rate_-1.0_number_30']
+        self.assertTrue(run.is_open_loop)
+        self.assertEqual(run.name, 'Open-loop / Number 30')
+
+    def test_fixed_rate_run_labeled_by_rate(self):
+        run = self._by_dir()['rate_1.5_number_4']
+        self.assertTrue(run.is_open_loop)
+        self.assertEqual(run.name, 'Rate 1.5 rps / Number 4')
+
+    def test_closed_loop_run_unaffected(self):
+        run = self._by_dir()['parallel_2_number_5']
+        self.assertFalse(run.is_open_loop)
+        self.assertEqual(run.name, 'Parallel 2 / Number 5')
+
+    def test_x_axis_detects_open_loop(self):
+        from evalscope.perf.utils.report import perf_charts
+        run = self._by_dir()['rate_-1.0_number_30']
+        _, x_title = perf_charts._x_axis([run])
+        self.assertEqual(x_title, 'Rate (req/s)')
+
+    def test_x_axis_closed_loop(self):
+        from evalscope.perf.utils.report import perf_charts
+        run = self._by_dir()['parallel_2_number_5']
+        _, x_title = perf_charts._x_axis([run])
+        self.assertEqual(x_title, 'Concurrency')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

Open-loop perf runs that don't pin a fixed request rate produce **no `perf_report.html`** — it's silently skipped, even though `performance_summary.txt`, `benchmark_summary.json`, `benchmark_percentile.json`, and `benchmark_data.db` are all written correctly.

For example, `workload_trace` replay (driven by trace arrival offsets, no `--rate`) ends the run with:

```
INFO: Performance summary saved to: .../performance_summary.txt
WARNING: No benchmark runs found under .../outputs/<name>. Skipping HTML report.
```

## Root cause

When rate is unset, the benchmark records `Request Rate = -1.0` (sentinel) and writes the run sub-directory as `rate_-1.0_number_<M>`. The loader regex has no sign in its character class, so the directory never matches and `RunLoader.load_all()` drops it:

```python
# evalscope/perf/utils/report/perf_data.py
_RATE_RE = re.compile(r'^rate_([\d.]+)_number_(\d+)$')   # rejects the leading '-'
```

With zero runs returned, `gen_perf_html_report()` logs *"No benchmark runs found ... Skipping HTML report"* and returns `''`.

## Fix

Allow an optional leading sign on the rate capture group:

```python
_RATE_RE = re.compile(r'^rate_(-?[\d.]+)_number_(\d+)$')
```

Positive-rate run dirs (`rate_1.5_number_4`) still match; `parallel_*` is unaffected.

## Verification

Re-ran a `workload_trace` open-loop run (rate=-1.0, 30 reqs) against a vLLM endpoint (`--enable-prompt-tokens-details`):

- **Before:** `WARNING: No benchmark runs found ... Skipping HTML report.` — no `perf_report.html`.
- **After:** `HTML report generated: .../perf_report.html` (165 KB interactive report, 26/30 success; 4 failures are unrelated `ServerDisconnectedError`).

Run dir confirmed named `rate_-1.0_number_30` — i.e. the negative-rate path that previously failed discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)