### PR TITLE
feat(cc_ocr_v2): add CC-OCR-V2 real-world document OCR benchmark

### DIFF
--- a/docs/en/benchmarks/cc_ocr_v2.md
+++ b/docs/en/benchmarks/cc_ocr_v2.md
@@ -1,0 +1,169 @@
+# CC-OCR-V2
+
+
+## Overview
+
+CC-OCR V2 is a challenging OCR benchmark tailored to real-world enterprise document processing. It deliberately
+over-samples the hard and corner cases that prior OCR benchmarks under-represent, such as photographed and
+scanned tables, handwritten formulas, multi-page receipts, and low-quality multilingual scene text.
+
+## Task Description
+
+- **Task Type**: Text recognition, document parsing, document grounding, key information extraction, and document VQA
+- **Input**: One or more document images plus the task instruction shipped with each sample
+- **Output**: Free-form text, LaTeX, HTML tables, SMILES strings, JSON objects, or bounding boxes, depending on the track
+- **Modalities**: Image + text, bilingual (Chinese / English) with 32 additional languages in the recognition track
+
+## Key Features
+
+- 7,093 official samples over 5 tracks and 16 sub-tasks, evaluated as one benchmark; 7,091 are
+  loaded because the dataset repository ships no image for two of them
+- **recognition**: multilingual (32 languages) and natural-scene text reading
+- **parsing**: complex tables, general documents, handwritten formulas, molecular structures, and information boards
+- **grounding**: text grounding (single box) and object grounding (multi-box detection with labels)
+- **extraction**: schema-driven key information extraction over business, public-service, and regulated records
+- **qa**: question answering over blueprints, dashboards, and financial documents
+- Prompts come from the official dataset, so results stay comparable to the published leaderboard
+
+## Evaluation Notes
+
+- Every sample yields one `score` in `[0, 1]`; each track uses its official metric:
+  recognition = token-level F1, parsing = edit similarity / TEDS, grounding = IoU,
+  extraction = field-level F1, qa = substring match with ANLS fallback
+- Subset scores are sample means; the per-track category also reports a macro average over its sub-tasks
+- The grounding prompts ask for boxes on a 0-1000 grid; predictions in absolute pixels are rescaled
+  as if normalized and therefore score close to zero, matching the official leaderboard behavior
+- Full-page parsing targets are long, so allow a generous `max_tokens` (4096 or more)
+- Requires: `apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`
+  (`pip install 'evalscope[cc_ocr_v2]'`)
+- The dataset is a file tree of images and answers (about 5 GB). Only the tracks listed in
+  `subset_list` are downloaded, so restricting subsets keeps the download small
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `cc_ocr_v2` |
+| **Dataset ID** | [evalscope/CC-OCR-V2](https://modelscope.cn/datasets/evalscope/CC-OCR-V2/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2605.03903) |
+| **Tags** | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |
+| **Metrics** | `score` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 7,091 |
+| Prompt Length (Mean) | 272.16 chars |
+| Prompt Length (Min/Max) | 10 / 1330 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `multi_lingual_recognition` | 639 | 101 | 101 | 101 |
+| `natural_scene_recognition` | 1,150 | 101.87 | 101 | 103 |
+| `complex_table_parsing` | 300 | 327 | 327 | 327 |
+| `formula_parsing` | 100 | 119 | 119 | 119 |
+| `general_documents_parsing` | 299 | 258 | 258 | 258 |
+| `info_board_parsing` | 26 | 701 | 701 | 701 |
+| `molecular_parsing` | 100 | 232 | 232 | 232 |
+| `object_grounding` | 734 | 491.83 | 306 | 1330 |
+| `text_grounding` | 734 | 369.88 | 358 | 468 |
+| `business_transactions` | 340 | 793.91 | 702 | 1105 |
+| `public_services` | 369 | 735.45 | 687 | 902 |
+| `regulated_records` | 300 | 798.84 | 722 | 898 |
+| `blueprint_qa` | 100 | 25.4 | 10 | 69 |
+| `dashboards_fact_qa` | 400 | 66.59 | 19 | 159 |
+| `dashboards_numeric_qa` | 500 | 70.49 | 19 | 148 |
+| `financial_documents_qa` | 1,000 | 41.77 | 14 | 115 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 7,116 |
+| Images per Sample | min: 1, max: 3, mean: 1.0 |
+| Resolution Range | 70x71 - 5313x7219 |
+| Formats | jpeg, png |
+
+
+## Sample Example
+
+**Subset**: `multi_lingual_recognition`
+
+```json
+{
+  "input": [
+    {
+      "id": "253834d2",
+      "content": [
+        {
+          "image": "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+        },
+        {
+          "text": "Please output only the text content from the image without any additional descriptions or formatting."
+        }
+      ]
+    }
+  ],
+  "target": "الآن بحق السماء يا دجونا، أكل طعامك المتحجر غير المطابقة ....Demonstrandum\n.للمواصفات واتركني بسلام .”قال دجونا بحزن وهو ينظر إلى الحقيبة الفارغة: “لقد ذهب كل شيء أنا هنا!” صرخ بصوت غالي مرح، وكتم إليري أنينًا آخر عندما رأى السيد دوفال يقفز“\n ... [TRUNCATED 1733 chars] ... حنة الحشد“\nكان هناك ضحكة خفيفة. كان الشخص الضعيف القلب الذي خاطبه المرافق شابًا زنجيًا\nقويًا، يرتدي ملابس بنية سيمفونية أنيقة، وقبعته القشية مبهرة على الكربون السخام\n!الموجود في جلده. ضحكت فتاة جميلة ملونة على ذراعه. “هيا يا عزيزتي، سوف نريهم",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "multi_lingual_recognition",
+  "metadata": {
+    "id": "0c780237abcb",
+    "task": "recognition",
+    "sub_task": "multi_lingual_recognition",
+    "scenario": "multi_lan_ocr_Arabic_Arabic_20",
+    "image_paths": [
+      "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+    ]
+  }
+}
+```
+
+*Note: Some content was truncated for display.*
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets cc_ocr_v2 \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['cc_ocr_v2'],
+    dataset_args={
+        'cc_ocr_v2': {
+            # subset_list: ['multi_lingual_recognition', 'natural_scene_recognition', 'complex_table_parsing']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -11,6 +11,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `baby_vision` | [BabyVision](../../benchmarks/baby_vision.md) | `MultiModal`, `QA`, `Reasoning` |
 | `blink` | [BLINK](../../benchmarks/blink.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `cc_bench` | [CCBench](../../benchmarks/cc_bench.md) | `Knowledge`, `MCQ`, `MultiModal` |
+| `cc_ocr_v2` | [CC-OCR-V2](../../benchmarks/cc_ocr_v2.md) | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |
 | `chartqa` | [ChartQA](../../benchmarks/chartqa.md) | `Knowledge`, `MultiModal`, `QA` |
 | `charxiv` | [CharXiv](../../benchmarks/charxiv.md) | `MultiModal`, `QA`, `Reasoning` |
 | `cmmmu` | [CMMMU](../../benchmarks/cmmmu.md) | `Chinese`, `Knowledge`, `MultiModal`, `QA` |
@@ -76,6 +77,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/baby_vision.md
 ../../benchmarks/blink.md
 ../../benchmarks/cc_bench.md
+../../benchmarks/cc_ocr_v2.md
 ../../benchmarks/chartqa.md
 ../../benchmarks/charxiv.md
 ../../benchmarks/cmmmu.md

--- a/docs/zh/benchmarks/cc_ocr_v2.md
+++ b/docs/zh/benchmarks/cc_ocr_v2.md
@@ -1,0 +1,166 @@
+# CC-OCR-V2
+
+
+## 概述
+
+CC-OCR V2 是一个面向真实企业文档处理场景的高难度 OCR 基准测试。它刻意对先前 OCR 基准测试中代表性不足的困难和边缘案例进行了过采样，例如拍摄或扫描的表格、手写公式、多页收据以及低质量的多语言自然场景文本。
+
+## 任务描述
+
+- **任务类型**：文本识别、文档解析、文档定位（grounding）、关键信息抽取和文档问答（VQA）
+- **输入**：一张或多张文档图像，以及每个样本附带的任务指令
+- **输出**：自由格式文本、LaTeX、HTML 表格、SMILES 字符串、JSON 对象或边界框，具体取决于任务赛道
+- **模态**：图像 + 文本，双语（中文 / 英文），识别赛道额外包含 32 种语言
+
+## 核心特性
+
+- 共包含 7,093 个官方样本，覆盖 5 个赛道和 16 个子任务，统一作为单一基准进行评估；由于数据集仓库中缺少其中两个样本的图像，实际加载 7,091 个样本
+- **识别（recognition）**：多语言（32 种语言）及自然场景文本阅读
+- **解析（parsing）**：复杂表格、通用文档、手写公式、分子结构和信息公告板
+- **定位（grounding）**：文本定位（单框）和对象定位（带标签的多框检测）
+- **抽取（extraction）**：基于模式（schema-driven）的关键信息抽取，涵盖商业、公共服务和监管记录
+- **问答（qa）**：针对蓝图、仪表盘和财务文档的问答任务
+- 提示词（prompts）直接来自官方数据集，确保结果可与已发布的排行榜进行比较
+
+## 评估说明
+
+- 每个样本产生一个 `[0, 1]` 范围内的 `score`；各赛道使用其官方指标：
+  - 识别 = token 级别 F1
+  - 解析 = 编辑相似度 / TEDS
+  - 定位 = IoU
+  - 抽取 = 字段级别 F1
+  - 问答 = 子串匹配，辅以 ANLS 回退策略
+- 子集得分是样本得分的均值；各赛道类别还会报告其子任务的宏平均分
+- 定位任务的提示要求在 0–1000 的归一化坐标网格上返回边界框；若预测使用绝对像素坐标，则会被重新缩放为归一化形式，否则得分将接近零，与官方排行榜行为一致
+- 全页解析的目标输出较长，因此需设置较大的 `max_tokens`（建议 4096 或更高）
+- 依赖项：`apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`
+  （可通过 `pip install 'evalscope[cc_ocr_v2]'` 安装）
+- 数据集以图像和答案组成的文件树形式提供（约 5 GB）。仅下载 `subset_list` 中指定的赛道，因此限制子集可显著减小下载体积
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `cc_ocr_v2` |
+| **数据集ID** | [evalscope/CC-OCR-V2](https://modelscope.cn/datasets/evalscope/CC-OCR-V2/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2605.03903) |
+| **标签** | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |
+| **指标** | `score` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 7,091 |
+| 提示词长度（平均） | 272.16 字符 |
+| 提示词长度（最小/最大） | 10 / 1330 字符 |
+
+**各子集统计：**
+
+| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |
+|--------|---------|-------------|------------|------------|
+| `multi_lingual_recognition` | 639 | 101 | 101 | 101 |
+| `natural_scene_recognition` | 1,150 | 101.87 | 101 | 103 |
+| `complex_table_parsing` | 300 | 327 | 327 | 327 |
+| `formula_parsing` | 100 | 119 | 119 | 119 |
+| `general_documents_parsing` | 299 | 258 | 258 | 258 |
+| `info_board_parsing` | 26 | 701 | 701 | 701 |
+| `molecular_parsing` | 100 | 232 | 232 | 232 |
+| `object_grounding` | 734 | 491.83 | 306 | 1330 |
+| `text_grounding` | 734 | 369.88 | 358 | 468 |
+| `business_transactions` | 340 | 793.91 | 702 | 1105 |
+| `public_services` | 369 | 735.45 | 687 | 902 |
+| `regulated_records` | 300 | 798.84 | 722 | 898 |
+| `blueprint_qa` | 100 | 25.4 | 10 | 69 |
+| `dashboards_fact_qa` | 400 | 66.59 | 19 | 159 |
+| `dashboards_numeric_qa` | 500 | 70.49 | 19 | 148 |
+| `financial_documents_qa` | 1,000 | 41.77 | 14 | 115 |
+
+**图像统计：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 7,116 |
+| 每样本图像数 | 最小: 1, 最大: 3, 平均: 1.0 |
+| 分辨率范围 | 70x71 - 5313x7219 |
+| 格式 | jpeg, png |
+
+
+## 样例示例
+
+**子集**: `multi_lingual_recognition`
+
+```json
+{
+  "input": [
+    {
+      "id": "253834d2",
+      "content": [
+        {
+          "image": "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+        },
+        {
+          "text": "Please output only the text content from the image without any additional descriptions or formatting."
+        }
+      ]
+    }
+  ],
+  "target": "الآن بحق السماء يا دجونا، أكل طعامك المتحجر غير المطابقة ....Demonstrandum\n.للمواصفات واتركني بسلام .”قال دجونا بحزن وهو ينظر إلى الحقيبة الفارغة: “لقد ذهب كل شيء أنا هنا!” صرخ بصوت غالي مرح، وكتم إليري أنينًا آخر عندما رأى السيد دوفال يقفز“\n ... [TRUNCATED 1733 chars] ... حنة الحشد“\nكان هناك ضحكة خفيفة. كان الشخص الضعيف القلب الذي خاطبه المرافق شابًا زنجيًا\nقويًا، يرتدي ملابس بنية سيمفونية أنيقة، وقبعته القشية مبهرة على الكربون السخام\n!الموجود في جلده. ضحكت فتاة جميلة ملونة على ذراعه. “هيا يا عزيزتي، سوف نريهم",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "multi_lingual_recognition",
+  "metadata": {
+    "id": "0c780237abcb",
+    "task": "recognition",
+    "sub_task": "multi_lingual_recognition",
+    "scenario": "multi_lan_ocr_Arabic_Arabic_20",
+    "image_paths": [
+      "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+    ]
+  }
+}
+```
+
+*注：部分内容因展示需要已被截断。*
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets cc_ocr_v2 \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['cc_ocr_v2'],
+    dataset_args={
+        'cc_ocr_v2': {
+            # subset_list: ['multi_lingual_recognition', 'natural_scene_recognition', 'complex_table_parsing']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -11,6 +11,7 @@
 | `baby_vision` | [BabyVision](../../benchmarks/baby_vision.md) | `MultiModal`, `QA`, `Reasoning` |
 | `blink` | [BLINK](../../benchmarks/blink.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `cc_bench` | [CCBench](../../benchmarks/cc_bench.md) | `Knowledge`, `MCQ`, `MultiModal` |
+| `cc_ocr_v2` | [CC-OCR-V2](../../benchmarks/cc_ocr_v2.md) | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |
 | `chartqa` | [ChartQA](../../benchmarks/chartqa.md) | `Knowledge`, `MultiModal`, `QA` |
 | `charxiv` | [CharXiv](../../benchmarks/charxiv.md) | `MultiModal`, `QA`, `Reasoning` |
 | `cmmmu` | [CMMMU](../../benchmarks/cmmmu.md) | `Chinese`, `Knowledge`, `MultiModal`, `QA` |
@@ -76,6 +77,7 @@
 ../../benchmarks/baby_vision.md
 ../../benchmarks/blink.md
 ../../benchmarks/cc_bench.md
+../../benchmarks/cc_ocr_v2.md
 ../../benchmarks/chartqa.md
 ../../benchmarks/charxiv.md
 ../../benchmarks/cmmmu.md

--- a/evalscope/benchmarks/_meta/cc_ocr_v2.json
+++ b/evalscope/benchmarks/_meta/cc_ocr_v2.json
@@ -1,0 +1,777 @@
+{
+  "meta": {
+    "pretty_name": "CC-OCR-V2",
+    "dataset_id": "evalscope/CC-OCR-V2",
+    "paper_url": "https://arxiv.org/abs/2605.03903",
+    "tags": [
+      "MultiModal",
+      "QA",
+      "Grounding",
+      "MultiLingual"
+    ],
+    "metrics": [
+      "score"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "multi_lingual_recognition",
+      "natural_scene_recognition",
+      "complex_table_parsing",
+      "formula_parsing",
+      "general_documents_parsing",
+      "info_board_parsing",
+      "molecular_parsing",
+      "object_grounding",
+      "text_grounding",
+      "business_transactions",
+      "public_services",
+      "regulated_records",
+      "blueprint_qa",
+      "dashboards_fact_qa",
+      "dashboards_numeric_qa",
+      "financial_documents_qa"
+    ],
+    "description": "\n## Overview\n\nCC-OCR V2 is a challenging OCR benchmark tailored to real-world enterprise document processing. It deliberately\nover-samples the hard and corner cases that prior OCR benchmarks under-represent, such as photographed and\nscanned tables, handwritten formulas, multi-page receipts, and low-quality multilingual scene text.\n\n## Task Description\n\n- **Task Type**: Text recognition, document parsing, document grounding, key information extraction, and document VQA\n- **Input**: One or more document images plus the task instruction shipped with each sample\n- **Output**: Free-form text, LaTeX, HTML tables, SMILES strings, JSON objects, or bounding boxes, depending on the track\n- **Modalities**: Image + text, bilingual (Chinese / English) with 32 additional languages in the recognition track\n\n## Key Features\n\n- 7,093 official samples over 5 tracks and 16 sub-tasks, evaluated as one benchmark; 7,091 are\n  loaded because the dataset repository ships no image for two of them\n- **recognition**: multilingual (32 languages) and natural-scene text reading\n- **parsing**: complex tables, general documents, handwritten formulas, molecular structures, and information boards\n- **grounding**: text grounding (single box) and object grounding (multi-box detection with labels)\n- **extraction**: schema-driven key information extraction over business, public-service, and regulated records\n- **qa**: question answering over blueprints, dashboards, and financial documents\n- Prompts come from the official dataset, so results stay comparable to the published leaderboard\n\n## Evaluation Notes\n\n- Every sample yields one `score` in `[0, 1]`; each track uses its official metric:\n  recognition = token-level F1, parsing = edit similarity / TEDS, grounding = IoU,\n  extraction = field-level F1, qa = substring match with ANLS fallback\n- Subset scores are sample means; the per-track category also reports a macro average over its sub-tasks\n- The grounding prompts ask for boxes on a 0-1000 grid; predictions in absolute pixels are rescaled\n  as if normalized and therefore score close to zero, matching the official leaderboard behavior\n- Full-page parsing targets are long, so allow a generous `max_tokens` (4096 or more)\n- Requires: `apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`\n  (`pip install 'evalscope[cc_ocr_v2]'`)\n- The dataset is a file tree of images and answers (about 5 GB). Only the tracks listed in\n  `subset_list` are downloaded, so restricting subsets keeps the download small\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm"
+  },
+  "statistics": {
+    "total_samples": 7091,
+    "subset_stats": [
+      {
+        "name": "multi_lingual_recognition",
+        "sample_count": 639,
+        "prompt_length_mean": 101,
+        "prompt_length_min": 101,
+        "prompt_length_max": 101,
+        "prompt_length_std": null,
+        "target_length_mean": 2066.78,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 639,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x1500",
+              "1024x1184",
+              "1024x1440",
+              "1024x1472",
+              "1024x1504",
+              "1024x1536",
+              "1024x1760",
+              "1024x1824",
+              "1056x1504",
+              "1056x1536"
+            ],
+            "resolution_range": {
+              "min": "598x912",
+              "max": "3072x4096"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "natural_scene_recognition",
+        "sample_count": 1150,
+        "prompt_length_mean": 101.87,
+        "prompt_length_min": 101,
+        "prompt_length_max": 103,
+        "prompt_length_std": 0.68,
+        "target_length_mean": 343.81,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 1150,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x750",
+              "1001x1666",
+              "1008x579",
+              "1008x754",
+              "1008x756",
+              "100x100",
+              "100x102",
+              "100x103",
+              "100x96",
+              "100x97"
+            ],
+            "resolution_range": {
+              "min": "70x71",
+              "max": "7020x5100"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "complex_table_parsing",
+        "sample_count": 300,
+        "prompt_length_mean": 327,
+        "prompt_length_min": 327,
+        "prompt_length_max": 327,
+        "prompt_length_std": null,
+        "target_length_mean": 4169.97,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 300,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x678",
+              "1008x1350",
+              "1010x450",
+              "1017x338",
+              "1018x2048",
+              "1033x758",
+              "1037x497",
+              "1044x838",
+              "1046x914",
+              "1047x292"
+            ],
+            "resolution_range": {
+              "min": "413x87",
+              "max": "4962x7014"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "formula_parsing",
+        "sample_count": 100,
+        "prompt_length_mean": 119,
+        "prompt_length_min": 119,
+        "prompt_length_max": 119,
+        "prompt_length_std": null,
+        "target_length_mean": 1365.27,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 100,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1028x556",
+              "1054x444",
+              "1067x467",
+              "1080x1036",
+              "1080x1278",
+              "1280x1707",
+              "1280x960",
+              "2060x2852",
+              "2188x2940",
+              "2330x3294"
+            ],
+            "resolution_range": {
+              "min": "454x230",
+              "max": "4032x3024"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "general_documents_parsing",
+        "sample_count": 299,
+        "prompt_length_mean": 258,
+        "prompt_length_min": 258,
+        "prompt_length_max": 258,
+        "prompt_length_std": null,
+        "target_length_mean": 2014.65,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 299,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x1413",
+              "1018x1776",
+              "1023x1620",
+              "1025x1025",
+              "1052x1600",
+              "1076x1712",
+              "1079x1600",
+              "1080x810",
+              "1090x1722",
+              "1096x1440"
+            ],
+            "resolution_range": {
+              "min": "467x437",
+              "max": "5093x6400"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "info_board_parsing",
+        "sample_count": 26,
+        "prompt_length_mean": 701,
+        "prompt_length_min": 701,
+        "prompt_length_max": 701,
+        "prompt_length_std": null,
+        "target_length_mean": 5936.04,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 26,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "2816x1536"
+            ],
+            "resolution_range": {
+              "min": "2816x1536",
+              "max": "2816x1536"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "molecular_parsing",
+        "sample_count": 100,
+        "prompt_length_mean": 232,
+        "prompt_length_min": 232,
+        "prompt_length_max": 232,
+        "prompt_length_std": null,
+        "target_length_mean": 58.11,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 100,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1017x947",
+              "1095x958",
+              "1246x1348",
+              "1279x1706",
+              "1319x927",
+              "1422x988",
+              "1430x817",
+              "1490x1937",
+              "1556x886",
+              "157x207"
+            ],
+            "resolution_range": {
+              "min": "226x114",
+              "max": "3072x4096"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "object_grounding",
+        "sample_count": 734,
+        "prompt_length_mean": 491.83,
+        "prompt_length_min": 306,
+        "prompt_length_max": 1330,
+        "prompt_length_std": 183.69,
+        "target_length_mean": 1080.83,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 734,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1035x2155",
+              "1044x1900",
+              "1045x826",
+              "1048x1626",
+              "1066x1493",
+              "1067x1578",
+              "1068x949",
+              "1080x1512",
+              "1080x1519",
+              "1080x1527"
+            ],
+            "resolution_range": {
+              "min": "367x703",
+              "max": "4961x7016"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "text_grounding",
+        "sample_count": 734,
+        "prompt_length_mean": 369.88,
+        "prompt_length_min": 358,
+        "prompt_length_max": 468,
+        "prompt_length_std": 16.59,
+        "target_length_mean": 29.33,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 734,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1035x2155",
+              "1044x1900",
+              "1045x826",
+              "1048x1626",
+              "1066x1493",
+              "1067x1578",
+              "1068x949",
+              "1080x1512",
+              "1080x1519",
+              "1080x1527"
+            ],
+            "resolution_range": {
+              "min": "367x703",
+              "max": "4961x7016"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "business_transactions",
+        "sample_count": 340,
+        "prompt_length_mean": 793.91,
+        "prompt_length_min": 702,
+        "prompt_length_max": 1105,
+        "prompt_length_std": 94.93,
+        "target_length_mean": 321.59,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 365,
+            "count_per_sample": {
+              "min": 1,
+              "max": 3,
+              "mean": 1.07
+            },
+            "resolutions": [
+              "1017x1525",
+              "1044x1900",
+              "1048x1626",
+              "1050x1400",
+              "1066x1493",
+              "1067x1578",
+              "1080x1439",
+              "1080x1512",
+              "1080x1527",
+              "1080x1528"
+            ],
+            "resolution_range": {
+              "min": "228x336",
+              "max": "4961x7016"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "public_services",
+        "sample_count": 369,
+        "prompt_length_mean": 735.45,
+        "prompt_length_min": 687,
+        "prompt_length_max": 902,
+        "prompt_length_std": 26.6,
+        "target_length_mean": 115.43,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 369,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1431",
+              "1025x1536",
+              "1061x1610",
+              "1080x1430",
+              "1080x1526",
+              "1080x1527",
+              "1080x1544",
+              "1080x1597",
+              "1080x810",
+              "1080x887"
+            ],
+            "resolution_range": {
+              "min": "354x500",
+              "max": "4869x6286"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "regulated_records",
+        "sample_count": 300,
+        "prompt_length_mean": 798.84,
+        "prompt_length_min": 722,
+        "prompt_length_max": 898,
+        "prompt_length_std": 57.37,
+        "target_length_mean": 219.98,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 300,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1068x949",
+              "1074x842",
+              "1080x1527",
+              "1080x1528",
+              "1231x1969",
+              "1245x968",
+              "1279x1064",
+              "1297x958",
+              "1376x917",
+              "1385x943"
+            ],
+            "resolution_range": {
+              "min": "220x140",
+              "max": "4961x7016"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "blueprint_qa",
+        "sample_count": 100,
+        "prompt_length_mean": 25.4,
+        "prompt_length_min": 10,
+        "prompt_length_max": 69,
+        "prompt_length_std": 18.16,
+        "target_length_mean": 11.32,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 100,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1728x2464",
+              "1792x2400",
+              "2400x1792",
+              "2816x1536"
+            ],
+            "resolution_range": {
+              "min": "1728x2464",
+              "max": "2816x1536"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "dashboards_fact_qa",
+        "sample_count": 400,
+        "prompt_length_mean": 66.59,
+        "prompt_length_min": 19,
+        "prompt_length_max": 159,
+        "prompt_length_std": 21.59,
+        "target_length_mean": 9.4,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 400,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x1582",
+              "1000x2755",
+              "1000x3303",
+              "1000x3428",
+              "1000x3500",
+              "1000x3655",
+              "1000x4423",
+              "1000x5428",
+              "1000x5574",
+              "1000x6329"
+            ],
+            "resolution_range": {
+              "min": "500x422",
+              "max": "5214x3873"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "dashboards_numeric_qa",
+        "sample_count": 500,
+        "prompt_length_mean": 70.49,
+        "prompt_length_min": 19,
+        "prompt_length_max": 148,
+        "prompt_length_std": 22.58,
+        "target_length_mean": 7.44,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x1294",
+              "1000x1403",
+              "1000x1876",
+              "1000x2713",
+              "1000x3273",
+              "1000x3320",
+              "1000x3735",
+              "1000x3893",
+              "1000x5117",
+              "1000x5138"
+            ],
+            "resolution_range": {
+              "min": "236x558",
+              "max": "7200x4800"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      },
+      {
+        "name": "financial_documents_qa",
+        "sample_count": 1000,
+        "prompt_length_mean": 41.77,
+        "prompt_length_min": 14,
+        "prompt_length_max": 115,
+        "prompt_length_std": 16.93,
+        "target_length_mean": 13.33,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 1000,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1006x847",
+              "1008x846",
+              "1030x1804",
+              "1048x596",
+              "1082x1682",
+              "1086x977",
+              "1103x1681",
+              "1135x1749",
+              "1142x1725",
+              "1146x1736"
+            ],
+            "resolution_range": {
+              "min": "586x710",
+              "max": "5313x7219"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 272.16,
+      "min": 10,
+      "max": 1330,
+      "std": 261.31
+    },
+    "target_length_mean": 693.95,
+    "computed_at": "2026-08-10T12:05:42.136420",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 7116,
+        "count_per_sample": {
+          "min": 1,
+          "max": 3,
+          "mean": 1.0
+        },
+        "resolutions": [
+          "1000x1294",
+          "1000x1403",
+          "1000x1413",
+          "1000x1500",
+          "1000x1582",
+          "1000x1876",
+          "1000x2713",
+          "1000x2755",
+          "1000x3273",
+          "1000x3303"
+        ],
+        "resolution_range": {
+          "min": "70x71",
+          "max": "5313x7219"
+        },
+        "formats": [
+          "jpeg",
+          "png"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "253834d2",
+          "content": [
+            {
+              "image": "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+            },
+            {
+              "text": "Please output only the text content from the image without any additional descriptions or formatting."
+            }
+          ]
+        }
+      ],
+      "target": "الآن بحق السماء يا دجونا، أكل طعامك المتحجر غير المطابقة ....Demonstrandum\n.للمواصفات واتركني بسلام .”قال دجونا بحزن وهو ينظر إلى الحقيبة الفارغة: “لقد ذهب كل شيء أنا هنا!” صرخ بصوت غالي مرح، وكتم إليري أنينًا آخر عندما رأى السيد دوفال يقفز“\n ... [TRUNCATED 1733 chars] ... حنة الحشد“\nكان هناك ضحكة خفيفة. كان الشخص الضعيف القلب الذي خاطبه المرافق شابًا زنجيًا\nقويًا، يرتدي ملابس بنية سيمفونية أنيقة، وقبعته القشية مبهرة على الكربون السخام\n!الموجود في جلده. ضحكت فتاة جميلة ملونة على ذراعه. “هيا يا عزيزتي، سوف نريهم",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "multi_lingual_recognition",
+      "metadata": {
+        "id": "0c780237abcb",
+        "task": "recognition",
+        "sub_task": "multi_lingual_recognition",
+        "scenario": "multi_lan_ocr_Arabic_Arabic_20",
+        "image_paths": [
+          "~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg"
+        ]
+      }
+    },
+    "subset": "multi_lingual_recognition",
+    "truncated": true
+  },
+  "readme": {
+    "en": "# CC-OCR-V2\n\n\n## Overview\n\nCC-OCR V2 is a challenging OCR benchmark tailored to real-world enterprise document processing. It deliberately\nover-samples the hard and corner cases that prior OCR benchmarks under-represent, such as photographed and\nscanned tables, handwritten formulas, multi-page receipts, and low-quality multilingual scene text.\n\n## Task Description\n\n- **Task Type**: Text recognition, document parsing, document grounding, key information extraction, and document VQA\n- **Input**: One or more document images plus the task instruction shipped with each sample\n- **Output**: Free-form text, LaTeX, HTML tables, SMILES strings, JSON objects, or bounding boxes, depending on the track\n- **Modalities**: Image + text, bilingual (Chinese / English) with 32 additional languages in the recognition track\n\n## Key Features\n\n- 7,093 official samples over 5 tracks and 16 sub-tasks, evaluated as one benchmark; 7,091 are\n  loaded because the dataset repository ships no image for two of them\n- **recognition**: multilingual (32 languages) and natural-scene text reading\n- **parsing**: complex tables, general documents, handwritten formulas, molecular structures, and information boards\n- **grounding**: text grounding (single box) and object grounding (multi-box detection with labels)\n- **extraction**: schema-driven key information extraction over business, public-service, and regulated records\n- **qa**: question answering over blueprints, dashboards, and financial documents\n- Prompts come from the official dataset, so results stay comparable to the published leaderboard\n\n## Evaluation Notes\n\n- Every sample yields one `score` in `[0, 1]`; each track uses its official metric:\n  recognition = token-level F1, parsing = edit similarity / TEDS, grounding = IoU,\n  extraction = field-level F1, qa = substring match with ANLS fallback\n- Subset scores are sample means; the per-track category also reports a macro average over its sub-tasks\n- The grounding prompts ask for boxes on a 0-1000 grid; predictions in absolute pixels are rescaled\n  as if normalized and therefore score close to zero, matching the official leaderboard behavior\n- Full-page parsing targets are long, so allow a generous `max_tokens` (4096 or more)\n- Requires: `apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`\n  (`pip install 'evalscope[cc_ocr_v2]'`)\n- The dataset is a file tree of images and answers (about 5 GB). Only the tracks listed in\n  `subset_list` are downloaded, so restricting subsets keeps the download small\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `cc_ocr_v2` |\n| **Dataset ID** | [evalscope/CC-OCR-V2](https://modelscope.cn/datasets/evalscope/CC-OCR-V2/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2605.03903) |\n| **Tags** | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |\n| **Metrics** | `score` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 7,091 |\n| Prompt Length (Mean) | 272.16 chars |\n| Prompt Length (Min/Max) | 10 / 1330 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `multi_lingual_recognition` | 639 | 101 | 101 | 101 |\n| `natural_scene_recognition` | 1,150 | 101.87 | 101 | 103 |\n| `complex_table_parsing` | 300 | 327 | 327 | 327 |\n| `formula_parsing` | 100 | 119 | 119 | 119 |\n| `general_documents_parsing` | 299 | 258 | 258 | 258 |\n| `info_board_parsing` | 26 | 701 | 701 | 701 |\n| `molecular_parsing` | 100 | 232 | 232 | 232 |\n| `object_grounding` | 734 | 491.83 | 306 | 1330 |\n| `text_grounding` | 734 | 369.88 | 358 | 468 |\n| `business_transactions` | 340 | 793.91 | 702 | 1105 |\n| `public_services` | 369 | 735.45 | 687 | 902 |\n| `regulated_records` | 300 | 798.84 | 722 | 898 |\n| `blueprint_qa` | 100 | 25.4 | 10 | 69 |\n| `dashboards_fact_qa` | 400 | 66.59 | 19 | 159 |\n| `dashboards_numeric_qa` | 500 | 70.49 | 19 | 148 |\n| `financial_documents_qa` | 1,000 | 41.77 | 14 | 115 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 7,116 |\n| Images per Sample | min: 1, max: 3, mean: 1.0 |\n| Resolution Range | 70x71 - 5313x7219 |\n| Formats | jpeg, png |\n\n\n## Sample Example\n\n**Subset**: `multi_lingual_recognition`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"253834d2\",\n      \"content\": [\n        {\n          \"image\": \"~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg\"\n        },\n        {\n          \"text\": \"Please output only the text content from the image without any additional descriptions or formatting.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"الآن بحق السماء يا دجونا، أكل طعامك المتحجر غير المطابقة ....Demonstrandum\\n.للمواصفات واتركني بسلام .”قال دجونا بحزن وهو ينظر إلى الحقيبة الفارغة: “لقد ذهب كل شيء أنا هنا!” صرخ بصوت غالي مرح، وكتم إليري أنينًا آخر عندما رأى السيد دوفال يقفز“\\n ... [TRUNCATED 1733 chars] ... حنة الحشد“\\nكان هناك ضحكة خفيفة. كان الشخص الضعيف القلب الذي خاطبه المرافق شابًا زنجيًا\\nقويًا، يرتدي ملابس بنية سيمفونية أنيقة، وقبعته القشية مبهرة على الكربون السخام\\n!الموجود في جلده. ضحكت فتاة جميلة ملونة على ذراعه. “هيا يا عزيزتي، سوف نريهم\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"multi_lingual_recognition\",\n  \"metadata\": {\n    \"id\": \"0c780237abcb\",\n    \"task\": \"recognition\",\n    \"sub_task\": \"multi_lingual_recognition\",\n    \"scenario\": \"multi_lan_ocr_Arabic_Arabic_20\",\n    \"image_paths\": [\n      \"~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg\"\n    ]\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets cc_ocr_v2 \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['cc_ocr_v2'],\n    dataset_args={\n        'cc_ocr_v2': {\n            # subset_list: ['multi_lingual_recognition', 'natural_scene_recognition', 'complex_table_parsing']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# CC-OCR-V2\n\n\n## 概述\n\nCC-OCR V2 是一个面向真实企业文档处理场景的高难度 OCR 基准测试。它刻意对先前 OCR 基准测试中代表性不足的困难和边缘案例进行了过采样，例如拍摄或扫描的表格、手写公式、多页收据以及低质量的多语言自然场景文本。\n\n## 任务描述\n\n- **任务类型**：文本识别、文档解析、文档定位（grounding）、关键信息抽取和文档问答（VQA）\n- **输入**：一张或多张文档图像，以及每个样本附带的任务指令\n- **输出**：自由格式文本、LaTeX、HTML 表格、SMILES 字符串、JSON 对象或边界框，具体取决于任务赛道\n- **模态**：图像 + 文本，双语（中文 / 英文），识别赛道额外包含 32 种语言\n\n## 核心特性\n\n- 共包含 7,093 个官方样本，覆盖 5 个赛道和 16 个子任务，统一作为单一基准进行评估；由于数据集仓库中缺少其中两个样本的图像，实际加载 7,091 个样本\n- **识别（recognition）**：多语言（32 种语言）及自然场景文本阅读\n- **解析（parsing）**：复杂表格、通用文档、手写公式、分子结构和信息公告板\n- **定位（grounding）**：文本定位（单框）和对象定位（带标签的多框检测）\n- **抽取（extraction）**：基于模式（schema-driven）的关键信息抽取，涵盖商业、公共服务和监管记录\n- **问答（qa）**：针对蓝图、仪表盘和财务文档的问答任务\n- 提示词（prompts）直接来自官方数据集，确保结果可与已发布的排行榜进行比较\n\n## 评估说明\n\n- 每个样本产生一个 `[0, 1]` 范围内的 `score`；各赛道使用其官方指标：\n  - 识别 = token 级别 F1\n  - 解析 = 编辑相似度 / TEDS\n  - 定位 = IoU\n  - 抽取 = 字段级别 F1\n  - 问答 = 子串匹配，辅以 ANLS 回退策略\n- 子集得分是样本得分的均值；各赛道类别还会报告其子任务的宏平均分\n- 定位任务的提示要求在 0–1000 的归一化坐标网格上返回边界框；若预测使用绝对像素坐标，则会被重新缩放为归一化形式，否则得分将接近零，与官方排行榜行为一致\n- 全页解析的目标输出较长，因此需设置较大的 `max_tokens`（建议 4096 或更高）\n- 依赖项：`apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`  \n  （可通过 `pip install 'evalscope[cc_ocr_v2]'` 安装）\n- 数据集以图像和答案组成的文件树形式提供（约 5 GB）。仅下载 `subset_list` 中指定的赛道，因此限制子集可显著减小下载体积\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `cc_ocr_v2` |\n| **数据集ID** | [evalscope/CC-OCR-V2](https://modelscope.cn/datasets/evalscope/CC-OCR-V2/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2605.03903) |\n| **标签** | `Grounding`, `MultiLingual`, `MultiModal`, `QA` |\n| **指标** | `score` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 7,091 |\n| 提示词长度（平均） | 272.16 字符 |\n| 提示词长度（最小/最大） | 10 / 1330 字符 |\n\n**各子集统计：**\n\n| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |\n|--------|---------|-------------|------------|------------|\n| `multi_lingual_recognition` | 639 | 101 | 101 | 101 |\n| `natural_scene_recognition` | 1,150 | 101.87 | 101 | 103 |\n| `complex_table_parsing` | 300 | 327 | 327 | 327 |\n| `formula_parsing` | 100 | 119 | 119 | 119 |\n| `general_documents_parsing` | 299 | 258 | 258 | 258 |\n| `info_board_parsing` | 26 | 701 | 701 | 701 |\n| `molecular_parsing` | 100 | 232 | 232 | 232 |\n| `object_grounding` | 734 | 491.83 | 306 | 1330 |\n| `text_grounding` | 734 | 369.88 | 358 | 468 |\n| `business_transactions` | 340 | 793.91 | 702 | 1105 |\n| `public_services` | 369 | 735.45 | 687 | 902 |\n| `regulated_records` | 300 | 798.84 | 722 | 898 |\n| `blueprint_qa` | 100 | 25.4 | 10 | 69 |\n| `dashboards_fact_qa` | 400 | 66.59 | 19 | 159 |\n| `dashboards_numeric_qa` | 500 | 70.49 | 19 | 148 |\n| `financial_documents_qa` | 1,000 | 41.77 | 14 | 115 |\n\n**图像统计：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 7,116 |\n| 每样本图像数 | 最小: 1, 最大: 3, 平均: 1.0 |\n| 分辨率范围 | 70x71 - 5313x7219 |\n| 格式 | jpeg, png |\n\n\n## 样例示例\n\n**子集**: `multi_lingual_recognition`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"253834d2\",\n      \"content\": [\n        {\n          \"image\": \"~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg\"\n        },\n        {\n          \"text\": \"Please output only the text content from the image without any additional descriptions or formatting.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"الآن بحق السماء يا دجونا، أكل طعامك المتحجر غير المطابقة ....Demonstrandum\\n.للمواصفات واتركني بسلام .”قال دجونا بحزن وهو ينظر إلى الحقيبة الفارغة: “لقد ذهب كل شيء أنا هنا!” صرخ بصوت غالي مرح، وكتم إليري أنينًا آخر عندما رأى السيد دوفال يقفز“\\n ... [TRUNCATED 1733 chars] ... حنة الحشد“\\nكان هناك ضحكة خفيفة. كان الشخص الضعيف القلب الذي خاطبه المرافق شابًا زنجيًا\\nقويًا، يرتدي ملابس بنية سيمفونية أنيقة، وقبعته القشية مبهرة على الكربون السخام\\n!الموجود في جلده. ضحكت فتاة جميلة ملونة على ذراعه. “هيا يا عزيزتي، سوف نريهم\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"multi_lingual_recognition\",\n  \"metadata\": {\n    \"id\": \"0c780237abcb\",\n    \"task\": \"recognition\",\n    \"sub_task\": \"multi_lingual_recognition\",\n    \"scenario\": \"multi_lan_ocr_Arabic_Arabic_20\",\n    \"image_paths\": [\n      \"~/.cache/modelscope/hub/datasets/evalscope/CC-OCR-V2/recognition/multi_lingual_recognition/images/multi_lan_ocr_Arabic_Arabic_20/0c780237abcb.jpg\"\n    ]\n  }\n}\n```\n\n*注：部分内容因展示需要已被截断。*\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets cc_ocr_v2 \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['cc_ocr_v2'],\n    dataset_args={\n        'cc_ocr_v2': {\n            # subset_list: ['multi_lingual_recognition', 'natural_scene_recognition', 'complex_table_parsing']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "a53d38b3ceb33f4d3ea084622555a610",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-10T12:23:51.218226",
+  "translation_updated_at": "2026-08-10T12:23:57"
+}

--- a/evalscope/benchmarks/cc_ocr_v2/cc_ocr_v2_adapter.py
+++ b/evalscope/benchmarks/cc_ocr_v2/cc_ocr_v2_adapter.py
@@ -103,7 +103,6 @@ class CCOCRV2Adapter(VisionLanguageAdapter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.reformat_subset = True
         self.add_aggregation_name = False
         self.category_map = SUBSET_TO_TRACK
 

--- a/evalscope/benchmarks/cc_ocr_v2/cc_ocr_v2_adapter.py
+++ b/evalscope/benchmarks/cc_ocr_v2/cc_ocr_v2_adapter.py
@@ -1,0 +1,246 @@
+# flake8: noqa: E501
+import os
+import re
+from typing import Any, Dict, List, Tuple
+
+from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
+from evalscope.api.dataset import (
+    DatasetDict,
+    Sample,
+    build_dataset_dict_from_record_map,
+    resolve_snapshot_or_local_path,
+)
+from evalscope.api.evaluator.state import TaskState
+from evalscope.api.messages import ChatMessageUser, Content, ContentImage, ContentText
+from evalscope.api.metric.scorer import Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from evalscope.utils.import_utils import check_import
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg', '.webp', '.bmp')
+
+# Track (level 1) -> sub-task (level 2). Sub-tasks are the report subsets; the finer-grained
+# scenario directories (level 3) only drive scenario-specific scoring rules.
+TASK_STRUCTURE: Dict[str, List[str]] = {
+    'recognition': ['multi_lingual_recognition', 'natural_scene_recognition'],
+    'parsing': [
+        'complex_table_parsing', 'formula_parsing', 'general_documents_parsing', 'info_board_parsing',
+        'molecular_parsing'
+    ],
+    'grounding': ['object_grounding', 'text_grounding'],
+    'extraction': ['business_transactions', 'public_services', 'regulated_records'],
+    'qa': ['blueprint_qa', 'dashboards_fact_qa', 'dashboards_numeric_qa', 'financial_documents_qa'],
+}
+
+SUBSET_TO_TRACK: Dict[str, str] = {
+    sub_task: track
+    for track, sub_tasks in TASK_STRUCTURE.items()
+    for sub_task in sub_tasks
+}
+
+SUBSET_LIST: List[str] = list(SUBSET_TO_TRACK)
+
+DESCRIPTION = """
+## Overview
+
+CC-OCR V2 is a challenging OCR benchmark tailored to real-world enterprise document processing. It deliberately
+over-samples the hard and corner cases that prior OCR benchmarks under-represent, such as photographed and
+scanned tables, handwritten formulas, multi-page receipts, and low-quality multilingual scene text.
+
+## Task Description
+
+- **Task Type**: Text recognition, document parsing, document grounding, key information extraction, and document VQA
+- **Input**: One or more document images plus the task instruction shipped with each sample
+- **Output**: Free-form text, LaTeX, HTML tables, SMILES strings, JSON objects, or bounding boxes, depending on the track
+- **Modalities**: Image + text, bilingual (Chinese / English) with 32 additional languages in the recognition track
+
+## Key Features
+
+- 7,093 official samples over 5 tracks and 16 sub-tasks, evaluated as one benchmark; 7,091 are
+  loaded because the dataset repository ships no image for two of them
+- **recognition**: multilingual (32 languages) and natural-scene text reading
+- **parsing**: complex tables, general documents, handwritten formulas, molecular structures, and information boards
+- **grounding**: text grounding (single box) and object grounding (multi-box detection with labels)
+- **extraction**: schema-driven key information extraction over business, public-service, and regulated records
+- **qa**: question answering over blueprints, dashboards, and financial documents
+- Prompts come from the official dataset, so results stay comparable to the published leaderboard
+
+## Evaluation Notes
+
+- Every sample yields one `score` in `[0, 1]`; each track uses its official metric:
+  recognition = token-level F1, parsing = edit similarity / TEDS, grounding = IoU,
+  extraction = field-level F1, qa = substring match with ANLS fallback
+- Subset scores are sample means; the per-track category also reports a macro average over its sub-tasks
+- The grounding prompts ask for boxes on a 0-1000 grid; predictions in absolute pixels are rescaled
+  as if normalized and therefore score close to zero, matching the official leaderboard behavior
+- Full-page parsing targets are long, so allow a generous `max_tokens` (4096 or more)
+- Requires: `apted`, `distance`, `lxml`, `python-Levenshtein`, `scipy`, `zss`
+  (`pip install 'evalscope[cc_ocr_v2]'`)
+- The dataset is a file tree of images and answers (about 5 GB). Only the tracks listed in
+  `subset_list` are downloaded, so restricting subsets keeps the download small
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='cc_ocr_v2',
+        pretty_name='CC-OCR-V2',
+        tags=[Tags.MULTI_MODAL, Tags.QA, Tags.GROUNDING, Tags.MULTI_LINGUAL],
+        description=DESCRIPTION,
+        dataset_id='evalscope/CC-OCR-V2',
+        subset_list=SUBSET_LIST,
+        metric_list=['score'],
+        eval_split='test',
+        paper_url='https://arxiv.org/abs/2605.03903',
+    )
+)
+class CCOCRV2Adapter(VisionLanguageAdapter):
+    """CC-OCR V2 is distributed as a file tree of ``question`` / ``answer`` / ``images`` folders,
+    so the dataset is assembled by scanning the snapshot instead of loading a tabular split."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reformat_subset = True
+        self.add_aggregation_name = False
+        self.category_map = SUBSET_TO_TRACK
+
+    def load(self) -> Tuple[DatasetDict, None]:
+        check_import(
+            module_name=['apted', 'distance', 'Levenshtein', 'lxml', 'scipy', 'zss'],
+            extra='cc_ocr_v2',
+            raise_error=True,
+            feature_name='CC-OCR-V2 benchmark',
+        )
+
+        unknown = [subset for subset in self.subset_list if subset not in SUBSET_TO_TRACK]
+        if unknown:
+            raise ValueError(f'Unknown CC-OCR V2 subsets {unknown}. Valid subsets are: {SUBSET_LIST}')
+
+        # Only fetch the selected sub-tasks; the full benchmark is roughly 5 GB of images.
+        dataset_root = resolve_snapshot_or_local_path(
+            self, allow_file_pattern=[f'{SUBSET_TO_TRACK[subset]}/{subset}/*' for subset in self.subset_list]
+        )
+
+        record_map = {}
+        for subset in self.subset_list:
+            records = self._scan_sub_task(dataset_root, subset)
+            if records:
+                record_map[subset] = records
+
+        if not record_map:
+            raise FileNotFoundError(f'No CC-OCR V2 samples found under {dataset_root}.')
+
+        return build_dataset_dict_from_record_map(
+            record_map=record_map,
+            sample_fields=self.record_to_sample,
+            location=self.dataset_id,
+            limit=self.limit,
+            repeats=self.repeats,
+            shuffle=self.shuffle,
+            seed=None,
+        ), None
+
+    def _scan_sub_task(self, dataset_root: str, sub_task: str) -> List[Dict[str, Any]]:
+        """Collect one record per question file, pairing it with its answer and image(s)."""
+        task_dir = os.path.join(dataset_root, SUBSET_TO_TRACK[sub_task], sub_task)
+        question_root = os.path.join(task_dir, 'question')
+        if not os.path.isdir(question_root):
+            logger.warning(f'CC-OCR V2 sub-task directory is missing: {question_root}')
+            return []
+
+        records: List[Dict[str, Any]] = []
+        for scenario in sorted(os.listdir(question_root)):
+            scenario_dir = os.path.join(question_root, scenario)
+            if not os.path.isdir(scenario_dir):
+                continue
+            image_index = _index_images(os.path.join(task_dir, 'images', scenario))
+            for question_name in sorted(os.listdir(scenario_dir)):
+                if not question_name.endswith('.txt'):
+                    continue
+                sample_id = question_name[:-len('.txt')]
+                answer_path = os.path.join(task_dir, 'answer', scenario, question_name)
+                image_paths = image_index.get(sample_id, [])
+                if not os.path.isfile(answer_path) or not image_paths:
+                    # Samples without an answer or image cannot be scored; drop them loudly
+                    # rather than letting them reach the model and score zero.
+                    logger.warning(f'Skipping incomplete CC-OCR V2 sample {sub_task}/{scenario}/{sample_id}.')
+                    continue
+                records.append({
+                    'id': sample_id,
+                    'sub_task': sub_task,
+                    'scenario': scenario,
+                    'question': _read_text(os.path.join(scenario_dir, question_name)),
+                    'answer': _read_text(answer_path),
+                    'image_paths': image_paths,
+                })
+        return records
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        # Images precede the instruction, matching the official request builder.
+        content: List[Content] = [ContentImage(image=path) for path in record['image_paths']]
+        content.append(ContentText(text=record['question']))
+
+        sub_task = record['sub_task']
+        return Sample(
+            input=[ChatMessageUser(content=content)],
+            target=record['answer'],
+            subset_key=sub_task,
+            metadata={
+                'id': record['id'],
+                'task': SUBSET_TO_TRACK[sub_task],
+                'sub_task': sub_task,
+                'scenario': record['scenario'],
+                # Grounding scoring reads the image size from this path to map predicted
+                # coordinates into pixels, so it must survive into the review records.
+                'image_paths': record['image_paths'],
+            },
+        )
+
+    def match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        from .utils import score_sample
+
+        score = Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+        )
+        score.value = {'score': score_sample(filtered_prediction, reference, task_state.metadata or {})}
+        score.main_score_name = 'score'
+        return score
+
+
+def _read_text(path: str) -> str:
+    with open(path, 'r', encoding='utf-8', errors='replace') as file:
+        return file.read()
+
+
+def _natural_key(name: str) -> List[Any]:
+    return [int(part) if part.isdigit() else part.lower() for part in re.split(r'(\d+)', name)]
+
+
+def _index_images(scenario_image_dir: str) -> Dict[str, List[str]]:
+    """Map each sample id to its image(s): a single ``<id>.<ext>`` file, or the page files of a
+    ``<id>/`` directory for multi-page documents."""
+    index: Dict[str, List[str]] = {}
+    if not os.path.isdir(scenario_image_dir):
+        return index
+
+    for name in os.listdir(scenario_image_dir):
+        path = os.path.join(scenario_image_dir, name)
+        if os.path.isdir(path):
+            pages = [page for page in os.listdir(path) if os.path.splitext(page)[1].lower() in IMAGE_EXTENSIONS]
+            if pages:
+                index[name] = [os.path.join(path, page) for page in pages]
+        else:
+            stem, extension = os.path.splitext(name)
+            if extension.lower() in IMAGE_EXTENSIONS:
+                index.setdefault(stem, []).append(path)
+
+    for paths in index.values():
+        # Natural order so page_2 precedes page_10 in multi-page documents.
+        paths.sort(key=lambda page_path: _natural_key(os.path.basename(page_path)))
+    return index

--- a/evalscope/benchmarks/cc_ocr_v2/requirements.txt
+++ b/evalscope/benchmarks/cc_ocr_v2/requirements.txt
@@ -1,0 +1,6 @@
+apted
+distance
+lxml
+python-Levenshtein
+scipy
+zss

--- a/evalscope/benchmarks/cc_ocr_v2/utils.py
+++ b/evalscope/benchmarks/cc_ocr_v2/utils.py
@@ -1,0 +1,688 @@
+# flake8: noqa: E501
+"""Per-sample scoring for CC-OCR V2, ported from the official evaluation scripts.
+
+Reference: https://github.com/eioss/CC-OCR-V2 (``src/evaluate_*.py``). Each track keeps its
+own metric, and every function below scores a single sample so the framework's ``mean``
+aggregation reproduces the official per-dataset averages.
+"""
+
+import ast
+import json
+import os
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+_CODE_FENCE_RE = re.compile(r'^```(?:json)?\s*(.*?)\s*```$', re.DOTALL | re.IGNORECASE)
+_TABLE_BLOCK_RE = re.compile(r'<table\b[^>]*>.*?</table>', re.IGNORECASE | re.DOTALL)
+_CUSTOM_SEP_RE = re.compile(r'[/／|｜]+')
+_BBOX_RE = re.compile(r'[\(\[]\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*[\)\]]')
+
+# LaTeX preamble commands dropped from document-parsing predictions before scoring.
+_LATEX_PREAMBLE_PATTERNS = [
+    r'\\documentclass\{.*?\}',
+    r'\\usepackage\[.*?\]\{.*?\}',
+    r'\\usepackage\{.*?\}',
+    r'\\geometry\{.*?\}',
+    r'\\begin\{document\}',
+    r'\\end\{document\}',
+    r'\\noindent',
+]
+
+_LATEX_META_TAIL = re.compile(
+    r'(?is)\n\s*(?:'
+    r'#{1,6}\s*(?:📝\s*)?(?:Notes(?:\s+on\s+Transcription)?\s*:?[^\n]*)'
+    r'|📌\s*Notes[^\n]*'
+    r')(?:\n.*)*\Z'
+)
+_LATEX_LEADING_FLUFF = re.compile(
+    r'(?is)^(?:'
+    r'Here (?:is|’s|\'s|are) (?:the )?(?:LaTeX|latex) [^\n]+(?:\n|$)'
+    r'|Note that [^\n]+(?:\n|$)'
+    r')+'
+)
+_HTML_META_TAIL = re.compile(
+    r'(?is)\n\s*(?:'
+    r'#{1,6}\s*(?:📝\s*)?Notes[^\n]*'
+    r'|📌\s*Notes[^\n]*'
+    r'|✅\s*\*{0,2}Note\*{0,2}\s*:'
+    r'|>{0,1}\s*\*{0,2}\s*Note\*{0,2}\s*:'
+    r')(?:\n.*)*\Z'
+)
+
+# Weight of the table TEDS term in the mixed text+table score used by info-board parsing.
+_CUSTOM_TABLE_WEIGHT = 0.9
+
+# ##########################
+# SHARED TEXT HELPERS
+# ##########################
+
+
+def strip_code_fence(text: str) -> str:
+    """Return the body of a fully fenced code block, or the text unchanged.
+
+    Only bare and ``json`` fences are recognised, matching the official scorers: an ``html`` or
+    ``latex`` fence is left in place and therefore counts against the prediction, except in the
+    parsing track which unwraps those tags explicitly.
+    """
+    text = text.strip()
+    match = _CODE_FENCE_RE.match(text)
+    return match.group(1).strip() if match else text
+
+
+def has_cjk(text: str) -> bool:
+    return any('\u4e00' <= char <= '\u9fff' for char in text)
+
+
+def convert_to_halfwidth(text: str) -> str:
+    table = str.maketrans(
+        '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～',
+        '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
+    )
+    return text.translate(table)
+
+
+def text_normalize_and_tokenize(
+    text: str,
+    is_keep_blank: bool = True,
+    is_lower: bool = True,
+    is_alphanum_only: bool = False,
+) -> List[str]:
+    """Tokenize OCR text into words (``is_keep_blank``) or characters."""
+    text = text.replace('\t', ' ').replace('\n', ' ').replace('###', '').replace('***', '')
+    text = re.sub(r'\s+', ' ', text)
+    if not is_keep_blank:
+        text = text.replace(' ', '')
+    tokens = text.split(' ') if is_keep_blank else list(text)
+    if is_lower:
+        tokens = [token.lower() for token in tokens]
+    if is_alphanum_only:
+        tokens = [re.sub('[^A-Za-z0-9]+', '', token) for token in tokens]
+    return [token for token in tokens if token]
+
+
+def token_multiset_f1(gt_tokens: Sequence[str], pred_tokens: Sequence[str]) -> float:
+    """F1 over token multisets. Single-sample micro and macro F1 coincide, so one
+    implementation serves both the recognition track and the info-board text term."""
+    pred_counter = Counter(pred_tokens)
+    right_num = sum(min(count, pred_counter.get(token, 0)) for token, count in Counter(gt_tokens).items())
+    recall = right_num / (len(gt_tokens) + 1e-9)
+    precision = right_num / (len(pred_tokens) + 1e-9)
+    return 2 * recall * precision / (recall + precision + 1e-9)
+
+
+def edit_similarity(pred: str, gt: str) -> float:
+    """``1 - normalized Levenshtein distance``; two empty strings count as identical."""
+    from evalscope.metrics.utils.functions import levenshtein_distance
+
+    length = max(len(pred), len(gt))
+    if length == 0:
+        return 1.0
+    return 1 - levenshtein_distance(pred, gt) / length
+
+
+# ##########################
+# RECOGNITION
+# ##########################
+
+
+def score_recognition(prediction: str, reference: str, scenario: str) -> float:
+    """Token-level F1. Chinese/Japanese/Korean/Arabic ground truth is scored per character;
+    multi-scene word-level data additionally keeps alphanumeric characters only."""
+    gt_text = reference.strip()
+    pred_text = strip_code_fence(prediction).strip()
+
+    is_word_level = not has_cjk(gt_text)
+    is_alphanum_only = is_word_level and scenario.startswith('multi_scene_ocr')
+
+    gt_tokens = text_normalize_and_tokenize(gt_text, is_word_level, True, is_alphanum_only)
+    pred_tokens = text_normalize_and_tokenize(pred_text, is_word_level, True, is_alphanum_only)
+    return token_multiset_f1(gt_tokens, pred_tokens)
+
+
+# ##########################
+# KEY INFORMATION EXTRACTION
+# ##########################
+
+
+def _fullwidth_to_halfwidth(text: str) -> str:
+    result = ''
+    for char in text:
+        code_point = ord(char)
+        if code_point == 0x3000:
+            code_point = 0x0020
+        elif code_point == 0xFFE5:
+            code_point = 0x00A5
+        elif code_point == 0x2014:
+            code_point = 0x002D
+        elif code_point == 0x2103:
+            result += chr(0x00B0) + 'C'
+            continue
+        elif 0xFF01 <= code_point <= 0xFF5E:
+            code_point -= 0xFEE0
+        result += chr(code_point)
+    result = result.replace('、', ',')
+    result = result.replace('-', '')
+    result = result.replace('–', '')
+    result = result.replace('’', "'")
+    return result.rstrip('。.')
+
+
+def _remove_unnecessary_spaces(text: str) -> str:
+    if '```json' in text:
+        match = re.search(r'```json\s*(.*?)\s*```', text, re.DOTALL)
+        if match:
+            text = match.group(1).strip()
+    elif '```' in text:
+        match = re.search(r'```\s*(.*?)\s*```', text, re.DOTALL)
+        if match:
+            text = match.group(1).strip()
+    return re.sub(r'\s+', '', text)
+
+
+def _normalize_kie_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_kie_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_kie_value(item) for item in value]
+    if isinstance(value, str):
+        return _remove_unnecessary_spaces(_fullwidth_to_halfwidth(value))
+    return value
+
+
+def _normalize_kie_dict(data: Any) -> Any:
+    """Sort keys and coerce leaves to lists of stripped strings (donut-style normalization)."""
+    if isinstance(data, dict):
+        new_data = {}
+        for key in sorted(data.keys(), key=lambda k: (len(k), k)):
+            value = _normalize_kie_dict(data[key])
+            if value:
+                if not isinstance(value, list):
+                    value = [value]
+                new_data[key] = value
+        return new_data
+    if isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            return [item for item in (_normalize_kie_dict(entry) for entry in data) if item]
+        return [str(item).strip() for item in data if type(item) in {str, int, float} and str(item).strip()]
+    return [str(data).strip()]
+
+
+def _flatten_kie_fields(data: Any) -> List[Tuple[str, Any]]:
+    """Flatten a nested dict into ``(dotted_key, leaf_value)`` pairs."""
+    flat: List[Tuple[str, Any]] = []
+
+    def _walk(value: Any, key: str = '') -> None:
+        if isinstance(value, dict):
+            for child_key, child_value in value.items():
+                _walk(child_value, f'{key}.{child_key}' if key else child_key)
+        elif isinstance(value, list):
+            for item in value:
+                _walk(item, key)
+        else:
+            flat.append((key, value))
+
+    _walk(data)
+    return flat
+
+
+def _parse_kie_json(text: str) -> Any:
+    content = text.strip()
+    if '```json' in content:
+        match = re.search(r'```json\s*(.*?)\s*```', content, re.DOTALL)
+        if match:
+            content = match.group(1)
+    elif '```' in content:
+        match = re.search(r'```\s*(.*?)\s*```', content, re.DOTALL)
+        if match:
+            content = match.group(1)
+    try:
+        return json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def score_kie(prediction: str, reference: str) -> float:
+    """Field-level F1 between the predicted and reference JSON objects."""
+    pred = _parse_kie_json(prediction)
+    gt = _parse_kie_json(reference)
+    if gt is None:
+        logger.warning('CC-OCR V2 extraction reference is not valid JSON; scoring the sample as 0.')
+        return 0.0
+
+    pred_fields = _flatten_kie_fields(_normalize_kie_dict(_normalize_kie_value(pred if pred is not None else {})))
+    gt_fields = _flatten_kie_fields(_normalize_kie_dict(_normalize_kie_value(gt)))
+
+    true_positive, mismatch = 0, 0
+    for field in pred_fields:
+        if field in gt_fields:
+            true_positive += 1
+            gt_fields.remove(field)
+        else:
+            mismatch += 1
+    mismatch += len(gt_fields)
+    return true_positive / (true_positive + mismatch / 2 + 1e-6)
+
+
+# ##########################
+# DOCUMENT QUESTION ANSWERING
+# ##########################
+
+
+def _parse_vqa_reference(reference: str) -> Any:
+    raw = reference.strip()
+    if raw.startswith('['):
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            try:
+                data = ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                data = None
+        if isinstance(data, list) and data:
+            return data
+    return raw
+
+
+def _anls(predict: str, answer: str) -> float:
+    from evalscope.metrics.utils.functions import levenshtein_distance
+
+    length = max(len(predict), len(answer))
+    if length == 0:
+        return 0.0
+    value = 1 - levenshtein_distance(predict, answer) / length
+    return value if value >= 0.5 else 0.0
+
+
+def _score_vqa_answer(predict: str, answer: str, is_chinese: bool, anls_fallback: bool) -> float:
+    """Substring match for short answers, ANLS for long ones (official CC-OCR V2 rule).
+
+    ``anls_fallback`` mirrors ``cn_vqa_evaluation``, which -- unlike every other branch of the
+    official scorers -- also falls back to ANLS when a short Chinese answer is not contained
+    in the prediction.
+    """
+    if is_chinese:
+        answer = answer.lower().strip().replace('\n', ' ').replace(' ', '')
+        predict = predict.lower().strip().replace('\n', ' ').replace(' ', '')
+        is_short = len(answer.split(',')) < 4
+    else:
+        answer = answer.lower().strip().replace('\n', ' ')
+        predict = predict.lower().strip().replace('\n', ' ')
+        is_short = len(answer.split()) < 5
+
+    if not is_short:
+        return _anls(predict, answer)
+    if answer in predict:
+        return 1.0
+    return _anls(predict, answer) if anls_fallback else 0.0
+
+
+def score_vqa(prediction: str, reference: str) -> float:
+    predict = strip_code_fence(prediction).strip()
+    if not predict:
+        return 0.0
+
+    answers = _parse_vqa_reference(reference)
+    is_list = isinstance(answers, list)
+    answer_list = [str(item) for item in answers] if is_list else [str(answers)]
+    is_chinese = has_cjk(' '.join(answer_list))
+    return max(_score_vqa_answer(predict, answer, is_chinese, is_chinese and not is_list) for answer in answer_list)
+
+
+# ##########################
+# GROUNDING
+# ##########################
+
+
+def iou_xyxy(box_a: Sequence[float], box_b: Sequence[float]) -> float:
+    ax1, ay1, ax2, ay2 = (float(value) for value in box_a[:4])
+    bx1, by1, bx2, by2 = (float(value) for value in box_b[:4])
+    inter_w = max(0.0, min(ax2, bx2) - max(ax1, bx1))
+    inter_h = max(0.0, min(ay2, by2) - max(ay1, by1))
+    inter = inter_w * inter_h
+    union = max(0.0, ax2 - ax1) * max(0.0, ay2 - ay1) + max(0.0, bx2 - bx1) * max(0.0, by2 - by1) - inter
+    return inter / union if union > 0 else 0.0
+
+
+def parse_point_box(text: str) -> Optional[List[float]]:
+    """Extract the first ``(x1, y1, x2, y2)`` tuple from free-form text."""
+    match = _BBOX_RE.search(strip_code_fence(text))
+    if not match:
+        return None
+    return [float(match.group(index)) for index in range(1, 5)]
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def normalize_bbox_xyxy(bbox: Any) -> Optional[List[float]]:
+    """Coerce the bbox notations emitted by different model families into ``[x1, y1, x2, y2]``."""
+    if isinstance(bbox, (list, tuple)):
+        if len(bbox) < 4:
+            return None
+        values = [_to_float(bbox[index]) for index in range(4)]
+        return None if any(value is None for value in values) else values
+    if not isinstance(bbox, dict):
+        return None
+
+    lowered = {str(key).lower().strip(): value for key, value in bbox.items() if key is not None}
+
+    def get(*names: str) -> Optional[float]:
+        for name in names:
+            if name in lowered:
+                value = _to_float(lowered[name])
+                if value is not None:
+                    return value
+        return None
+
+    for keys in (('x1', 'y1', 'x2', 'y2'), ('x1', 'y', 'x2', 'y2'), ('xmin', 'ymin', 'xmax', 'ymax'),
+                 ('left', 'top', 'right', 'bottom'), ('x0', 'y0', 'x1', 'y1')):
+        corners = [get(key) for key in keys]
+        if all(corner is not None for corner in corners):
+            return corners
+
+    x, y = get('x'), get('y')
+    width, height = get('width', 'w'), get('height', 'h')
+    if None not in (x, y, width, height):
+        return [x, y, x + width, y + height]
+    return None
+
+
+def parse_object_list(text: str) -> Optional[List[List[float]]]:
+    """Parse a JSON array of detections into a list of ``[x1, y1, x2, y2]`` boxes."""
+    content = strip_code_fence(text)
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        try:
+            data = ast.literal_eval(content)
+        except (ValueError, SyntaxError):
+            return None
+    if not isinstance(data, list):
+        return None
+
+    boxes = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        label = item.get('label', item.get('category_name'))
+        bbox = item.get('bbox_2d') or item.get('bbox') or item.get('box_2d')
+        if label is None or not bbox:
+            continue
+        xyxy = normalize_bbox_xyxy(bbox)
+        if xyxy is not None:
+            boxes.append(xyxy)
+    return boxes
+
+
+def _image_size(image_path: str) -> Optional[Tuple[int, int]]:
+    if not image_path or not os.path.exists(image_path):
+        return None
+    from PIL import Image
+
+    with Image.open(image_path) as image:
+        return image.size
+
+
+def _to_pixel_boxes(boxes: List[List[float]], size: Optional[Tuple[int, int]]) -> List[List[float]]:
+    """Rescale predicted boxes to pixels. Values within ``[0, 1]`` are treated as unit
+    normalized, anything larger as the 0-1000 grid requested by the prompt."""
+    if not size:
+        return boxes
+    width, height = size
+    scale = 1 if max(value for box in boxes for value in box[:4]) <= 1.0 else 1000
+    return [[box[0] * width / scale, box[1] * height / scale, box[2] * width / scale, box[3] * height / scale]
+            for box in boxes]
+
+
+def score_text_grounding(prediction: str, reference: str, image_path: str) -> float:
+    try:
+        gt_box = ast.literal_eval(reference.strip())
+    except (ValueError, SyntaxError):
+        gt_box = None
+    if not isinstance(gt_box, (list, tuple)) or len(gt_box) < 4:
+        logger.warning('CC-OCR V2 text grounding reference is not a bounding box; scoring the sample as 0.')
+        return 0.0
+
+    pred_box = parse_point_box(prediction)
+    if pred_box is None:
+        return 0.0
+    return iou_xyxy(_to_pixel_boxes([pred_box], _image_size(image_path))[0], gt_box)
+
+
+def score_object_grounding(prediction: str, reference: str, image_path: str) -> float:
+    """Mean IoU over ground-truth boxes after optimal one-to-one matching."""
+    import numpy as np
+    from scipy.optimize import linear_sum_assignment
+
+    gt_boxes = parse_object_list(reference)
+    if not gt_boxes:
+        logger.warning('CC-OCR V2 object grounding reference has no boxes; scoring the sample as 0.')
+        return 0.0
+
+    pred_boxes = parse_object_list(prediction)
+    if not pred_boxes:
+        return 0.0
+
+    pred_boxes = _to_pixel_boxes(pred_boxes, _image_size(image_path))
+    iou_matrix = np.array([[iou_xyxy(gt, pred) for pred in pred_boxes] for gt in gt_boxes])
+    rows, cols = linear_sum_assignment(-iou_matrix)
+    return float(iou_matrix[rows, cols].sum() / len(gt_boxes))
+
+
+# ##########################
+# DOCUMENT PARSING
+# ##########################
+
+
+def parsing_op(scenario: str) -> str:
+    """Map a parsing scenario directory name to its scoring mode."""
+    name = scenario.lower()
+    for keyword in ('formula', 'molecular', 'custom', 'table'):
+        if keyword in name:
+            return keyword
+    return 'doc'
+
+
+def extract_and_clean_tables(text: str) -> str:
+    """Concatenate all ``<table>`` blocks with whitespace collapsed, as TEDS expects."""
+    if '</table>' not in text:
+        text += '</table>'
+
+    tables = []
+    for table in re.findall(r'<table.*?>.*?</table>', text, re.DOTALL):
+        table = re.sub(r'<table.*?>', '<table>', table)
+        table = re.sub(r'>\s+<', '><', table)
+        table = re.sub(
+            r'>(.*?)<', lambda m: '>' + m.group(1).replace('\n', '').replace(' ', '') + '<', table, flags=re.DOTALL
+        )
+        tables.append(table.replace('\n', '').strip())
+    return ''.join(tables)
+
+
+def _strip_latex_chatter(text: str) -> str:
+    text = _LATEX_META_TAIL.sub('', (text or '').strip())
+    if not text:
+        return text
+    starts = [
+        match.start()
+        for match in (re.search(r'(?m)^\\documentclass\b', text), re.search(r'(?m)^\\begin\s*\{', text))
+        if match is not None
+    ]
+    if starts:
+        text = text[min(starts):]
+    else:
+        text = _LATEX_LEADING_FLUFF.sub('', text)
+    return text.strip()
+
+
+def _strip_html_chatter(text: str) -> str:
+    text = _HTML_META_TAIL.sub('', (text or '').strip())
+    if not text:
+        return text
+    match = re.search(r'(?i)<\s*(?:!DOCTYPE\b|html\b|body\b|table\b|div\b|h[1-6]\b|p\b|main\b|section\b)', text)
+    if match is not None:
+        text = text[match.start():]
+    return text.lstrip()
+
+
+def _unwrap_fenced_block(text: str, tag: str) -> str:
+    """Pull out the body of a ```<tag> block even when the closing fence is missing."""
+    body = text.strip()
+    fence = f'```{tag}'
+    if fence in body:
+        rest = body.split(fence, 1)[1]
+        body = rest.split('```', 1)[0] if '```' in rest else rest
+    return body.strip()
+
+
+def _unwrap_fenced_html(prediction: str) -> str:
+    return _strip_html_chatter(_unwrap_fenced_block(prediction, 'html'))
+
+
+def _teds_score(gt_html: str, pred_html: str) -> float:
+    # Reuse the OCRBench-v2 TEDS implementation instead of shipping a second copy.
+    from evalscope.benchmarks.ocr_bench.ocr_bench_v2.TEDS_metric import TEDS
+
+    try:
+        return float(TEDS(structure_only=False, n_jobs=1).evaluate(pred_html, gt_html))
+    except Exception as error:
+        # Truncated or malformed predictions can produce HTML that the tree builder rejects
+        # (e.g. a non-numeric colspan); such a prediction simply earns no credit.
+        logger.warning(f'CC-OCR V2 TEDS computation failed, scoring the table as 0: {error}')
+        return 0.0
+
+
+def _wrap_html(fragment: str) -> str:
+    return f'<html><body>{fragment}</body></html>'
+
+
+def _score_parsing_doc(prediction: str, reference: str) -> float:
+    for pattern in _LATEX_PREAMBLE_PATTERNS:
+        prediction = re.sub(pattern, '', prediction)
+    prediction = _strip_latex_chatter(_unwrap_fenced_block(prediction, 'latex'))
+    return edit_similarity(prediction.replace(' ', '').replace('\n', ''), reference.replace(' ', '').replace('\n', ''))
+
+
+def _score_parsing_table(prediction: str, reference: str) -> float:
+    pred = convert_to_halfwidth(extract_and_clean_tables(_unwrap_fenced_html(prediction)))
+    gt = convert_to_halfwidth(extract_and_clean_tables(reference))
+    return _teds_score(_wrap_html(gt), _wrap_html(pred))
+
+
+def _score_parsing_formula(prediction: str, reference: str) -> float:
+    pred = prediction.strip().replace('\n', ' ').replace('```latex',
+                                                         '').replace('```', '').replace('\t', ' ').replace(' ', '')
+    return edit_similarity(pred, reference.replace(' ', ''))
+
+
+def _score_parsing_molecular(prediction: str, reference: str) -> float:
+    pred = prediction.strip().replace('\n', '').replace(' ', '').replace('<smiles>', '').replace('</smiles>', '')
+    return edit_similarity(pred, reference.replace(' ', ''))
+
+
+def _html_to_plain_text(fragment: str) -> str:
+    if not fragment.strip():
+        return ''
+    from lxml import html as lxml_html
+
+    parser = lxml_html.HTMLParser(encoding='utf-8', remove_comments=True)
+    root = lxml_html.fromstring(f'<div>{fragment}</div>', parser=parser)
+    return (root.text_content() or '').strip()
+
+
+def _custom_text_tokens(mixed: str) -> List[str]:
+    plain = _html_to_plain_text(_TABLE_BLOCK_RE.sub('', mixed))
+    plain = re.sub(r'\s+', ' ', _CUSTOM_SEP_RE.sub(' ', convert_to_halfwidth(plain))).strip()
+    return text_normalize_and_tokenize(plain, is_keep_blank=False, is_lower=False)
+
+
+def _custom_table_teds(gt_raw: str, pred_inner: str) -> float:
+    """Average TEDS over tables paired by document order."""
+    from lxml import etree
+    from lxml import html as lxml_html
+
+    gt_flat = extract_and_clean_tables(gt_raw).strip()
+    pred_flat = extract_and_clean_tables(pred_inner).strip()
+    if not gt_flat and not pred_flat:
+        return 1.0
+    if not gt_flat or not pred_flat:
+        return 0.0
+
+    parser = lxml_html.HTMLParser(encoding='utf-8', remove_comments=True)
+    gt_tables = lxml_html.fromstring(_wrap_html(convert_to_halfwidth(gt_flat)), parser=parser).xpath('body/table')
+    pred_tables = lxml_html.fromstring(_wrap_html(convert_to_halfwidth(pred_flat)), parser=parser).xpath('body/table')
+    if not gt_tables or not pred_tables:
+        return 0.0
+
+    scores = []
+    for index in range(max(len(gt_tables), len(pred_tables))):
+        if index >= len(gt_tables) or index >= len(pred_tables):
+            scores.append(0.0)
+            continue
+        gt_html = _wrap_html(etree.tostring(gt_tables[index], encoding='unicode', method='html'))
+        pred_html = _wrap_html(etree.tostring(pred_tables[index], encoding='unicode', method='html'))
+        scores.append(_teds_score(gt_html, pred_html))
+    return sum(scores) / len(scores)
+
+
+def _score_parsing_custom(prediction: str, reference: str) -> float:
+    pred_inner = _unwrap_fenced_html(prediction)
+    gt_tokens = _custom_text_tokens(reference)
+    pred_tokens = _custom_text_tokens(pred_inner)
+    text_score = 1.0 if not gt_tokens and not pred_tokens else token_multiset_f1(gt_tokens, pred_tokens)
+    table_score = _custom_table_teds(reference, pred_inner)
+    return (1.0 - _CUSTOM_TABLE_WEIGHT) * text_score + _CUSTOM_TABLE_WEIGHT * table_score
+
+
+def score_parsing(prediction: str, reference: str, scenario: str) -> float:
+    op = parsing_op(scenario)
+    if op == 'formula':
+        return _score_parsing_formula(prediction, reference)
+    if op == 'molecular':
+        return _score_parsing_molecular(prediction, reference)
+    if op == 'custom':
+        return _score_parsing_custom(prediction, reference)
+    if op == 'table':
+        return _score_parsing_table(prediction, reference)
+    return _score_parsing_doc(prediction, reference)
+
+
+# ##########################
+# DISPATCH
+# ##########################
+
+
+def score_sample(prediction: str, reference: str, metadata: Dict[str, Any]) -> float:
+    """Score one sample with the metric of its track."""
+    task = metadata.get('task', '')
+    scenario = metadata.get('scenario', '')
+
+    if task == 'recognition':
+        return score_recognition(prediction, reference, scenario)
+    if task == 'extraction':
+        return score_kie(prediction, reference)
+    if task == 'qa':
+        return score_vqa(prediction, reference)
+    if task == 'parsing':
+        return score_parsing(prediction, reference, scenario)
+    if task == 'grounding':
+        image_path = (metadata.get('image_paths') or [''])[0]
+        if metadata.get('sub_task') == 'object_grounding':
+            return score_object_grounding(prediction, reference, image_path)
+        return score_text_grounding(prediction, reference, image_path)
+    raise ValueError(f'Unknown CC-OCR V2 task: {task!r}')

--- a/evalscope/benchmarks/cc_ocr_v2/utils.py
+++ b/evalscope/benchmarks/cc_ocr_v2/utils.py
@@ -65,9 +65,11 @@ _CUSTOM_TABLE_WEIGHT = 0.9
 def strip_code_fence(text: str) -> str:
     """Return the body of a fully fenced code block, or the text unchanged.
 
-    Only bare and ``json`` fences are recognised, matching the official scorers: an ``html`` or
-    ``latex`` fence is left in place and therefore counts against the prediction, except in the
-    parsing track which unwraps those tags explicitly.
+    The pattern is copied from the official scorers (``evaluate_recognition.py``,
+    ``evaluate_vqa.py``, ``evaluate_grounding.py``), which accept a bare or ``json`` fence only.
+    An ``html`` or ``latex`` fence still loses its backticks, but the language tag itself is not
+    consumed and so leaks into the scored text and costs the prediction points. The parsing track
+    therefore unwraps those two languages explicitly instead of relying on this helper.
     """
     text = text.strip()
     match = _CODE_FENCE_RE.match(text)
@@ -131,8 +133,15 @@ def edit_similarity(pred: str, gt: str) -> float:
 
 
 def score_recognition(prediction: str, reference: str, scenario: str) -> float:
-    """Token-level F1. Chinese/Japanese/Korean/Arabic ground truth is scored per character;
-    multi-scene word-level data additionally keeps alphanumeric characters only."""
+    """Token-level F1, scored per character when the reference contains a CJK ideograph.
+
+    This mirrors the CC-OCR V2 entry point ``evaluate_recognition.py::main`` (``--mode auto``),
+    which switches to character level from ``_has_cjk`` on the reference text alone. Arabic and
+    Korean therefore stay word-level here: the ``dataset_name in ["Arabic", "Japanese",
+    "Korean"]`` rule belongs to the CC-OCR v1 ``OcrEvaluator`` class, which V2 no longer calls.
+    Word-level multi-scene data additionally keeps alphanumeric characters only, matching the
+    official ``_path_indicates_multi_scene``.
+    """
     gt_text = reference.strip()
     pred_text = strip_code_fence(prediction).strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev              = {file = ["requirements/dev.txt"]}
 docs             = {file = ["requirements/docs.txt"]}
 
 ocr_bench        = {file = ["evalscope/benchmarks/ocr_bench/requirements.txt"]}
+cc_ocr_v2        = {file = ["evalscope/benchmarks/cc_ocr_v2/requirements.txt"]}
 omnidoc_bench    = {file = ["evalscope/benchmarks/omnidoc_bench/legacy/requirements.txt"]}
 maritime_ocr_bench = {file = ["evalscope/benchmarks/maritime_ocr_bench/requirements.txt"]}
 miniwob          = {file = ["evalscope/benchmarks/miniwob/requirements.txt"]}

--- a/tests/benchmark/test_cc_ocr_v2.py
+++ b/tests/benchmark/test_cc_ocr_v2.py
@@ -102,14 +102,33 @@ def test_parse_point_box_reads_the_first_tuple() -> None:
     assert parse_point_box('I cannot locate that text.') is None
 
 
-def test_score_text_grounding_rescales_predictions() -> None:
-    """Without an image the prediction is compared as-is; with one it is mapped from the
-    0-1000 grid requested by the prompt into pixels."""
+def test_score_text_grounding_without_image_compares_as_is() -> None:
     reference = '[100.0, 100.0, 200.0, 200.0]'
     assert score_text_grounding('(100, 100, 200, 200)', reference, '') == 1.0
     assert score_text_grounding('no box here', reference, '') == 0.0
     # A malformed reference cannot be scored
     assert score_text_grounding('(100, 100, 200, 200)', 'not a box', '') == 0.0
+
+
+def test_score_text_grounding_maps_normalized_predictions_to_pixels(tmp_path) -> None:
+    """Regression: nothing else exercises the rescaling branch.
+
+    Every model observed so far answered in absolute pixels, so a run never reaches the
+    ``scale=1000`` path -- a silent break here would zero out the score of every model that
+    actually obeys the prompt, while leaving the rest of the suite green.
+    """
+    from PIL import Image
+
+    image_path = str(tmp_path / 'page.png')
+    Image.new('RGB', (1000, 500), 'white').save(image_path)
+
+    reference = '[400.0, 100.0, 600.0, 300.0]'  # pixels
+    # The same box expressed on the 0-1000 grid the prompt asks for, and unit normalized
+    assert score_text_grounding('(400, 200, 600, 600)', reference, image_path) == pytest.approx(1.0)
+    assert score_text_grounding('(0.4, 0.2, 0.6, 0.6)', reference, image_path) == pytest.approx(1.0)
+    # Absolute pixels are read as 0-1000 values and therefore land elsewhere, matching the
+    # official scorer, which normalizes the same way.
+    assert score_text_grounding('(400, 100, 600, 300)', reference, image_path) < 0.5
 
 
 def test_parse_object_list_accepts_common_bbox_notations() -> None:

--- a/tests/benchmark/test_cc_ocr_v2.py
+++ b/tests/benchmark/test_cc_ocr_v2.py
@@ -9,7 +9,7 @@ import os
 import pytest
 import tempfile
 
-from evalscope.benchmarks.cc_ocr_v2.cc_ocr_v2_adapter import SUBSET_LIST, SUBSET_TO_TRACK, TASK_STRUCTURE, _index_images
+from evalscope.benchmarks.cc_ocr_v2.cc_ocr_v2_adapter import _index_images
 from evalscope.benchmarks.cc_ocr_v2.utils import (
     parse_object_list,
     parse_point_box,
@@ -22,15 +22,7 @@ from evalscope.benchmarks.cc_ocr_v2.utils import (
     score_text_grounding,
     score_vqa,
     strip_code_fence,
-    token_multiset_f1,
 )
-
-
-def test_subset_structure_is_consistent() -> None:
-    assert len(SUBSET_LIST) == 16
-    assert len(set(SUBSET_LIST)) == 16, 'subset names double as DatasetDict keys and must be unique'
-    assert set(SUBSET_TO_TRACK.values()) == set(TASK_STRUCTURE)
-    assert SUBSET_TO_TRACK['text_grounding'] == 'grounding'
 
 
 def test_strip_code_fence_only_unwraps_bare_and_json_fences() -> None:
@@ -46,12 +38,6 @@ def test_strip_code_fence_only_unwraps_bare_and_json_fences() -> None:
     assert strip_code_fence('```latex\n\\alpha\n```') == 'latex\n\\alpha'
     # A fence that is not the whole reply is left alone
     assert strip_code_fence('text ```json\n1\n``` tail').startswith('text ```json')
-
-
-def test_token_multiset_f1_counts_duplicates() -> None:
-    assert token_multiset_f1(['a', 'b'], ['a', 'b']) == pytest.approx(1.0)
-    assert token_multiset_f1(['a', 'a'], ['a']) == pytest.approx(2 / 3)
-    assert token_multiset_f1(['a'], []) == 0.0
 
 
 def test_score_recognition_tokenizes_per_language() -> None:

--- a/tests/benchmark/test_cc_ocr_v2.py
+++ b/tests/benchmark/test_cc_ocr_v2.py
@@ -1,0 +1,196 @@
+"""Unit tests for the CC-OCR V2 scorers.
+
+Every track uses a different metric and the answer conventions differ per scenario, so a
+regression here silently shifts scores instead of raising. The expected values below were
+cross-checked against the official ``src/evaluate_*.py`` scripts.
+"""
+import json
+import os
+import pytest
+import tempfile
+
+from evalscope.benchmarks.cc_ocr_v2.cc_ocr_v2_adapter import SUBSET_LIST, SUBSET_TO_TRACK, TASK_STRUCTURE, _index_images
+from evalscope.benchmarks.cc_ocr_v2.utils import (
+    parse_object_list,
+    parse_point_box,
+    parsing_op,
+    score_kie,
+    score_object_grounding,
+    score_parsing,
+    score_recognition,
+    score_sample,
+    score_text_grounding,
+    score_vqa,
+    strip_code_fence,
+    token_multiset_f1,
+)
+
+
+def test_subset_structure_is_consistent() -> None:
+    assert len(SUBSET_LIST) == 16
+    assert len(set(SUBSET_LIST)) == 16, 'subset names double as DatasetDict keys and must be unique'
+    assert set(SUBSET_TO_TRACK.values()) == set(TASK_STRUCTURE)
+    assert SUBSET_TO_TRACK['text_grounding'] == 'grounding'
+
+
+def test_strip_code_fence_only_unwraps_bare_and_json_fences() -> None:
+    """Regression: the official scorers accept only bare and ``json`` fences.
+
+    An ``html`` or ``latex`` fence is not recognised, so the tag itself leaks into the scored
+    text and costs the prediction points -- which is why the parsing track unwraps those
+    fences explicitly instead of relying on this helper.
+    """
+    assert strip_code_fence('```json\n{"a": 1}\n```') == '{"a": 1}'
+    assert strip_code_fence('```\nplain\n```') == 'plain'
+    assert strip_code_fence('```html\n<p>x</p>\n```') == 'html\n<p>x</p>'
+    assert strip_code_fence('```latex\n\\alpha\n```') == 'latex\n\\alpha'
+    # A fence that is not the whole reply is left alone
+    assert strip_code_fence('text ```json\n1\n``` tail').startswith('text ```json')
+
+
+def test_token_multiset_f1_counts_duplicates() -> None:
+    assert token_multiset_f1(['a', 'b'], ['a', 'b']) == pytest.approx(1.0)
+    assert token_multiset_f1(['a', 'a'], ['a']) == pytest.approx(2 / 3)
+    assert token_multiset_f1(['a'], []) == 0.0
+
+
+def test_score_recognition_tokenizes_per_language() -> None:
+    # English scene text: word level, alphanumeric only for multi_scene scenarios
+    scenario = 'multi_scene_ocr_document_text_CORD_100'
+    assert score_recognition('Lemon Tea 25.000', 'Lemon Tea 25.000', scenario) == pytest.approx(1.0)
+    # Punctuation is dropped for multi_scene word-level data, so it cannot cost points
+    assert score_recognition('Lemon, Tea 25000', 'Lemon Tea 25.000', scenario) == pytest.approx(1.0)
+    # Chinese ground truth switches to character level
+    zh_scenario = 'multi_scene_ocr_document_text_zh_doc_100'
+    assert score_recognition('合计金额', '合计金额', zh_scenario) == pytest.approx(1.0)
+    assert 0.0 < score_recognition('合计', '合计金额', zh_scenario) < 1.0
+    # Non-multi_scene scenarios keep punctuation, so the token no longer matches
+    assert score_recognition('bonjour!', 'bonjour', 'multi_lan_ocr_French_French_20') == 0.0
+
+
+def test_score_kie_matches_fields() -> None:
+    reference = json.dumps({'Name': '周志强', 'Total Amount': '1674.00'}, ensure_ascii=False)
+    assert score_kie(reference, reference) == pytest.approx(1.0, abs=1e-5)
+    assert score_kie(f'```json\n{reference}\n```', reference) == pytest.approx(1.0, abs=1e-5)
+    # One field right, one wrong: that is 1 true positive plus a false positive and a false
+    # negative, so F1 = 1 / (1 + 2/2) = 0.5
+    half = json.dumps({'Name': '周志强', 'Total Amount': '0.00'}, ensure_ascii=False)
+    assert score_kie(half, reference) == pytest.approx(0.5, abs=1e-5)
+    # Unparseable prediction earns nothing but must not raise
+    assert score_kie('I cannot read this image.', reference) == 0.0
+
+
+def test_score_vqa_short_and_long_answers() -> None:
+    # Short English answer: substring match, no partial credit
+    assert score_vqa('The total is 1,234 dollars.', '1,234') == 1.0
+    assert score_vqa('The total is 9,999 dollars.', '1,234') == 0.0
+    assert score_vqa('total two thousand', 'total one thousand') == 0.0
+    # Short Chinese answers fall back to ANLS -- the one asymmetry in the official scorers
+    assert score_vqa('合计金额一千圆', '合计金额一千元') == pytest.approx(6 / 7)
+    # Long answers are scored by ANLS with a 0.5 floor
+    long_answer = 'the quick brown fox jumps over the lazy dog'
+    assert score_vqa(long_answer, long_answer) == 1.0
+    assert score_vqa('completely different words here entirely', long_answer) == 0.0
+    # A list of acceptable answers takes the best match
+    assert score_vqa('it is 42', json.dumps(['7', '42'])) == 1.0
+    assert score_vqa('', '42') == 0.0
+
+
+def test_parse_point_box_reads_the_first_tuple() -> None:
+    assert parse_point_box('(845, 163, 1102, 307)') == [845.0, 163.0, 1102.0, 307.0]
+    assert parse_point_box('The box is [0.1, 0.2, 0.3, 0.4].') == [0.1, 0.2, 0.3, 0.4]
+    assert parse_point_box('I cannot locate that text.') is None
+
+
+def test_score_text_grounding_rescales_predictions() -> None:
+    """Without an image the prediction is compared as-is; with one it is mapped from the
+    0-1000 grid requested by the prompt into pixels."""
+    reference = '[100.0, 100.0, 200.0, 200.0]'
+    assert score_text_grounding('(100, 100, 200, 200)', reference, '') == 1.0
+    assert score_text_grounding('no box here', reference, '') == 0.0
+    # A malformed reference cannot be scored
+    assert score_text_grounding('(100, 100, 200, 200)', 'not a box', '') == 0.0
+
+
+def test_parse_object_list_accepts_common_bbox_notations() -> None:
+    payload = json.dumps([
+        {'bbox_2d': [1, 2, 3, 4], 'label': 'DATE'},
+        {'box_2d': {'xmin': 5, 'ymin': 6, 'xmax': 7, 'ymax': 8}, 'category_name': 'CITY'},
+        {'bbox': {'x': 10, 'y': 10, 'width': 5, 'height': 5}, 'label': 'ZIP'},
+        {'label': 'no box'},
+    ])
+    assert parse_object_list(payload) == [[1, 2, 3, 4], [5, 6, 7, 8], [10, 10, 15, 15]]
+    assert parse_object_list('not json at all') is None
+
+
+def test_score_object_grounding_averages_matched_iou() -> None:
+    reference = json.dumps([
+        {'bbox_2d': [0, 0, 10, 10], 'label': 'A'},
+        {'bbox_2d': [100, 100, 110, 110], 'label': 'B'},
+    ])
+    assert score_object_grounding(reference, reference, '') == 1.0
+    # One of two boxes recovered -> mean IoU over ground-truth boxes is 0.5
+    partial = json.dumps([{'bbox_2d': [0, 0, 10, 10], 'label': 'A'}])
+    assert abs(score_object_grounding(partial, reference, '') - 0.5) < 1e-9
+    assert score_object_grounding('sorry, nothing found', reference, '') == 0.0
+
+
+def test_parsing_op_detection_covers_every_scenario_family() -> None:
+    assert parsing_op('doc_parsing_formula_formula_handwriting_100') == 'formula'
+    assert parsing_op('doc_parsing_molecular_molecular_handwriting_100') == 'molecular'
+    assert parsing_op('doc_parsing_custom_info_board_8') == 'custom'
+    assert parsing_op('doc_parsing_table_table_photo_150') == 'table'
+    assert parsing_op('doc_parsing_doc_doc_scan_150') == 'doc'
+
+
+def test_score_parsing_per_op() -> None:
+    formula = r'\frac{1}{2}'
+    assert score_parsing(f'```latex\n{formula}\n```', formula, 'doc_parsing_formula_formula_x_1') == 1.0
+    smiles = 'O=C(N)CC'
+    assert score_parsing(f'<smiles>{smiles}</smiles>', smiles, 'doc_parsing_molecular_molecular_x_1') == 1.0
+
+    table = '<table><tr><td>a</td><td>b</td></tr></table>'
+    assert score_parsing(f'```html\n{table}\n```', table, 'doc_parsing_table_table_photo_1') == 1.0
+    assert score_parsing('no table at all', table, 'doc_parsing_table_table_photo_1') == 0.0
+
+    doc = r'\section{Report} Total: 42'
+    assert score_parsing(doc, doc, 'doc_parsing_doc_doc_scan_1') == 1.0
+    assert score_parsing('', doc, 'doc_parsing_doc_doc_scan_1') == 0.0
+
+
+def test_malformed_table_prediction_scores_zero_instead_of_raising() -> None:
+    """A garbled table can leave a non-numeric ``colspan``; the official TEDS tree builder
+    raises ``ValueError`` on it, which would abort the whole run instead of scoring 0."""
+    reference = '<table><tr><td colspan="2">a</td></tr></table>'
+    prediction = '<table><tr><td colspan="a b">x</td></tr></table>'
+    assert score_parsing(prediction, reference, 'doc_parsing_table_table_photo_1') == 0.0
+
+
+def test_score_sample_dispatches_on_metadata() -> None:
+    metadata = {
+        'task': 'recognition',
+        'sub_task': 'natural_scene_recognition',
+        'scenario': 'multi_scene_ocr_document_text_CORD_100',
+        'image_paths': [],
+    }
+    assert score_sample('TOTAL 30', 'TOTAL 30', metadata) == pytest.approx(1.0)
+
+    metadata = {'task': 'grounding', 'sub_task': 'text_grounding', 'scenario': 'x', 'image_paths': []}
+    assert score_sample('(1, 1, 2, 2)', '[1, 1, 2, 2]', metadata) == 1.0
+
+
+def test_index_images_handles_single_files_and_page_directories() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        open(os.path.join(root, 'aaa.jpg'), 'wb').close()
+        open(os.path.join(root, 'notes.txt'), 'wb').close()
+        pages = os.path.join(root, 'bbb')
+        os.makedirs(pages)
+        for name in ('page_10.jpg', 'page_2.jpg', 'page_1.jpg'):
+            open(os.path.join(pages, name), 'wb').close()
+
+        index = _index_images(root)
+        assert index['aaa'] == [os.path.join(root, 'aaa.jpg')]
+        # Multi-page documents keep natural page order, not lexicographic order
+        assert [os.path.basename(path) for path in index['bbb']] == ['page_1.jpg', 'page_2.jpg', 'page_10.jpg']
+        assert 'notes' not in index
+        assert _index_images(os.path.join(root, 'missing')) == {}

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -514,6 +514,16 @@ class TestVLMBenchmark(TestBenchmark):
         dataset_args = {'subset_list': ['CAD']}
         self._run_dataset_test('screenspot_pro', dataset_args=dataset_args, limit=5, use_mock=True)
 
+    def test_cc_ocr_v2(self):
+        """Test CC-OCR-V2 real-world document OCR benchmark."""
+        dataset_args = {'subset_list': ['info_board_parsing', 'text_grounding', 'blueprint_qa']}
+        self._run_dataset_test('cc_ocr_v2', dataset_args=dataset_args, limit=5)
+
+    def test_cc_ocr_v2_mock(self):
+        """Test CC-OCR-V2 with mock LLM."""
+        dataset_args = {'subset_list': ['info_board_parsing']}
+        self._run_dataset_test('cc_ocr_v2', dataset_args=dataset_args, limit=5, use_mock=True)
+
     def test_perception_bench(self):
         """Test PerceptionBench atomic visual perception benchmark."""
         dataset_args = {'subset_list': ['ocr_error']}


### PR DESCRIPTION
## Summary

Adds **CC-OCR-V2** ([paper](https://arxiv.org/abs/2605.03903), [`evalscope/CC-OCR-V2`](https://modelscope.cn/datasets/evalscope/CC-OCR-V2/summary)) as a native VLM benchmark: 7,093 hard real-world document-processing samples across 5 OCR tracks and 16 sub-tasks, each track scored with its own official metric.

```bash
pip install 'evalscope[cc_ocr_v2]'
evalscope eval --model qwen-vl-plus --datasets cc_ocr_v2 --limit 5
```

| Track | Sub-tasks | Official metric |
|---|---|---|
| recognition | multi_lingual (32 langs), natural_scene | token-level F1 |
| parsing | complex_table, general_documents, formula, molecular, info_board | TEDS / edit similarity |
| grounding | text_grounding, object_grounding | IoU (Hungarian-matched for multi-box) |
| extraction | business_transactions, public_services, regulated_records | field-level F1 |
| qa | blueprint, dashboards_fact, dashboards_numeric, financial_documents | substring match + ANLS fallback |

## Design notes

- **Standard dataset flow.** The dataset is a file tree of `question/answer/images` folders, not a tabular split, so `load()` scans a snapshot and feeds `build_dataset_dict_from_record_map()` — shuffle / `limit` / `repeats` / indexing all keep working. No custom loader, no new registry.
- **Partial download.** `allow_file_pattern` is derived from the selected `subset_list`; the full benchmark is ~5 GB of images, so restricting subsets keeps the download proportional.
- **Local image paths, not base64.** The model layer converts them lazily via `file_as_data_uri`, and the dashboard resolves them through its existing `/api/v1/reports/media/file` proxy. Encoding 7k document images up front would hold several GB in memory.
- **16 sub-tasks as subsets, 5 tracks via `category_map`.** Level-3 scenario names collide across sub-tasks (e.g. `multi_scene_ocr_document_text_SIBR_351` appears under both grounding sub-tasks), so they live in metadata and only drive scenario-specific scoring rules. The report shows the per-track micro average plus the macro-over-sub-tasks number the paper uses.
- **Reuse.** Table scoring imports the existing `ocr_bench_v2.TEDS_metric.TEDS` rather than vendoring a third copy; edit distance goes through `evalscope.metrics.utils.functions.levenshtein_distance`.
- **Deliberately not reused:** the registered `anls` metric. Its normalization differs (collapses whitespace, divides by un-normalized lengths, thresholds after `min` over answers) while CC-OCR uses short-answer substring match + long-answer ANLS with an extra Chinese space-stripping rule. Reusing it would diverge from the official evaluator.

## Verification

Scoring was cross-checked against the official `src/evaluate_*.py` scripts:

| Check | Result |
|---|---|
| 312 synthetic cases (exact GT / char-dropped / empty / garbage / 3 fence styles / trailing chatter), all 5 tracks and all 5 parsing modes | **0 mismatches** |
| 71 real-API predictions (`qwen-vl-plus`), **all 16 subsets** | **0 mismatches, 0 unparseable** |
| All 7,093 ground-truth files parsed | ✅ |
| Multi-page samples (2- and 3-page documents) end-to-end via `local_path` | pages sent in natural order, scores re-derived ✅ |
| Dashboard: `/reports/list`, `/reports/dataframe`, `/reports/predictions`, `/reports/chart` | 16 subsets / 5 categories, values match the report |
| Dashboard media proxy | 32/32 images served as real JPEG/PNG bytes, every subset covered |
| `make lint`, 15 unit tests, mock e2e, `test_ci_lite` | pass |

Two things that came out of the cross-check are worth a reviewer's attention:

1. **Code-fence handling.** The official scorers only unwrap bare and ` ```json ` fences. An earlier revision here also unwrapped ` ```html `/` ```latex `, which silently *inflated* scores, because outside the parsing track those fence tokens are meant to count against the prediction. `strip_code_fence` now mirrors the official regex, and `test_strip_code_fence_only_unwraps_bare_and_json_fences` pins it.
2. **One deliberate deviation from upstream.** The official TEDS tree builder raises `ValueError: invalid literal for int()` on a non-numeric `colspan`, which a garbled table prediction can produce — upstream this aborts the whole run. Here it is caught and scored 0 with a warning (`test_malformed_table_prediction_scores_zero_instead_of_raising`).

## Expected behaviours that look like bugs

- **Grounding scores ≈ 0 for pixel-coordinate models.** The prompts ask for a 0-1000 grid; the official scorer rescales anything above 1.0 as if normalized, so absolute-pixel answers land far from the target. This matches the published leaderboard (`qwen-vl-max-latest` = 3.70 on Grounding) and is documented in the description.
- **7,091 samples loaded, not 7,093.** The dataset repository ships no image for two sample ids (`multi_lingual_recognition/.../0913e4fab7c9`, `general_documents_parsing/.../4a74943cc5a4`, verified against the hub file listing). They are skipped with a warning rather than reaching the model and scoring 0.

## Files

- `evalscope/benchmarks/cc_ocr_v2/{__init__.py,cc_ocr_v2_adapter.py,utils.py,requirements.txt}`
- `tests/benchmark/test_cc_ocr_v2.py` (15 parser/scoring unit tests), `tests/benchmark/test_vlm.py` (real + mock smoke tests)
- `pyproject.toml`: `cc_ocr_v2` extra
- Generated by `make docs-pipeline`: `evalscope/benchmarks/_meta/cc_ocr_v2.json`, `docs/{en,zh}/benchmarks/cc_ocr_v2.md`, `docs/{en,zh}/get_started/supported_dataset/vlm.md`
