### PR TITLE
fix: add encoding='utf-8' to remaining core file read/write for Windows compatibility

### DIFF
--- a/evalscope/collections/schema.py
+++ b/evalscope/collections/schema.py
@@ -91,12 +91,12 @@ class CollectionSchema:
 
     def dump_json(self, file_path: str) -> None:
         d = self.to_dict()
-        with open(file_path, 'w') as f:
+        with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(d, f, ensure_ascii=False, indent=4)
 
     @classmethod
     def from_json(cls, file_path: str) -> 'CollectionSchema':
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
         return cls.from_dict(data)
 

--- a/evalscope/perf/plugin/api/dashscope_api.py
+++ b/evalscope/perf/plugin/api/dashscope_api.py
@@ -36,7 +36,7 @@ class DashScopeApiPlugin(ApiPluginBase):
                 if param.query_template.startswith('@'):
                     file_path = param.query_template[1:]
                     if os.path.exists(file_path):
-                        with open(file_path, 'r') as file:
+                        with open(file_path, 'r', encoding='utf-8') as file:
                             query = json.load(file)
                     else:
                         raise FileNotFoundError(f'{file_path}')

--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -61,7 +61,7 @@ class OpenaiPlugin(DefaultApiPlugin):
                 if param.query_template.startswith('@'):
                     file_path = param.query_template[1:]
                     if os.path.exists(file_path):
-                        with open(file_path, 'r') as file:
+                        with open(file_path, 'r', encoding='utf-8') as file:
                             query = json.load(file)
                     else:
                         raise FileNotFoundError(f'{file_path}')

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -185,7 +185,7 @@ class OpenAIResponsesPlugin(DefaultApiPlugin):
     def _load_query_template(query_template: str) -> Dict:
         if query_template.startswith('@'):
             file_path = query_template[1:]
-            with open(file_path, 'r') as file:
+            with open(file_path, 'r', encoding='utf-8') as file:
                 return json.load(file)
         return json.loads(query_template)
 

--- a/evalscope/perf/sla/sla_run.py
+++ b/evalscope/perf/sla/sla_run.py
@@ -409,7 +409,7 @@ class SLAAutoTuner:
         formatted = {f'{self.sla_variable}_{val}': res for val, res in self.results_cache.items()}
         json_path = os.path.join(self.args.outputs_dir, 'sla_summary.json')
         try:
-            with open(json_path, 'w') as f:
+            with open(json_path, 'w', encoding='utf-8') as f:
                 json.dump(formatted, f, indent=4)
             logger.info(f'SLA summary saved to: {json_path}')
         except Exception as e:

--- a/evalscope/perf/utils/db_util.py
+++ b/evalscope/perf/utils/db_util.py
@@ -49,7 +49,7 @@ def encode_data(data) -> str:
 
 
 def write_json_file(data, output_path):
-    with open(output_path, 'w') as f:
+    with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=4, ensure_ascii=False)
 
 

--- a/evalscope/service/blueprints/eval.py
+++ b/evalscope/service/blueprints/eval.py
@@ -239,7 +239,7 @@ def get_evaluation_progress():
 
     progress_file = os.path.join(OUTPUT_DIR, task_id, 'progress.json')
     try:
-        with open(progress_file, 'r') as f:
+        with open(progress_file, 'r', encoding='utf-8') as f:
             progress = json.load(f)
         return jsonify(progress), 200
     except FileNotFoundError:

--- a/evalscope/service/blueprints/perf.py
+++ b/evalscope/service/blueprints/perf.py
@@ -190,7 +190,7 @@ def get_performance_progress():
 
     progress_file = os.path.join(OUTPUT_DIR, task_id, 'perf', 'progress.json')
     try:
-        with open(progress_file, 'r') as f:
+        with open(progress_file, 'r', encoding='utf-8') as f:
             progress = json.load(f)
         return jsonify(progress), 200
     except FileNotFoundError:

--- a/evalscope/summarizer/summarizer.py
+++ b/evalscope/summarizer/summarizer.py
@@ -26,7 +26,7 @@ class Summarizer:
 
         report_files: list = glob.glob(os.path.join(reports_dir, '**/*.json'))
         for report_file in report_files:
-            with open(report_file, 'r') as f:
+            with open(report_file, 'r', encoding='utf-8') as f:
                 res_list.append(json.load(f))
 
         report_table: str = gen_table(reports_path_list=[reports_dir])

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -392,7 +392,7 @@ def dict_to_yaml(d: dict, yaml_file: str) -> None:
             created automatically.
     """
     _ensure_dir(os.path.dirname(yaml_file))
-    with open(yaml_file, 'w') as f:
+    with open(yaml_file, 'w', encoding='utf-8') as f:
         yaml.dump(d, f, default_flow_style=False, allow_unicode=True, Dumper=yaml.SafeDumper)
 
 
@@ -408,7 +408,7 @@ def json_to_dict(json_file: str) -> Any:
     Raises:
         json.JSONDecodeError: When the file cannot be parsed.
     """
-    with open(json_file, 'r') as f:
+    with open(json_file, 'r', encoding='utf-8') as f:
         try:
             return json.load(f)
         except json.JSONDecodeError as e:
@@ -426,7 +426,7 @@ def dict_to_json(d: dict, json_file: str) -> None:
     """
     json_file = os.path.expanduser(json_file)
     _ensure_dir(os.path.dirname(json_file))
-    with open(json_file, 'w') as f:
+    with open(json_file, 'w', encoding='utf-8') as f:
         json.dump(d, f, indent=4, ensure_ascii=False)
 
 

--- a/evalscope/utils/tqdm_utils/progress_tracker.py
+++ b/evalscope/utils/tqdm_utils/progress_tracker.py
@@ -131,7 +131,7 @@ class ProgressTracker:
         }
         logger.debug(f'Processed / Total: {processed} / {self._total_count} | {percent}%')
         tmp = self._path + '.tmp'
-        with open(tmp, 'w') as f:
+        with open(tmp, 'w', encoding='utf-8') as f:
             json.dump(state, f, indent=2, ensure_ascii=False)
         os.replace(tmp, self._path)
 


### PR DESCRIPTION
## 问题

继 #1515 修复 `yaml_to_dict` 的编码问题之后，排查发现核心链路中还有多处文本文件读写未指定 `encoding='utf-8'`。在非 UTF-8 默认编码环境（如 Windows 中文系统，默认 GBK）下：

- 读取含中文的 JSON/模板文件会抛出 `UnicodeDecodeError`
- 使用 `ensure_ascii=False` / `allow_unicode=True` 写出中文内容时会抛出 `UnicodeEncodeError`

## 修复范围

本 PR 与 #1515 互补（不含其已修复的 `yaml_to_dict`），共 11 个文件 / 14 处：

| 文件 | 位置 | 说明 |
| --- | --- | --- |
| `evalscope/utils/io_utils.py` | `dict_to_yaml` / `json_to_dict` / `dict_to_json` | 写侧 `allow_unicode=True` / `ensure_ascii=False`，读侧对称修复 |
| `evalscope/perf/utils/db_util.py` | `write_json_file` | `ensure_ascii=False` 写 benchmark 结果 |
| `evalscope/perf/plugin/api/openai_api.py` | query_template 读取 | `@file` 模板可能含中文 |
| `evalscope/perf/plugin/api/dashscope_api.py` | query_template 读取 | 同上 |
| `evalscope/perf/plugin/api/openai_responses_api.py` | `_load_query_template` | 同上 |
| `evalscope/perf/sla/sla_run.py` | sla_summary.json 写入 | |
| `evalscope/service/blueprints/perf.py` | progress.json 读取 | Web 服务进度接口 |
| `evalscope/service/blueprints/eval.py` | progress.json 读取 | 同上 |
| `evalscope/collections/schema.py` | `dump_json` / `from_json` | collection schema 常含中文任务名 |
| `evalscope/summarizer/summarizer.py` | report JSON 读取 | |
| `evalscope/utils/tqdm_utils/progress_tracker.py` | 进度状态写入 | `ensure_ascii=False` |

## 说明

- 未改动 vendored / 第三方代码（`metrics/vision/t2v_metrics/.../lavis/`、`third_party/`）。
- benchmarks / backend/rag_eval 下仍有少量同类问题，可后续按需跟进。
- `make lint` 全部通过。

Related: #1515
