### PR TITLE
fix(multi_choices): parse answer labels the model wrapped in brackets

### DIFF
--- a/evalscope/utils/multi_choices.py
+++ b/evalscope/utils/multi_choices.py
@@ -152,11 +152,27 @@ def format_example(
     return f'{question}\n{choices_text}\nANSWER: {answer.text}'
 
 
-def _fallback_parse_answer(completion: str) -> Optional[set[str]]:
+# A label the model may wrap the way the options are printed, optionally listing several labels:
+# '(A)', '[A]', '(A, C)'.  Only label-shaped content is accepted, so bracketed prose such as
+# '(see the diagram above)' and an echoed '[LETTER]' placeholder stay unparseable.
+_BRACKETED_LABEL = r'[\(\[（【]\s*([A-Za-z\d](?:\s*[,，]\s*[A-Za-z\d])*)\s*[\)\]）】]'
+
+# Models frequently give the label in that wrapped form and then append the option text, e.g.
+# 'ANSWER: (A) 36'.  Neither the strict nor the loose pattern accepts a leading bracket, so
+# without this pattern such a reply reaches `_fallback_parse_answer` and is answered with an
+# arbitrary capital letter taken from the reasoning.
+_BRACKETED_ANSWER_RE = re.compile(rf'(?i)ANSWER\s*:\s*\**\s*{_BRACKETED_LABEL}')
+_BRACKETED_ANSWER_ZH_RE = re.compile(rf'答案\s*[:：]\s*\**\s*{_BRACKETED_LABEL}')
+
+
+def _fallback_parse_answer(completion: str, allowed_options: set[str]) -> Optional[set[str]]:
     # Fallback to find the last upper case letter
     for letter in reversed(completion):
         if letter.isupper():
-            return {letter}
+            # A letter that is not one of the sample's labels cannot be the model's choice, and
+            # returning it would record an answer the model never gave.  Reporting no answer
+            # scores the same (an invalid label never equals the target) and stays diagnosable.
+            return {letter} if letter in allowed_options else None
     return None
 
 
@@ -180,6 +196,8 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
     """
     text = state.output.completion if completion is None else completion
 
+    allowed_options = set(answer_character(i) for i in range(len(state.choices)))
+
     # First check whether the string strictly ends with the expected answer
     # In this case, we're looking for a single line which contains the expected
     # ANSWER: <answer> string with only whitespace or a period/full stop at the end.
@@ -187,34 +205,32 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
     # placeholder the model echoed from the prompt (e.g. `ANSWER: [LETTER]`) matches
     # with a whitespace-only capture and shadows the real answer that follows.
     match = re.search(
-        r'(?i)^ANSWER\s*:\s*([A-Za-z\d][A-Za-z\d ,]*)\s*(?:$|\n|\.)',
+        r'(?i)^ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)\s*(?:$|\n|\.)',
         text,
         flags=re.MULTILINE,
     )
+
+    # The alphanumeric-start rule above also rejects a label the model wrapped in brackets,
+    # so try that form explicitly before giving up on the answer marker.
+    if match is None:
+        match = _BRACKETED_ANSWER_RE.search(text)
 
     # If we couldn't match the strict version, we can try the less strict
     # version for backward compatibility
     if match is None:
         match = re.search(
-            r'(?i)ANSWER\s*:\s*([A-Za-z\d][A-Za-z\d ,]*)(?:[^\w]|\n|$|\.)',
+            r'(?i)ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)(?:[^\w]|\n|$|\.)',
             text,
         )
 
     if match is None:
-        fallback_answer = _fallback_parse_answer(text)
-        if fallback_answer:
-            return fallback_answer
-
-    if match is None:
-        return set()
+        return _fallback_parse_answer(text, allowed_options) or set()
 
     matched = match.group(1)
 
     # Strip trailing period / full stop
     matched = matched.strip()
     matched = matched.rstrip('.')
-
-    allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
     if multiple_correct:
         # Match must contain only the allowed choices
@@ -260,20 +276,20 @@ def parse_answers_zh(state: TaskState, multiple_correct: bool = False, completio
     """
     text = state.output.completion if completion is None else completion
 
+    allowed_options = set(answer_character(i) for i in range(len(state.choices)))
+
     # Simple pattern to capture answers with optional bold markdown
-    pattern = r'答案\s*[:：]\s*([A-Za-z0-9,，]+)'
+    pattern = r'答案\s*[:：]\s*\**\s*([A-Za-z0-9,，]+)'
     match = re.search(pattern, text, flags=re.MULTILINE)
 
+    # The pattern above cannot start on a bracket, so try a wrapped label explicitly.
     if match is None:
-        fallback_answer = _fallback_parse_answer(text)
-        if fallback_answer:
-            return fallback_answer
+        match = _BRACKETED_ANSWER_ZH_RE.search(text)
 
     if match is None:
-        return set()
+        return _fallback_parse_answer(text, allowed_options) or set()
 
     matched = match.group(1).strip().rstrip('。.')
-    allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
     if multiple_correct:
         # Handle comma-separated or continuous letters

--- a/evalscope/utils/multi_choices.py
+++ b/evalscope/utils/multi_choices.py
@@ -240,6 +240,10 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
 
         matched = matched.replace(' ', '')
 
+        # The bracketed pattern also accepts a full-width comma, which the split below would
+        # otherwise keep inside the label and turn a valid multi-select answer into no answer.
+        matched = matched.replace('，', ',')
+
         split_comma = set(matched.split(','))
         if split_comma.issubset(allowed_options):
             answers = split_comma

--- a/tests/test_multi_choices.py
+++ b/tests/test_multi_choices.py
@@ -79,6 +79,16 @@ def test_parse_answers_wrapped_multiple_answers() -> None:
     assert parse_answers(_make_state('reasoning\nANSWER: (A, C)'), multiple_correct=True) == {'A', 'C'}
 
 
+def test_parse_answers_wrapped_multiple_answers_full_width_comma() -> None:
+    """The bracketed pattern accepts a full-width comma, so the splitting must too.
+
+    Otherwise the label is captured but never split, and a valid multi-select answer is
+    recorded as no answer at all.
+    """
+    assert parse_answers(_make_state('reasoning\nANSWER: (A，C)'), multiple_correct=True) == {'A', 'C'}
+    assert parse_answers_zh(_make_state('推理过程\n答案：（A，C）'), multiple_correct=True) == {'A', 'C'}
+
+
 def test_parse_answers_ignores_bracketed_prose() -> None:
     """Only label-shaped bracket contents may be read as an answer."""
     assert parse_answers(_make_state('ANSWER: (see the diagram above)')).isdisjoint(set('ABCD'))

--- a/tests/test_multi_choices.py
+++ b/tests/test_multi_choices.py
@@ -50,6 +50,57 @@ def test_parse_answers_bracketed_letter() -> None:
     assert parse_answers(_make_state('reasoning\nANSWER: [B]')) == {'B'}
 
 
+TRAILING_SENTENCE = '\nLet me know if you need more.'
+
+WRAPPED_ANSWER_LINES = [
+    'ANSWER: B',
+    'ANSWER: (B)',
+    'ANSWER: [B]',
+    'ANSWER: **B**',
+    'ANSWER: (B) 300',
+    '### Final Answer: **(B) 300**',
+]
+
+
+def test_parse_answers_wrapped_label_does_not_depend_on_trailing_text() -> None:
+    """A wrapped label must be parsed, not guessed from the last capital in the reply.
+
+    Regression test: these forms used to reach `_fallback_parse_answer`, which returns the
+    last upper-case character of the whole reply. They therefore appeared to work whenever the
+    chosen label happened to be that character, and silently broke as soon as any prose
+    followed - scoring a correct answer as a miss.
+    """
+    for answer_line in WRAPPED_ANSWER_LINES:
+        assert parse_answers(_make_state(f'reasoning\n{answer_line}')) == {'B'}, answer_line
+        assert parse_answers(_make_state(f'reasoning\n{answer_line}{TRAILING_SENTENCE}')) == {'B'}, answer_line
+
+
+def test_parse_answers_wrapped_multiple_answers() -> None:
+    assert parse_answers(_make_state('reasoning\nANSWER: (A, C)'), multiple_correct=True) == {'A', 'C'}
+
+
+def test_parse_answers_ignores_bracketed_prose() -> None:
+    """Only label-shaped bracket contents may be read as an answer."""
+    assert parse_answers(_make_state('ANSWER: (see the diagram above)')).isdisjoint(set('ABCD'))
+
+
+def test_fallback_rejects_letters_outside_the_choice_set() -> None:
+    """A guessed letter that is not one of the sample's labels must not be reported.
+
+    It cannot be the model's choice, so recording it invents an answer that never existed;
+    reporting nothing scores the same and leaves the review file diagnosable.
+    """
+    assert parse_answers(_make_state('the shape is Z-like')) == set()
+
+
+def test_parse_answers_zh_wrapped_label() -> None:
+    """The Chinese parser accepts half- and full-width wrappers around the label."""
+    for answer_line in ['答案：(B)', '答案：（B）', '答案：**B**', '答案：（B）36 千克']:
+        assert parse_answers_zh(_make_state(f'推理过程\n{answer_line}')) == {'B'}, answer_line
+        # A trailing English sentence would otherwise hand the fallback an unrelated capital
+        assert parse_answers_zh(_make_state(f'推理过程\n{answer_line}\nNote: hope this helps.')) == {'B'}, answer_line
+
+
 def test_parse_answers_placeholder_only_yields_no_valid_option() -> None:
     completion = 'The last line of your response should be ANSWER: [LETTER] and nothing else.'
     assert parse_answers(_make_state(completion)).isdisjoint({'A', 'B', 'C', 'D'})


### PR DESCRIPTION
## Problem

`parse_answers` requires the captured label to start with an alphanumeric character, so it cannot match a label the model wrapped the way the options are printed:

```
ANSWER: (A)        ANSWER: [A]        ANSWER: **A**        ANSWER: (A) 36
```

Such replies fall through to `_fallback_parse_answer`, which returns **the last upper-case character of the entire reply** without validating it against the sample's labels.

The wrapped forms therefore look supported while actually being guessed — the existing `test_parse_answers_bracketed_letter` passes for exactly that reason. Adding one ordinary trailing sentence exposes it (model chose **B** in every row):

| answer line | alone | + `\nLet me know if you need more.` | |
|---|---|---|---|
| `ANSWER: B` | `B` | `B` | parsed |
| `ANSWER: (B)` | `B` | `L` | guessed |
| `ANSWER: [B]` | `B` | `L` | guessed |
| `ANSWER: **B**` | `B` | `L` | guessed |
| `ANSWER: (B) 300` | `B` | `L` | guessed |

A real example from an AGIEval run, scored 0 despite being correct:

```
**Answer: (A) She will consider his proposal inappropriate.**   ->  extracted 'S'
```

Two related consequences: a bracketed multi-select answer `ANSWER: (A, C)` yielded only `C`, and the unvalidated fallback records labels that are not in the choice set at all (`choices=A-D`, reply `the shape is Z-like` -> `Z`).

## Changes

1. **A bracketed-label pattern**, tried after the strict one. It accepts only label-shaped contents — `(A)`, `[A]`, `(A, C)` and full-width variants — so bracketed prose (`ANSWER: (see the diagram above)`) and an echoed `ANSWER: [LETTER]` placeholder stay unparseable, which is why the alphanumeric-start rule exists. Both existing patterns additionally tolerate leading markdown emphasis. This also fixes the bracketed multi-select case.
2. **The fallback validates its guess** against the choice set. A letter that is not a label cannot be the model's answer, so returning it only records an answer that never existed. This part is score-neutral by construction: an invalid label can never equal the target.

`parse_answers_zh` receives both changes, including full-width `（`/`）`.

## Measurement

Re-scored the stored predictions of an existing AGIEval run (`limit=5`, 105 items, qwen-plus) with `rerun_review` — no new model calls — running **this branch against its merge base**, so no unrelated change is mixed in:

```
overall            0.6952  ->  0.7048
extractions changed:   11
of which scores changed: 1     (the '(A) She will ...' case above)
regressions:             0
```

The other 10 are replies that never gave an answer (truncated reasoning, or asking for the passage) and previously had a letter invented for them — `T`, `I`, `W`, `M`, `G`, `S` — and now correctly record none, confirming change 2 is score-neutral.

Also verified on LogicVista (447 items, PR #1556): one item recovers a point it had earned, and four review records stop showing labels the model never chose.

Note on prevalence: bracketed labels are common (84 of 262 replies carrying an `ANSWER:` marker across the AGIEval review files I had locally), but whether each is mis-scored depends on whether a later capital letter follows, so the score impact per run is modest while the extraction-correctness impact is systematic.

## Compatibility

- 46 of the 50 adapters built on `MultiChoiceAdapter` inherit this parsing path, so scores may move **upward** for benchmarks whose models use the wrapped style. That is a correctness fix, not a regression, but it is worth a changelog note.
- All 8 pre-existing tests in `tests/test_multi_choices.py` still pass unchanged, including the two that pin the placeholder-echo and filter behaviour.
- 4 new tests were confirmed to fail on the merge base and pass here.
- `make lint` and `tests/cli/test_all.py::TestRun::test_ci_lite` pass.

Once this lands, the adapter-level workaround added in #1556 (`logic_vista`) becomes redundant and can be deleted.
