### PR TITLE
fix(config): pass reasoning_effort through instead of whitelisting it

### DIFF
--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -59,7 +59,7 @@ The `--generation-config` parameter supports the following options (comma-separa
 | `top_logprobs` | `int` | Return the top N tokens and their probabilities (range 0~20) | OpenAI-compatible, HuggingFace |
 | `parallel_tool_calls` | `bool` | Whether to support parallel tool calls | OpenAI, Groq |
 | `response_schema` | `dict` | Request structured output (JSON Schema); the output still needs to be validated | OpenAI, Google, Mistral |
-| `reasoning_effort` | `str` | Reasoning effort level. One of `low` / `medium` (default) / `high` | OpenAI o1 series |
+| `reasoning_effort` | `str` | Reasoning effort level, passed through to the server as-is (e.g. `none` / `minimal` / `low` / `medium` / `high` / `xhigh`); the accepted values are decided by the model and the server | OpenAI-compatible |
 | `reasoning_tokens` | `int` | Maximum tokens budget for reasoning (thinking budget) | Anthropic Claude |
 | `reasoning_summary` | `str` | Reasoning summary verbosity. One of `concise` / `detailed` / `auto` | OpenAI reasoning series |
 | `reasoning_history` | `str` | How to encode prior-turn assistant `reasoning_content` in multi-turn requests. One of `reasoning_field` (default; pass as independent top-level field, works for DeepSeek V4 thinking, Qwen3 thinking), `think_tag` (embed as `<think>...</think>` in content string, legacy Together/Groq compatible), `none` (strip entirely; **required for DeepSeek R1 legacy** which forbids `reasoning_content` in requests) | OpenAI-compatible |

--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -59,7 +59,7 @@ The `--generation-config` parameter supports the following options (comma-separa
 | `top_logprobs` | `int` | Return the top N tokens and their probabilities (range 0~20) | OpenAI-compatible, HuggingFace |
 | `parallel_tool_calls` | `bool` | Whether to support parallel tool calls | OpenAI, Groq |
 | `response_schema` | `dict` | Request structured output (JSON Schema); the output still needs to be validated | OpenAI, Google, Mistral |
-| `reasoning_effort` | `str` | Reasoning effort level, passed through to the server as-is (e.g. `none` / `minimal` / `low` / `medium` / `high` / `xhigh`); the accepted values are decided by the model and the server | OpenAI-compatible |
+| `reasoning_effort` | `str` | Reasoning effort level, passed through to the server as-is (e.g. `none` / `minimal` / `low` / `medium` / `high` / `xhigh` / `max`); the accepted values are decided by the model and the server | OpenAI-compatible |
 | `reasoning_tokens` | `int` | Maximum tokens budget for reasoning (thinking budget) | Anthropic Claude |
 | `reasoning_summary` | `str` | Reasoning summary verbosity. One of `concise` / `detailed` / `auto` | OpenAI reasoning series |
 | `reasoning_history` | `str` | How to encode prior-turn assistant `reasoning_content` in multi-turn requests. One of `reasoning_field` (default; pass as independent top-level field, works for DeepSeek V4 thinking, Qwen3 thinking), `think_tag` (embed as `<think>...</think>` in content string, legacy Together/Groq compatible), `none` (strip entirely; **required for DeepSeek R1 legacy** which forbids `reasoning_content` in requests) | OpenAI-compatible |

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -59,7 +59,7 @@
 | `top_logprobs` | `int` | 返回概率最高的前N个token（范围0~20） | OpenAI兼容、HuggingFace |
 | `parallel_tool_calls` | `bool` | 工具调用是否支持并行 | OpenAI、Groq |
 | `response_schema` | `dict` | 请求结构化输出（JSON Schema），仍需对输出做校验 | OpenAI、Google、Mistral |
-| `reasoning_effort` | `str` | reasoning 努力程度，原样透传给服务端（如 `none` / `minimal` / `low` / `medium` / `high` / `xhigh`），合法取值由具体模型和服务端决定 | OpenAI兼容 |
+| `reasoning_effort` | `str` | reasoning 努力程度，原样透传给服务端（如 `none` / `minimal` / `low` / `medium` / `high` / `xhigh` / `max`），合法取值由具体模型和服务端决定 | OpenAI兼容 |
 | `reasoning_tokens` | `int` | reasoning 最大 token 预算（thinking budget） | Anthropic Claude |
 | `reasoning_summary` | `str` | reasoning 摘要级别，可选 `concise` / `detailed` / `auto` | OpenAI reasoning 系列 |
 | `reasoning_history` | `str` | 多轮对话中如何编码上一轮 assistant 的 `reasoning_content`。可选值：`reasoning_field`（默认，作为独立顶层字段透传，适配 DeepSeek V4 thinking、Qwen3 thinking 等）、`think_tag`（编码为 `<think>...</think>` 塞进 content 字符串，兼容旧版 Together / Groq 等部署）、`none`（完全剥离，DeepSeek R1 等禁止回传 `reasoning_content` 的 legacy 模型必须显式设此值） | OpenAI兼容 |

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -59,7 +59,7 @@
 | `top_logprobs` | `int` | 返回概率最高的前N个token（范围0~20） | OpenAI兼容、HuggingFace |
 | `parallel_tool_calls` | `bool` | 工具调用是否支持并行 | OpenAI、Groq |
 | `response_schema` | `dict` | 请求结构化输出（JSON Schema），仍需对输出做校验 | OpenAI、Google、Mistral |
-| `reasoning_effort` | `str` | reasoning 努力程度，可选 `low` / `medium`（默认）/ `high` | OpenAI o1 系列 |
+| `reasoning_effort` | `str` | reasoning 努力程度，原样透传给服务端（如 `none` / `minimal` / `low` / `medium` / `high` / `xhigh`），合法取值由具体模型和服务端决定 | OpenAI兼容 |
 | `reasoning_tokens` | `int` | reasoning 最大 token 预算（thinking budget） | Anthropic Claude |
 | `reasoning_summary` | `str` | reasoning 摘要级别，可选 `concise` / `detailed` / `auto` | OpenAI reasoning 系列 |
 | `reasoning_history` | `str` | 多轮对话中如何编码上一轮 assistant 的 `reasoning_content`。可选值：`reasoning_field`（默认，作为独立顶层字段透传，适配 DeepSeek V4 thinking、Qwen3 thinking 等）、`think_tag`（编码为 `<think>...</think>` 塞进 content 字符串，兼容旧版 Together / Groq 等部署）、`none`（完全剥离，DeepSeek R1 等禁止回传 `reasoning_content` 的 legacy 模型必须显式设此值） | OpenAI兼容 |

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -106,8 +106,14 @@ class GenerateConfig(BaseModel):
     parallel_tool_calls: Optional[bool] = Field(default=None)
     """Whether to enable parallel function calling during tool use (defaults to True). OpenAI and Groq only."""
 
-    reasoning_effort: Optional[Literal['low', 'medium', 'high']] = Field(default=None)
-    """Constrains effort on reasoning for reasoning models (defaults to `medium`). Open AI o1 models only."""
+    reasoning_effort: Optional[str] = Field(default=None)
+    """Constrains effort on reasoning for reasoning models, passed through to the provider as-is.
+
+    Not validated client-side: the accepted values are provider- and model-specific and keep
+    expanding (OpenAI alone spans `minimal`, `low`, `medium`, `high`, `none` and `xhigh` across
+    model generations), and OpenAI-compatible servers such as vLLM and SGLang define their own.
+    An unsupported value is rejected by the server rather than by this schema.
+    """
 
     reasoning_tokens: Optional[int] = Field(default=None)
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""

--- a/evalscope/api/model/generate_config.py
+++ b/evalscope/api/model/generate_config.py
@@ -110,9 +110,10 @@ class GenerateConfig(BaseModel):
     """Constrains effort on reasoning for reasoning models, passed through to the provider as-is.
 
     Not validated client-side: the accepted values are provider- and model-specific and keep
-    expanding (OpenAI alone spans `minimal`, `low`, `medium`, `high`, `none` and `xhigh` across
-    model generations), and OpenAI-compatible servers such as vLLM and SGLang define their own.
-    An unsupported value is rejected by the server rather than by this schema.
+    expanding (OpenAI alone documents `none`, `minimal`, `low`, `medium`, `high`, `xhigh` and
+    `max`, each supported by a different subset of models), and OpenAI-compatible servers such
+    as vLLM and SGLang define their own. An unsupported value is rejected by the server rather
+    than by this schema.
     """
 
     reasoning_tokens: Optional[int] = Field(default=None)

--- a/tests/models/test_openai_reasoning.py
+++ b/tests/models/test_openai_reasoning.py
@@ -149,6 +149,6 @@ def test_reasoning_history_default_is_none():
 
 def test_reasoning_effort_passes_through_provider_specific_values():
     """Issue #1555: the effort whitelist blocked values that current providers accept."""
-    for value in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh'):
+    for value in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'):
         params = openai_completion_params('gpt-5.1', GenerateConfig(reasoning_effort=value), tools=False)
         assert params['reasoning_effort'] == value

--- a/tests/models/test_openai_reasoning.py
+++ b/tests/models/test_openai_reasoning.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 from evalscope.api.messages import ChatMessageAssistant, ContentReasoning, ContentText
 from evalscope.api.model import GenerateConfig
 from evalscope.api.tool import ToolCall, ToolFunction
-from evalscope.models.utils.openai import openai_chat_message
+from evalscope.models.utils.openai import openai_chat_message, openai_completion_params
 
 
 def _asst_reasoning_and_text(reasoning: str, text: str) -> ChatMessageAssistant:
@@ -145,3 +145,10 @@ def test_reasoning_history_rejects_legacy_literal_values():
 
 def test_reasoning_history_default_is_none():
     assert GenerateConfig().reasoning_history is None
+
+
+def test_reasoning_effort_passes_through_provider_specific_values():
+    """Issue #1555: the effort whitelist blocked values that current providers accept."""
+    for value in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh'):
+        params = openai_completion_params('gpt-5.1', GenerateConfig(reasoning_effort=value), tools=False)
+        assert params['reasoning_effort'] == value


### PR DESCRIPTION
## What

`GenerateConfig.reasoning_effort` was typed as a closed enum:

```python
reasoning_effort: Optional[Literal['low', 'medium', 'high']] = Field(default=None)
```

This is a whitelist from the o1 era (the docstring still said "Open AI o1 models only"). Every value providers have shipped since is rejected by pydantic before a request is even built — verified locally: `none`, `minimal`, `xhigh`, `max` all fail validation, only `low`/`medium`/`high` pass.

The set of legal values is provider- and model-specific and keeps growing (`minimal` for gpt-5, `none` for gpt-5.1, `xhigh` for gpt-5.1-codex-max), and OpenAI-compatible servers such as vLLM and SGLang define their own. A client-side whitelist is structurally doomed to lag, so this types the field as `str` and lets the server be the authority on what it accepts.

## Changes

- `evalscope/api/model/generate_config.py`: `Literal[...]` -> `str`, docstring explains why it is not validated client-side.
- `docs/{zh,en}/get_started/parameters.md`: the row no longer advertises a three-value enum / "o1 series".
- `tests/models/test_openai_reasoning.py`: one test asserting the six current values survive validation and land in the request params.

No behavior change for existing configs: the field was already passed through verbatim by `openai_completion_params` (and as `reasoning.effort` by the Responses API path), and `None` still omits it.

## Test

```
pytest tests/models -q          # 46 passed
pre-commit run --files <changed files>   # all passed
```

Closes #1555
