### PR TITLE
feat(perception_bench): add PerceptionBench atomic visual perception benchmark

### DIFF
--- a/docs/en/benchmarks/perception_bench.md
+++ b/docs/en/benchmarks/perception_bench.md
@@ -1,0 +1,161 @@
+# PerceptionBench
+
+
+## Overview
+
+PerceptionBench is a benchmark from Moonshot AI that evaluates the atomic visual perception
+capabilities of multimodal large language models. It is built bottom-up: the earliest failure
+points of frontier MLLMs on 42 existing benchmarks were diagnosed to derive an error taxonomy
+whose perception branch defines ten atomic perceptual capabilities. Each question isolates a
+single capability, so difficulty stems from perception rather than reasoning or knowledge.
+
+## Task Description
+
+- **Task Type**: Visual Perception (open-ended question answering)
+- **Input**: One or more images interleaved with a question
+- **Output**: Free-form short answer with a uniquely determined reference
+- **Domain**: Atomic visual perception across ten capabilities
+
+## Key Features
+
+- 3,000 verified questions covering ten atomic perceptual capabilities
+- 1,800 questions (60%) are atomic sub-questions decomposed from attributed failures on source
+  benchmarks; 1,200 (40%) are newly authored on supplemented images
+- Subsets follow the ten `error_category` labels: visual relation, counting, attribute,
+  depth & 3D perception, localization, comparison, fine-grained recognition, contextual
+  integration, OCR, and perception-related hallucination
+- Multi-image questions are supported: images are interleaved into the question via
+  `<|image_N|>` placeholders
+- Samples carrying a `hint` (coordinate convention or image dimensions) pass it as a system
+  message, matching the official message builder
+
+## Evaluation Notes
+
+- Default evaluation uses the **train** split (3,000 samples, single split dataset)
+- Primary metric: **Accuracy**, reported overall and per capability
+- Scoring follows the official protocol: an LLM judge grades the free-form answer against the
+  reference with the teacher-grading prompt and returns a strict 0/1 verdict per item
+  (`[reason]` / `[judge] True|False`); the paper uses GPT-oss-120B, whose agreement with human
+  judgment is 99.7% on a 300-sample audit
+- Empty or failed generations are scored 0 without invoking the judge
+- Requires `judge_model_args` configuration for the LLM judge
+- The dataset embeds images as base64 data URIs (~1.6 GB download on first use)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `perception_bench` |
+| **Dataset ID** | [moonshotai/PerceptionBench](https://modelscope.cn/datasets/moonshotai/PerceptionBench/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2607.24957) |
+| **Tags** | `MultiModal`, `QA` |
+| **Metrics** | `acc` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `train` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 3,000 |
+| Prompt Length (Mean) | 233.87 chars |
+| Prompt Length (Min/Max) | 29 / 1076 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `visual_relation_error` | 330 | 275.62 | 43 | 876 |
+| `visual_counting_error` | 330 | 161.11 | 37 | 831 |
+| `visual_attribute_error` | 330 | 225.58 | 34 | 1006 |
+| `depth_3d_perception_error` | 330 | 278.5 | 60 | 976 |
+| `visual_localization_error` | 330 | 284.79 | 62 | 1076 |
+| `visual_comparison_error` | 279 | 270.14 | 39 | 801 |
+| `fine_grained_recognition_error` | 290 | 225.91 | 44 | 917 |
+| `context_integration_error` | 255 | 277.04 | 58 | 845 |
+| `ocr_error` | 255 | 175.39 | 29 | 934 |
+| `hallucination` | 271 | 150.94 | 42 | 515 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 3,567 |
+| Images per Sample | min: 1, max: 8, mean: 1.19 |
+| Resolution Range | 101x64 - 5712x4953 |
+| Formats | jpeg, png, webp |
+
+
+## Sample Example
+
+**Subset**: `visual_relation_error`
+
+```json
+{
+  "input": [
+    {
+      "id": "28bf28ec",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~97.9KB]"
+        },
+        {
+          "text": "How many arrows does the dashed box intersect with? Just answer with the number."
+        }
+      ]
+    }
+  ],
+  "target": "4",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "visual_relation_error",
+  "metadata": {
+    "index": 5,
+    "problem": "<|image_1|>How many arrows does the dashed box intersect with? Just answer with the number.",
+    "error_category": "visual_relation_error",
+    "source_bmk": "NA",
+    "source_idx": null
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets perception_bench \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['perception_bench'],
+    dataset_args={
+        'perception_bench': {
+            # subset_list: ['visual_relation_error', 'visual_counting_error', 'visual_attribute_error']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -47,6 +47,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `omni_bench` | [OmniBench](../../benchmarks/omni_bench.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `omni_doc_bench` | [OmniDocBench](../../benchmarks/omni_doc_bench.md) | `Knowledge`, `MultiModal`, `QA` |
 | `omni_doc_bench_v1_6` | [OmniDocBench-v1.6](../../benchmarks/omni_doc_bench_v1_6.md) | `Knowledge`, `MultiModal`, `QA` |
+| `perception_bench` | [PerceptionBench](../../benchmarks/perception_bench.md) | `MultiModal`, `QA` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
 | `science_qa` | [ScienceQA](../../benchmarks/science_qa.md) | `Knowledge`, `MCQ`, `MultiModal` |
@@ -110,6 +111,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/omni_bench.md
 ../../benchmarks/omni_doc_bench.md
 ../../benchmarks/omni_doc_bench_v1_6.md
+../../benchmarks/perception_bench.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md
 ../../benchmarks/science_qa.md

--- a/docs/zh/benchmarks/perception_bench.md
+++ b/docs/zh/benchmarks/perception_bench.md
@@ -1,0 +1,148 @@
+# PerceptionBench
+
+
+## 概述
+
+PerceptionBench 是由 Moonshot AI 提出的一项基准测试，用于评估多模态大语言模型（MLLM）的原子级视觉感知能力。该基准采用自底向上的构建方式：通过对前沿 MLLM 在 42 个现有基准上最早出现的失败点进行诊断，归纳出一个错误分类体系，其中感知分支定义了十种原子级感知能力。每个问题仅聚焦于单一能力，因此其难度来源于感知本身，而非推理或知识。
+
+## 任务描述
+
+- **任务类型**：视觉感知（开放式问答）
+- **输入**：一张或多张图像与一个问题交错排列
+- **输出**：自由格式的简短答案，且具有唯一确定的参考答案
+- **领域**：涵盖十种原子级视觉感知能力
+
+## 主要特性
+
+- 包含 3,000 个经过验证的问题，覆盖十种原子级感知能力
+- 其中 1,800 个问题（60%）是从源基准中归因失败案例分解出的原子子问题；1,200 个问题（40%）是在补充图像上全新编写的问题
+- 子集对应十种 `error_category` 标签：视觉关系、计数、属性、深度与 3D 感知、定位、比较、细粒度识别、上下文整合、OCR 和感知相关幻觉
+- 支持多图像问题：图像通过 `<|image_N|>` 占位符嵌入到问题中
+- 对于带有 `hint`（坐标约定或图像尺寸）的样本，会以系统消息形式传递，与官方消息构建器保持一致
+
+## 评估说明
+
+- 默认评估使用 **train** 切分（3,000 个样本，单切分数据集）
+- 主要指标：**准确率（Accuracy）**，报告整体及各能力维度的结果
+- 评分遵循官方协议：使用 LLM 评判器，根据教师评分提示（teacher-grading prompt）将自由格式答案与参考答案对比，并对每个样本返回严格的 0/1 判定（`[reason]` / `[judge] True|False`）；论文中使用的 GPT-oss-120B 模型在 300 个样本的人工审核中与人类判断的一致性达 99.7%
+- 空输出或生成失败的样本直接记为 0 分，不调用评判器
+- 需要配置 `judge_model_args` 以指定 LLM 评判器
+- 数据集中图像以 base64 data URI 形式嵌入（首次使用时下载约 1.6 GB）
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `perception_bench` |
+| **数据集ID** | [moonshotai/PerceptionBench](https://modelscope.cn/datasets/moonshotai/PerceptionBench/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2607.24957) |
+| **标签** | `MultiModal`, `QA` |
+| **指标** | `acc` |
+| **默认示例数** | 0-shot |
+| **评估切分** | `train` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 3,000 |
+| 提示词长度（平均） | 233.87 字符 |
+| 提示词长度（最小/最大） | 29 / 1076 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `visual_relation_error` | 330 | 275.62 | 43 | 876 |
+| `visual_counting_error` | 330 | 161.11 | 37 | 831 |
+| `visual_attribute_error` | 330 | 225.58 | 34 | 1006 |
+| `depth_3d_perception_error` | 330 | 278.5 | 60 | 976 |
+| `visual_localization_error` | 330 | 284.79 | 62 | 1076 |
+| `visual_comparison_error` | 279 | 270.14 | 39 | 801 |
+| `fine_grained_recognition_error` | 290 | 225.91 | 44 | 917 |
+| `context_integration_error` | 255 | 277.04 | 58 | 845 |
+| `ocr_error` | 255 | 175.39 | 29 | 934 |
+| `hallucination` | 271 | 150.94 | 42 | 515 |
+
+**图像统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 3,567 |
+| 每样本图像数 | 最小: 1, 最大: 8, 平均: 1.19 |
+| 分辨率范围 | 101x64 - 5712x4953 |
+| 格式 | jpeg, png, webp |
+
+
+## 样例示例
+
+**子集**: `visual_relation_error`
+
+```json
+{
+  "input": [
+    {
+      "id": "28bf28ec",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~97.9KB]"
+        },
+        {
+          "text": "How many arrows does the dashed box intersect with? Just answer with the number."
+        }
+      ]
+    }
+  ],
+  "target": "4",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "visual_relation_error",
+  "metadata": {
+    "index": 5,
+    "problem": "<|image_1|>How many arrows does the dashed box intersect with? Just answer with the number.",
+    "error_category": "visual_relation_error",
+    "source_bmk": "NA",
+    "source_idx": null
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets perception_bench \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['perception_bench'],
+    dataset_args={
+        'perception_bench': {
+            # subset_list: ['visual_relation_error', 'visual_counting_error', 'visual_attribute_error']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -47,6 +47,7 @@
 | `omni_bench` | [OmniBench](../../benchmarks/omni_bench.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `omni_doc_bench` | [OmniDocBench](../../benchmarks/omni_doc_bench.md) | `Knowledge`, `MultiModal`, `QA` |
 | `omni_doc_bench_v1_6` | [OmniDocBench-v1.6](../../benchmarks/omni_doc_bench_v1_6.md) | `Knowledge`, `MultiModal`, `QA` |
+| `perception_bench` | [PerceptionBench](../../benchmarks/perception_bench.md) | `MultiModal`, `QA` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
 | `science_qa` | [ScienceQA](../../benchmarks/science_qa.md) | `Knowledge`, `MCQ`, `MultiModal` |
@@ -110,6 +111,7 @@
 ../../benchmarks/omni_bench.md
 ../../benchmarks/omni_doc_bench.md
 ../../benchmarks/omni_doc_bench_v1_6.md
+../../benchmarks/perception_bench.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md
 ../../benchmarks/science_qa.md

--- a/evalscope/benchmarks/_meta/perception_bench.json
+++ b/evalscope/benchmarks/_meta/perception_bench.json
@@ -1,0 +1,547 @@
+{
+  "meta": {
+    "pretty_name": "PerceptionBench",
+    "dataset_id": "moonshotai/PerceptionBench",
+    "paper_url": "https://arxiv.org/abs/2607.24957",
+    "tags": [
+      "MultiModal",
+      "QA"
+    ],
+    "metrics": [
+      "acc"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "train",
+    "train_split": "",
+    "subset_list": [
+      "visual_relation_error",
+      "visual_counting_error",
+      "visual_attribute_error",
+      "depth_3d_perception_error",
+      "visual_localization_error",
+      "visual_comparison_error",
+      "fine_grained_recognition_error",
+      "context_integration_error",
+      "ocr_error",
+      "hallucination"
+    ],
+    "description": "\n## Overview\n\nPerceptionBench is a benchmark from Moonshot AI that evaluates the atomic visual perception\ncapabilities of multimodal large language models. It is built bottom-up: the earliest failure\npoints of frontier MLLMs on 42 existing benchmarks were diagnosed to derive an error taxonomy\nwhose perception branch defines ten atomic perceptual capabilities. Each question isolates a\nsingle capability, so difficulty stems from perception rather than reasoning or knowledge.\n\n## Task Description\n\n- **Task Type**: Visual Perception (open-ended question answering)\n- **Input**: One or more images interleaved with a question\n- **Output**: Free-form short answer with a uniquely determined reference\n- **Domain**: Atomic visual perception across ten capabilities\n\n## Key Features\n\n- 3,000 verified questions covering ten atomic perceptual capabilities\n- 1,800 questions (60%) are atomic sub-questions decomposed from attributed failures on source\n  benchmarks; 1,200 (40%) are newly authored on supplemented images\n- Subsets follow the ten `error_category` labels: visual relation, counting, attribute,\n  depth & 3D perception, localization, comparison, fine-grained recognition, contextual\n  integration, OCR, and perception-related hallucination\n- Multi-image questions are supported: images are interleaved into the question via\n  `<|image_N|>` placeholders\n- Samples carrying a `hint` (coordinate convention or image dimensions) pass it as a system\n  message, matching the official message builder\n\n## Evaluation Notes\n\n- Default evaluation uses the **train** split (3,000 samples, single split dataset)\n- Primary metric: **Accuracy**, reported overall and per capability\n- Scoring follows the official protocol: an LLM judge grades the free-form answer against the\n  reference with the teacher-grading prompt and returns a strict 0/1 verdict per item\n  (`[reason]` / `[judge] True|False`); the paper uses GPT-oss-120B, whose agreement with human\n  judgment is 99.7% on a 300-sample audit\n- Empty or failed generations are scored 0 without invoking the judge\n- Requires `judge_model_args` configuration for the LLM judge\n- The dataset embeds images as base64 data URIs (~1.6 GB download on first use)\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm"
+  },
+  "statistics": {
+    "total_samples": 3000,
+    "subset_stats": [
+      {
+        "name": "visual_relation_error",
+        "sample_count": 330,
+        "prompt_length_mean": 275.62,
+        "prompt_length_min": 43,
+        "prompt_length_max": 876,
+        "prompt_length_std": 154.22,
+        "target_length_mean": 2.69,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 384,
+            "count_per_sample": {
+              "min": 1,
+              "max": 4,
+              "mean": 1.16
+            },
+            "resolutions": [
+              "1000x556",
+              "1000x563",
+              "100x100",
+              "1010x637",
+              "1023x605",
+              "1023x995",
+              "1024x353",
+              "1024x533",
+              "1024x735",
+              "1024x789"
+            ],
+            "resolution_range": {
+              "min": "85x87",
+              "max": "4128x4128"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "visual_counting_error",
+        "sample_count": 330,
+        "prompt_length_mean": 161.11,
+        "prompt_length_min": 37,
+        "prompt_length_max": 831,
+        "prompt_length_std": 101.24,
+        "target_length_mean": 2.04,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 392,
+            "count_per_sample": {
+              "min": 1,
+              "max": 5,
+              "mean": 1.19
+            },
+            "resolutions": [
+              "1000x560",
+              "100x100",
+              "100x138",
+              "1024x1024",
+              "1024x538",
+              "1024x640",
+              "1036x775",
+              "1039x294",
+              "1042x586",
+              "1048x486"
+            ],
+            "resolution_range": {
+              "min": "100x100",
+              "max": "5559x4070"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "visual_attribute_error",
+        "sample_count": 330,
+        "prompt_length_mean": 225.58,
+        "prompt_length_min": 34,
+        "prompt_length_max": 1006,
+        "prompt_length_std": 152.11,
+        "target_length_mean": 2.27,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 372,
+            "count_per_sample": {
+              "min": 1,
+              "max": 6,
+              "mean": 1.13
+            },
+            "resolutions": [
+              "1000x752",
+              "1008x1008",
+              "100x100",
+              "100x110",
+              "101x64",
+              "1024x1024",
+              "1024x573",
+              "1024x642",
+              "1024x670",
+              "1024x694"
+            ],
+            "resolution_range": {
+              "min": "101x64",
+              "max": "3996x3996"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "depth_3d_perception_error",
+        "sample_count": 330,
+        "prompt_length_mean": 278.5,
+        "prompt_length_min": 60,
+        "prompt_length_max": 976,
+        "prompt_length_std": 139.17,
+        "target_length_mean": 2.01,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 438,
+            "count_per_sample": {
+              "min": 1,
+              "max": 8,
+              "mean": 1.33
+            },
+            "resolutions": [
+              "1000x752",
+              "100x135",
+              "1023x649",
+              "1024x496",
+              "1024x987",
+              "1035x776",
+              "1036x776",
+              "1059x479",
+              "1072x707",
+              "1074x956"
+            ],
+            "resolution_range": {
+              "min": "80x81",
+              "max": "4577x1500"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "visual_localization_error",
+        "sample_count": 330,
+        "prompt_length_mean": 284.79,
+        "prompt_length_min": 62,
+        "prompt_length_max": 1076,
+        "prompt_length_std": 155.06,
+        "target_length_mean": 2.4,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 378,
+            "count_per_sample": {
+              "min": 1,
+              "max": 8,
+              "mean": 1.15
+            },
+            "resolutions": [
+              "1000x1316",
+              "1004x648",
+              "100x100",
+              "1010x960",
+              "1023x612",
+              "1023x649",
+              "1024x496",
+              "1024x576",
+              "1024x732",
+              "1024x735"
+            ],
+            "resolution_range": {
+              "min": "100x100",
+              "max": "3456x4608"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "visual_comparison_error",
+        "sample_count": 279,
+        "prompt_length_mean": 270.14,
+        "prompt_length_min": 39,
+        "prompt_length_max": 801,
+        "prompt_length_std": 144.08,
+        "target_length_mean": 3.01,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 317,
+            "count_per_sample": {
+              "min": 1,
+              "max": 4,
+              "mean": 1.14
+            },
+            "resolutions": [
+              "1000x752",
+              "100x100",
+              "100x104",
+              "1023x758",
+              "1024x1020",
+              "1024x488",
+              "1024x491",
+              "1024x496",
+              "1024x520",
+              "1024x531"
+            ],
+            "resolution_range": {
+              "min": "100x100",
+              "max": "5712x4953"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "fine_grained_recognition_error",
+        "sample_count": 290,
+        "prompt_length_mean": 225.91,
+        "prompt_length_min": 44,
+        "prompt_length_max": 917,
+        "prompt_length_std": 149.03,
+        "target_length_mean": 1.91,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 343,
+            "count_per_sample": {
+              "min": 1,
+              "max": 6,
+              "mean": 1.18
+            },
+            "resolutions": [
+              "1000x556",
+              "1000x752",
+              "100x100",
+              "100x102",
+              "1015x805",
+              "1024x1000",
+              "1024x1015",
+              "1024x1017",
+              "1024x1024",
+              "1024x1447"
+            ],
+            "resolution_range": {
+              "min": "66x103",
+              "max": "4128x4128"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "context_integration_error",
+        "sample_count": 255,
+        "prompt_length_mean": 277.04,
+        "prompt_length_min": 58,
+        "prompt_length_max": 845,
+        "prompt_length_std": 149.47,
+        "target_length_mean": 2.21,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 359,
+            "count_per_sample": {
+              "min": 1,
+              "max": 5,
+              "mean": 1.41
+            },
+            "resolutions": [
+              "100x135",
+              "100x145",
+              "100x146",
+              "1018x699",
+              "1024x1017",
+              "1024x296",
+              "1024x318",
+              "1024x488",
+              "1024x671",
+              "1024x806"
+            ],
+            "resolution_range": {
+              "min": "80x81",
+              "max": "4032x3024"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "ocr_error",
+        "sample_count": 255,
+        "prompt_length_mean": 175.39,
+        "prompt_length_min": 29,
+        "prompt_length_max": 934,
+        "prompt_length_std": 98.49,
+        "target_length_mean": 5.47,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 285,
+            "count_per_sample": {
+              "min": 1,
+              "max": 6,
+              "mean": 1.12
+            },
+            "resolutions": [
+              "1007x1024",
+              "1011x1024",
+              "1015x805",
+              "1023x510",
+              "1024x1017",
+              "1024x1447",
+              "1024x465",
+              "1024x488",
+              "1024x533",
+              "1024x534"
+            ],
+            "resolution_range": {
+              "min": "160x60",
+              "max": "5119x3413"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "hallucination",
+        "sample_count": 271,
+        "prompt_length_mean": 150.94,
+        "prompt_length_min": 42,
+        "prompt_length_max": 515,
+        "prompt_length_std": 82.55,
+        "target_length_mean": 1.59,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 299,
+            "count_per_sample": {
+              "min": 1,
+              "max": 5,
+              "mean": 1.1
+            },
+            "resolutions": [
+              "1011x1024",
+              "1023x649",
+              "1024x1447",
+              "1024x483",
+              "1024x488",
+              "1024x533",
+              "1024x654",
+              "1024x704",
+              "1024x721",
+              "1024x727"
+            ],
+            "resolution_range": {
+              "min": "127x123",
+              "max": "3456x4608"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 233.87,
+      "min": 29,
+      "max": 1076,
+      "std": 144.61
+    },
+    "target_length_mean": 2.52,
+    "computed_at": "2026-08-06T15:39:26.184335",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 3567,
+        "count_per_sample": {
+          "min": 1,
+          "max": 8,
+          "mean": 1.19
+        },
+        "resolutions": [
+          "1000x1316",
+          "1000x556",
+          "1000x560",
+          "1000x563",
+          "1000x752",
+          "1004x648",
+          "1007x1024",
+          "1008x1008",
+          "100x100",
+          "100x102"
+        ],
+        "resolution_range": {
+          "min": "101x64",
+          "max": "5712x4953"
+        },
+        "formats": [
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "28bf28ec",
+          "content": [
+            {
+              "image": "[BASE64_IMAGE: png, ~97.9KB]"
+            },
+            {
+              "text": "How many arrows does the dashed box intersect with? Just answer with the number."
+            }
+          ]
+        }
+      ],
+      "target": "4",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "visual_relation_error",
+      "metadata": {
+        "index": 5,
+        "problem": "<|image_1|>How many arrows does the dashed box intersect with? Just answer with the number.",
+        "error_category": "visual_relation_error",
+        "source_bmk": "NA",
+        "source_idx": null
+      }
+    },
+    "subset": "visual_relation_error",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# PerceptionBench\n\n\n## Overview\n\nPerceptionBench is a benchmark from Moonshot AI that evaluates the atomic visual perception\ncapabilities of multimodal large language models. It is built bottom-up: the earliest failure\npoints of frontier MLLMs on 42 existing benchmarks were diagnosed to derive an error taxonomy\nwhose perception branch defines ten atomic perceptual capabilities. Each question isolates a\nsingle capability, so difficulty stems from perception rather than reasoning or knowledge.\n\n## Task Description\n\n- **Task Type**: Visual Perception (open-ended question answering)\n- **Input**: One or more images interleaved with a question\n- **Output**: Free-form short answer with a uniquely determined reference\n- **Domain**: Atomic visual perception across ten capabilities\n\n## Key Features\n\n- 3,000 verified questions covering ten atomic perceptual capabilities\n- 1,800 questions (60%) are atomic sub-questions decomposed from attributed failures on source\n  benchmarks; 1,200 (40%) are newly authored on supplemented images\n- Subsets follow the ten `error_category` labels: visual relation, counting, attribute,\n  depth & 3D perception, localization, comparison, fine-grained recognition, contextual\n  integration, OCR, and perception-related hallucination\n- Multi-image questions are supported: images are interleaved into the question via\n  `<|image_N|>` placeholders\n- Samples carrying a `hint` (coordinate convention or image dimensions) pass it as a system\n  message, matching the official message builder\n\n## Evaluation Notes\n\n- Default evaluation uses the **train** split (3,000 samples, single split dataset)\n- Primary metric: **Accuracy**, reported overall and per capability\n- Scoring follows the official protocol: an LLM judge grades the free-form answer against the\n  reference with the teacher-grading prompt and returns a strict 0/1 verdict per item\n  (`[reason]` / `[judge] True|False`); the paper uses GPT-oss-120B, whose agreement with human\n  judgment is 99.7% on a 300-sample audit\n- Empty or failed generations are scored 0 without invoking the judge\n- Requires `judge_model_args` configuration for the LLM judge\n- The dataset embeds images as base64 data URIs (~1.6 GB download on first use)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `perception_bench` |\n| **Dataset ID** | [moonshotai/PerceptionBench](https://modelscope.cn/datasets/moonshotai/PerceptionBench/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2607.24957) |\n| **Tags** | `MultiModal`, `QA` |\n| **Metrics** | `acc` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `train` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 3,000 |\n| Prompt Length (Mean) | 233.87 chars |\n| Prompt Length (Min/Max) | 29 / 1076 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `visual_relation_error` | 330 | 275.62 | 43 | 876 |\n| `visual_counting_error` | 330 | 161.11 | 37 | 831 |\n| `visual_attribute_error` | 330 | 225.58 | 34 | 1006 |\n| `depth_3d_perception_error` | 330 | 278.5 | 60 | 976 |\n| `visual_localization_error` | 330 | 284.79 | 62 | 1076 |\n| `visual_comparison_error` | 279 | 270.14 | 39 | 801 |\n| `fine_grained_recognition_error` | 290 | 225.91 | 44 | 917 |\n| `context_integration_error` | 255 | 277.04 | 58 | 845 |\n| `ocr_error` | 255 | 175.39 | 29 | 934 |\n| `hallucination` | 271 | 150.94 | 42 | 515 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 3,567 |\n| Images per Sample | min: 1, max: 8, mean: 1.19 |\n| Resolution Range | 101x64 - 5712x4953 |\n| Formats | jpeg, png, webp |\n\n\n## Sample Example\n\n**Subset**: `visual_relation_error`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"28bf28ec\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~97.9KB]\"\n        },\n        {\n          \"text\": \"How many arrows does the dashed box intersect with? Just answer with the number.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"4\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"visual_relation_error\",\n  \"metadata\": {\n    \"index\": 5,\n    \"problem\": \"<|image_1|>How many arrows does the dashed box intersect with? Just answer with the number.\",\n    \"error_category\": \"visual_relation_error\",\n    \"source_bmk\": \"NA\",\n    \"source_idx\": null\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets perception_bench \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['perception_bench'],\n    dataset_args={\n        'perception_bench': {\n            # subset_list: ['visual_relation_error', 'visual_counting_error', 'visual_attribute_error']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# PerceptionBench\n\n\n## 概述\n\nPerceptionBench 是由 Moonshot AI 提出的一项基准测试，用于评估多模态大语言模型（MLLM）的原子级视觉感知能力。该基准采用自底向上的构建方式：通过对前沿 MLLM 在 42 个现有基准上最早出现的失败点进行诊断，归纳出一个错误分类体系，其中感知分支定义了十种原子级感知能力。每个问题仅聚焦于单一能力，因此其难度来源于感知本身，而非推理或知识。\n\n## 任务描述\n\n- **任务类型**：视觉感知（开放式问答）\n- **输入**：一张或多张图像与一个问题交错排列\n- **输出**：自由格式的简短答案，且具有唯一确定的参考答案\n- **领域**：涵盖十种原子级视觉感知能力\n\n## 主要特性\n\n- 包含 3,000 个经过验证的问题，覆盖十种原子级感知能力\n- 其中 1,800 个问题（60%）是从源基准中归因失败案例分解出的原子子问题；1,200 个问题（40%）是在补充图像上全新编写的问题\n- 子集对应十种 `error_category` 标签：视觉关系、计数、属性、深度与 3D 感知、定位、比较、细粒度识别、上下文整合、OCR 和感知相关幻觉\n- 支持多图像问题：图像通过 `<|image_N|>` 占位符嵌入到问题中\n- 对于带有 `hint`（坐标约定或图像尺寸）的样本，会以系统消息形式传递，与官方消息构建器保持一致\n\n## 评估说明\n\n- 默认评估使用 **train** 切分（3,000 个样本，单切分数据集）\n- 主要指标：**准确率（Accuracy）**，报告整体及各能力维度的结果\n- 评分遵循官方协议：使用 LLM 评判器，根据教师评分提示（teacher-grading prompt）将自由格式答案与参考答案对比，并对每个样本返回严格的 0/1 判定（`[reason]` / `[judge] True|False`）；论文中使用的 GPT-oss-120B 模型在 300 个样本的人工审核中与人类判断的一致性达 99.7%\n- 空输出或生成失败的样本直接记为 0 分，不调用评判器\n- 需要配置 `judge_model_args` 以指定 LLM 评判器\n- 数据集中图像以 base64 data URI 形式嵌入（首次使用时下载约 1.6 GB）\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `perception_bench` |\n| **数据集ID** | [moonshotai/PerceptionBench](https://modelscope.cn/datasets/moonshotai/PerceptionBench/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2607.24957) |\n| **标签** | `MultiModal`, `QA` |\n| **指标** | `acc` |\n| **默认示例数** | 0-shot |\n| **评估切分** | `train` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 3,000 |\n| 提示词长度（平均） | 233.87 字符 |\n| 提示词长度（最小/最大） | 29 / 1076 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `visual_relation_error` | 330 | 275.62 | 43 | 876 |\n| `visual_counting_error` | 330 | 161.11 | 37 | 831 |\n| `visual_attribute_error` | 330 | 225.58 | 34 | 1006 |\n| `depth_3d_perception_error` | 330 | 278.5 | 60 | 976 |\n| `visual_localization_error` | 330 | 284.79 | 62 | 1076 |\n| `visual_comparison_error` | 279 | 270.14 | 39 | 801 |\n| `fine_grained_recognition_error` | 290 | 225.91 | 44 | 917 |\n| `context_integration_error` | 255 | 277.04 | 58 | 845 |\n| `ocr_error` | 255 | 175.39 | 29 | 934 |\n| `hallucination` | 271 | 150.94 | 42 | 515 |\n\n**图像统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 3,567 |\n| 每样本图像数 | 最小: 1, 最大: 8, 平均: 1.19 |\n| 分辨率范围 | 101x64 - 5712x4953 |\n| 格式 | jpeg, png, webp |\n\n\n## 样例示例\n\n**子集**: `visual_relation_error`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"28bf28ec\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~97.9KB]\"\n        },\n        {\n          \"text\": \"How many arrows does the dashed box intersect with? Just answer with the number.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"4\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"visual_relation_error\",\n  \"metadata\": {\n    \"index\": 5,\n    \"problem\": \"<|image_1|>How many arrows does the dashed box intersect with? Just answer with the number.\",\n    \"error_category\": \"visual_relation_error\",\n    \"source_bmk\": \"NA\",\n    \"source_idx\": null\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets perception_bench \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['perception_bench'],\n    dataset_args={\n        'perception_bench': {\n            # subset_list: ['visual_relation_error', 'visual_counting_error', 'visual_attribute_error']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "aa4d9c37736b1d37a5ee689bf1956f10",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-06T15:39:35.193926",
+  "translation_updated_at": "2026-08-06T15:39:40"
+}

--- a/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
+++ b/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
@@ -10,6 +10,7 @@ from evalscope.api.metric.scorer import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
 from evalscope.utils.logger import get_logger
+from .utils import build_judge_prompt, parse_judge_verdict
 
 logger = get_logger()
 
@@ -161,14 +162,12 @@ class PerceptionBenchAdapter(VisionLanguageAdapter):
         task_state: TaskState,
     ) -> Score:
         """Score a prediction with the official PerceptionBench teacher-grading judge."""
-        from .utils import build_judge_prompt, parse_judge_verdict
-
         score = Score(
             extracted_prediction=filtered_prediction,
             prediction=original_prediction,
         )
 
-        if not (original_prediction or '').strip():
+        if not original_prediction.strip():
             # Mirrors the official evaluator: unanswered items score 0 without a judge call.
             score.value = {'acc': 0.0}
             score.explanation = 'failed to obtain answer'

--- a/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
+++ b/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
@@ -1,0 +1,180 @@
+# flake8: noqa: E501
+import base64
+from typing import Any, Dict, List, Optional
+
+from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageSystem, ChatMessageUser, Content
+from evalscope.api.metric.scorer import Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+DESCRIPTION = """
+## Overview
+
+PerceptionBench is a benchmark from Moonshot AI that evaluates the atomic visual perception
+capabilities of multimodal large language models. It is built bottom-up: the earliest failure
+points of frontier MLLMs on 42 existing benchmarks were diagnosed to derive an error taxonomy
+whose perception branch defines ten atomic perceptual capabilities. Each question isolates a
+single capability, so difficulty stems from perception rather than reasoning or knowledge.
+
+## Task Description
+
+- **Task Type**: Visual Perception (open-ended question answering)
+- **Input**: One or more images interleaved with a question
+- **Output**: Free-form short answer with a uniquely determined reference
+- **Domain**: Atomic visual perception across ten capabilities
+
+## Key Features
+
+- 3,000 verified questions covering ten atomic perceptual capabilities
+- 1,800 questions (60%) are atomic sub-questions decomposed from attributed failures on source
+  benchmarks; 1,200 (40%) are newly authored on supplemented images
+- Subsets follow the ten `error_category` labels: visual relation, counting, attribute,
+  depth & 3D perception, localization, comparison, fine-grained recognition, contextual
+  integration, OCR, and perception-related hallucination
+- Multi-image questions are supported: images are interleaved into the question via
+  `<|image_N|>` placeholders
+- Samples carrying a `hint` (coordinate convention or image dimensions) pass it as a system
+  message, matching the official message builder
+
+## Evaluation Notes
+
+- Default evaluation uses the **train** split (3,000 samples, single split dataset)
+- Primary metric: **Accuracy**, reported overall and per capability
+- Scoring follows the official protocol: an LLM judge grades the free-form answer against the
+  reference with the teacher-grading prompt and returns a strict 0/1 verdict per item
+  (`[reason]` / `[judge] True|False`); the paper uses GPT-oss-120B, whose agreement with human
+  judgment is 99.7% on a 300-sample audit
+- Empty or failed generations are scored 0 without invoking the judge
+- Requires `judge_model_args` configuration for the LLM judge
+- The dataset embeds images as base64 data URIs (~1.6 GB download on first use)
+"""
+
+SUBSET_LIST = [
+    'visual_relation_error',
+    'visual_counting_error',
+    'visual_attribute_error',
+    'depth_3d_perception_error',
+    'visual_localization_error',
+    'visual_comparison_error',
+    'fine_grained_recognition_error',
+    'context_integration_error',
+    'ocr_error',
+    'hallucination',
+]
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='perception_bench',
+        pretty_name='PerceptionBench',
+        dataset_id='moonshotai/PerceptionBench',
+        tags=[Tags.MULTI_MODAL, Tags.QA],
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2607.24957',
+        subset_list=SUBSET_LIST,
+        metric_list=['acc'],
+        eval_split='train',
+    )
+)
+class PerceptionBenchAdapter(VisionLanguageAdapter):
+    """Data adapter for moonshotai/PerceptionBench.
+
+    Interleaves the question with its images following the official `<|image_N|>`
+    placeholder convention and scores free-form answers with the official LLM judge.
+    """
+    llm_judge_default = True
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reformat_subset = True
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Optional[Sample]:
+        """Convert a PerceptionBench record to a Sample."""
+        problem: str = record.get('problem', '')
+        images: List[str] = record.get('image') or []
+
+        # Official placeholders are <|image_N|>; normalize them to the framework syntax.
+        text = problem
+        image_map = {}
+        for idx, image in enumerate(images, start=1):
+            text = text.replace(f'<|image_{idx}|>', f'<image_{idx}>')
+            image_map[idx] = self._data_uri_to_base64(image)
+
+        content_list: List[Content] = self._parse_text_with_images(text=text, image_map=image_map)
+        if not content_list:
+            logger.warning(f'Record {record.get("index")} has no usable content, skipping.')
+            return None
+
+        messages = []
+        hint: str = record.get('hint') or ''
+        if hint.strip():
+            messages.append(ChatMessageSystem(content=hint))
+        messages.append(ChatMessageUser(content=content_list))
+
+        return Sample(
+            input=messages,
+            target=str(record.get('answer', '')),
+            subset_key=record.get('error_category', ''),
+            metadata={
+                'index': record.get('index'),
+                'problem': problem,
+                'error_category': record.get('error_category', ''),
+                'source_bmk': record.get('source_bmk', ''),
+                'source_idx': record.get('source_idx'),
+            },
+        )
+
+    def _data_uri_to_base64(self, image: str) -> str:
+        """Re-encode a base64 data URI so the shared image size limit applies."""
+        header, _, payload = image.partition(',')
+        if not payload:
+            # Not a data URI (e.g. a plain URL): pass through unchanged.
+            return image
+        image_format = header.split('/')[-1].split(';')[0] or 'jpeg'
+        return self._image_bytes_to_base64(base64.b64decode(payload), default_format=image_format)
+
+    def llm_match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        """Score a prediction with the official PerceptionBench teacher-grading judge."""
+        from .utils import build_judge_prompt, parse_judge_verdict
+
+        score = Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+        )
+
+        if not (original_prediction or '').strip():
+            # Mirrors the official evaluator: unanswered items score 0 without a judge call.
+            score.value = {'acc': 0.0}
+            score.explanation = 'failed to obtain answer'
+            return score
+
+        metadata = task_state.metadata or {}
+        prompt = build_judge_prompt(
+            question=metadata.get('problem', task_state.input_text),
+            prediction=original_prediction,
+            reference=reference,
+        )
+        judge_response = self.llm_judge.judge(prompt)
+        judge_score, judge_reason = parse_judge_verdict(judge_response)
+
+        score.value = {'acc': judge_score}
+        score.explanation = f'LLM judge: {judge_response}'
+        score.metadata = {
+            'source': 'llm_judge',
+            'judge_strategy': self.judge_strategy,
+            'model': self.llm_judge.model_id,
+            'judge_reason': judge_reason,
+        }
+        return score

--- a/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
+++ b/evalscope/benchmarks/perception_bench/perception_bench_adapter.py
@@ -103,8 +103,12 @@ class PerceptionBenchAdapter(VisionLanguageAdapter):
         text = problem
         image_map = {}
         for idx, image in enumerate(images, start=1):
+            image_b64 = self._data_uri_to_base64(image)
+            if image_b64 is None:
+                logger.warning(f'Record {record.get("index")} has an undecodable image, skipping.')
+                return None
             text = text.replace(f'<|image_{idx}|>', f'<image_{idx}>')
-            image_map[idx] = self._data_uri_to_base64(image)
+            image_map[idx] = image_b64
 
         content_list: List[Content] = self._parse_text_with_images(text=text, image_map=image_map)
         if not content_list:
@@ -130,14 +134,24 @@ class PerceptionBenchAdapter(VisionLanguageAdapter):
             },
         )
 
-    def _data_uri_to_base64(self, image: str) -> str:
-        """Re-encode a base64 data URI so the shared image size limit applies."""
+    def _data_uri_to_base64(self, image: str) -> Optional[str]:
+        """Re-encode a base64 data URI so the shared image size limit applies.
+
+        Returns:
+            Optional[str]: The re-encoded data URI, the original string when the value
+            is not a data URI, or ``None`` when the payload cannot be decoded so that
+            the caller can skip the record instead of aborting the dataset load.
+        """
         header, _, payload = image.partition(',')
         if not payload:
             # Not a data URI (e.g. a plain URL): pass through unchanged.
             return image
         image_format = header.split('/')[-1].split(';')[0] or 'jpeg'
-        return self._image_bytes_to_base64(base64.b64decode(payload), default_format=image_format)
+        try:
+            return self._image_bytes_to_base64(base64.b64decode(payload), default_format=image_format)
+        except Exception as e:
+            logger.warning(f'Failed to decode image data URI: {e}')
+            return None
 
     def llm_match_score(
         self,

--- a/evalscope/benchmarks/perception_bench/utils.py
+++ b/evalscope/benchmarks/perception_bench/utils.py
@@ -1,0 +1,148 @@
+# flake8: noqa: E501
+"""Utilities for the PerceptionBench judge protocol.
+
+Ports the official grading prompt and verdict parsing from
+https://github.com/MoonshotAI/PerceptionBench (``eval/judge_prompt.txt`` and ``eval/eval.py``).
+"""
+import re
+from typing import Tuple
+
+JUDGE_TEMPLATE = """Please act as a professional teacher and grade the student's answer. Below are the question, the student's answer, and the reference answer. Based on the question and the reference answer, analyze the student's answer and judge whether it correctly answers the question. I will provide several examples to help you understand how to judge.
+
+========== [Output Format] ==========
+Return your judgment in the following format. The first field [reason] gives the reason for your judgment; the second field [judge] gives your verdict as a single boolean, i.e., True or False. Make sure your output ends with True or False.
+[reason]
+<a brief justification of no more than 100 tokens>
+[judge]
+False
+
+========== [Notice] ==========
+0. You only need to compare the consistency between the reference answer and the student's answer, focusing especially on the content after summarizing phrases such as "Final answer:". The reference answer is absolutely correct; judge solely by whether the student's final result matches it, even if the solution process is correct.
+1. If the question contains multiple sub-questions, output the student's answer, the reference answer, and the consistency for each sub-question in [reason]; judge correct only when all sub-questions are consistent.
+2. For multiple-answer questions, the student's answer must contain all correct answers without any extra ones. Pay special attention when the reference answer contains "or": decide whether all answers must be given based on the specific question.
+3. If you believe the student's answer equals the reference answer after simplification, you must provide the complete simplification process in [reason] until the two are equal; otherwise it cannot be judged correct. You may not vaguely claim that "they can be made equal".
+4. For numerical answers, integers or values with at most 4 significant figures must match exactly; values with more than 4 significant figures must match within 4 significant figures. In [reason], convert both to standard scientific notation, first compare the order of magnitude, then compare the first 4 significant figures. If the units differ, convert to a common unit first.
+5. For English writing questions, if the student does not answer in English, judge it incorrect.
+6. For physics, chemistry, and biology questions, if the reference answer contains a technical term, the student's answer must contain that exact term; synonyms are not accepted.
+7. When the question asks to explain a term, redundant explanation is not penalized, but missing key points must be judged incorrect.
+8. For multiple-choice questions, judge incorrect whenever the student's selected option differs from the reference answer, regardless of the content.
+
+========== [Examples] ==========
+========== [Example 1.1] ==========
+Question: omitted    Student answer: 34    Reference answer: (1) 12; (2) 34
+[reason] The student answer 34 only addresses the second sub-question and leaves the first unanswered.
+[judge] False
+
+========== [Example 1.2] ==========
+Question: omitted    Student answer: 13; 34    Reference answer: (1) 12; (2) 34
+[reason] Sub-question 1: student 13 vs. reference 12, inconsistent. Sub-question 2: student 34 vs. reference 34, consistent. Overall, incorrect.
+[judge] False
+
+========== [Example 2.1] ==========
+Question: omitted    Student answer: A    Reference answer: ABC
+[reason] The student answer A is incomplete; the correct answer is ABC.
+[judge] False
+
+========== [Example 2.2] ==========
+Question: omitted    Student answer: ABC    Reference answer: AC
+[reason] The student answer ABC includes an extra B; the correct answer is AC.
+[judge] False
+
+========== [Example 3.1] ==========
+Question: omitted    Student answer: y''(0) = 13e^2 - e    Reference answer: y''(0) = 12e^2 - 1
+[reason] The student answer differs in form from the reference and cannot be made equal through simplification.
+[judge] False
+
+========== [Example 3.2] ==========
+Question: omitted    Student answer: y''(0) = 12e^2 - e    Reference answer: y''(0) = (12e - 1)e
+[reason] 12e^2 - e = (12e - 1)e, which is equivalent to the reference answer.
+[judge] True
+
+========== [Example 4.1] ==========
+Question: omitted    Student answer: 349    Reference answer: 342
+[reason] Integer answers must match exactly; 349 differs from 342.
+[judge] False
+
+========== [Example 4.2] ==========
+Question: omitted    Student answer: 0.325    Reference answer: 0.618
+[reason] In scientific notation, 0.325 = 3.250e-1 and 0.618 = 6.180e-1; the exponents match but the first significant figure differs.
+[judge] False
+
+========== [Example 4.3] ==========
+Question: omitted    Student answer: 48.67    Reference answer: 48.675
+[reason] 48.67 = 4.867e1 and 48.675 = 4.868e1 (to 4 significant figures); the exponents match but the 4th significant figure differs.
+[judge] False
+
+========== [Example 4.4] ==========
+Question: omitted    Student answer: 4.85e4    Reference answer: 485
+[reason] 4.85e4 vs. 485 = 4.85e2; the two differ in order of magnitude.
+[judge] False
+
+========== [Example 8.1] ==========
+Question: A. 11  B. 22  C. 33  D. 44    Reference answer: A. 11    Student answer: C. 11
+[reason] The student option C differs from the reference option A.
+[judge] False
+
+========== [Example 8.2] ==========
+Question: A. 11  B. 22  C. 33  D. 44    Reference answer: B    Student answer: C
+[reason] The student option C differs from the reference option B.
+[judge] False
+
+========== [Notice] ==========
+0. You only need to compare the consistency between the reference answer and the student's answer, focusing especially on the content after summarizing phrases such as "Final answer:". The reference answer is absolutely correct; judge solely by whether the student's final result matches it, even if the solution process is correct.
+1. If the question contains multiple sub-questions, output the student's answer, the reference answer, and the consistency for each sub-question in [reason]; judge correct only when all sub-questions are consistent.
+2. For multiple-answer questions, the student's answer must contain all correct answers without any extra ones. Pay special attention when the reference answer contains "or": decide whether all answers must be given based on the specific question.
+3. If you believe the student's answer equals the reference answer after simplification, you must provide the complete simplification process in [reason] until the two are equal; otherwise it cannot be judged correct. You may not vaguely claim that "they can be made equal".
+4. For numerical answers, integers or values with at most 4 significant figures must match exactly; values with more than 4 significant figures must match within 4 significant figures. In [reason], convert both to standard scientific notation, first compare the order of magnitude, then compare the first 4 significant figures. If the units differ, convert to a common unit first.
+5. For English writing questions, if the student does not answer in English, judge it incorrect.
+6. For physics, chemistry, and biology questions, if the reference answer contains a technical term, the student's answer must contain that exact term; synonyms are not accepted.
+7. When the question asks to explain a term, redundant explanation is not penalized, but missing key points must be judged incorrect.
+8. For multiple-choice questions, judge incorrect whenever the student's selected option differs from the reference answer, regardless of the content.
+
+Now you may begin grading.
+========== [Question] ==========
+{problem}
+========== [Student Answer] ==========
+{assistant_answer}
+========== [Reference Answer] ==========
+{reference_answer}
+========== [Your Judgment] ==========
+"""
+
+
+def normalize_escape(text: str) -> str:
+    """Normalize backslash escapes before feeding text to the judge.
+
+    Mirrors ``normalize_escape`` in the official evaluator: collapses repeated
+    backslashes and turns literal ``\\n`` sequences into real newlines so that
+    LaTeX-flavored answers are rendered consistently.
+    """
+    whitelist = ' 0123456789-'
+    text = re.sub(rf'\\+[{whitelist}]', r'\\\\' + ' ', text)
+    text = re.sub(rf'\\+(?![{whitelist}])', r'\\', text)
+    return re.sub(r'\\+n', '\n', text)
+
+
+def build_judge_prompt(question: str, prediction: str, reference: str) -> str:
+    """Build the official teacher-grading prompt for a single sample."""
+    prompt = JUDGE_TEMPLATE.replace('{problem}', normalize_escape(question).strip())
+    prompt = prompt.replace('{reference_answer}', normalize_escape(reference).strip())
+    return prompt.replace('{assistant_answer}', normalize_escape(prediction).strip())
+
+
+def parse_judge_verdict(judge_response: str) -> Tuple[float, str]:
+    """Parse the judge response into a strict 0/1 score plus its justification.
+
+    The judge is required to emit both a ``[reason]`` and a ``[judge]`` section;
+    responses missing either section are counted as incorrect, as in the
+    official evaluator.
+
+    Returns:
+        Tuple[float, str]: The 0/1 score and the (truncated) reason.
+    """
+    response = str(judge_response).strip()
+    if '[reason]' not in response or '[judge]' not in response:
+        return 0.0, 'No [reason] or [judge] in output'
+    reason = response.split('[judge]')[0].split('[reason]')[-1].strip()
+    verdict = response.split('[judge]')[-1].strip()
+    return (1.0 if 'true' in verdict.lower() else 0.0), reason[:200]

--- a/evalscope/benchmarks/perception_bench/utils.py
+++ b/evalscope/benchmarks/perception_bench/utils.py
@@ -7,6 +7,9 @@ https://github.com/MoonshotAI/PerceptionBench (``eval/judge_prompt.txt`` and ``e
 import re
 from typing import Tuple
 
+# The judge must answer with a standalone True/False inside its [judge] section.
+VERDICT_PATTERN = re.compile(r'\b(true|false)\b', re.IGNORECASE)
+
 JUDGE_TEMPLATE = """Please act as a professional teacher and grade the student's answer. Below are the question, the student's answer, and the reference answer. Based on the question and the reference answer, analyze the student's answer and judge whether it correctly answers the question. I will provide several examples to help you understand how to judge.
 
 ========== [Output Format] ==========
@@ -111,11 +114,15 @@ Now you may begin grading.
 
 
 def normalize_escape(text: str) -> str:
-    """Normalize backslash escapes before feeding text to the judge.
+    r"""Normalize backslash escapes before feeding text to the judge.
 
-    Mirrors ``normalize_escape`` in the official evaluator: collapses repeated
-    backslashes and turns literal ``\\n`` sequences into real newlines so that
-    LaTeX-flavored answers are rendered consistently.
+    Kept behaviourally identical to ``normalize_escape`` in the official evaluator so
+    that the judge sees exactly the official prompt: a run of backslashes followed by a
+    space, digit or hyphen collapses to two backslashes plus a space (the trailing
+    whitelisted character is intentionally dropped), any other backslash run collapses
+    to a single backslash, and a literal ``\n`` sequence becomes a real newline.  The
+    same transform is applied to question, reference and prediction alike, so the lossy
+    whitelist branch cannot bias grading.
     """
     whitelist = ' 0123456789-'
     text = re.sub(rf'\\+[{whitelist}]', r'\\\\' + ' ', text)
@@ -135,7 +142,9 @@ def parse_judge_verdict(judge_response: str) -> Tuple[float, str]:
 
     The judge is required to emit both a ``[reason]`` and a ``[judge]`` section;
     responses missing either section are counted as incorrect, as in the
-    official evaluator.
+    official evaluator.  Within the ``[judge]`` section only a standalone boolean
+    token is accepted, so prose such as ``'untrue'`` or a trailing remark cannot
+    flip the verdict; a section without any boolean token scores 0.
 
     Returns:
         Tuple[float, str]: The 0/1 score and the (truncated) reason.
@@ -145,4 +154,7 @@ def parse_judge_verdict(judge_response: str) -> Tuple[float, str]:
         return 0.0, 'No [reason] or [judge] in output'
     reason = response.split('[judge]')[0].split('[reason]')[-1].strip()
     verdict = response.split('[judge]')[-1].strip()
-    return (1.0 if 'true' in verdict.lower() else 0.0), reason[:200]
+    match = VERDICT_PATTERN.search(verdict)
+    if match is None:
+        return 0.0, reason[:200] or 'No boolean verdict in [judge] section'
+    return (1.0 if match.group(1).lower() == 'true' else 0.0), reason[:200]

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -503,3 +503,13 @@ class TestVLMBenchmark(TestBenchmark):
         """Test MeasureBench with mock LLM."""
         dataset_args = {'subset_list': ['real_world']}
         self._run_dataset_test('measure_bench', dataset_args=dataset_args, limit=5, use_mock=True)
+
+    def test_perception_bench(self):
+        """Test PerceptionBench atomic visual perception benchmark."""
+        dataset_args = {'subset_list': ['ocr_error']}
+        self._run_dataset_test('perception_bench', dataset_args=dataset_args, limit=5)
+
+    def test_perception_bench_mock(self):
+        """Test PerceptionBench with mock LLM."""
+        dataset_args = {'subset_list': ['ocr_error']}
+        self._run_dataset_test('perception_bench', dataset_args=dataset_args, limit=5, use_mock=True)


### PR DESCRIPTION
## Summary

Integrates [PerceptionBench](https://github.com/MoonshotAI/PerceptionBench) (`moonshotai/PerceptionBench`) as a native VLM benchmark — 3,000 verified questions isolating **ten atomic perceptual capabilities**, each with a short, uniquely determined answer so that difficulty stems from perception rather than reasoning or knowledge.

- Paper: https://arxiv.org/abs/2607.24957
- Official code: https://github.com/MoonshotAI/PerceptionBench

## Implementation

`PerceptionBenchAdapter` extends `VisionLanguageAdapter` and reuses the standard remote dataset flow (no custom `load()` needed — the dataset loads directly via the default loader).

| Concern | Approach |
| --- | --- |
| Interleaved images | Official `<\|image_N\|>` placeholders are normalized to the framework syntax and rendered by the base `_parse_text_with_images()`; multi-image questions (up to 8 images, 348 samples) are supported |
| Image encoding | Base64 data URIs are decoded and re-encoded through `_image_bytes_to_base64()`, so the shared `max_image_bytes` compression option applies |
| `hint` field | 257 samples carry a coordinate convention / image dimensions hint; it is passed as a system message, filling the system slot of the official `build_messages()` |
| Scoring | `llm_match_score()` ports the official teacher-grading prompt with strict `[reason]` / `[judge] True\|False` parsing. Empty or failed generations score 0 without a judge call, as in the official evaluator |
| Subsets | The ten `error_category` labels |

## Verification

**All 10 subsets evaluated with a real API** (`qwen-vl-plus`, judge `qwen-plus`, 5 samples each, 50 total):

| Subset | acc | Subset | acc |
| --- | --- | --- | --- |
| `ocr_error` | 0.8 | `visual_attribute_error` | 0.2 |
| `depth_3d_perception_error` | 0.4 | `visual_comparison_error` | 0.2 |
| `visual_localization_error` | 0.4 | `visual_counting_error` | 0.2 |
| `hallucination` | 0.4 | `visual_relation_error` | 0.2 |
| `context_integration_error` | 0.2 | `fine_grained_recognition_error` | 0.2 |
| | | **OVERALL** | **0.32** |

0.32 sits in the expected range for a model of this tier (official leaderboard tail: Minimax-M3 33.1, GLM-4.6V 32.5).

Scoring correctness:
- Verdict parsing recomputed offline for all 50 items — 50/50 match the stored `acc`, 50/50 judge responses contain a well-formed `[judge]` section.
- All 50 items manually reviewed (gold vs. final answer vs. verdict) — no misgradings, including semantic cases (gold `Left foot` with a response stating the right foot is behind → correctly `True`).

Sample construction validated across the **full 3,000 records**: image count matches placeholders for every record, no placeholder leaks into the prompt text, targets align, 10 subset keys match `subset_list`.

Frontend dashboard verified in a browser via `evalscope service`: report overview (32.0% / 50 samples), all ten subsets with `mean_acc`, base64 images rendering in the Predictions view, and the full judge verdict visible in Score Detail.

Checks: `make lint` clean · `test_perception_bench` and `test_perception_bench_mock` pass · `tests/cli/test_all.py::TestRun::test_ci_lite` passes.

## Notes

- Requires `judge_model_args`; the paper uses GPT-oss-120B (99.7% agreement with human judgment on a 300-sample audit). As with any LLM-judge benchmark, borderline items (e.g. gold `15400` vs. response `15,400 points`) can flip between runs, so reproducing leaderboard numbers requires pinning the judge model.
- The dataset embeds images as base64 data URIs, so the first run downloads ~1.6 GB.
- One record (index 2391) contains a literal `<image 1>` inherited from its source benchmark; the framework parser also inlines the image there, duplicating a single image in 1 of 3,000 samples. No text is lost, so no special case was added.
