### PR TITLE
fix: assign result of str.replace() in math parser

### DIFF
--- a/evalscope/metrics/math/parser.py
+++ b/evalscope/metrics/math/parser.py
@@ -174,8 +174,8 @@ def strip_answer_string(string):
     string = re.sub(r'\\mbox{.*?}', '', string)
 
     # quote
-    string.replace("'", '')
-    string.replace('"', '')
+    string = string.replace("'", '')
+    string = string.replace('"', '')
 
     # i, j
     if 'j' in string and 'i' not in string:


### PR DESCRIPTION
string.replace() returns a new string and does not mutate in place. The return values were discarded, so quotes were never actually removed from answer strings, causing math_equal to report false negatives.