### PR TITLE
fix: add encoding='utf-8' to yaml_to_dict for Windows compatibility

### DIFF
--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -375,7 +375,7 @@ def yaml_to_dict(yaml_file: str) -> Any:
     Raises:
         yaml.YAMLError: When the file cannot be parsed.
     """
-    with open(yaml_file, 'r') as f:
+    with open(yaml_file, 'r', encoding='utf-8') as f:
         try:
             return yaml.safe_load(f)
         except yaml.YAMLError as e:


### PR DESCRIPTION
## 问题

`yaml_to_dict` 函数在打开 YAML 文件时未指定编码参数：

```python
with open(yaml_file, 'r') as f:   # Windows 默认 GBK
```

## 影响

在非 UTF-8 默认编码环境（如 Windows 中文系统）下，Python 会以系统默认编码（GBK）读取 UTF-8 文件。当 YAML 配置文件中包含中文注释或内容时，会抛出 `UnicodeDecodeError`，导致 Web 评估页面无法加载报告列表。

## 修复

```python
with open(yaml_file, 'r', encoding='utf-8') as f:
```

与该项目中其他文件读取函数（`jsonl_to_list`、`csv_to_list`、`tsv_to_list`）保持一致，均已指定 `encoding='utf-8'`。