### PR TITLE
fix(web): accept completed invoke status

### DIFF
--- a/evalscope/web/src/api/schemas/endpointSchemas.test.ts
+++ b/evalscope/web/src/api/schemas/endpointSchemas.test.ts
@@ -29,7 +29,7 @@ const ENDPOINT_CASES: Array<{ name: string; schema: ZodType; valid: unknown }> =
   },
   { name: 'log', schema: logResponseSchema, valid: { text: '', head_line: 0, tail_line: 0, total_lines: 0 } },
   { name: 'task status', schema: taskStatusResponseSchema, valid: { status: 'running', task_id: 'task-1' } },
-  { name: 'eval invoke', schema: evalInvokeResponseSchema, valid: { status: 'ok', task_id: 'task-1' } },
+  { name: 'eval invoke', schema: evalInvokeResponseSchema, valid: { status: 'completed', task_id: 'task-1' } },
   { name: 'progress', schema: progressResponseSchema, valid: { percent: 50, phase: 'evaluate' } },
   { name: 'benchmarks', schema: benchmarksResponseSchema, valid: { text: [] } },
   { name: 'report scan', schema: scanResponseSchema, valid: { reports: ['run-a'] } },
@@ -121,5 +121,15 @@ describe('endpoint response schemas', () => {
 
   it.each(ENDPOINT_CASES)('rejects a non-object $name response', ({ schema }) => {
     expect(schema.safeParse(null).success).toBe(false)
+  })
+})
+
+describe('invoke response status schema', () => {
+  it.each(['ok', 'completed', 'error', 'stopped'])('accepts the supported status %s', (status) => {
+    expect(evalInvokeResponseSchema.safeParse({ status, task_id: 'task-1' }).success).toBe(true)
+  })
+
+  it('rejects an unknown status', () => {
+    expect(evalInvokeResponseSchema.safeParse({ status: 'unknown', task_id: 'task-1' }).success).toBe(false)
   })
 })

--- a/evalscope/web/src/api/schemas/eval.schema.ts
+++ b/evalscope/web/src/api/schemas/eval.schema.ts
@@ -10,7 +10,7 @@
 import { z } from 'zod'
 
 /** Accepted invoke status values. */
-export const invokeStatusSchema = z.enum(['ok', 'error', 'stopped'])
+export const invokeStatusSchema = z.enum(['ok', 'completed', 'error', 'stopped'])
 
 /** Runtime contract for an evaluation invoke response. */
 export const evalInvokeResponseSchema = z.object({


### PR DESCRIPTION
## Summary

  Allow the Web dashboard to accept `completed` as a valid invoke response status.

## Problem

<img width="2396" height="1195" alt="image" src="https://github.com/user-attachments/assets/54099000-bc49-4d92-b315-f023e45acf21" />


  The evaluation and performance invoke endpoints return the following status after a successful task:

  ```json
  {
    "status": "completed",
    "task_id": "..."
  }
```
  However, the frontend runtime schema only accepted:

  - ok
  - error
  - stopped

  As a result, successfully completed tasks were rejected by Zod and displayed as:

  DomainError: Response validation failed

## Changes

  - Add completed to invokeStatusSchema.
  - Preserve ok for backward compatibility.
  - Update the endpoint schema fixture to reflect the current backend response.
  - Add regression tests covering all supported statuses.
  - Add a test ensuring unknown statuses are still rejected.

## Testing

  - 37 endpoint schema tests passed.
  - TypeScript and Vite production build passed.
  - ESLint passed for the modified files.

## Compatibility

  This change is backward compatible. Existing ok, error, and stopped responses remain supported.