### PR TITLE
fix(web): allow null reasoning_tokens in report content blocks

### DIFF
--- a/evalscope/web/src/api/schemas/reports.schema.test.ts
+++ b/evalscope/web/src/api/schemas/reports.schema.test.ts
@@ -64,4 +64,19 @@ describe('loadReportResponseSchema real report compatibility', () => {
 
     expect(result.success).toBe(true)
   })
+
+  it('accepts a reasoning block with a null reasoning_tokens, as emitted when the backend has no token count', () => {
+    // ContentReasoning.reasoning_tokens is `Optional[int] = None` on the Python side, which
+    // serializes as an explicit JSON `null` rather than an absent key. Reasoning models that
+    // don't report a token count (e.g. via completion_tokens_details) hit this on every turn.
+    const result = chatMessageSchema.safeParse({
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', reasoning: 'thinking it through...', reasoning_tokens: null },
+        { type: 'text', text: 'final answer' },
+      ],
+    })
+
+    expect(result.success).toBe(true)
+  })
 })

--- a/evalscope/web/src/api/schemas/reports.schema.ts
+++ b/evalscope/web/src/api/schemas/reports.schema.ts
@@ -146,7 +146,7 @@ export const contentBlockSchema = z.object({
   type: z.enum(['text', 'reasoning', 'image', 'audio', 'video', 'data']),
   text: z.string().optional(),
   reasoning: z.string().optional(),
-  reasoning_tokens: z.number().optional(),
+  reasoning_tokens: z.number().nullable().optional(),
   image: z.string().optional(),
   audio: z.string().optional(),
   video: z.string().optional(),

--- a/evalscope/web/src/components/single/chat/MediaBlocks.tsx
+++ b/evalscope/web/src/components/single/chat/MediaBlocks.tsx
@@ -51,7 +51,7 @@ export function VideoBlock({ src, format }: { src: string; format?: string }) {
 }
 
 /** Collapsible reasoning block rendered above the main answer. */
-export function ReasoningBlock({ text, tokens }: { text: string; tokens?: number }) {
+export function ReasoningBlock({ text, tokens }: { text: string; tokens?: number | null }) {
   const { t } = useLocale()
   const [open, setOpen] = useState(false)
   return (


### PR DESCRIPTION
ContentReasoning.reasoning_tokens is Optional[int] = None on the Python side, which serializes as an explicit JSON null rather than an absent key. The zod schema only allowed number|undefined, so any reasoning model that doesn't report a token count (e.g. no
completion_tokens_details.reasoning_tokens from the API) failed report validation on every subset - reproduced against a real report (eval_1786353041334) and confirmed fixed.

Widen ReasoningBlock's tokens prop to number | null to match; it already guards with `tokens != null` at render time.