### PR TITLE
fix: validate service output directory

### DIFF
--- a/evalscope/cli/start_service.py
+++ b/evalscope/cli/start_service.py
@@ -1,6 +1,7 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 """CLI command for starting the EvalScope Flask service."""
-from argparse import ArgumentParser
+import os
+from argparse import ArgumentParser, ArgumentTypeError
 
 from evalscope.cli.base import CLICommand
 
@@ -8,6 +9,14 @@ from evalscope.cli.base import CLICommand
 def subparser_func(args):
     """Function which will be called for a specific sub parser."""
     return ServiceCMD(args)
+
+
+def existing_directory(value: str) -> str:
+    """Return an existing directory path or produce an argparse error."""
+    path = os.path.abspath(value)
+    if not os.path.isdir(path):
+        raise ArgumentTypeError(f'output directory does not exist: {path}')
+    return path
 
 
 class ServiceCMD(CLICommand):
@@ -26,7 +35,7 @@ class ServiceCMD(CLICommand):
         parser.add_argument('--port', type=int, default=9000, help='Port to listen on (default: 9000)')
         parser.add_argument(
             '--outputs',
-            type=str,
+            type=existing_directory,
             default=None,
             help='Root directory for evaluation outputs (default: ./outputs). '
             'The web dashboard will use this as the default scan path.'

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -1,5 +1,4 @@
 import argparse
-
 import pytest
 
 from evalscope.cli.start_service import existing_directory

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -1,0 +1,16 @@
+import argparse
+
+import pytest
+
+from evalscope.cli.start_service import existing_directory
+
+
+def test_existing_directory_returns_absolute_path(tmp_path):
+    assert existing_directory(str(tmp_path)) == str(tmp_path)
+
+
+def test_existing_directory_rejects_missing_path(tmp_path):
+    missing_path = tmp_path / 'missing'
+
+    with pytest.raises(argparse.ArgumentTypeError, match='output directory does not exist'):
+        existing_directory(str(missing_path))


### PR DESCRIPTION
## Background

When running the example from the [Quick Experience](https://evalscope.readthedocs.io/en/latest/get_started/visualization.html#quick-experience) guide:

```bash
evalscope service --outputs examples/viz
```

`examples/viz` may not exist in the local working directory. The backend service still starts, and the frontend then shows the confusing error:

```text
root_path is required and must be an existing directory
```

## Summary

- Validate --outputs as an existing directory during argparse processing.
- Prevent the service from starting with an invalid output root.
- Replace the misleading frontend error with a clear CLI error.

## Before

An invalid --outputs path allowed the backend service to start, then the frontend reported:
`root_path is required and must be an existing directory`.

## After

```text
usage: EvalScope Command Line tool service ...
EvalScope Command Line tool service: error: argument --outputs: output directory does not exist: /private/tmp/not_exist_dir
```

The backend now fails during argument parsing and exits with status code 2. The service does not start, so the frontend is not opened with an invalid output root.

## Tests

- `pytest -q tests/cli/test_service.py`
- CLI invalid-output smoke test exits with code 2