### PR TITLE
Fix async loop shutdown timeout cascade

### DIFF
--- a/evalscope/utils/asyncio_runtime.py
+++ b/evalscope/utils/asyncio_runtime.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Awaitable, Callable, Coroutine, List, Optional, TypeVar
+from weakref import WeakSet
 
 from evalscope.utils.logger import get_logger
 
@@ -96,6 +97,7 @@ class AsyncioLoopThread:
     """
 
     __slots__ = (
+        '__weakref__',
         '_name',
         '_health_label',
         '_state_lock',
@@ -315,7 +317,9 @@ class AsyncioLoopRunner:
 
     _local = threading.local()
     _all_handles_lock = threading.Lock()
-    _all_handles: List[AsyncioLoopThread] = []
+    # Timed-out handles stay discoverable for late close callbacks while their
+    # loop thread exits, then disappear automatically once no owner retains them.
+    _all_handles: WeakSet[AsyncioLoopThread] = WeakSet()
 
     @classmethod
     def _get_handle(cls) -> AsyncioLoopThread:
@@ -326,7 +330,7 @@ class AsyncioLoopRunner:
         handle = AsyncioLoopThread(name=f'EvalLoop[{owner_name}]', health_label=owner_name)
         cls._local.handle = handle
         with cls._all_handles_lock:
-            cls._all_handles.append(handle)
+            cls._all_handles.add(handle)
         return handle
 
     @classmethod
@@ -337,18 +341,20 @@ class AsyncioLoopRunner:
 
     @classmethod
     def shutdown_for_thread(cls, join_timeout: float = 5.0) -> None:
-        """Stop and release the loop bound to the calling thread, if any."""
+        """Stop and release the loop bound to the calling thread, if any.
+
+        A timed-out handle is detached from the worker so its next task can
+        create a fresh loop, while the old loop continues shutting down.
+        """
         handle: Optional[AsyncioLoopThread] = getattr(cls._local, 'handle', None)
         if handle is None:
             return
-        if not handle.stop(join_timeout=join_timeout):
-            return
+        stopped = handle.stop(join_timeout=join_timeout)
         cls._local.handle = None
+        if not stopped:
+            return
         with cls._all_handles_lock:
-            try:
-                cls._all_handles.remove(handle)
-            except ValueError:
-                pass
+            cls._all_handles.discard(handle)
 
     @classmethod
     def shutdown_all(cls, join_timeout: float = 5.0) -> None:

--- a/tests/test_function_utils.py
+++ b/tests/test_function_utils.py
@@ -364,8 +364,7 @@ def test_asyncio_loop_thread_drains_task_finalizer_callbacks_before_loop_close()
     assert owner_loop.is_closed()
 
 
-def test_asyncio_loop_runner_keeps_timed_out_generation_registered() -> None:
-    owner_loop = AsyncioLoopRunner.run(_current_loop())
+def test_asyncio_loop_runner_replaces_timed_out_worker_handle() -> None:
     blocker_started = threading.Event()
     release_blocker = threading.Event()
 
@@ -373,21 +372,38 @@ def test_asyncio_loop_runner_keeps_timed_out_generation_registered() -> None:
         blocker_started.set()
         release_blocker.wait()
 
-    owner_loop.call_soon_threadsafe(_block_owner_loop)
-    assert blocker_started.wait(timeout=1)
+    def _start_blocked_loop() -> tuple[str, AsyncioLoopThread, asyncio.AbstractEventLoop, bool]:
+        owner_loop = AsyncioLoopRunner.run(_current_loop())
+        handle = AsyncioLoopRunner._local.handle
+        owner_loop.call_soon_threadsafe(_block_owner_loop)
+        assert blocker_started.wait(timeout=1)
 
-    AsyncioLoopRunner.shutdown_for_thread(join_timeout=0.01)
-    handle = AsyncioLoopRunner._local.handle
-    assert handle is not None
-    assert handle in AsyncioLoopRunner._all_handles
-    assert handle.owns(owner_loop)
+        AsyncioLoopRunner.shutdown_for_thread(join_timeout=0.01)
+        released = getattr(AsyncioLoopRunner._local, 'handle', None) is None
+        return threading.current_thread().name, handle, owner_loop, released
 
-    release_blocker.set()
-    AsyncioLoopRunner.shutdown_for_thread(join_timeout=1)
+    def _run_on_reused_worker() -> tuple[str, AsyncioLoopThread, asyncio.AbstractEventLoop]:
+        owner_loop = AsyncioLoopRunner.run(_current_loop())
+        return threading.current_thread().name, AsyncioLoopRunner._local.handle, owner_loop
 
-    assert AsyncioLoopRunner._local.handle is None
-    assert handle not in AsyncioLoopRunner._all_handles
-    assert owner_loop.is_closed()
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_thread, timed_out_handle, first_loop, released = executor.submit(_start_blocked_loop).result()
+        try:
+            second_thread, replacement_handle, second_loop = executor.submit(_run_on_reused_worker).result()
+
+            assert released
+            assert first_thread == second_thread
+            assert replacement_handle is not timed_out_handle
+            assert second_loop is not first_loop
+            assert timed_out_handle in AsyncioLoopRunner._all_handles
+            assert timed_out_handle.owns(first_loop)
+        finally:
+            release_blocker.set()
+            assert timed_out_handle.stop(join_timeout=1)
+            executor.submit(AsyncioLoopRunner.shutdown_for_thread).result()
+
+    assert first_loop.is_closed()
+    assert second_loop.is_closed()
 
 
 def test_asyncio_loop_runner_keeps_worker_handle_registered_after_shutdown_all() -> None:


### PR DESCRIPTION
## Summary

- detach a worker's thread-local asyncio handle when loop shutdown exceeds its join timeout
- keep timed-out handles globally discoverable through weak references while their loop threads finish cleanup
- add a regression test proving a reused `ThreadPoolExecutor` worker creates a fresh loop instead of cascading `STOPPING` errors

## Root cause

`run_in_threads_with_progress` shuts down each worker's `AsyncioLoopRunner` after every sample. If shutdown timed out, `shutdown_for_thread` returned without clearing the thread-local handle. The handle therefore remained in `STOPPING`, and the next sample assigned to the same executor worker failed immediately with:

```
RuntimeError: EvalLoop[...] is stopping and cannot accept new work.
```

This is especially damaging for long-running agent and sandbox benchmarks because `--ignore-errors` can hide the infrastructure failure behind completed progress or failed scores.

## Implementation

On timeout, the old handle is now detached from the worker's thread-local state so the next sample can create a clean loop. The old generation is not falsely marked closed or forcefully abandoned: it remains in the global weak handle registry while its loop thread completes shutdown, preserving late close-callback discovery without retaining closed handles indefinitely.

## Validation

- `make lint`
- `pytest -q tests/test_function_utils.py tests/models/test_async_client_lifecycle.py tests/agent/test_sandbox_service.py tests/agent/external/test_bridge_lifecycle.py -p no:warnings` — 81 passed
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings` — passed
- regression test passed on Python 3.10 and Python 3.12
- integration reproduction with the real default shutdown timeout completed both samples on a reused worker with no errors and a fresh replacement loop
