### PR TITLE
fix: normalise ARC answerKey digits to letters in arc_adapter

### DIFF
--- a/evalscope/benchmarks/arc/arc_adapter.py
+++ b/evalscope/benchmarks/arc/arc_adapter.py
@@ -57,6 +57,7 @@ class ARCAdapter(MultiChoiceAdapter):
         super().__init__(**kwargs)
 
     def record_to_sample(self, record) -> Sample:
+        # Convert choice labels to indices (A->0, B->1, etc.)
         choice_texts = record['choices']['text']
         # ARC dataset answerKey is mostly a letter ("A"-"D"), but some entries
         # use digit strings ("1"-"4"). Normalise everything to letters.

--- a/evalscope/benchmarks/arc/arc_adapter.py
+++ b/evalscope/benchmarks/arc/arc_adapter.py
@@ -57,9 +57,12 @@ class ARCAdapter(MultiChoiceAdapter):
         super().__init__(**kwargs)
 
     def record_to_sample(self, record) -> Sample:
-        # Convert choice labels to indices (A->0, B->1, etc.)
         choice_texts = record['choices']['text']
+        # ARC dataset answerKey is mostly a letter ("A"-"D"), but some entries
+        # use digit strings ("1"-"4"). Normalise everything to letters.
         answer_key = record['answerKey']
+        if answer_key.isdigit():
+            answer_key = chr(ord('A') + int(answer_key) - 1)
 
         return Sample(
             input=record['question'],


### PR DESCRIPTION
## 问题

ARC 数据集（`allenai/ai2_arc`）的 `answerKey` 大部分是字母格式（"A"~"D"），但部分条目使用数字格式（"1"~"4"）。经实际查询数据集确认：

| 子集 | 总数 | 数字格式 | 字母格式 |
|------|------|----------|----------|
| ARC-Easy | 2,376 | 97 | 2,279 |
| ARC-Challenge | 1,172 | 22 | 1,150 |
| **合计** | **3,548** | **119** | 3,429 |

`MultipleChoiceTemplate.SINGLE_ANSWER` prompt 模板教模型输出字母格式的答案，但 `record_to_sample` 将原始 `answerKey` 直接透传为 `target`，不做格式转换。

## 影响

模型正确回答字母（如 "B"）vs 数据集中的数字答案（"2"）→ 字符串比较 `"B" != "2"` → 被判 0 分。119 道题（占 3.4%）受影响。

## 修复

```python
answer_key = record['answerKey']
if answer_key.isdigit():
    answer_key = chr(ord('A') + int(answer_key) - 1)
```

## 排查范围

已检查所有 50+ `MultiChoiceAdapter` 子类，其他适配器均无此问题：mmlu 已用 `'ABCD'[idx]`，gpqa 已用 `chr(65+idx)`，hellaswag 已用数组索引。