### PR TITLE
fix: per-subset float limit and Anthropic tool call id sanitization

### DIFF
--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -337,11 +337,11 @@ class DatasetDict:
         for key, samples in data_dict.items():
             if key not in subset_list:
                 continue
-            # Apply limit if specified
+            # Apply limit if specified; resolve float limits per subset without
+            # mutating `limit`, so each subset takes its own fraction
             if limit is not None:
-                if isinstance(limit, float):
-                    limit = int(len(samples) * limit)
-                samples = samples[:limit]
+                subset_limit = int(len(samples) * limit) if isinstance(limit, float) else limit
+                samples = samples[:subset_limit]
             # Repeat k times; always deepcopy to avoid mutating the original dataset
             # (repeats=0 yields empty list; repeats=1 yields one isolated copy per sample)
             samples = [copy.deepcopy(sample) for sample in samples for _ in range(repeats)]

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from anthropic import APIStatusError
 from anthropic.types import (
@@ -41,6 +42,7 @@ from evalscope.utils.url_utils import data_uri_mime_type, data_uri_to_base64, fi
 
 BASE_64_DATA_REMOVED = '<base64-data-removed>'
 NO_CONTENT = '[No content]'
+TOOL_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
 AnthropicCacheStrategy = Literal['evaluation', 'recent_messages']
 AnthropicSystemParam = Union[str, List[TextBlockParam]]
 
@@ -231,6 +233,63 @@ def anthropic_message_param(message: ChatMessage) -> MessageParam:
         return MessageParam(role='user', content=content)
 
 
+def _sanitize_tool_call_ids(messages: List[ChatMessage]) -> List[ChatMessage]:
+    """Rewrite tool call ids so they satisfy Anthropic's ``^[a-zA-Z0-9_-]+$``
+    constraint and are unique across the conversation.
+
+    Dataset-provided histories (e.g. general_fc) may carry ids like
+    ``functions.search:0`` which contain illegal characters and repeat across
+    turns, causing 400 errors from the Anthropic API. Ids that are already
+    legal and unique are kept as-is (model-generated ``toolu_xxx`` ids are
+    unaffected). tool_use/tool_result pairing is preserved by remapping each
+    assistant turn's ids and applying the same mapping to subsequent tool
+    messages. Modified messages are copied; the originals are not mutated.
+    """
+    used_ids: set[str] = set()
+
+    def new_id(old_id: str) -> str:
+        sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', old_id) or 'tool_call'
+        candidate = sanitized
+        suffix = 1
+        while candidate in used_ids:
+            candidate = f'{sanitized}_{suffix}'
+            suffix += 1
+        return candidate
+
+    result: List[ChatMessage] = []
+    id_map: Dict[str, str] = {}
+    for message in messages:
+        if isinstance(message, ChatMessageAssistant) and message.tool_calls:
+            # Each assistant turn starts a fresh mapping scope
+            id_map = {}
+            tool_calls: List[ToolCall] = []
+            changed = False
+            for tool_call in message.tool_calls:
+                old_id = str(tool_call.id)
+                mapped_id = old_id if TOOL_ID_PATTERN.match(old_id) and old_id not in used_ids else new_id(old_id)
+                used_ids.add(mapped_id)
+                id_map[old_id] = mapped_id
+                if mapped_id != old_id:
+                    tool_calls.append(tool_call.model_copy(update={'id': mapped_id}))
+                    changed = True
+                else:
+                    tool_calls.append(tool_call)
+            message = message.model_copy(update={'tool_calls': tool_calls}) if changed else message
+        elif isinstance(message, ChatMessageTool):
+            old_id = str(message.tool_call_id)
+            if old_id in id_map:
+                mapped_id = id_map[old_id]
+            elif TOOL_ID_PATTERN.match(old_id):
+                mapped_id = old_id
+            else:
+                # Orphan tool message: sanitize independently
+                mapped_id = new_id(old_id)
+            if mapped_id != old_id:
+                message = message.model_copy(update={'tool_call_id': mapped_id})
+        result.append(message)
+    return result
+
+
 def anthropic_chat_messages(
     messages: List[ChatMessage],
     cache_control: Optional[Dict[str, Any]] = None,
@@ -243,6 +302,9 @@ def anthropic_chat_messages(
     """
     system_message: Optional[AnthropicSystemParam] = None
     message_params: List[MessageParam] = []
+
+    # Normalize tool call ids to satisfy Anthropic's id constraints
+    messages = _sanitize_tool_call_ids(messages)
 
     for message in messages:
         if message.role == 'system':

--- a/evalscope/models/utils/anthropic.py
+++ b/evalscope/models/utils/anthropic.py
@@ -22,6 +22,7 @@ from anthropic.types import (
     ToolUseBlock,
     ToolUseBlockParam,
 )
+from collections import deque
 from copy import copy
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
 
@@ -243,7 +244,9 @@ def _sanitize_tool_call_ids(messages: List[ChatMessage]) -> List[ChatMessage]:
     legal and unique are kept as-is (model-generated ``toolu_xxx`` ids are
     unaffected). tool_use/tool_result pairing is preserved by remapping each
     assistant turn's ids and applying the same mapping to subsequent tool
-    messages. Modified messages are copied; the originals are not mutated.
+    messages; duplicate ids within one turn are disambiguated positionally,
+    pairing each tool_result with its own tool_use in order of appearance.
+    Modified messages are copied; the originals are not mutated.
     """
     used_ids: set[str] = set()
 
@@ -257,7 +260,7 @@ def _sanitize_tool_call_ids(messages: List[ChatMessage]) -> List[ChatMessage]:
         return candidate
 
     result: List[ChatMessage] = []
-    id_map: Dict[str, str] = {}
+    id_map: Dict[str, deque[str]] = {}
     for message in messages:
         if isinstance(message, ChatMessageAssistant) and message.tool_calls:
             # Each assistant turn starts a fresh mapping scope
@@ -268,7 +271,7 @@ def _sanitize_tool_call_ids(messages: List[ChatMessage]) -> List[ChatMessage]:
                 old_id = str(tool_call.id)
                 mapped_id = old_id if TOOL_ID_PATTERN.match(old_id) and old_id not in used_ids else new_id(old_id)
                 used_ids.add(mapped_id)
-                id_map[old_id] = mapped_id
+                id_map.setdefault(old_id, deque()).append(mapped_id)
                 if mapped_id != old_id:
                     tool_calls.append(tool_call.model_copy(update={'id': mapped_id}))
                     changed = True
@@ -278,7 +281,10 @@ def _sanitize_tool_call_ids(messages: List[ChatMessage]) -> List[ChatMessage]:
         elif isinstance(message, ChatMessageTool):
             old_id = str(message.tool_call_id)
             if old_id in id_map:
-                mapped_id = id_map[old_id]
+                # Consume mapped ids positionally so duplicate ids within one
+                # turn pair each tool_result with its own tool_use
+                queue = id_map[old_id]
+                mapped_id = queue.popleft() if len(queue) > 1 else queue[0]
             elif TOOL_ID_PATTERN.match(old_id):
                 mapped_id = old_id
             else:

--- a/tests/api/test_dataset_dict_limit.py
+++ b/tests/api/test_dataset_dict_limit.py
@@ -1,0 +1,41 @@
+from typing import List
+
+from evalscope.api.dataset import MemoryDataset, Sample
+from evalscope.api.dataset.dataset import DatasetDict
+
+
+def _build_dataset(subset_sizes: dict) -> MemoryDataset:
+    samples: List[Sample] = []
+    for subset_key, size in subset_sizes.items():
+        for idx in range(size):
+            samples.append(Sample(input=f'{subset_key}-{idx}', subset_key=subset_key))
+    return MemoryDataset(samples, name='dummy')
+
+
+def test_from_dataset_float_limit_applies_per_subset() -> None:
+    # Regression test for issue #1525: a float limit must be resolved
+    # against each subset's own size, not the first subset's size.
+    dataset = _build_dataset({'small': 4, 'large': 10})
+
+    dataset_dict = DatasetDict.from_dataset(dataset, subset_list=['small', 'large'], limit=0.5)
+
+    assert len(dataset_dict['small']) == 2  # 4 * 0.5
+    assert len(dataset_dict['large']) == 5  # 10 * 0.5, was 2 before the fix
+
+
+def test_from_dataset_int_limit_applies_per_subset() -> None:
+    dataset = _build_dataset({'small': 4, 'large': 10})
+
+    dataset_dict = DatasetDict.from_dataset(dataset, subset_list=['small', 'large'], limit=3)
+
+    assert len(dataset_dict['small']) == 3
+    assert len(dataset_dict['large']) == 3
+
+
+def test_from_dataset_no_limit_keeps_all_samples() -> None:
+    dataset = _build_dataset({'small': 4, 'large': 10})
+
+    dataset_dict = DatasetDict.from_dataset(dataset, subset_list=['small', 'large'], limit=None)
+
+    assert len(dataset_dict['small']) == 4
+    assert len(dataset_dict['large']) == 10

--- a/tests/models/test_anthropic_tool_id_sanitize.py
+++ b/tests/models/test_anthropic_tool_id_sanitize.py
@@ -1,0 +1,115 @@
+"""Tests for Anthropic tool call id sanitization (issue #1523).
+
+Dataset-provided histories (e.g. general_fc) carry tool call ids like
+``functions.search:0`` which violate Anthropic's ``^[a-zA-Z0-9_-]+$``
+constraint and repeat across turns. The conversion layer must rewrite them
+while preserving tool_use/tool_result pairing.
+"""
+import pytest
+import re
+
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageTool, ChatMessageUser
+from evalscope.api.tool import ToolCall, ToolFunction
+
+VALID_ID = re.compile(r'^[a-zA-Z0-9_-]+$')
+
+
+def _anthropic_utils():
+    pytest.importorskip('anthropic')
+    from evalscope.models.utils import anthropic
+
+    return anthropic
+
+
+def _tool_call(call_id: str, name: str = 'search') -> ToolCall:
+    return ToolCall(id=call_id, function=ToolFunction(name=name, arguments={'query': 'q'}))
+
+
+def _collect_blocks(messages, block_type: str):
+    blocks = []
+    for message in messages:
+        content = message['content']
+        if isinstance(content, str):
+            continue
+        blocks.extend(block for block in content if block.get('type') == block_type)
+    return blocks
+
+
+def test_illegal_and_duplicate_tool_ids_are_sanitized_and_paired():
+    anthropic = _anthropic_utils()
+
+    # Two turns reusing the same illegal id, mirroring general_fc data
+    _, messages = anthropic.anthropic_chat_messages([
+        ChatMessageUser(content='first question'),
+        ChatMessageAssistant(content='', tool_calls=[_tool_call('functions.search:0')]),
+        ChatMessageTool(content='result 1', tool_call_id='functions.search:0'),
+        ChatMessageAssistant(content='', tool_calls=[_tool_call('functions.search:0')]),
+        ChatMessageTool(content='result 2', tool_call_id='functions.search:0'),
+        ChatMessageUser(content='second question'),
+    ])
+
+    tool_use_blocks = _collect_blocks(messages, 'tool_use')
+    tool_result_blocks = _collect_blocks(messages, 'tool_result')
+    assert len(tool_use_blocks) == 2
+    assert len(tool_result_blocks) == 2
+
+    tool_use_ids = [block['id'] for block in tool_use_blocks]
+    tool_result_ids = [block['tool_use_id'] for block in tool_result_blocks]
+
+    # All ids must satisfy Anthropic's constraint
+    for tool_id in tool_use_ids + tool_result_ids:
+        assert VALID_ID.match(tool_id), f'illegal id: {tool_id}'
+    # Ids must be unique across turns
+    assert len(set(tool_use_ids)) == 2
+    # Each tool_result must pair with its own turn's tool_use
+    assert tool_result_ids == tool_use_ids
+
+
+def test_multiple_tool_calls_in_one_turn_keep_distinct_pairing():
+    anthropic = _anthropic_utils()
+
+    _, messages = anthropic.anthropic_chat_messages([
+        ChatMessageUser(content='question'),
+        ChatMessageAssistant(
+            content='',
+            tool_calls=[_tool_call('functions.search:0'), _tool_call('functions.search:1')],
+        ),
+        ChatMessageTool(content='result 0', tool_call_id='functions.search:0'),
+        ChatMessageTool(content='result 1', tool_call_id='functions.search:1'),
+        ChatMessageUser(content='follow up'),
+    ])
+
+    tool_use_ids = [block['id'] for block in _collect_blocks(messages, 'tool_use')]
+    tool_result_ids = [block['tool_use_id'] for block in _collect_blocks(messages, 'tool_result')]
+
+    assert len(set(tool_use_ids)) == 2
+    assert tool_result_ids == tool_use_ids
+
+
+def test_legal_tool_ids_are_kept_unchanged():
+    anthropic = _anthropic_utils()
+
+    _, messages = anthropic.anthropic_chat_messages([
+        ChatMessageUser(content='question'),
+        ChatMessageAssistant(content='', tool_calls=[_tool_call('toolu_abc123')]),
+        ChatMessageTool(content='result', tool_call_id='toolu_abc123'),
+        ChatMessageUser(content='follow up'),
+    ])
+
+    tool_use_ids = [block['id'] for block in _collect_blocks(messages, 'tool_use')]
+    tool_result_ids = [block['tool_use_id'] for block in _collect_blocks(messages, 'tool_result')]
+
+    assert tool_use_ids == ['toolu_abc123']
+    assert tool_result_ids == ['toolu_abc123']
+
+
+def test_sanitization_does_not_mutate_original_messages():
+    anthropic = _anthropic_utils()
+
+    assistant = ChatMessageAssistant(content='', tool_calls=[_tool_call('functions.search:0')])
+    tool = ChatMessageTool(content='result', tool_call_id='functions.search:0')
+
+    anthropic.anthropic_chat_messages([ChatMessageUser(content='q'), assistant, tool])
+
+    assert assistant.tool_calls[0].id == 'functions.search:0'
+    assert tool.tool_call_id == 'functions.search:0'

--- a/tests/models/test_anthropic_tool_id_sanitize.py
+++ b/tests/models/test_anthropic_tool_id_sanitize.py
@@ -86,6 +86,29 @@ def test_multiple_tool_calls_in_one_turn_keep_distinct_pairing():
     assert tool_result_ids == tool_use_ids
 
 
+def test_duplicate_ids_within_one_turn_pair_positionally():
+    anthropic = _anthropic_utils()
+
+    # Malformed history: one assistant turn reuses the SAME id for two calls
+    _, messages = anthropic.anthropic_chat_messages([
+        ChatMessageUser(content='question'),
+        ChatMessageAssistant(
+            content='',
+            tool_calls=[_tool_call('functions.search:0'), _tool_call('functions.search:0')],
+        ),
+        ChatMessageTool(content='result A', tool_call_id='functions.search:0'),
+        ChatMessageTool(content='result B', tool_call_id='functions.search:0'),
+        ChatMessageUser(content='follow up'),
+    ])
+
+    tool_use_ids = [block['id'] for block in _collect_blocks(messages, 'tool_use')]
+    tool_result_ids = [block['tool_use_id'] for block in _collect_blocks(messages, 'tool_result')]
+
+    # Each tool_use gets a distinct id and is referenced exactly once, in order
+    assert len(set(tool_use_ids)) == 2
+    assert tool_result_ids == tool_use_ids
+
+
 def test_legal_tool_ids_are_kept_unchanged():
     anthropic = _anthropic_utils()
 


### PR DESCRIPTION
## Summary

Fixes two P1 bugs:

1. **#1525** — On datasets with multiple subsets built via `DatasetDict.from_dataset` (e.g. MMLU-Pro), a float `--limit` was resolved into an integer using the **first** subset's size, then that integer was reused for **all** subsets (the loop mutated the `limit` variable in place). With `--limit 0.1` on MMLU-Pro, every subset got exactly 41 samples (574 total) instead of ~10% of each subset (~1203 total).
2. **#1523** — `general_fc` (and any dataset with pre-recorded tool-call history) failed with 400 errors when evaluated via `--eval-type anthropic_api`. The conversion layer passed dataset-provided tool call ids (e.g. `functions.search:0`) straight through to the Anthropic API, violating its `^[a-zA-Z0-9_-]+$` id constraint; the same id also repeats across turns in the data, breaking tool_use/tool_result pairing.

Closes #1525
Closes #1523

## Changes

- `evalscope/api/dataset/dataset.py`: resolve float limits into a per-subset local `subset_limit` instead of mutating `limit` on the first iteration.
- `evalscope/models/utils/anthropic.py`: new `_sanitize_tool_call_ids()` pre-pass in `anthropic_chat_messages()` — replaces illegal characters with `_`, deduplicates ids across turns with a numeric suffix, and applies the same per-turn mapping to subsequent tool messages so tool_use/tool_result pairing is preserved. Already-legal unique ids (e.g. model-generated `toolu_xxx`) are kept unchanged, and messages are copied via `model_copy` so original samples are never mutated.
- New regression tests: `tests/api/test_dataset_dict_limit.py` (3 cases), `tests/models/test_anthropic_tool_id_sanitize.py` (4 cases, no network).

## Testing

- Unit: 7 new tests pass; `tests/models/test_anthropic_prompt_cache.py` regression passes; `tests/cli/test_all.py::TestRun::test_ci_lite` passes; `make lint` clean.
- E2E #1525 (local vLLM, Qwen2.5-0.5B-Instruct): `--datasets mmlu_pro --limit 0.01` now yields per-subset Num of 4/13/11/9/11/7/8/12/7/4/8/9/7/3 (113 total ≈ 12032 x 1%), instead of a constant count reused from the first subset.
- E2E #1523 (local vLLM `/v1/messages` with `--enable-auto-tool-choice --tool-call-parser hermes`): 100 general_fc samples via `--eval-type anthropic_api` completed with **zero** 400 errors; 68 of them carried tool-message history with illegal ids (`functions.img_gen:0`, `functions.search:1`, ...), so the sanitization path was genuinely exercised. Offline check: all 2000 general_fc conversations convert to legal, per-conversation-unique, correctly paired ids (2136 tool_use/tool_result pairs).
