### PR TITLE
fix(perf): sync server-reported cached_tokens for single-turn runs

### DIFF
--- a/evalscope/perf/utils/benchmark_util.py
+++ b/evalscope/perf/utils/benchmark_util.py
@@ -127,6 +127,10 @@ class BenchmarkData:
         if self.completion_tokens and self.completion_tokens > 1 and n_chunks > 1:
             self.decoded_tokens_per_iter = (self.completion_tokens - 1) / (n_chunks - 1)
 
+        # Sync server-reported cached tokens for single-turn runs; don't overwrite.
+        if self.cached_tokens is None and self.real_cached_tokens is not None:
+            self.cached_tokens = self.real_cached_tokens
+
     def update_gpu_usage(self) -> None:
         """Update max GPU memory usage across all visible CUDA devices."""
         if check_import('torch', raise_warning=False):

--- a/tests/perf/test_stream_metrics.py
+++ b/tests/perf/test_stream_metrics.py
@@ -182,5 +182,38 @@ class TestPercentileBucketing(unittest.TestCase):
                 os.unlink(db)
 
 
+class TestSingleTurnCachedTokenSync(unittest.TestCase):
+    """Cache-hit normalization for single-turn (open-loop / closed-loop) runs.
+
+    Regression coverage for issue #1506: server-reported cached tokens land in
+    ``real_cached_tokens`` but were never synced to ``cached_tokens``, so single-turn
+    cache metrics stayed at 0.
+    """
+
+    def setUp(self):
+        self.plugin = _DummyPlugin(152, 24)
+
+    def test_finalize_syncs_real_cached_tokens(self):
+        data = _make(prompt_tokens=152, completion_tokens=24, is_stream=False)
+        data.real_cached_tokens = 128
+        data.finalize(self.plugin)
+        self.assertEqual(data.cached_tokens, 128)
+
+    def test_finalize_does_not_overwrite_existing_cached_tokens(self):
+        data = _make(prompt_tokens=152, completion_tokens=24, is_stream=False)
+        data.real_cached_tokens = 128
+        data.cached_tokens = 0
+        data.finalize(self.plugin)
+        self.assertEqual(data.cached_tokens, 0)
+
+    def test_accumulator_reports_cached_percent_for_single_turn(self):
+        acc = MetricsAccumulator()
+        data = _make(prompt_tokens=152, completion_tokens=24, is_stream=False)
+        data.real_cached_tokens = 128
+        acc.update(data, self.plugin)
+        result = acc.to_result()
+        self.assertAlmostEqual(result.avg_cached_percent, 128 / 152 * 100.0)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1506.

In single-turn (open-loop / closed-loop) OpenAI API benchmarks, the server-reported cache hit count from `usage.prompt_tokens_details.cached_tokens` is parsed into `BenchmarkData.real_cached_tokens`, but was never synced to `cached_tokens` — the field that both `MetricsAccumulator` and `WorkloadTimeline` consume. As a result, `Cached Prompt tok/s`, cached token counts, and `avg_cached_percent` always showed 0. Previously the sync only happened inside the multi-turn strategy.

## Fix

Normalize `real_cached_tokens` into `cached_tokens` in `BenchmarkData.finalize()`, without overwriting a value already set by multi-turn strategies:

```python
if self.cached_tokens is None and self.real_cached_tokens is not None:
    self.cached_tokens = self.real_cached_tokens
```

`finalize()` runs before both consumers read `cached_tokens` (`MetricsAccumulator.update` calls it before reading; `metrics_consumer` triggers it before `workload_timeline.feed`), so single-turn, open-loop, and closed-loop paths are all covered. Multi-turn behavior is unchanged (equivalent assignment).

## Tests

Added `TestSingleTurnCachedTokenSync` in `tests/perf/test_stream_metrics.py`:
- `finalize()` syncs `real_cached_tokens` -> `cached_tokens`
- `finalize()` does not overwrite an already-set `cached_tokens`
- `MetricsAccumulator` reports correct `avg_cached_percent` for a single-turn request

Verified:
- `pytest tests/perf/test_stream_metrics.py` — 12 passed (3 new)
- `pytest tests/perf/test_workload_timeline.py tests/perf/test_trace_metrics.py` — 21 passed (no regression)
- pre-commit (flake8 / isort / yapf) — passed