### PR TITLE
feat(perf): add min row to percentile table and label avg latency metrics

### DIFF
--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -246,9 +246,11 @@ def get_percentile_results(result_db_path: str, api_type: str = None) -> Percent
             ) if row[col_indices[DatabaseColumns.LATENCY]] > 0 else float('nan') for row in rows],
         }
 
-    # Calculate percentiles for each metric and build transposed dict
-    percentile_labels = [f'{p}%' for p in percentiles] + ['max']
-    all_percentiles = percentiles + [100]
+    # Calculate percentiles for each metric and build transposed dict.
+    # Percentile 0 maps to the sorted minimum, surfaced as the 'min' row so
+    # best-case latency can be read alongside 'max' and the p99 tail.
+    percentile_labels = ['min'] + [f'{p}%' for p in percentiles] + ['max']
+    all_percentiles = [0] + percentiles + [100]
     transposed: Dict[str, list] = {PercentileMetrics.PERCENTILES: percentile_labels}
     for metric_name, data in metrics.items():
         metric_percentiles = calculate_percentiles(data, all_percentiles)

--- a/evalscope/perf/utils/perf_constants.py
+++ b/evalscope/perf/utils/perf_constants.py
@@ -39,9 +39,9 @@ class Metrics:
     # LLM-specific
     OUTPUT_TOKEN_THROUGHPUT = 'Output Throughput (tok/s)'
     TOTAL_TOKEN_THROUGHPUT = 'Total Throughput (tok/s)'
-    AVERAGE_TIME_TO_FIRST_TOKEN = 'TTFT (ms)'
-    AVERAGE_TIME_PER_OUTPUT_TOKEN = 'TPOT (ms)'
-    AVERAGE_INTER_TOKEN_LATENCY = 'ITL (ms)'
+    AVERAGE_TIME_TO_FIRST_TOKEN = 'Avg TTFT (ms)'
+    AVERAGE_TIME_PER_OUTPUT_TOKEN = 'Avg TPOT (ms)'
+    AVERAGE_INTER_TOKEN_LATENCY = 'Avg ITL (ms)'
     AVERAGE_OUTPUT_TOKENS_PER_REQUEST = 'Avg Output Tokens'
 
     # Embedding / Rerank-specific
@@ -50,11 +50,11 @@ class Metrics:
     # Multi-turn specific
     AVERAGE_INPUT_TURNS_PER_REQUEST = 'Avg Turns/Request'
     AVERAGE_CACHED_PERCENT = 'KV Cache Hit Rate (%)'
-    AVERAGE_FIRST_TURN_TTFT = 'First-Turn TTFT (ms)'
-    AVERAGE_SUBSEQUENT_TURN_TTFT = 'Subsequent-Turn TTFT (ms)'
+    AVERAGE_FIRST_TURN_TTFT = 'Avg First-Turn TTFT (ms)'
+    AVERAGE_SUBSEQUENT_TURN_TTFT = 'Avg Subsequent-Turn TTFT (ms)'
 
     # Speculative decoding specific
-    AVERAGE_DECODED_TOKENS_PER_ITER = 'Decoded Tok/Iter'
+    AVERAGE_DECODED_TOKENS_PER_ITER = 'Avg Decoded Tok/Iter'
     APPROX_SPECULATIVE_ACCEPTANCE_RATE = 'Spec. Accept Rate'
 
     @staticmethod

--- a/tests/perf/test_stream_metrics.py
+++ b/tests/perf/test_stream_metrics.py
@@ -157,6 +157,23 @@ class TestPercentileBucketing(unittest.TestCase):
             self.assertNotEqual(tpot, 0.0, f'TPOT at {p} must not be 0 (non-stream excluded)')
             self.assertEqual(row['ITL (ms)'], 30.0, f'ITL at {p} must be 30ms (stream-only)')
 
+    def test_min_row_reports_best_case_latency(self):
+        # The 'min' row (P0) must be present and hold the smallest latency values
+        # for TTFT/TPOT/ITL so best-case latency is readable alongside 'max'.
+        result = get_percentile_results(self.db, api_type='openai')
+        rows = result.to_list()
+        labels = [r['Percentiles'] for r in rows]
+        self.assertEqual(labels[0], 'min', "'min' must be the first percentile row")
+        self.assertIn('max', labels)
+        min_row = rows[0]
+        # Stream TPOT values are 30/60/90/120ms -> min 30ms; TTFT fixed at 500ms; ITL 30ms.
+        self.assertEqual(min_row['TPOT (ms)'], 30.0)
+        self.assertEqual(min_row['TTFT (ms)'], 500.0)
+        self.assertEqual(min_row['ITL (ms)'], 30.0)
+        # min must not exceed the corresponding max for the same metric.
+        max_row = next(r for r in rows if r['Percentiles'] == 'max')
+        self.assertLessEqual(min_row['TPOT (ms)'], max_row['TPOT (ms)'])
+
     def test_pure_non_stream_percentiles_fall_back_to_all_rows(self):
         # Pure non-stream run: no stream rows, so streaming metrics fall back to
         # all rows (backward compatible) instead of producing NaN.


### PR DESCRIPTION
## What's changed

Fixes #1511 (both the feature request and the follow-up console-clarity feedback).

### 1. Add a `min` row (P0) to the percentile table
The percentile results table previously reported `1% … 99% / max` but no minimum. This adds a leading `min` column so best-case latency is readable alongside the p99 tail and `max`, covering all metrics (TTFT / TPOT / ITL / Latency, plus throughput and token counts).

`calculate_percentiles` already maps percentile `0` to the sorted minimum, so the change is limited to prepending `0`/`'min'` to the percentile label list — fully backward compatible for existing `1%~99%`/`max`/`get_p99` consumers.

```
┌────────────────┬────────┬────────┬─── … ───┬────────┐
│ Metric         │    min │     1% │   …     │    max │
├────────────────┼────────┼────────┼─── … ───┼────────┤
│ Avg TTFT (ms)  │ 366.48 │ 366.48 │   …     │ 638.76 │
│ Avg TPOT (ms)  │  15.06 │  15.06 │   …     │  21.79 │
└────────────────┴────────┴────────┴─── … ───┴────────┘
```

### 2. Label the average latency metrics in the summary table
The `Benchmarking summary` table listed `TTFT (ms)` / `TPOT (ms)` / `ITL (ms)` without indicating they are averages, while `Avg Latency (s)` did — inconsistent and ambiguous. All average-based metrics now carry the `Avg` prefix:

- `TTFT/TPOT/ITL (ms)` → `Avg TTFT/TPOT/ITL (ms)`
- `First-Turn TTFT (ms)` / `Subsequent-Turn TTFT (ms)` → `Avg …`
- `Decoded Tok/Iter` → `Avg Decoded Tok/Iter`

Non-average metrics (throughputs, `KV Cache Hit Rate (%)`, `Spec. Accept Rate`) are left unchanged.

These names are the single source of truth (`Metrics` in `perf_constants.py`), so the summary table label, `benchmark_summary.json` key, and HTML report update consistently. The per-request rich-display table (which already has explicit avg/p50/p99/max columns) and the percentile table are unaffected.

> Note: this renames a few keys in `benchmark_summary.json` (e.g. `TTFT (ms)` → `Avg TTFT (ms)`), consistent with the earlier v1.9.x label rework. Backward-compat aliasing for old archives was intentionally not added.

## Testing
- New unit test `test_min_row_reports_best_case_latency` covering the `min` row.
- All perf unit tests pass (`tests/perf/test_stream_metrics.py`, `test_rich_display.py`, `test_perf_report_loader.py`, `test_perf_archive.py`).
- Verified end-to-end against a live OpenAI-compatible endpoint (summary + percentile tables render as expected).
- `pre-commit` (flake8 / isort / yapf) passes.
