### PR TITLE
feat(perf): add startup_ramp_seconds for multi-turn benchmark

### DIFF
--- a/evalscope/perf/arguments.py
+++ b/evalscope/perf/arguments.py
@@ -200,6 +200,26 @@ class Arguments(BaseArgument):
     in_flight_task_multiplier: int = 2
     """Max scheduled tasks = parallel * this multiplier."""
 
+    startup_ramp_seconds: Optional[float] = None
+    """Stagger multi-turn workers' initial spawn across this many seconds
+    via a Poisson schedule; worker 0 fires at phase start, worker n-1 at
+    exactly ``value`` seconds after. Disabled when None / 0. Applies
+    once at each phase start; takes no part in steady-state operation
+    (``--rate`` still governs turn-to-turn pacing). Auto-skipped on
+    warmup when ``warmup_count <= warmup_ramp_min_conversations`` and on
+    benchmark when ``parallel <= benchmark_ramp_min_parallel``.
+    Single-turn strategies ignore this.
+
+    """
+
+    warmup_ramp_min_conversations: int = 3
+    """Skip the warmup-phase startup ramp when ``warmup_count <=`` this
+    value. Set 0 to disable the guardrail."""
+
+    benchmark_ramp_min_parallel: int = 3
+    """Skip the benchmark-phase startup ramp when ``parallel <=`` this
+    value. Set 0 to disable the guardrail."""
+
     num_workers: int = 0
     """Number of worker processes for CPU-bound dataset/request generation.
 
@@ -475,6 +495,27 @@ class Arguments(BaseArgument):
     def _validate_in_flight_task_multiplier(cls, v: int) -> int:
         return _at_least_one(v)
 
+    @field_validator('startup_ramp_seconds', mode='after')
+    @classmethod
+    def _validate_startup_ramp_seconds(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError(f'--startup-ramp-seconds must be >= 0, got {v}')
+        return v
+
+    @field_validator('warmup_ramp_min_conversations', mode='after')
+    @classmethod
+    def _validate_warmup_ramp_min_conversations(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f'--warmup-ramp-min-conversations must be >= 0, got {v}')
+        return v
+
+    @field_validator('benchmark_ramp_min_parallel', mode='after')
+    @classmethod
+    def _validate_benchmark_ramp_min_parallel(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f'--benchmark-ramp-min-parallel must be >= 0, got {v}')
+        return v
+
     @field_validator('num_workers', mode='after')
     @classmethod
     def _validate_num_workers(cls, v: int) -> int:
@@ -744,6 +785,37 @@ def _add_performance_arguments(parser: argparse.ArgumentParser) -> None:
              'completion (multi-turn finishes every remaining turn of any already-claimed trace, '
              'matching trie). Warmup ignores this. When both --number and --duration are set, '
              'whichever limit is reached first ends the run.')  # noqa: E501
+    parser.add_argument(
+        '--startup-ramp-seconds', type=float, default=None,
+        help=(
+            'Stagger the multi-turn workers\' initial spawn across this many seconds '
+            '(Poisson schedule, rescaled to the requested duration). Solves the '
+            'parallel-sized burst at phase start. Applies at the start of BOTH the '
+            'warmup and benchmark phases; once all workers have spawned the ramp takes '
+            'no further part. Auto-skipped on the warmup phase when warmup count <= 3 '
+            'and on the benchmark phase when --parallel <= 3. Independent of --rate '
+            '(which paces within-conversation turns). Single-turn strategies ignore '
+            'this flag. The ramp window consumes part of any --duration budget on the '
+            'benchmark phase. Default None = disabled (legacy all-at-once spawn).'
+        ),
+    )
+    parser.add_argument(
+        '--warmup-ramp-min-conversations', type=int, default=3,
+        help=(
+            'Skip the warmup-phase startup ramp when warmup_count is at or below this '
+            'value. Default 3 (warmup needs at least 4 conversations for the ramp to '
+            'fire). Set to 0 to disable the warmup-phase ramp guardrail entirely '
+            '(startup-ramp-seconds will always apply on warmup when > 0).'
+        ),
+    )
+    parser.add_argument(
+        '--benchmark-ramp-min-parallel', type=int, default=3,
+        help=(
+            'Skip the benchmark-phase startup ramp when --parallel is at or below '
+            'this value. Default 3 (need at least 4 workers for the ramp curve to be '
+            'visible). Set to 0 to disable the benchmark-phase ramp guardrail entirely.'
+        ),
+    )
 
 
 def _add_sla_arguments(parser: argparse.ArgumentParser) -> None:

--- a/evalscope/perf/core/strategies/multi_turn.py
+++ b/evalscope/perf/core/strategies/multi_turn.py
@@ -223,39 +223,105 @@ class MultiTurnStrategy(BenchmarkStrategy):
                 })
 
     async def run(self) -> None:
-        # Two-phase dispatch: warmup conversations complete in full before any
-        # benchmark conversation starts.  ``_conv_index`` persists across
-        # phases so warmup and benchmark pull disjoint conversations from the
-        # dataset (first ``warmup_count`` vs. the rest).
+        # Two-phase dispatch. ``_conv_index`` carries over so each phase
+        # pulls disjoint conversations from the pool.
         if self._warmup_count > 0:
-            # Warmup ignores --duration (warmup must finish in full before
-            # the timed benchmark window begins, mirroring trie's model).
-            await self._run_phase(budget=self._warmup_count, is_warmup=True, deadline=None)
+            warmup_apply_ramp = (self._warmup_count > self.args.warmup_ramp_min_conversations)
+            if not warmup_apply_ramp and self.args.startup_ramp_seconds:
+                logger.info(
+                    f'Warmup count ({self._warmup_count}) <= '
+                    f'{self.args.warmup_ramp_min_conversations}: '
+                    'skipping startup ramp on warmup.'
+                )
+            await self._run_phase(
+                budget=self._warmup_count,
+                is_warmup=True,
+                deadline=None,
+                apply_startup_ramp=warmup_apply_ramp,
+            )
+        benchmark_apply_ramp = (self.args.parallel > self.args.benchmark_ramp_min_parallel)
+        if not benchmark_apply_ramp and self.args.startup_ramp_seconds:
+            logger.info(
+                f'Parallel ({self.args.parallel}) <= '
+                f'{self.args.benchmark_ramp_min_parallel}: '
+                'skipping startup ramp on benchmark.'
+            )
         await self._run_phase(
             budget=self.args.number,
             is_warmup=False,
             deadline=self._compute_deadline(self.args.duration),
+            apply_startup_ramp=benchmark_apply_ramp,
         )
 
-    async def _run_phase(self, budget: int, is_warmup: bool, deadline: Optional[float] = None) -> None:
+    async def _run_phase(
+        self,
+        budget: int,
+        is_warmup: bool,
+        deadline: Optional[float] = None,
+        apply_startup_ramp: bool = False,
+    ) -> None:
         """Spawn ``args.parallel`` workers and drain them within one phase.
 
-        When ``deadline`` is set, workers stop claiming new conversations once
-        wall-clock crosses it, but any conversation already in progress is
-        allowed to finish all its turns (trace-level soft exit, matches trie).
-        ``budget`` is still honoured as an upper bound on the number of
-        conversations claimed; whichever limit (count or wall-clock) is hit
-        first ends the phase.
+        Whichever of ``budget`` or ``deadline`` fires first ends the phase.
+        With a deadline, already-claimed conversations still run to
+        completion (trace-level soft exit, matches trie).
+        ``apply_startup_ramp`` enables a one-time Poisson spawn stagger
+        (see ``_spawn_workers``).
         """
         self._phase_counter = 0
         self._phase_budget = budget
         self._phase_is_warmup = is_warmup
         self._phase_deadline = deadline
-        workers = [asyncio.create_task(self._worker(worker_id=i)) for i in range(self.args.parallel)]
+        workers = await self._spawn_workers(apply_startup_ramp=apply_startup_ramp)
         try:
             await asyncio.gather(*workers)
         finally:
             for worker in workers:
                 if not worker.done():
                     worker.cancel()
-            await asyncio.gather(*workers, return_exceptions=True)
+            if workers:
+                await asyncio.gather(*workers, return_exceptions=True)
+
+    async def _spawn_workers(self, apply_startup_ramp: bool) -> List[asyncio.Task]:
+        """Spawn ``args.parallel`` workers, optionally staggered across
+        ``startup_ramp_seconds`` via a Poisson schedule (worker 0 immediate,
+        worker n-1 at exactly ``ramp_s``). Disabled ramp or ``parallel == 0``
+        falls back to instant legacy spawn. Returns tasks in spawn order;
+        partial lists on mid-ramp cancellation are cleaned up by the caller.
+        """
+        n = self.args.parallel
+        if n <= 0:
+            return []
+
+        ramp_s: Optional[float] = None
+        if apply_startup_ramp:
+            cfg = self.args.startup_ramp_seconds
+            if cfg is not None and cfg > 0:
+                ramp_s = float(cfg)
+
+        if ramp_s is None:
+            return [asyncio.create_task(self._worker(worker_id=i)) for i in range(n)]
+
+        # n-1 inter-arrival samples cumulated; rescale so the realised total
+        # spans exactly ramp_s (counteracts exponential-sample drift). Worker
+        # 0 fires at the anchor; the array starts at 0 by construction.
+        if n == 1:
+            target_times = np.array([time.perf_counter()])
+        else:
+            offsets = np.cumsum(np.random.exponential(ramp_s / (n - 1), size=n - 1))
+            if offsets[-1] > 0:
+                offsets *= ramp_s / offsets[-1]
+            target_times = np.concatenate(([0.0], offsets)) + time.perf_counter()
+
+        logger.info(f'Startup ramp enabled: staggering {n} worker spawns across '
+                    f'{ramp_s:.3f}s (Poisson).')
+
+        workers: List[asyncio.Task] = []
+        for i in range(n):
+            sleep_s = target_times[i] - time.perf_counter()
+            if self._phase_deadline is not None:  # don't oversleep past deadline
+                sleep_s = min(sleep_s, self._phase_deadline - time.perf_counter())
+            if sleep_s > 0:
+                await asyncio.sleep(sleep_s)
+            workers.append(asyncio.create_task(self._worker(worker_id=i)))
+        return workers

--- a/tests/perf/test_multi_turn_startup_ramp.py
+++ b/tests/perf/test_multi_turn_startup_ramp.py
@@ -1,0 +1,244 @@
+"""Tests for the multi-turn ``startup_ramp_seconds`` mechanism."""
+import argparse
+import asyncio
+import inspect
+import numpy as np
+import pytest
+from unittest.mock import patch
+
+from evalscope.perf.arguments import Arguments, add_argument
+from evalscope.perf.core.strategies import multi_turn as mt
+from evalscope.perf.core.strategies.multi_turn import MultiTurnStrategy
+
+# --- Field defaults, CLI, validators ---
+
+
+_RAMP_FIELDS = [
+    ('startup_ramp_seconds', '--startup-ramp-seconds', None),
+    ('warmup_ramp_min_conversations', '--warmup-ramp-min-conversations', 3),
+    ('benchmark_ramp_min_parallel', '--benchmark-ramp-min-parallel', 3),
+]
+
+
+@pytest.mark.parametrize('field,cli,default', _RAMP_FIELDS)
+def test_field_default_and_cli(field, cli, default):
+    f = Arguments.model_fields[field]
+    assert f.default is default
+    p = argparse.ArgumentParser()
+    add_argument(p)
+    actions = [a for a in p._actions if cli in a.option_strings]
+    assert actions and actions[0].default is default
+
+
+def test_negative_threshold_rejected():
+    with pytest.raises(Exception) as ei:
+        Arguments.model_validate({
+            'model': 'm', 'url': 'http://x/v1/chat/completions',
+            'dataset': 'openqa', 'parallel': 4, 'number': 10,
+            'multi_turn': True,
+            'warmup_ramp_min_conversations': -1,
+        })
+    assert 'warmup-ramp-min-conversations' in str(ei.value)
+
+
+def test_threshold_zero_disables_guardrail():
+    args = Arguments.model_validate({
+        'model': 'm', 'url': 'http://x/v1/chat/completions',
+        'dataset': 'openqa', 'parallel': 4, 'number': 10,
+        'multi_turn': True,
+        'startup_ramp_seconds': 5.0,
+        'warmup_ramp_min_conversations': 0,
+        'benchmark_ramp_min_parallel': 0,
+    })
+    assert args.warmup_ramp_min_conversations == 0
+    assert args.benchmark_ramp_min_parallel == 0
+
+
+# --- No module-level constants; strategy reads via self.args ---
+
+
+def test_thresholds_live_on_arguments():
+    assert not hasattr(mt, '_WARMUP_RAMP_MIN_CONVERSATIONS')
+    assert not hasattr(mt, '_BENCHMARK_RAMP_MIN_PARALLEL')
+    src = inspect.getsource(MultiTurnStrategy.run)
+    assert 'self.args.warmup_ramp_min_conversations' in src
+    assert 'self.args.benchmark_ramp_min_parallel' in src
+
+
+# --- Schedule math ---
+
+
+@pytest.mark.parametrize('seed', [0, 1, 42, 999])
+def test_rescale_locks_last_worker_to_ramp(seed):
+    n, ramp_s = 32, 12.0
+    np.random.seed(seed)
+    offsets = np.cumsum(np.random.exponential(ramp_s / (n - 1), size=n - 1))
+    if offsets[-1] > 0:
+        offsets *= ramp_s / offsets[-1]
+    assert offsets[-1] == pytest.approx(ramp_s, abs=1e-9)
+
+
+def test_rescale_preserves_gap_ratios():
+    n, ramp_s = 50, 5.0
+    np.random.seed(7)
+    offsets = np.cumsum(np.random.exponential(ramp_s / (n - 1), size=n - 1))
+    ratios_before = np.diff(offsets) / offsets[-1]
+    np.testing.assert_allclose(
+        ratios_before, np.diff(offsets * ramp_s / offsets[-1]) / ramp_s,
+    )
+
+
+# --- Spawn loop with mocked clock ---
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    state = {'now': 1000.0}
+    monkeypatch.setattr(mt.time, 'perf_counter', lambda: state['now'])
+
+    async def sleep(s):
+        state['now'] += s
+    monkeypatch.setattr(mt.asyncio, 'sleep', sleep)
+    return state
+
+
+@pytest.fixture
+def noop_worker(monkeypatch):
+    async def noop(self, worker_id):  # noqa: ARG001
+        return None
+    monkeypatch.setattr(MultiTurnStrategy, '_worker', noop)
+
+
+@pytest.fixture
+def capture_create_task(monkeypatch):
+    captured = []
+    real = asyncio.create_task
+    monkeypatch.setattr(
+        mt.asyncio, 'create_task',
+        lambda coro, **kw: captured.append(mt.time.perf_counter()) or real(coro, **kw),
+    )
+    return captured
+
+
+def _strategy(parallel, ramp_s):
+    args = Arguments.model_validate({
+        'model': 'm', 'url': 'http://x/v1/chat/completions',
+        'dataset': 'openqa', 'parallel': parallel, 'number': 10,
+        'multi_turn': True, 'warmup_num': 0,
+        'startup_ramp_seconds': ramp_s,
+    })
+    if isinstance(args.parallel, list):
+        args.parallel = args.parallel[0]
+    if isinstance(args.number, list):
+        args.number = args.number[0]
+    return MultiTurnStrategy(args, None, None, asyncio.Queue(), [])
+
+
+async def _drive(strategy, apply_ramp):
+    """Run ``_spawn_workers`` and clean up no-op tasks."""
+    workers = await strategy._spawn_workers(apply_startup_ramp=apply_ramp)
+    for w in workers:
+        w.cancel()
+    if workers:
+        await asyncio.gather(*workers, return_exceptions=True)
+
+
+@pytest.mark.parametrize(
+    'parallel,ramp_s,apply_ramp,expected_advance',
+    [
+        (20, 10.0, True, 10.0),     # ramp on advances exactly ramp_s
+        (1, 5.0, True, 0.0),        # parallel=1 short-circuit
+        (16, None, True, 0.0),      # ramp disabled (None)
+        (8, 0.0, True, 0.0),        # ramp disabled (0)
+        (8, 4.0, False, 0.0),       # apply_ramp=False short-circuits
+    ],
+)
+def test_spawn_loop_semantics(
+    parallel, ramp_s, apply_ramp, expected_advance,
+    fake_clock, noop_worker, capture_create_task,
+):
+    asyncio.run(_drive(_strategy(parallel, ramp_s), apply_ramp))
+
+    if parallel > 0:
+        assert len(capture_create_task) == parallel
+    assert fake_clock['now'] - 1000.0 == pytest.approx(expected_advance, abs=1e-9)
+
+
+def test_ramp_first_worker_immediate_last_at_exactly_ramp(
+    fake_clock, noop_worker, capture_create_task,
+):
+    n, ramp_s = 20, 10.0
+    asyncio.run(_drive(_strategy(n, ramp_s), apply_ramp=True))
+
+    assert capture_create_task[0] == pytest.approx(1000.0, abs=1e-9)
+    assert capture_create_task[-1] == pytest.approx(1000.0 + ramp_s, abs=1e-9)
+    assert (np.diff(capture_create_task) > 0).all()
+
+
+def test_spawn_zero_parallel_returns_empty(
+    fake_clock, noop_worker, capture_create_task,
+):
+    s = _strategy(parallel=0, ramp_s=10.0)
+    asyncio.run(_drive(s, apply_ramp=True))
+    assert capture_create_task == []
+    assert fake_clock['now'] == 1000.0
+
+
+def test_spawn_does_not_sleep_past_phase_deadline(
+    fake_clock, noop_worker, capture_create_task,
+):
+    n, ramp_s = 20, 10.0
+    deadline = 1000.0 + 5.0  # mid-ramp
+
+    async def drive_with_deadline():
+        s = _strategy(n, ramp_s)
+        s._phase_deadline = deadline
+        workers = await s._spawn_workers(apply_startup_ramp=True)
+        for w in workers:
+            w.cancel()
+        await asyncio.gather(*workers, return_exceptions=True)
+
+    asyncio.run(drive_with_deadline())
+
+    assert fake_clock['now'] <= deadline
+    assert len(capture_create_task) == n
+
+
+# --- Lifetime: ramp helper called exactly once per phase ---
+
+
+def test_spawn_workers_called_exactly_once_per_phase(
+    fake_clock, noop_worker, capture_create_task,
+):
+    s = _strategy(parallel=100, ramp_s=30.0)
+    spawn_calls = {'n': 0}
+    real_spawn = s._spawn_workers
+
+    async def counting(apply_startup_ramp):
+        spawn_calls['n'] += 1
+        return await real_spawn(apply_startup_ramp)
+
+    with patch.object(MultiTurnStrategy, '_spawn_workers', side_effect=counting):
+        async def drive():
+            s._phase_counter = 0
+            s._phase_budget = 100
+            s._phase_is_warmup = False
+            s._phase_deadline = None
+            await s._run_phase(
+                budget=100, is_warmup=False, deadline=None,
+                apply_startup_ramp=True,
+            )
+
+        asyncio.run(drive())
+
+    assert spawn_calls['n'] == 1
+    assert len(capture_create_task) == 100
+
+
+# --- run() gate skip-log gating ---
+
+
+def test_run_skip_logs_gated_by_ramp_configured():
+    src = inspect.getsource(MultiTurnStrategy.run)
+    assert 'if not warmup_apply_ramp and self.args.startup_ramp_seconds:' in src
+    assert 'if not benchmark_apply_ramp and self.args.startup_ramp_seconds:' in src


### PR DESCRIPTION
Staggers worker spawn across the first `parallel` slots using a Poisson schedule (rescaled so worker n-1 lands exactly at the configured duration). Once the ramp completes, `--rate` resumes governing turn-to-turn pacing.

Applies at the start of both warmup and benchmark phases. Two threshold fields gate the ramp against configurations where the curve would not be visible: `warmup_ramp_min_conversations` and
`benchmark_ramp_min_parallel` (each default 3, set 0 to disable).