### PR TITLE
Add JobBench benchmark

### DIFF
--- a/docs/en/benchmarks/job_bench.md
+++ b/docs/en/benchmarks/job_bench.md
@@ -1,0 +1,158 @@
+# JobBench
+
+
+## Overview
+
+JobBench evaluates agentic systems on realistic professional work tasks that require reading reference files, producing
+deliverables, and reconciling multi-source information. This adapter uses the ModelScope dataset
+`evalscope/job-bench`.
+
+## Task Description
+
+- **Task Type**: Agentic professional work / deliverable generation
+- **Input**: Workplace-style task prompt with optional reference files under `reference_files/`
+- **Output**: Final deliverable files written to `jobbench_output/`
+- **Dataset**: ModelScope `evalscope/job-bench`
+- **Metric**: Weighted LLM-judge rubric score (`normalized_score`)
+
+## Evaluation Notes
+
+- The default evaluation split is `main`.
+- Configure `judge_model_args` for rubric scoring.
+- `normalized_score` is the primary weighted score (`total_score / max_score`); `pass_rate` is the unweighted
+  proportion of fully passed rubrics; `total_score` is the raw sum of passed rubric weights.
+- Docker runs use `python:3.11-slim-bookworm` by default. For formal evaluation, provide an image with the Office,
+  PDF, and spreadsheet tools required by the tasks.
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `job_bench` |
+| **Dataset ID** | [evalscope/job-bench](https://modelscope.cn/datasets/evalscope/job-bench/summary) |
+| **Paper** | N/A |
+| **Tags** | `Agent`, `Knowledge`, `MultiTurn` |
+| **Metrics** | `normalized_score`, `pass_rate`, `total_score` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `main` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 65 |
+| Prompt Length (Mean) | 3344.32 chars |
+| Prompt Length (Min/Max) | 2000 / 4920 chars |
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "203fd1aa",
+      "content": "You are preparing the Statistical Analysis Plan for Phase III trial XR-2847 evaluating cardiovascular disease prevention. The sponsor requires validation of statistical assumptions against empirical data and regulatory alignment before protoc ... [TRUNCATED 2026 chars] ... erables.\n\nWrite every final deliverable file under `jobbench_output`. Do not put intermediate scratch files there.\nYour final message may summarize what you produced, but files requested by the task must be actual files in\n`jobbench_output`.\n"
+    }
+  ],
+  "id": 0,
+  "group_id": 0,
+  "tools": [
+    {
+      "name": "bash",
+      "description": "Execute a bash command inside the sandbox environment. Returns the combined stdout / stderr output of the command.",
+      "parameters": {
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The bash command to execute."
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Maximum execution time in seconds (default: 60).",
+            "default": 60
+          }
+        },
+        "required": [
+          "command"
+        ]
+      }
+    },
+    {
+      "name": "python_exec",
+      "description": "Execute Python source code inside the sandbox environment. Returns stdout and stderr output.",
+      "parameters": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Python source code to execute."
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Maximum execution time in seconds (default: 60).",
+            "default": 60
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "task_id": "biostatisticians__task1",
+    "reference_files": [
+      "dataset/biostatisticians/task1/task_folder/Clinical_Study_Proposal_CVD_Prevention.csv",
+      "dataset/biostatisticians/task1/task_folder/framingham.csv"
+    ],
+    "rubric_json": "{\n  \"rubrics\": [\n    {\n      \"rubric\": \"Does the analysis calculate the observed 10-year CHD event rate in the eligible population as 20.2% (236/1166) and identify this as higher than the assumed 15% control group rate?\",\n      \"weight\": 10,\n ... [TRUNCATED 4642 chars] ... ge criterion and by the sysBP criterion separately\",\n        \"The flow shows the final eligible population count (1,166)\",\n        \"The flow enables verification of the filtering process and assessment of generalizability\"\n      ]\n    }\n  ]\n}"
+  }
+}
+```
+
+*Note: Some content was truncated for display.*
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{question}
+```
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets job_bench \
+    --agent-config '{"mode":"native","strategy":"function_calling","max_steps":250}' \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import TaskConfig, run_task
+from evalscope.api.agent import NativeAgentConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['job_bench'],
+    agent_config=NativeAgentConfig(
+        strategy='function_calling',
+        max_steps=250,
+    ),
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/agent.md
+++ b/docs/en/get_started/supported_dataset/agent.md
@@ -14,6 +14,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 | `gaia` | [GAIA](../../benchmarks/gaia.md) | `Agent`, `MultiTurn`, `Reasoning` |
 | `gdpval` | [GDPval](../../benchmarks/gdpval.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `general_fc` | [General-FunctionCalling](../../benchmarks/general_fc.md) | `Agent`, `Custom`, `FunctionCalling` |
+| `job_bench` | [JobBench](../../benchmarks/job_bench.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `k2_verifier` | [K2-Vendor-Verifier](../../benchmarks/k2_verifier.md) | `Agent`, `FunctionCalling` |
 | `kimi_verifier` | [Kimi-Vendor-Verifier (Param Compliance)](../../benchmarks/kimi_verifier.md) | `Agent`, `FunctionCalling` |
 | `mcp_atlas` | [MCP-Atlas](../../benchmarks/mcp_atlas.md) | `Agent`, `MultiTurn` |
@@ -48,6 +49,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 ../../benchmarks/gaia.md
 ../../benchmarks/gdpval.md
 ../../benchmarks/general_fc.md
+../../benchmarks/job_bench.md
 ../../benchmarks/k2_verifier.md
 ../../benchmarks/kimi_verifier.md
 ../../benchmarks/mcp_atlas.md

--- a/docs/zh/benchmarks/job_bench.md
+++ b/docs/zh/benchmarks/job_bench.md
@@ -1,0 +1,153 @@
+# JobBench
+
+
+## 概述
+
+JobBench 评估智能体系统在真实专业工作场景中的表现，这些任务要求系统能够阅读参考文件、生成交付成果，并整合多源信息。本适配器使用 ModelScope 数据集 `evalscope/job-bench`。
+
+## 任务描述
+
+- **任务类型**：智能体专业工作 / 交付成果生成
+- **输入**：包含可选参考文件（位于 `reference_files/` 目录下）的职场风格任务提示
+- **输出**：最终交付成果文件写入 `jobbench_output/` 目录
+- **数据集**：ModelScope `evalscope/job-bench`
+- **评估指标**：加权 LLM 评分标准得分（`normalized_score`）
+
+## 评估说明
+
+- 默认评估划分（split）为 `main`。
+- 请配置 `judge_model_args` 以进行评分标准打分。
+- `normalized_score` 是主要的加权得分（`total_score / max_score`）；`pass_rate` 是完全通过评分项的未加权比例；`total_score` 是通过评分项权重的原始总和。
+- Docker 运行默认使用 `python:3.11-slim-bookworm` 镜像。正式评估时，请提供包含任务所需 Office、PDF 和电子表格工具的镜像。
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `job_bench` |
+| **数据集ID** | [evalscope/job-bench](https://modelscope.cn/datasets/evalscope/job-bench/summary) |
+| **论文** | 无 |
+| **标签** | `Agent`, `Knowledge`, `MultiTurn` |
+| **指标** | `normalized_score`, `pass_rate`, `total_score` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `main` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 65 |
+| 提示词长度（平均） | 3344.32 字符 |
+| 提示词长度（最小/最大） | 2000 / 4920 字符 |
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "203fd1aa",
+      "content": "You are preparing the Statistical Analysis Plan for Phase III trial XR-2847 evaluating cardiovascular disease prevention. The sponsor requires validation of statistical assumptions against empirical data and regulatory alignment before protoc ... [TRUNCATED 2026 chars] ... erables.\n\nWrite every final deliverable file under `jobbench_output`. Do not put intermediate scratch files there.\nYour final message may summarize what you produced, but files requested by the task must be actual files in\n`jobbench_output`.\n"
+    }
+  ],
+  "id": 0,
+  "group_id": 0,
+  "tools": [
+    {
+      "name": "bash",
+      "description": "Execute a bash command inside the sandbox environment. Returns the combined stdout / stderr output of the command.",
+      "parameters": {
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The bash command to execute."
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Maximum execution time in seconds (default: 60).",
+            "default": 60
+          }
+        },
+        "required": [
+          "command"
+        ]
+      }
+    },
+    {
+      "name": "python_exec",
+      "description": "Execute Python source code inside the sandbox environment. Returns stdout and stderr output.",
+      "parameters": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Python source code to execute."
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Maximum execution time in seconds (default: 60).",
+            "default": 60
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "task_id": "biostatisticians__task1",
+    "reference_files": [
+      "dataset/biostatisticians/task1/task_folder/Clinical_Study_Proposal_CVD_Prevention.csv",
+      "dataset/biostatisticians/task1/task_folder/framingham.csv"
+    ],
+    "rubric_json": "{\n  \"rubrics\": [\n    {\n      \"rubric\": \"Does the analysis calculate the observed 10-year CHD event rate in the eligible population as 20.2% (236/1166) and identify this as higher than the assumed 15% control group rate?\",\n      \"weight\": 10,\n ... [TRUNCATED 4642 chars] ... ge criterion and by the sysBP criterion separately\",\n        \"The flow shows the final eligible population count (1,166)\",\n        \"The flow enables verification of the filtering process and assessment of generalizability\"\n      ]\n    }\n  ]\n}"
+  }
+}
+```
+
+*注：部分内容因展示需要已被截断。*
+
+## 提示模板
+
+**提示模板：**
+```text
+{question}
+```
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets job_bench \
+    --agent-config '{"mode":"native","strategy":"function_calling","max_steps":250}' \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import TaskConfig, run_task
+from evalscope.api.agent import NativeAgentConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['job_bench'],
+    agent_config=NativeAgentConfig(
+        strategy='function_calling',
+        max_steps=250,
+    ),
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/agent.md
+++ b/docs/zh/get_started/supported_dataset/agent.md
@@ -14,6 +14,7 @@
 | `gaia` | [GAIA](../../benchmarks/gaia.md) | `Agent`, `MultiTurn`, `Reasoning` |
 | `gdpval` | [GDPval](../../benchmarks/gdpval.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `general_fc` | [General-FunctionCalling](../../benchmarks/general_fc.md) | `Agent`, `Custom`, `FunctionCalling` |
+| `job_bench` | [JobBench](../../benchmarks/job_bench.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `k2_verifier` | [K2-Vendor-Verifier](../../benchmarks/k2_verifier.md) | `Agent`, `FunctionCalling` |
 | `kimi_verifier` | [Kimi-Vendor-Verifier (Param Compliance)](../../benchmarks/kimi_verifier.md) | `Agent`, `FunctionCalling` |
 | `mcp_atlas` | [MCP-Atlas](../../benchmarks/mcp_atlas.md) | `Agent`, `MultiTurn` |
@@ -48,6 +49,7 @@
 ../../benchmarks/gaia.md
 ../../benchmarks/gdpval.md
 ../../benchmarks/general_fc.md
+../../benchmarks/job_bench.md
 ../../benchmarks/k2_verifier.md
 ../../benchmarks/kimi_verifier.md
 ../../benchmarks/mcp_atlas.md

--- a/evalscope/benchmarks/_meta/job_bench.json
+++ b/evalscope/benchmarks/_meta/job_bench.json
@@ -1,0 +1,129 @@
+{
+  "meta": {
+    "pretty_name": "JobBench",
+    "dataset_id": "evalscope/job-bench",
+    "paper_url": null,
+    "tags": [
+      "Agent",
+      "Knowledge",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "normalized_score",
+      "pass_rate",
+      "total_score"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "main",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nJobBench evaluates agentic systems on realistic professional work tasks that require reading reference files, producing\ndeliverables, and reconciling multi-source information. This adapter uses the ModelScope dataset\n`evalscope/job-bench`.\n\n## Task Description\n\n- **Task Type**: Agentic professional work / deliverable generation\n- **Input**: Workplace-style task prompt with optional reference files under `reference_files/`\n- **Output**: Final deliverable files written to `jobbench_output/`\n- **Dataset**: ModelScope `evalscope/job-bench`\n- **Metric**: Weighted LLM-judge rubric score (`normalized_score`)\n\n## Evaluation Notes\n\n- The default evaluation split is `main`.\n- Configure `judge_model_args` for rubric scoring.\n- `normalized_score` is the primary weighted score (`total_score / max_score`); `pass_rate` is the unweighted\n  proportion of fully passed rubrics; `total_score` is the raw sum of passed rubric weights.\n- Docker runs use `python:3.11-slim-bookworm` by default. For formal evaluation, provide an image with the Office,\n  PDF, and spreadsheet tools required by the tasks.\n",
+    "prompt_template": "{question}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "agent",
+    "agent_config": {
+      "strategy": "function_calling",
+      "max_steps": 250
+    }
+  },
+  "statistics": {
+    "total_samples": 65,
+    "subset_stats": [
+      {
+        "name": "default",
+        "sample_count": 65,
+        "prompt_length_mean": 3344.32,
+        "prompt_length_min": 2000,
+        "prompt_length_max": 4920,
+        "prompt_length_std": 582.11,
+        "target_length_mean": null
+      }
+    ],
+    "prompt_length": {
+      "mean": 3344.32,
+      "min": 2000,
+      "max": 4920,
+      "std": 582.11
+    },
+    "target_length_mean": null,
+    "computed_at": "2026-07-23T16:40:07.716638"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "203fd1aa",
+          "content": "You are preparing the Statistical Analysis Plan for Phase III trial XR-2847 evaluating cardiovascular disease prevention. The sponsor requires validation of statistical assumptions against empirical data and regulatory alignment before protoc ... [TRUNCATED 2026 chars] ... erables.\n\nWrite every final deliverable file under `jobbench_output`. Do not put intermediate scratch files there.\nYour final message may summarize what you produced, but files requested by the task must be actual files in\n`jobbench_output`.\n"
+        }
+      ],
+      "id": 0,
+      "group_id": 0,
+      "tools": [
+        {
+          "name": "bash",
+          "description": "Execute a bash command inside the sandbox environment. Returns the combined stdout / stderr output of the command.",
+          "parameters": {
+            "properties": {
+              "command": {
+                "type": "string",
+                "description": "The bash command to execute."
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Maximum execution time in seconds (default: 60).",
+                "default": 60
+              }
+            },
+            "required": [
+              "command"
+            ]
+          }
+        },
+        {
+          "name": "python_exec",
+          "description": "Execute Python source code inside the sandbox environment. Returns stdout and stderr output.",
+          "parameters": {
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Python source code to execute."
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Maximum execution time in seconds (default: 60).",
+                "default": 60
+              }
+            },
+            "required": [
+              "code"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "task_id": "biostatisticians__task1",
+        "reference_files": [
+          "dataset/biostatisticians/task1/task_folder/Clinical_Study_Proposal_CVD_Prevention.csv",
+          "dataset/biostatisticians/task1/task_folder/framingham.csv"
+        ],
+        "rubric_json": "{\n  \"rubrics\": [\n    {\n      \"rubric\": \"Does the analysis calculate the observed 10-year CHD event rate in the eligible population as 20.2% (236/1166) and identify this as higher than the assumed 15% control group rate?\",\n      \"weight\": 10,\n ... [TRUNCATED 4642 chars] ... ge criterion and by the sysBP criterion separately\",\n        \"The flow shows the final eligible population count (1,166)\",\n        \"The flow enables verification of the filtering process and assessment of generalizability\"\n      ]\n    }\n  ]\n}"
+      }
+    },
+    "subset": "default",
+    "truncated": true
+  },
+  "readme": {
+    "en": "# JobBench\n\n\n## Overview\n\nJobBench evaluates agentic systems on realistic professional work tasks that require reading reference files, producing\ndeliverables, and reconciling multi-source information. This adapter uses the ModelScope dataset\n`evalscope/job-bench`.\n\n## Task Description\n\n- **Task Type**: Agentic professional work / deliverable generation\n- **Input**: Workplace-style task prompt with optional reference files under `reference_files/`\n- **Output**: Final deliverable files written to `jobbench_output/`\n- **Dataset**: ModelScope `evalscope/job-bench`\n- **Metric**: Weighted LLM-judge rubric score (`normalized_score`)\n\n## Evaluation Notes\n\n- The default evaluation split is `main`.\n- Configure `judge_model_args` for rubric scoring.\n- `normalized_score` is the primary weighted score (`total_score / max_score`); `pass_rate` is the unweighted\n  proportion of fully passed rubrics; `total_score` is the raw sum of passed rubric weights.\n- Docker runs use `python:3.11-slim-bookworm` by default. For formal evaluation, provide an image with the Office,\n  PDF, and spreadsheet tools required by the tasks.\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `job_bench` |\n| **Dataset ID** | [evalscope/job-bench](https://modelscope.cn/datasets/evalscope/job-bench/summary) |\n| **Paper** | N/A |\n| **Tags** | `Agent`, `Knowledge`, `MultiTurn` |\n| **Metrics** | `normalized_score`, `pass_rate`, `total_score` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `main` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 65 |\n| Prompt Length (Mean) | 3344.32 chars |\n| Prompt Length (Min/Max) | 2000 / 4920 chars |\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"203fd1aa\",\n      \"content\": \"You are preparing the Statistical Analysis Plan for Phase III trial XR-2847 evaluating cardiovascular disease prevention. The sponsor requires validation of statistical assumptions against empirical data and regulatory alignment before protoc ... [TRUNCATED 2026 chars] ... erables.\\n\\nWrite every final deliverable file under `jobbench_output`. Do not put intermediate scratch files there.\\nYour final message may summarize what you produced, but files requested by the task must be actual files in\\n`jobbench_output`.\\n\"\n    }\n  ],\n  \"id\": 0,\n  \"group_id\": 0,\n  \"tools\": [\n    {\n      \"name\": \"bash\",\n      \"description\": \"Execute a bash command inside the sandbox environment. Returns the combined stdout / stderr output of the command.\",\n      \"parameters\": {\n        \"properties\": {\n          \"command\": {\n            \"type\": \"string\",\n            \"description\": \"The bash command to execute.\"\n          },\n          \"timeout\": {\n            \"type\": \"number\",\n            \"description\": \"Maximum execution time in seconds (default: 60).\",\n            \"default\": 60\n          }\n        },\n        \"required\": [\n          \"command\"\n        ]\n      }\n    },\n    {\n      \"name\": \"python_exec\",\n      \"description\": \"Execute Python source code inside the sandbox environment. Returns stdout and stderr output.\",\n      \"parameters\": {\n        \"properties\": {\n          \"code\": {\n            \"type\": \"string\",\n            \"description\": \"Python source code to execute.\"\n          },\n          \"timeout\": {\n            \"type\": \"number\",\n            \"description\": \"Maximum execution time in seconds (default: 60).\",\n            \"default\": 60\n          }\n        },\n        \"required\": [\n          \"code\"\n        ]\n      }\n    }\n  ],\n  \"metadata\": {\n    \"task_id\": \"biostatisticians__task1\",\n    \"reference_files\": [\n      \"dataset/biostatisticians/task1/task_folder/Clinical_Study_Proposal_CVD_Prevention.csv\",\n      \"dataset/biostatisticians/task1/task_folder/framingham.csv\"\n    ],\n    \"rubric_json\": \"{\\n  \\\"rubrics\\\": [\\n    {\\n      \\\"rubric\\\": \\\"Does the analysis calculate the observed 10-year CHD event rate in the eligible population as 20.2% (236/1166) and identify this as higher than the assumed 15% control group rate?\\\",\\n      \\\"weight\\\": 10,\\n ... [TRUNCATED 4642 chars] ... ge criterion and by the sysBP criterion separately\\\",\\n        \\\"The flow shows the final eligible population count (1,166)\\\",\\n        \\\"The flow enables verification of the filtering process and assessment of generalizability\\\"\\n      ]\\n    }\\n  ]\\n}\"\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{question}\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets job_bench \\\n    --agent-config '{\"mode\":\"native\",\"strategy\":\"function_calling\",\"max_steps\":250}' \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import TaskConfig, run_task\nfrom evalscope.api.agent import NativeAgentConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['job_bench'],\n    agent_config=NativeAgentConfig(\n        strategy='function_calling',\n        max_steps=250,\n    ),\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# JobBench\n\n\n## 概述\n\nJobBench 评估智能体系统在真实专业工作场景中的表现，这些任务要求系统能够阅读参考文件、生成交付成果，并整合多源信息。本适配器使用 ModelScope 数据集 `evalscope/job-bench`。\n\n## 任务描述\n\n- **任务类型**：智能体专业工作 / 交付成果生成\n- **输入**：包含可选参考文件（位于 `reference_files/` 目录下）的职场风格任务提示\n- **输出**：最终交付成果文件写入 `jobbench_output/` 目录\n- **数据集**：ModelScope `evalscope/job-bench`\n- **评估指标**：加权 LLM 评分标准得分（`normalized_score`）\n\n## 评估说明\n\n- 默认评估划分（split）为 `main`。\n- 请配置 `judge_model_args` 以进行评分标准打分。\n- `normalized_score` 是主要的加权得分（`total_score / max_score`）；`pass_rate` 是完全通过评分项的未加权比例；`total_score` 是通过评分项权重的原始总和。\n- Docker 运行默认使用 `python:3.11-slim-bookworm` 镜像。正式评估时，请提供包含任务所需 Office、PDF 和电子表格工具的镜像。\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `job_bench` |\n| **数据集ID** | [evalscope/job-bench](https://modelscope.cn/datasets/evalscope/job-bench/summary) |\n| **论文** | 无 |\n| **标签** | `Agent`, `Knowledge`, `MultiTurn` |\n| **指标** | `normalized_score`, `pass_rate`, `total_score` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `main` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 65 |\n| 提示词长度（平均） | 3344.32 字符 |\n| 提示词长度（最小/最大） | 2000 / 4920 字符 |\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"203fd1aa\",\n      \"content\": \"You are preparing the Statistical Analysis Plan for Phase III trial XR-2847 evaluating cardiovascular disease prevention. The sponsor requires validation of statistical assumptions against empirical data and regulatory alignment before protoc ... [TRUNCATED 2026 chars] ... erables.\\n\\nWrite every final deliverable file under `jobbench_output`. Do not put intermediate scratch files there.\\nYour final message may summarize what you produced, but files requested by the task must be actual files in\\n`jobbench_output`.\\n\"\n    }\n  ],\n  \"id\": 0,\n  \"group_id\": 0,\n  \"tools\": [\n    {\n      \"name\": \"bash\",\n      \"description\": \"Execute a bash command inside the sandbox environment. Returns the combined stdout / stderr output of the command.\",\n      \"parameters\": {\n        \"properties\": {\n          \"command\": {\n            \"type\": \"string\",\n            \"description\": \"The bash command to execute.\"\n          },\n          \"timeout\": {\n            \"type\": \"number\",\n            \"description\": \"Maximum execution time in seconds (default: 60).\",\n            \"default\": 60\n          }\n        },\n        \"required\": [\n          \"command\"\n        ]\n      }\n    },\n    {\n      \"name\": \"python_exec\",\n      \"description\": \"Execute Python source code inside the sandbox environment. Returns stdout and stderr output.\",\n      \"parameters\": {\n        \"properties\": {\n          \"code\": {\n            \"type\": \"string\",\n            \"description\": \"Python source code to execute.\"\n          },\n          \"timeout\": {\n            \"type\": \"number\",\n            \"description\": \"Maximum execution time in seconds (default: 60).\",\n            \"default\": 60\n          }\n        },\n        \"required\": [\n          \"code\"\n        ]\n      }\n    }\n  ],\n  \"metadata\": {\n    \"task_id\": \"biostatisticians__task1\",\n    \"reference_files\": [\n      \"dataset/biostatisticians/task1/task_folder/Clinical_Study_Proposal_CVD_Prevention.csv\",\n      \"dataset/biostatisticians/task1/task_folder/framingham.csv\"\n    ],\n    \"rubric_json\": \"{\\n  \\\"rubrics\\\": [\\n    {\\n      \\\"rubric\\\": \\\"Does the analysis calculate the observed 10-year CHD event rate in the eligible population as 20.2% (236/1166) and identify this as higher than the assumed 15% control group rate?\\\",\\n      \\\"weight\\\": 10,\\n ... [TRUNCATED 4642 chars] ... ge criterion and by the sysBP criterion separately\\\",\\n        \\\"The flow shows the final eligible population count (1,166)\\\",\\n        \\\"The flow enables verification of the filtering process and assessment of generalizability\\\"\\n      ]\\n    }\\n  ]\\n}\"\n  }\n}\n```\n\n*注：部分内容因展示需要已被截断。*\n\n## 提示模板\n\n**提示模板：**\n```text\n{question}\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets job_bench \\\n    --agent-config '{\"mode\":\"native\",\"strategy\":\"function_calling\",\"max_steps\":250}' \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import TaskConfig, run_task\nfrom evalscope.api.agent import NativeAgentConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['job_bench'],\n    agent_config=NativeAgentConfig(\n        strategy='function_calling',\n        max_steps=250,\n    ),\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "f4b6eb26760810f544eb8754db85c162",
+    "needs_translation": false
+  },
+  "updated_at": "2026-07-23T16:40:07.724714",
+  "translation_updated_at": "2026-07-23T16:40:09"
+}

--- a/evalscope/benchmarks/job_bench/__init__.py
+++ b/evalscope/benchmarks/job_bench/__init__.py
@@ -1,0 +1,3 @@
+from .job_bench_adapter import JobBenchAdapter
+
+__all__ = ['JobBenchAdapter']

--- a/evalscope/benchmarks/job_bench/job_bench_adapter.py
+++ b/evalscope/benchmarks/job_bench/job_bench_adapter.py
@@ -15,7 +15,7 @@ from evalscope.api.metric import Score
 from evalscope.api.model import Model
 from evalscope.api.registry import register_benchmark
 from evalscope.api.sandbox import merge_sandbox_config_dicts
-from evalscope.constants import HubType, Tags
+from evalscope.constants import HubType, JudgeStrategy, Tags
 from evalscope.utils.import_utils import is_build_doc
 from evalscope.utils.logger import get_logger
 from .utils import (
@@ -91,6 +91,8 @@ class JobBenchAdapter(AgentLoopAdapter):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+        if self.judge_strategy == JudgeStrategy.LLM_RECALL:
+            raise ValueError("JobBench does not support judge_strategy='llm_recall'; use 'auto' or 'llm'.")
         self._snapshot_dir: Optional[Path] = None
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:

--- a/evalscope/benchmarks/job_bench/job_bench_adapter.py
+++ b/evalscope/benchmarks/job_bench/job_bench_adapter.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from evalscope.agent.tools.bash import BASH_TOOL_INFO, run_bash
+from evalscope.agent.tools.python_exec import PYTHON_EXEC_TOOL_INFO, run_python_exec
+from evalscope.api.agent import AgentEnvironment
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.benchmark.adapters import AgentLoopAdapter
+from evalscope.api.dataset import DatasetHub, Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.metric import Score
+from evalscope.api.model import Model
+from evalscope.api.registry import register_benchmark
+from evalscope.api.sandbox import merge_sandbox_config_dicts
+from evalscope.constants import HubType, Tags
+from evalscope.utils.import_utils import is_build_doc
+from evalscope.utils.logger import get_logger
+from .utils import (
+    SANDBOX_OUTPUT_DIR,
+    SANDBOX_REFERENCE_DIR,
+    JobBenchArtifactEnvironment,
+    artifact_dir,
+    evaluate_job_bench_output,
+    parse_rubrics,
+)
+
+logger = get_logger()
+
+_DATASET_ID = 'evalscope/job-bench'
+_DEFAULT_DOCKER_IMAGE = 'python:3.11-slim-bookworm'
+
+_DESCRIPTION = """
+## Overview
+
+JobBench evaluates agentic systems on realistic professional work tasks that require reading reference files, producing
+deliverables, and reconciling multi-source information. This adapter uses the ModelScope dataset
+`evalscope/job-bench`.
+
+## Task Description
+
+- **Task Type**: Agentic professional work / deliverable generation
+- **Input**: Workplace-style task prompt with optional reference files under `reference_files/`
+- **Output**: Final deliverable files written to `jobbench_output/`
+- **Dataset**: ModelScope `evalscope/job-bench`
+- **Metric**: Weighted LLM-judge rubric score (`normalized_score`)
+
+## Evaluation Notes
+
+- The default evaluation split is `main`.
+- Configure `judge_model_args` for rubric scoring.
+- `normalized_score` is the primary weighted score (`total_score / max_score`); `pass_rate` is the unweighted
+  proportion of fully passed rubrics; `total_score` is the raw sum of passed rubric weights.
+- Docker runs use `python:3.11-slim-bookworm` by default. For formal evaluation, provide an image with the Office,
+  PDF, and spreadsheet tools required by the tasks.
+"""
+
+_PROMPT_SUFFIX = f"""
+
+Reference files, when present, are available under `{SANDBOX_REFERENCE_DIR}/`.
+Use the bash or python_exec tools to inspect inputs and create the requested deliverables.
+
+Write every final deliverable file under `{SANDBOX_OUTPUT_DIR}`. Do not put intermediate scratch files there.
+Your final message may summarize what you produced, but files requested by the task must be actual files in
+`{SANDBOX_OUTPUT_DIR}`.
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='job_bench',
+        pretty_name='JobBench',
+        tags=[Tags.AGENT, Tags.KNOWLEDGE, Tags.MULTI_TURN],
+        description=_DESCRIPTION,
+        dataset_id=_DATASET_ID,
+        subset_list=['default'],
+        default_subset='default',
+        eval_split='main',
+        prompt_template='{question}',
+        metric_list=['normalized_score', 'pass_rate', 'total_score'],
+    )
+)
+class JobBenchAdapter(AgentLoopAdapter):
+    """JobBench adapter using ModelScope data and EvalScope's agent loop."""
+
+    llm_judge_default = True
+    strategy_name = 'function_calling'
+    max_steps_default = 250
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._snapshot_dir: Optional[Path] = None
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        if self._snapshot_dir is None and not is_build_doc():
+            self._snapshot_dir = Path(
+                DatasetHub(
+                    data_id_or_path=self.dataset_id,
+                    data_source=self.dataset_hub or HubType.MODELSCOPE,
+                    force_redownload=self.force_redownload,
+                    cache_dir=self.dataset_dir,
+                ).download_snapshot()
+            ).resolve()
+
+        reference_files = [str(path) for path in record.get('reference_files') or []]
+        reference_hint = ''
+        if reference_files:
+            reference_hint = '\n\nReference files for this task:\n' + '\n'.join(
+                f'- {SANDBOX_REFERENCE_DIR}/{Path(path).name}' for path in reference_files
+            )
+
+        metadata = {
+            'task_id': record['task_id'],
+            'reference_files': reference_files,
+            'rubric_json': record.get('rubric_json'),
+        }
+        if self._snapshot_dir is not None and reference_files:
+            reference_dir = (self._snapshot_dir / Path(reference_files[0]).parent).resolve()
+            if reference_dir.is_relative_to(self._snapshot_dir) and reference_dir.is_dir():
+                metadata['reference_dir'] = str(reference_dir)
+            else:
+                logger.warning(f'JobBench reference directory not found: {reference_dir}')
+
+        return Sample(
+            input=f"{record['prompt'].strip()}{reference_hint}{_PROMPT_SUFFIX}",
+            tools=[BASH_TOOL_INFO, PYTHON_EXEC_TOOL_INFO],
+            metadata=metadata,
+        )
+
+    def run_inference(self, model: Model, sample: Sample, output_dir: str, **kwargs: Any) -> TaskState:
+        sample.metadata['artifact_dir'] = str(artifact_dir(sample, output_dir))
+        return super().run_inference(model, sample, output_dir, **kwargs)
+
+    def build_tools(self, sample: Sample) -> Dict[str, Any]:
+        return {
+            'bash': run_bash,
+            'python_exec': run_python_exec,
+        }
+
+    def build_environment(self, sample: Sample) -> Optional[AgentEnvironment]:
+        agent_config = self._task_config.agent_config if self._task_config is not None else None
+        if getattr(agent_config, 'environment', None) == 'docker':
+            return self._build_docker_environment(sample)
+
+        from evalscope.agent.environments.local import TemporaryLocalAgentEnvironment
+
+        env = TemporaryLocalAgentEnvironment(sample_id=sample.id, prefix='evalscope-jobbench-')
+        reference_dir = sample.metadata.get('reference_dir')
+        if reference_dir:
+            shutil.copytree(reference_dir, env.working_dir / SANDBOX_REFERENCE_DIR)
+        host_artifact_dir = Path(sample.metadata['artifact_dir'])
+        host_output_dir = host_artifact_dir / SANDBOX_OUTPUT_DIR
+        host_output_dir.mkdir(parents=True, exist_ok=True)
+        (env.working_dir / SANDBOX_OUTPUT_DIR).symlink_to(host_output_dir, target_is_directory=True)
+        return JobBenchArtifactEnvironment(
+            env=env,
+            artifact_dir=host_artifact_dir,
+            metadata=sample.metadata,
+        )
+
+    def _build_docker_environment(self, sample: Sample) -> AgentEnvironment:
+        from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
+
+        defaults: Dict[str, Any] = {
+            'image': _DEFAULT_DOCKER_IMAGE,
+            'working_dir': '/workspace',
+            'network_enabled': True,
+        }
+        sandbox_config = merge_sandbox_config_dicts(defaults, self._task_sandbox_config())
+        host_artifact_dir = Path(sample.metadata['artifact_dir'])
+        host_output_dir = host_artifact_dir / SANDBOX_OUTPUT_DIR
+        host_output_dir.mkdir(parents=True, exist_ok=True)
+        volumes = {
+            str(host_output_dir): {
+                'bind': f'/workspace/{SANDBOX_OUTPUT_DIR}',
+                'mode': 'rw',
+            }
+        }
+        reference_dir = sample.metadata.get('reference_dir')
+        if reference_dir and Path(reference_dir).is_dir():
+            volumes[reference_dir] = {
+                'bind': f'/workspace/{SANDBOX_REFERENCE_DIR}',
+                'mode': 'ro',
+            }
+        sandbox_config['volumes'] = {**sandbox_config.get('volumes', {}), **volumes}
+
+        env = EnclaveAgentEnvironment(
+            engine='docker',
+            sandbox_config=sandbox_config,
+            timeout=self._native_command_timeout(),
+        )
+        return JobBenchArtifactEnvironment(
+            env=env,
+            artifact_dir=host_artifact_dir,
+            metadata=sample.metadata,
+        )
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        return Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+            value={
+                'normalized_score': 0.0,
+                'pass_rate': 0.0,
+                'total_score': 0.0,
+            },
+            metadata={
+                'official_score_computed': False,
+                'note': 'JobBench quality scoring requires judge_model_args.',
+            },
+            main_score_name='normalized_score',
+        )
+
+    def llm_match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        if self.llm_judge is None:
+            raise ValueError('JobBench requires judge_model_args for LLM-based rubric scoring.')
+
+        evaluation = evaluate_job_bench_output(
+            output_dir=Path(task_state.metadata['artifact_dir']) / SANDBOX_OUTPUT_DIR,
+            rubrics=parse_rubrics(task_state.metadata.get('rubric_json')),
+            judge=self.llm_judge.judge,
+        )
+        scorecard = evaluation['scorecard']
+        return Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+            value={
+                'normalized_score': float(scorecard['normalized_score']),
+                'pass_rate': float(scorecard['pass_rate']),
+                'total_score': float(scorecard['total_score']),
+            },
+            metadata={
+                'judge_model': self.llm_judge.model_id,
+                'task_id': task_state.metadata.get('task_id'),
+                'artifact_dir': task_state.metadata.get('artifact_dir'),
+                'output_files': task_state.metadata.get('output_files') or [],
+                'max_score': float(scorecard['max_score']),
+                'rubrics': evaluation['rubrics'],
+                'error': evaluation.get('error'),
+            },
+            main_score_name='normalized_score',
+        )

--- a/evalscope/benchmarks/job_bench/utils.py
+++ b/evalscope/benchmarks/job_bench/utils.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from zipfile import BadZipFile, ZipFile
+
+from evalscope.api.agent import AgentEnvironment
+from evalscope.api.agent.types import ExecResult
+from evalscope.api.messages import ChatMessageSystem, ChatMessageUser, ContentImage, ContentText
+from evalscope.utils.io_utils import safe_filename
+
+SANDBOX_REFERENCE_DIR = 'reference_files'
+SANDBOX_OUTPUT_DIR = 'jobbench_output'
+HOST_ARTIFACT_ROOT = 'artifacts/job_bench'
+
+MAX_CHARS_PER_FILE_DEFAULT = 200_000
+MAX_VISION_IMAGES_DEFAULT = 8
+SQLITE_EXTS = {'db', 'sqlite', 'sqlite3'}
+SQLITE_ROWS_PER_TABLE = 500
+VISION_IMAGE_EXTS = {'png', 'jpg', 'jpeg', 'gif', 'webp'}
+VISION_MIME = {
+    'png': 'image/png',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'gif': 'image/gif',
+    'webp': 'image/webp',
+}
+VISUAL_RUBRIC_PATTERN = re.compile(
+    r'\b(plot|figure|visualization|visualisation|visualize|visualise|'
+    r'heatmap|histogram|scatter ?plot|biplot|diagram|q[- ]?q)\b',
+    re.IGNORECASE,
+)
+
+
+class JobBenchArtifactEnvironment(AgentEnvironment):
+    name = 'job_bench_artifact'
+
+    def __init__(self, env: AgentEnvironment, artifact_dir: Path, metadata: Dict[str, Any]) -> None:
+        self._env = env
+        self._artifact_dir = artifact_dir
+        self._metadata = metadata
+
+    async def exec(
+        self,
+        cmd: List[str],
+        *,
+        cwd: Optional[str] = None,
+        input: Optional[str] = None,
+        timeout: Optional[float] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> ExecResult:
+        return await self._env.exec(cmd, cwd=cwd, input=input, timeout=timeout, env=env)
+
+    async def close(self) -> None:
+        try:
+            await self._env.close()
+        finally:
+            output_dir = self._artifact_dir / SANDBOX_OUTPUT_DIR
+            self._metadata['artifact_dir'] = str(self._artifact_dir)
+            self._metadata['output_files'] = [{
+                'path': f'{SANDBOX_OUTPUT_DIR}/{path.relative_to(output_dir).as_posix()}',
+                'local_path': str(path),
+            } for path in sorted(output_dir.rglob('*')) if path.is_file()]
+
+
+def artifact_dir(sample: Any, output_dir: str) -> Path:
+    task_id = str(sample.metadata.get('task_id') or sample.id or 'unknown')
+    return (Path(output_dir) / HOST_ARTIFACT_ROOT / safe_filename(task_id)).resolve()
+
+
+def parse_rubrics(value: Any) -> List[Dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if isinstance(value, dict):
+        rubrics = value.get('rubrics') or value.get('evaluation_rubrics') or []
+        return [item for item in rubrics if isinstance(item, dict)]
+    return []
+
+
+def normalize_criteria(rubric: Dict[str, Any]) -> List[str]:
+    criterion_raw = rubric.get('criterion', [])
+    if isinstance(criterion_raw, str):
+        return [criterion_raw]
+    if isinstance(criterion_raw, list):
+        return [str(item) for item in criterion_raw]
+    return []
+
+
+def build_failed_rubric_result(
+    rubric_index: int,
+    rubric: Dict[str, Any],
+    overall_reasoning: str,
+) -> Dict[str, Any]:
+    criteria = normalize_criteria(rubric)
+    return {
+        'index': rubric_index,
+        'rubric': rubric.get('rubric', ''),
+        'weight': rubric.get('weight', 0),
+        'result': {
+            'passed': False,
+            'score': 0,
+            'criteria_count': len(criteria),
+            'criteria_passed': 0,
+            'criteria_results': [{
+                'index': idx,
+                'criterion': criterion,
+                'passed': False,
+                'reasoning': overall_reasoning,
+                'evidence': '',
+            } for idx, criterion in enumerate(criteria)],
+            'overall_reasoning': overall_reasoning,
+        },
+    }
+
+
+def build_scorecard(results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    total_score = sum(float(result['result']['score']) for result in results)
+    max_score = sum(float(result.get('weight') or 0) for result in results)
+    passed_count = sum(1 for result in results if result['result']['passed'])
+    total_count = len(results)
+    normalized = round(total_score / max_score, 4) if max_score > 0 else 0.0
+    pass_rate = round(passed_count / total_count, 4) if total_count > 0 else 0.0
+    return {
+        'total_score': total_score,
+        'max_score': max_score,
+        'normalized_score': normalized,
+        'pass_rate': pass_rate,
+        'passed_count': passed_count,
+        'total_count': total_count,
+    }
+
+
+def convert_file_to_text(path: Path, max_chars: int = MAX_CHARS_PER_FILE_DEFAULT) -> str:
+    ext = path.suffix.lower().lstrip('.')
+    if ext in (
+        'txt',
+        'md',
+        'csv',
+        'py',
+        'json',
+        'sh',
+        'log',
+        'xml',
+        'html',
+        'css',
+        'js',
+        'ts',
+        'yaml',
+        'yml',
+        'ini',
+        'cfg',
+        'conf',
+        'sql',
+        'rules',
+        'geojson',
+    ):
+        content = _read_text(path)
+    elif ext in ('xlsx', 'xls'):
+        content = _excel_to_text(path)
+    elif ext == 'docx':
+        content = _docx_to_text(path)
+    elif ext == 'pdf':
+        content = _pdf_to_text(path)
+    elif ext in SQLITE_EXTS:
+        content = _sqlite_to_text(path)
+    elif ext == 'pptx':
+        content = _pptx_to_text(path)
+    elif ext == 'ipynb':
+        content = _notebook_to_text(path)
+    elif ext in ('png', 'jpg', 'jpeg', 'gif', 'svg', 'bmp', 'webp'):
+        content = f'[Image file: {path.name} - cannot extract text content]'
+    else:
+        content = f'[Binary or unsupported file type: {ext} - {path.name}]'
+    if ext not in SQLITE_EXTS and len(content) > max_chars:
+        return content[:max_chars] + f'\n... [Content truncated at {max_chars} characters]'
+    return content
+
+
+def extract_all_file_contents(output_dir: Path, max_chars_per_file: int = MAX_CHARS_PER_FILE_DEFAULT) -> str:
+    parts = []
+    for file_path in sorted(output_dir.rglob('*')):
+        if not file_path.is_file():
+            continue
+        content = convert_file_to_text(file_path, max_chars=max_chars_per_file)
+        relative_name = file_path.relative_to(output_dir).as_posix()
+        parts.append(f'=== FILE: {relative_name} ===\n{content}\n')
+    return '\n'.join(parts)
+
+
+def rubric_needs_vision(rubric: Dict[str, Any]) -> bool:
+    text = rubric.get('rubric', '') or ''
+    criterion = rubric.get('criterion', [])
+    if isinstance(criterion, list):
+        text = text + ' ' + ' '.join(str(item) for item in criterion)
+    elif isinstance(criterion, str):
+        text = text + ' ' + criterion
+    return bool(VISUAL_RUBRIC_PATTERN.search(text))
+
+
+def collect_image_attachments(output_dir: Path, cap: int = MAX_VISION_IMAGES_DEFAULT) -> List[Tuple[str, str]]:
+    if not output_dir.exists() or cap <= 0:
+        return []
+
+    attachments: List[Tuple[str, str]] = []
+    seen_hashes = set()
+
+    def add_attachment(name: str, mime: str, image_bytes: bytes) -> bool:
+        digest = hashlib.sha256(image_bytes).hexdigest()
+        if digest in seen_hashes:
+            return False
+        seen_hashes.add(digest)
+        encoded = base64.b64encode(image_bytes).decode('ascii')
+        attachments.append((name, f'data:{mime};base64,{encoded}'))
+        return len(attachments) >= cap
+
+    for path in sorted(output_dir.rglob('*')):
+        if not path.is_file() or path.suffix.lower().lstrip('.') not in VISION_IMAGE_EXTS:
+            continue
+        try:
+            image_bytes = path.read_bytes()
+        except OSError:
+            continue
+        ext = path.suffix.lower().lstrip('.')
+        if add_attachment(path.relative_to(output_dir).as_posix(), VISION_MIME[ext], image_bytes):
+            return attachments
+
+    for docx_path in sorted(output_dir.rglob('*.docx')):
+        try:
+            with ZipFile(docx_path) as archive:
+                for media_name in sorted(archive.namelist()):
+                    ext = Path(media_name).suffix.lower().lstrip('.')
+                    if not media_name.startswith('word/media/') or ext not in VISION_IMAGE_EXTS:
+                        continue
+                    name = f'{docx_path.relative_to(output_dir).as_posix()}:{media_name}'
+                    if add_attachment(name, VISION_MIME[ext], archive.read(media_name)):
+                        return attachments
+        except (BadZipFile, OSError):
+            continue
+
+    for notebook_path in sorted(output_dir.rglob('*.ipynb')):
+        try:
+            notebook = json.loads(notebook_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for cell_index, cell in enumerate(notebook.get('cells', [])):
+            for output_index, output in enumerate(cell.get('outputs', [])):
+                data = output.get('data', {})
+                if not isinstance(data, dict):
+                    continue
+                for mime in VISION_MIME.values():
+                    encoded = data.get(mime)
+                    if isinstance(encoded, list):
+                        encoded = ''.join(str(part) for part in encoded)
+                    if not isinstance(encoded, str):
+                        continue
+                    try:
+                        image_bytes = base64.b64decode(''.join(encoded.split()), validate=True)
+                    except (ValueError, binascii.Error):
+                        continue
+                    name = (
+                        f'{notebook_path.relative_to(output_dir).as_posix()}:'
+                        f'cell-{cell_index}-output-{output_index}'
+                    )
+                    if add_attachment(name, mime, image_bytes):
+                        return attachments
+    return attachments
+
+
+def build_judge_prompt(rubric: Dict[str, Any], file_contents: str, vision_used: bool) -> str:
+    rubric_text = rubric.get('rubric', '')
+    criteria = normalize_criteria(rubric)
+    criteria_list_text = '\n'.join(f'Criterion {idx}: {criterion}' for idx, criterion in enumerate(criteria))
+    return f"""You are an evaluation judge. Your task is to evaluate ALL criteria for a single rubric.
+
+## Rubric Description
+{rubric_text}
+
+## Criteria to Evaluate (Judge ALL of them)
+{criteria_list_text}
+
+## Output Files Content
+The following are the contents of all output files to evaluate:
+
+{file_contents}
+
+## Evaluation Rules
+- Evaluate EACH criterion listed above independently
+- For each criterion: determine if it PASSES or FAILS
+- Semantic matching is acceptable (you don't need exact wording match)
+- Binary judgment for each criterion: PASS or FAIL only
+- The rubric passes ONLY if ALL criteria pass
+
+## Output Format
+Return your judgment as a JSON object with EXACTLY this structure (no markdown, no extra text):
+{{
+  "criteria_results": [
+    {{"index": 0, "passed": true/false, "reasoning": "...", "evidence": "..."}},
+    {{"index": 1, "passed": true/false, "reasoning": "...", "evidence": "..."}}
+  ],
+  "rubric_passed": true/false,
+  "overall_reasoning": "Summary of why the rubric passed or failed"
+}}
+
+IMPORTANT:
+- criteria_results array must have exactly {len(criteria)} items (one for each criterion)
+- rubric_passed should be true ONLY if ALL criteria passed
+- Include specific evidence from the output files{' and the attached images' if vision_used else ''}
+"""
+
+
+def parse_judge_json(content: str) -> Dict[str, Any]:
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r'```(?:json)?\s*\n(.*?)\n\s*```', content, re.DOTALL)
+    if fence:
+        try:
+            return json.loads(fence.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    first = content.find('{')
+    last = content.rfind('}')
+    if first != -1 and last > first:
+        try:
+            return json.loads(content[first:last + 1])
+        except json.JSONDecodeError:
+            pass
+    raise ValueError(f'Could not extract JSON from response: {content[:500]}')
+
+
+def judge_rubric(
+    *,
+    rubric_index: int,
+    rubric: Dict[str, Any],
+    file_contents: str,
+    judge: Callable[..., str],
+    image_attachments: Optional[List[Tuple[str, str]]] = None,
+) -> Dict[str, Any]:
+    weight = rubric.get('weight', 0)
+    criteria = normalize_criteria(rubric)
+    attached_images = list(image_attachments or []) if rubric_needs_vision(rubric) else []
+    vision_used = bool(attached_images)
+    prompt = build_judge_prompt(rubric, file_contents, vision_used=vision_used)
+
+    try:
+        if vision_used:
+            content = [ContentText(text=prompt)]
+            content.append(ContentText(text=f'\n## Attached Images ({len(attached_images)} files)'))
+            for idx, (name, url) in enumerate(attached_images, start=1):
+                content.append(ContentText(text=f'Image {idx}: {name}'))
+                content.append(ContentImage(image=url))
+            raw_response = judge(
+                messages=[
+                    ChatMessageSystem(content='You are an evaluation judge. Return valid JSON only, with no markdown.'),
+                    ChatMessageUser(content=content),
+                ]
+            )
+        else:
+            raw_response = judge(
+                prompt=prompt,
+                system_prompt='You are an evaluation judge. Return valid JSON only, with no markdown.',
+            )
+        parsed = parse_judge_json(raw_response.strip())
+    except Exception as exc:
+        return build_failed_rubric_result(rubric_index, rubric, f'Judge failed: {exc}')
+
+    model_criteria = parsed.get('criteria_results', [])
+    criteria_results = []
+    for idx, criterion in enumerate(criteria):
+        item = model_criteria[idx] if idx < len(model_criteria) and isinstance(model_criteria[idx], dict) else {}
+        criteria_results.append({
+            'index': idx,
+            'criterion': criterion,
+            'passed': bool(item.get('passed', False)),
+            'reasoning': item.get('reasoning', ''),
+            'evidence': item.get('evidence', ''),
+        })
+
+    rubric_passed = bool(parsed.get('rubric_passed', False))
+    return {
+        'index': rubric_index,
+        'rubric': rubric.get('rubric', ''),
+        'weight': weight,
+        'result': {
+            'passed': rubric_passed,
+            'score': weight if rubric_passed else 0,
+            'criteria_count': len(criteria),
+            'criteria_passed': sum(1 for item in criteria_results if item['passed']),
+            'criteria_results': criteria_results,
+            'overall_reasoning': parsed.get('overall_reasoning', ''),
+        },
+    }
+
+
+def evaluate_job_bench_output(
+    *,
+    output_dir: Path,
+    rubrics: List[Dict[str, Any]],
+    judge: Callable[..., str],
+) -> Dict[str, Any]:
+    if not rubrics:
+        return {
+            'scorecard': build_scorecard([]),
+            'rubrics': [],
+            'error': 'no rubrics',
+        }
+    if not output_dir.exists() or not any(path.is_file() for path in output_dir.rglob('*')):
+        results = [
+            build_failed_rubric_result(idx, rubric, 'No output files found in the model output directory.')
+            for idx, rubric in enumerate(rubrics)
+        ]
+        return {'scorecard': build_scorecard(results), 'rubrics': results}
+
+    file_contents = extract_all_file_contents(output_dir)
+    if not file_contents.strip():
+        results = [
+            build_failed_rubric_result(idx, rubric, 'Output files were unreadable or empty after conversion.')
+            for idx, rubric in enumerate(rubrics)
+        ]
+        return {'scorecard': build_scorecard(results), 'rubrics': results}
+
+    image_attachments = collect_image_attachments(output_dir)
+    results = []
+    for idx, rubric in enumerate(rubrics):
+        results.append(
+            judge_rubric(
+                rubric_index=idx,
+                rubric=rubric,
+                file_contents=file_contents,
+                judge=judge,
+                image_attachments=image_attachments,
+            )
+        )
+    return {
+        'scorecard': build_scorecard(results),
+        'rubrics': results,
+    }
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding='utf-8', errors='replace')
+    except Exception as exc:
+        return f'[ERROR: Failed to read text file: {path.name}: {exc}]'
+
+
+def _excel_to_text(path: Path) -> str:
+    try:
+        import pandas as pd
+
+        xl = pd.ExcelFile(str(path))
+        parts = []
+        for sheet in xl.sheet_names:
+            df = pd.read_excel(xl, sheet_name=sheet)
+            parts.append(f'=== Sheet: {sheet} ===\n{df.to_csv(index=False)}')
+        return '\n'.join(parts)
+    except ImportError:
+        return f'[ERROR: pandas/openpyxl not available for {path.name}]'
+    except Exception as exc:
+        return f'[ERROR: Failed to read Excel {path.name}: {exc}]'
+
+
+def _docx_to_text(path: Path) -> str:
+    try:
+        import mammoth
+
+        with open(str(path), 'rb') as f:
+            result = mammoth.convert_to_markdown(f)
+        return result.value
+    except ImportError:
+        return f'[ERROR: mammoth not available for {path.name}]'
+    except Exception as exc:
+        return f'[ERROR: Failed to read DOCX {path.name}: {exc}]'
+
+
+def _pdf_to_text(path: Path) -> str:
+    try:
+        import pdfplumber
+
+        with pdfplumber.open(str(path)) as pdf:
+            parts = []
+            for idx, page in enumerate(pdf.pages):
+                text = page.extract_text(layout=True) or ''
+                parts.append(f'=== Page {idx + 1} ===\n{text}')
+        return '\n'.join(parts)
+    except ImportError:
+        return f'[ERROR: pdfplumber not available for {path.name}]'
+    except Exception as exc:
+        return f'[ERROR: Failed to read PDF {path.name}: {exc}]'
+
+
+def _sqlite_to_text(path: Path) -> str:
+    import sqlite3 as sqlite
+
+    try:
+        con = sqlite.connect(str(path))
+        cur = con.cursor()
+        schema = con.execute('SELECT sql FROM sqlite_master WHERE sql IS NOT NULL').fetchall()
+        parts = ['=== Schema ===']
+        parts.extend(row[0] for row in schema if row[0])
+        tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+        for table in tables:
+            parts.append(f'\n=== Table: {table} ===')
+            try:
+                total_rows = con.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+                rows = cur.execute(f'SELECT * FROM "{table}" LIMIT {SQLITE_ROWS_PER_TABLE}').fetchall()
+                cols = [d[0] for d in cur.description]
+                parts.append(f'-- total_rows: {total_rows}; shown: {len(rows)} (LIMIT {SQLITE_ROWS_PER_TABLE})')
+                parts.append(','.join(cols))
+                for row in rows:
+                    parts.append(','.join('' if value is None else str(value) for value in row))
+            except Exception as exc:
+                parts.append(f'[ERROR reading table {table}: {exc}]')
+        con.close()
+        return '\n'.join(parts)
+    except Exception as exc:
+        return f'[ERROR: Failed to read SQLite {path.name}: {exc}]'
+
+
+def _pptx_to_text(path: Path) -> str:
+    try:
+        from pptx import Presentation
+
+        prs = Presentation(str(path))
+        parts = []
+        for idx, slide in enumerate(prs.slides):
+            parts.append(f'=== Slide {idx + 1} ===')
+            for shape in slide.shapes:
+                if hasattr(shape, 'text') and shape.text:
+                    parts.append(shape.text)
+        return '\n'.join(parts)
+    except ImportError:
+        return f'[ERROR: python-pptx not available for {path.name}]'
+    except Exception as exc:
+        return f'[ERROR: Failed to read PowerPoint {path.name}: {exc}]'
+
+
+def _notebook_to_text(path: Path) -> str:
+    try:
+        nb = json.loads(path.read_text(encoding='utf-8'))
+        parts = []
+        for cell in nb.get('cells', []):
+            parts.append(f'=== {cell.get("cell_type", "unknown")} ===')
+            parts.append(''.join(cell.get('source', [])))
+            for output in cell.get('outputs', []):
+                if 'text' in output:
+                    parts.append(''.join(output['text']))
+        return '\n'.join(parts)
+    except Exception as exc:
+        return f'[ERROR: Failed to read notebook {path.name}: {exc}]'

--- a/evalscope/benchmarks/job_bench/utils.py
+++ b/evalscope/benchmarks/job_bench/utils.py
@@ -5,6 +5,7 @@ import binascii
 import hashlib
 import json
 import re
+from contextlib import closing
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from zipfile import BadZipFile, ZipFile
@@ -508,25 +509,24 @@ def _sqlite_to_text(path: Path) -> str:
     import sqlite3 as sqlite
 
     try:
-        con = sqlite.connect(str(path))
-        cur = con.cursor()
-        schema = con.execute('SELECT sql FROM sqlite_master WHERE sql IS NOT NULL').fetchall()
-        parts = ['=== Schema ===']
-        parts.extend(row[0] for row in schema if row[0])
-        tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
-        for table in tables:
-            parts.append(f'\n=== Table: {table} ===')
-            try:
-                total_rows = con.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
-                rows = cur.execute(f'SELECT * FROM "{table}" LIMIT {SQLITE_ROWS_PER_TABLE}').fetchall()
-                cols = [d[0] for d in cur.description]
-                parts.append(f'-- total_rows: {total_rows}; shown: {len(rows)} (LIMIT {SQLITE_ROWS_PER_TABLE})')
-                parts.append(','.join(cols))
-                for row in rows:
-                    parts.append(','.join('' if value is None else str(value) for value in row))
-            except Exception as exc:
-                parts.append(f'[ERROR reading table {table}: {exc}]')
-        con.close()
+        with closing(sqlite.connect(str(path))) as con:
+            cur = con.cursor()
+            schema = con.execute('SELECT sql FROM sqlite_master WHERE sql IS NOT NULL').fetchall()
+            parts = ['=== Schema ===']
+            parts.extend(row[0] for row in schema if row[0])
+            tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+            for table in tables:
+                parts.append(f'\n=== Table: {table} ===')
+                try:
+                    total_rows = con.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+                    rows = cur.execute(f'SELECT * FROM "{table}" LIMIT {SQLITE_ROWS_PER_TABLE}').fetchall()
+                    cols = [d[0] for d in cur.description]
+                    parts.append(f'-- total_rows: {total_rows}; shown: {len(rows)} (LIMIT {SQLITE_ROWS_PER_TABLE})')
+                    parts.append(','.join(cols))
+                    for row in rows:
+                        parts.append(','.join('' if value is None else str(value) for value in row))
+                except Exception as exc:
+                    parts.append(f'[ERROR reading table {table}: {exc}]')
         return '\n'.join(parts)
     except Exception as exc:
         return f'[ERROR: Failed to read SQLite {path.name}: {exc}]'

--- a/tests/benchmark/test_agent.py
+++ b/tests/benchmark/test_agent.py
@@ -272,6 +272,26 @@ class TestAgentBenchmark(TestBenchmark):
             debug=False,
         )
 
+    def test_job_bench(self):
+        """Test JobBench end-to-end with Docker artifacts and LLM judging."""
+        if not env.get('DASHSCOPE_API_KEY'):
+            self.skipTest('DASHSCOPE_API_KEY is required for the JobBench end-to-end test.')
+
+        self._run_dataset_test(
+            'job_bench',
+            limit=5,
+            eval_batch_size=5,
+            collect_perf=False,
+            debug=False,
+            agent_config=NativeAgentConfig(environment='docker', max_steps=80),
+            sandbox=SandboxTaskConfig(
+                default_config={
+                    'image': 'python:3.11-slim-bookworm',
+                    'network_enabled': True,
+                }
+            ),
+        )
+
     def test_wide_search(self):
         """Test WideSearch with real qwen-plus, bash, Fetch MCP, and LLM judging."""
         if not env.get('DASHSCOPE_API_KEY'):


### PR DESCRIPTION
## Summary

- add the native `job_bench` benchmark backed by the ModelScope `evalscope/job-bench` mirror
- run tasks through EvalScope's agent loop with local or Docker workspaces and persistent deliverable artifacts
- port JobBench rubric judging, document extraction, visual attachments, and weighted score aggregation
- add generated benchmark documentation and a real API Docker E2E test

## User impact

Users can evaluate agents on JobBench with EvalScope's existing runner and judge configuration. Reference files are
resolved from the cached ModelScope snapshot, while task deliverables remain available under the EvalScope output
directory after the sandbox is removed.

## Validation

- `pre-commit run --files ...` passed
- `make docs-pipeline BENCHMARK=job_bench FORCE=1` passed
- real API E2E passed with main split, `limit=5`, `eval_batch_size=5`, Docker, and `max_steps=80`
- E2E produced 5 predictions, 5 reviews, 5 artifact directories, and 11 deliverable files
