### PR TITLE
fix(ifbench): download correct NLTK English tagger

### DIFF
--- a/evalscope/utils/resource_utils.py
+++ b/evalscope/utils/resource_utils.py
@@ -27,6 +27,7 @@ def check_nltk_data(name: str) -> None:
     import nltk
 
     GITEE_MIRROR = 'https://gitee.com/yzy0612/nltk_data/raw/gh-pages/packages'
+    NLTK_DATA_RAW = 'https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages'
 
     MIRROR_MAP = {
         'punkt_tab': {
@@ -47,11 +48,11 @@ def check_nltk_data(name: str) -> None:
             ],
         },
         'averaged_perceptron_tagger_eng': {
-            'resource_path': 'taggers/averaged_perceptron_tagger',
-            'zip_name': 'averaged_perceptron_tagger.zip',
+            'resource_path': 'taggers/averaged_perceptron_tagger_eng/',
+            'zip_name': 'averaged_perceptron_tagger_eng.zip',
             'extract_dir': 'taggers',
             'urls': [
-                f'{GITEE_MIRROR}/taggers/averaged_perceptron_tagger.zip',
+                f'{NLTK_DATA_RAW}/taggers/averaged_perceptron_tagger_eng.zip',
             ],
         },
     }
@@ -83,14 +84,14 @@ def check_nltk_data(name: str) -> None:
                     os.remove(zip_path)
         raise RuntimeError(f'All mirrors failed for "{meta["zip_name"]}": {last_error}')
 
-    try:
-        if name in MIRROR_MAP:
-            meta = MIRROR_MAP[name]
-            if not has_resource(meta['resource_path']):
-                logger.warning(f'NLTK resource "{name}" not found, downloading from mirror.')
-                download_from_mirrors(meta)
-    except Exception as e:
-        logger.error(f'NLTK data setup failed: {e}')
+    meta = MIRROR_MAP.get(name)
+    if meta is None or has_resource(meta['resource_path']):
+        return
+
+    logger.warning(f'NLTK resource "{name}" not found, downloading from mirror.')
+    download_from_mirrors(meta)
+    if not has_resource(meta['resource_path']):
+        raise RuntimeError(f'NLTK resource "{name}" is still unavailable after download.')
 
 
 def _create_empty_benchmark_entry() -> Dict[str, Any]:

--- a/tests/test_resource_utils.py
+++ b/tests/test_resource_utils.py
@@ -1,0 +1,107 @@
+import pytest
+import sys
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+from evalscope.utils import resource_utils
+
+
+class _FakeNltkData:
+
+    def __init__(self, available: bool = False):
+        self.available = available
+        self.lookups = []
+
+    def find(self, resource_path: str) -> str:
+        self.lookups.append(resource_path)
+        if not self.available:
+            raise LookupError(resource_path)
+        return resource_path
+
+
+@pytest.fixture(autouse=True)
+def clear_check_nltk_data_cache() -> Iterator[None]:
+    resource_utils.check_nltk_data.cache_clear()
+    yield
+    resource_utils.check_nltk_data.cache_clear()
+
+
+def _install_fake_nltk(monkeypatch: pytest.MonkeyPatch, data: _FakeNltkData) -> None:
+    monkeypatch.setitem(sys.modules, 'nltk', SimpleNamespace(data=data))
+
+
+def test_check_nltk_data_skips_existing_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = _FakeNltkData(available=True)
+    _install_fake_nltk(monkeypatch, data)
+    download_calls = []
+    monkeypatch.setattr(resource_utils, 'download_url', lambda *args, **kwargs: download_calls.append((args, kwargs)))
+
+    resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
+
+    assert data.lookups == ['taggers/averaged_perceptron_tagger_eng/']
+    assert download_calls == []
+
+
+def test_check_nltk_data_downloads_english_tagger(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data = _FakeNltkData()
+    _install_fake_nltk(monkeypatch, data)
+    monkeypatch.setenv('HOME', str(tmp_path))
+    download_urls = []
+
+    def fake_download(url: str, save_path: str) -> None:
+        download_urls.append(url)
+        with zipfile.ZipFile(save_path, 'w') as archive:
+            archive.writestr('averaged_perceptron_tagger_eng/weights.json', '{}')
+        data.available = True
+
+    monkeypatch.setattr(resource_utils, 'download_url', fake_download)
+
+    resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
+
+    assert download_urls == [
+        'https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/taggers/'
+        'averaged_perceptron_tagger_eng.zip'
+    ]
+    assert data.lookups == [
+        'taggers/averaged_perceptron_tagger_eng/',
+        'taggers/averaged_perceptron_tagger_eng/',
+    ]
+    assert not (tmp_path / 'nltk_data/taggers/averaged_perceptron_tagger_eng.zip').exists()
+
+
+def test_check_nltk_data_raises_when_resource_is_still_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data = _FakeNltkData()
+    _install_fake_nltk(monkeypatch, data)
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    def fake_download(url: str, save_path: str) -> None:
+        with zipfile.ZipFile(save_path, 'w') as archive:
+            archive.writestr('wrong_resource/weights.json', '{}')
+
+    monkeypatch.setattr(resource_utils, 'download_url', fake_download)
+
+    with pytest.raises(RuntimeError, match='still unavailable after download'):
+        resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
+
+    assert not (tmp_path / 'nltk_data/taggers/averaged_perceptron_tagger_eng.zip').exists()
+
+
+def test_check_nltk_data_propagates_download_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data = _FakeNltkData()
+    _install_fake_nltk(monkeypatch, data)
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    def fail_download(url: str, save_path: str) -> None:
+        raise OSError('offline')
+
+    monkeypatch.setattr(resource_utils, 'download_url', fail_download)
+
+    with pytest.raises(RuntimeError, match='All mirrors failed'):
+        resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
+
+    assert not (tmp_path / 'nltk_data/taggers/averaged_perceptron_tagger_eng.zip').exists()


### PR DESCRIPTION
## Summary

This PR fixes the NLTK resource setup used by IFBench for English part-of-speech tagging.

IFBench requests `averaged_perceptron_tagger_eng`, but the resource helper currently checks and downloads the legacy `averaged_perceptron_tagger` package. Setup can therefore appear to succeed while the resource required by current NLTK remains unavailable.

## Root Cause

The mirror entry for `averaged_perceptron_tagger_eng` maps the requested resource to different legacy names:

```text
requested:  taggers/averaged_perceptron_tagger_eng/
checked:    taggers/averaged_perceptron_tagger
downloaded: averaged_perceptron_tagger.zip
```

Current NLTK loads the English perceptron tagger from `taggers/averaged_perceptron_tagger_eng/`, so downloading the legacy package does not satisfy the lookup.

The helper also catches setup failures and only logs them, which allows evaluation to continue until NLTK raises a less direct lookup error later.

## Changes

- Check and download `averaged_perceptron_tagger_eng.zip` from the official NLTK data repository.
- Verify the resource is discoverable after extraction.
- Propagate download and post-download validation failures to the caller.
- Keep existing resources as a no-op and preserve the existing cache behavior.
- Add regression tests for existing, successfully downloaded, still-missing, and failed-download resources.

## Validation

```bash
python -m pytest tests/test_resource_utils.py -q
```

Result:

```text
4 passed
```

The relevant pre-commit hooks also passed:

```text
flake8, isort, yapf, trailing whitespace, YAML, end-of-file,
requirements, quote normalization, merge-conflict, and line-ending checks
```

The configured NLTK 3.10.0 runtime resolves the corrected resource path successfully, and the official `_eng` archive URL returns HTTP 200.

## Scope

This change only affects automatic setup for mapped NLTK resources. It does not change IFBench instructions, scoring rules, dataset loading, or already-installed resources.
