### PR TITLE
fix(perf): explain how to proceed when a tokenizer has no chat template

### DIFF
--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -298,7 +298,7 @@ Replay behaviour is tuned via `--dataset-args`:
 
 When benchmarking a `chat/completions` endpoint, `--apply-chat-template` is on by default and the client applies the chat template before counting tokens, so client-side lengths line up with the `usage.prompt_tokens` reported by the service; the tokenizer given to `--tokenizer-path` must therefore ship a Jinja chat template. DeepSeek-V3.2 / V4 provide `encoding` scripts instead, and base / pretrain checkpoints have no template either — those fail with an error that lists the available options.
 
-Two things to watch out for: without `--tokenizer-path`, `--min/max-prompt-length` filters by characters instead of tokens; and borrowing another model's tokenizer does not fail, but a mismatched vocabulary silently distorts token counts.
+Two things to watch out for: without `--tokenizer-path`, `--min-prompt-length` / `--max-prompt-length` filter by characters instead of tokens; and borrowing another model's tokenizer does not fail, but a mismatched vocabulary silently distorts token counts.
 
 ## Output
 

--- a/docs/en/user_guides/stress_test/parameters.md
+++ b/docs/en/user_guides/stress_test/parameters.md
@@ -280,7 +280,7 @@ Replay behaviour is tuned via `--dataset-args`:
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `--tokenizer-path` | `str` | Tokenizer weights path<br>Used to calculate the number of tokens in input and output<br>Usually located in the same directory as model weights | `None` |
+| `--tokenizer-path` | `str` | Tokenizer weights path<br>Used to calculate the number of tokens in input and output<br>Usually located in the same directory as model weights<br>When benchmarking a chat endpoint, the tokenizer must ship a chat template (see the note below) | `None` |
 | `--frequency-penalty` | `float` | frequency_penalty value | - |
 | `--logprobs` | `bool` | Whether to return logarithmic probabilities | - |
 | `--max-tokens` | `int` or `int int` | Maximum number of tokens that can be generated<br>• A single integer: fixed value, e.g. `--max-tokens 2048`<br>• Two integers: `min max`, sampled uniformly at random per request, e.g. `--max-tokens 512 2048` | `2048` |
@@ -293,6 +293,12 @@ Replay behaviour is tuned via `--dataset-args`:
 | `--top-p` | `float` | Top-p sampling | - |
 | `--top-k` | `int` | Top-k sampling | - |
 | `--extra-args` | `str` | Additional parameters to be passed in the request body<br>JSON string format<br>Example: `'{"ignore_eos": true}'` | - |
+
+### Tokenizer and chat template
+
+When benchmarking a `chat/completions` endpoint, `--apply-chat-template` is on by default and the client applies the chat template before counting tokens, so client-side lengths line up with the `usage.prompt_tokens` reported by the service; the tokenizer given to `--tokenizer-path` must therefore ship a Jinja chat template. DeepSeek-V3.2 / V4 provide `encoding` scripts instead, and base / pretrain checkpoints have no template either — those fail with an error that lists the available options.
+
+Two things to watch out for: without `--tokenizer-path`, `--min/max-prompt-length` filters by characters instead of tokens; and borrowing another model's tokenizer does not fail, but a mismatched vocabulary silently distorts token counts.
 
 ## Output
 

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -280,7 +280,7 @@ trace 文件为 JSONL，每行一条请求记录：
 
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
-| `--tokenizer-path` | `str` | 分词器权重路径<br>用于计算输入和输出的token数量<br>通常与模型权重在同一目录 | `None` |
+| `--tokenizer-path` | `str` | 分词器权重路径<br>用于计算输入和输出的token数量<br>通常与模型权重在同一目录<br>压测 chat 接口时，该分词器需自带 chat template（详见下方说明） | `None` |
 | `--frequency-penalty` | `float` | frequency_penalty值 | - |
 | `--logprobs` | `bool` | 是否返回对数概率 | - |
 | `--max-tokens` | `int` 或 `int int` | 可以生成的最大token数量<br>• 单个整数：固定值，如 `--max-tokens 2048`<br>• 两个整数：`最小值 最大值`，每次请求从该范围均匀随机采样，如 `--max-tokens 512 2048` | `2048` |
@@ -293,6 +293,12 @@ trace 文件为 JSONL，每行一条请求记录：
 | `--top-p` | `float` | top_p采样 | - |
 | `--top-k` | `int` | top_k采样 | - |
 | `--extra-args` | `str` | 额外传入请求体的参数<br>JSON字符串格式<br>示例：`'{"ignore_eos": true}'` | - |
+
+### 分词器与 chat template
+
+压测 `chat/completions` 接口时 `--apply-chat-template` 默认开启，客户端会先套上 chat template 再统计 token 数，使长度计算与服务端 `usage.prompt_tokens` 对齐；因此 `--tokenizer-path` 指向的分词器必须自带 Jinja 格式的 chat template。DeepSeek-V3.2 / V4 官方改为提供 `encoding` 脚本，base / pretrain 权重也不带模板，这类权重会直接报错，报错信息中列出了可选的处理方式。
+
+两个易错点：不传 `--tokenizer-path` 时 `--min/max-prompt-length` 按字符数而非 token 数过滤；借用其它模型的分词器不会报错，但词表不一致会默默把 token 统计算偏。
 
 ## 结果输出
 

--- a/docs/zh/user_guides/stress_test/parameters.md
+++ b/docs/zh/user_guides/stress_test/parameters.md
@@ -298,7 +298,7 @@ trace 文件为 JSONL，每行一条请求记录：
 
 压测 `chat/completions` 接口时 `--apply-chat-template` 默认开启，客户端会先套上 chat template 再统计 token 数，使长度计算与服务端 `usage.prompt_tokens` 对齐；因此 `--tokenizer-path` 指向的分词器必须自带 Jinja 格式的 chat template。DeepSeek-V3.2 / V4 官方改为提供 `encoding` 脚本，base / pretrain 权重也不带模板，这类权重会直接报错，报错信息中列出了可选的处理方式。
 
-两个易错点：不传 `--tokenizer-path` 时 `--min/max-prompt-length` 按字符数而非 token 数过滤；借用其它模型的分词器不会报错，但词表不一致会默默把 token 统计算偏。
+两个易错点：不传 `--tokenizer-path` 时 `--min-prompt-length` / `--max-prompt-length` 按字符数而非 token 数过滤；借用其它模型的分词器不会报错，但词表不一致会默默把 token 统计算偏。
 
 ## 结果输出
 

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -67,11 +67,16 @@ def tokenize_chat_messages(tokenizer, messages: List[Dict], add_generation_promp
         List[int]: Flat list of token IDs.
 
     Raises:
+        ImportError: Propagated unchanged when an optional dependency (e.g. jinja2) is missing.
         ValueError: If the tokenizer has no chat template usable for these messages.
         TypeError: If the tokenizer returns an unexpected type that cannot be converted.
     """
     try:
         result = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=add_generation_prompt)
+    except ImportError:
+        # Missing optional dependency (e.g. jinja2): the template exists, so surface the
+        # real dependency error instead of the misleading no-template hint.
+        raise
     except Exception as e:
         name = getattr(tokenizer, 'name_or_path', None) or type(tokenizer).__name__
         raise ValueError(

--- a/evalscope/perf/plugin/datasets/utils.py
+++ b/evalscope/perf/plugin/datasets/utils.py
@@ -5,6 +5,18 @@ from evalscope.utils.logger import get_logger
 
 logger = get_logger()
 
+# Guidance appended to the error raised when `apply_chat_template` fails.
+_NO_CHAT_TEMPLATE_HINT = (
+    'Some checkpoints ship no Jinja chat template at all (DeepSeek-V3.2 / V4 provide `encoding` scripts '
+    'instead, and base/pretrain checkpoints have none), and some templates reject the message shape used '
+    'here. The template is applied client-side only to count prompt tokens the way the model service does. '
+    'Options:\n'
+    '  1. drop `--tokenizer-path` and let the `usage` reported by the model service provide token counts;\n'
+    '  2. use a tokenizer that ships a chat template and shares the vocabulary of the served model (a '
+    'different vocabulary silently distorts token counts);\n'
+    '  3. pass `--no-apply-chat-template` and benchmark a text-completions endpoint instead.'
+)
+
 
 def load_tokenizer(tokenizer_path: str) -> object:
     """Load a tokenizer from the given path, with a fallback for models that lack ``max_position_embeddings``.
@@ -55,9 +67,16 @@ def tokenize_chat_messages(tokenizer, messages: List[Dict], add_generation_promp
         List[int]: Flat list of token IDs.
 
     Raises:
+        ValueError: If the tokenizer has no chat template usable for these messages.
         TypeError: If the tokenizer returns an unexpected type that cannot be converted.
     """
-    result = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=add_generation_prompt)
+    try:
+        result = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=add_generation_prompt)
+    except Exception as e:
+        name = getattr(tokenizer, 'name_or_path', None) or type(tokenizer).__name__
+        raise ValueError(
+            f'Failed to apply the chat template of tokenizer `{name}`: {e}\n{_NO_CHAT_TEMPLATE_HINT}'
+        ) from e
 
     # Old transformers: returns List[int] directly.
     if isinstance(result, list):

--- a/tests/perf/test_chat_template_error.py
+++ b/tests/perf/test_chat_template_error.py
@@ -1,0 +1,73 @@
+"""Tests for the actionable error raised when a tokenizer has no usable chat template (issue #1548).
+
+DeepSeek-V3.2 / V4 ship no Jinja chat template (the model card points at ``encoding`` scripts
+instead) and base/pretrain checkpoints have none either, so ``apply_chat_template`` fails.  Perf
+must explain what to do instead of leaking the raw transformers error.
+"""
+
+import pytest
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.datasets import base as base_mod
+from evalscope.perf.plugin.datasets.line_by_line import LineByLineDatasetPlugin
+from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
+
+TEMPLATE_ERROR = 'cannot use chat template functions because tokenizer.chat_template is not set'
+MESSAGES = [{'role': 'user', 'content': 'hi'}]
+
+
+class NoTemplateTokenizer:
+    """One token per character, and no chat template -- like a base checkpoint."""
+
+    name_or_path = '/models/deepseek-v4-flash'
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) for c in text]
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=True):
+        raise ValueError(TEMPLATE_ERROR)
+
+
+class BareTokenizer:
+    """Tokenizer that does not expose ``apply_chat_template`` at all."""
+
+    name_or_path = 'bert-base-uncased'
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) for c in text]
+
+
+def test_error_reports_tokenizer_cause_and_options():
+    with pytest.raises(ValueError) as excinfo:
+        tokenize_chat_messages(NoTemplateTokenizer(), MESSAGES)
+    message = str(excinfo.value)
+    assert '/models/deepseek-v4-flash' in message
+    assert TEMPLATE_ERROR in message
+    assert 'drop `--tokenizer-path`' in message
+    assert 'shares the vocabulary' in message
+    assert '--no-apply-chat-template' in message
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+def test_error_when_apply_chat_template_is_missing():
+    with pytest.raises(ValueError) as excinfo:
+        tokenize_chat_messages(BareTokenizer(), MESSAGES)
+    assert 'bert-base-uncased' in str(excinfo.value)
+
+
+def test_length_filter_reports_the_error(tmp_path, monkeypatch):
+    """Reproduces #1548: a text dataset filtering prompts by token length on a chat endpoint."""
+    monkeypatch.setattr(base_mod, 'load_tokenizer', lambda path: NoTemplateTokenizer())
+    path = tmp_path / 'lines.txt'
+    path.write_text('hello world', encoding='utf-8')
+    args = Arguments(
+        model='test-model',
+        url='http://localhost:8080/v1/chat/completions',
+        dataset='line_by_line',
+        dataset_path=str(path),
+        tokenizer_path='fake',
+    )
+    plugin = LineByLineDatasetPlugin(args)
+    with pytest.raises(ValueError) as excinfo:
+        list(plugin.build_messages())
+    assert 'Failed to apply the chat template' in str(excinfo.value)

--- a/tests/perf/test_chat_template_error.py
+++ b/tests/perf/test_chat_template_error.py
@@ -37,6 +37,15 @@ class BareTokenizer:
         return [ord(c) for c in text]
 
 
+class MissingDepTokenizer:
+    """Tokenizer whose template needs an optional dependency that is not installed."""
+
+    name_or_path = 'some/model'
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=True):
+        raise ImportError('apply_chat_template requires jinja2 to be installed.')
+
+
 def test_error_reports_tokenizer_cause_and_options():
     with pytest.raises(ValueError) as excinfo:
         tokenize_chat_messages(NoTemplateTokenizer(), MESSAGES)
@@ -53,6 +62,12 @@ def test_error_when_apply_chat_template_is_missing():
     with pytest.raises(ValueError) as excinfo:
         tokenize_chat_messages(BareTokenizer(), MESSAGES)
     assert 'bert-base-uncased' in str(excinfo.value)
+
+
+def test_import_error_propagates_unchanged():
+    # A missing optional dependency is not a missing template; keep the real error.
+    with pytest.raises(ImportError):
+        tokenize_chat_messages(MissingDepTokenizer(), MESSAGES)
 
 
 def test_length_filter_reports_the_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

`evalscope perf` aborts with the raw transformers error when the tokenizer given to `--tokenizer-path` has no Jinja chat template:

```
tokenizer.chat_template is not set and no template argument was passed
```

Nothing in that message says which of the user's flags to change, so the run just dies. Reported in #1548 (DeepSeek-V4) and previously in #1119 (DeepSeek-V3.2, closed with a workaround rather than a fix). It is not DeepSeek-specific: the same failure hits any base/pretrain checkpoint, since those ship no template either and `--apply-chat-template` is enabled automatically for `chat/completions` URLs.

Perf applies the template client-side only so that prompt lengths and the no-`usage` fallback count tokens the way the model service does, so the failure is recoverable — the user just has to be told how.

## How

`tokenize_chat_messages()` is the single choke point for every chat-template application in perf (length filtering, random-dataset template overhead, the `usage` fallback, and `--tokenize-prompt`). Wrapping it there covers all of them:

```
Failed to apply the chat template of tokenizer `/models/deepseek-v4-flash`: Cannot use chat
template functions because tokenizer.chat_template is not set and no template argument was passed!
Some checkpoints ship no Jinja chat template at all (DeepSeek-V3.2 / V4 provide `encoding` scripts
instead, and base/pretrain checkpoints have none), and some templates reject the message shape used
here. The template is applied client-side only to count prompt tokens the way the model service
does. Options:
  1. drop `--tokenizer-path` and let the `usage` reported by the model service provide token counts;
  2. use a tokenizer that ships a chat template and shares the vocabulary of the served model (a
     different vocabulary silently distorts token counts);
  3. pass `--no-apply-chat-template` and benchmark a text-completions endpoint instead.
```

The original exception is preserved as `__cause__`. No fallback or degradation is introduced: token accounting stays exact or fails.

Docs: `--tokenizer-path` now states the constraint, plus a short subsection covering the two things the error message cannot convey — that lengths are filtered by characters without a tokenizer, and that borrowing another model's tokenizer does not fail but silently distorts counts (the follow-up question asked in #1548).

## Tests

`tests/perf/test_chat_template_error.py`: message content and exception chaining, a tokenizer without `apply_chat_template` at all, and an end-to-end reproduction of #1548 through a dataset plugin's length filter.

```
pytest tests/perf/test_chat_template_error.py -q                    # 3 passed
pytest tests/perf/test_request_generation.py tests/perf/test_prefix_injection.py \
       tests/perf/test_target_input_len.py tests/perf/test_openai_api_parse_responses.py -q   # 51 passed
make lint                                                          # clean
```

## Follow-ups (not in this PR)

Two pre-existing defects are exposed but not caused by this change, and are better fixed on their own:

- `OpenaiPlugin.build_request()` swallows any exception into `return None`, so on the `--tokenize-prompt` path this error is logged but the run continues with a `None` request.
- `test_connection()` treats it as retryable and re-warns every 10s until `--total-timeout`, then exits with a misleading timeout message (same shape as #1261).
