### PR TITLE
fix(web): normalize backend null to undefined at the API validation boundary

### DIFF
--- a/evalscope/web/src/api/client.test.ts
+++ b/evalscope/web/src/api/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { apiValidated } from './client'
+
+/** Stub `fetch` to return `body` as a successful JSON response. */
+function mockJsonResponse(body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => body }) as unknown as Response),
+  )
+}
+
+describe('apiValidated backend-null normalization', () => {
+  it('accepts explicit nulls for .optional() fields nested at any depth', async () => {
+    // Mirrors how the backend emits Optional[...] = None (Pydantic) and NaN
+    // cells (pandas to_json): explicit JSON null rather than an absent key.
+    const schema = z.object({
+      top: z.number().optional(),
+      nested: z.object({
+        inner: z.string().optional(),
+        items: z.array(z.object({ token: z.number().optional() })),
+      }),
+    })
+    mockJsonResponse({
+      top: null,
+      nested: { inner: null, items: [{ token: null }, { token: 7 }] },
+    })
+
+    const result = await apiValidated('/api/v1/test', schema)
+
+    expect(result).toEqual({
+      top: undefined,
+      nested: { inner: undefined, items: [{ token: undefined }, { token: 7 }] },
+    })
+  })
+
+  it('still rejects a null where the schema requires a concrete value', async () => {
+    const schema = z.object({ required: z.number() })
+    mockJsonResponse({ required: null })
+
+    await expect(apiValidated('/api/v1/test', schema)).rejects.toMatchObject({ kind: 'validation' })
+  })
+})

--- a/evalscope/web/src/api/client.ts
+++ b/evalscope/web/src/api/client.ts
@@ -99,12 +99,43 @@ async function parseJson<T>(res: Response): Promise<T> {
 }
 
 /**
+ * Recursively replace every `null` with `undefined`.
+ *
+ * The Python backend expresses "no value" as an explicit JSON `null`: Pydantic
+ * `model_dump()` emits `null` for `Optional[...] = None` fields, and pandas
+ * `DataFrame.to_json()` emits `null` for `NaN`/`None` cells. Normalising `null`
+ * to an absent value at this single trust boundary lets every schema field
+ * declared with `.optional()` accept the backend's nulls, so new optional
+ * fields do not each need an explicit `.nullable()`.
+ */
+function nullToUndefined(value: unknown): unknown {
+  if (value === null) return undefined
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = nullToUndefined(value[i])
+    }
+    return value
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    for (const key of Object.keys(obj)) {
+      obj[key] = nullToUndefined(obj[key])
+    }
+    return obj
+  }
+  return value
+}
+
+/**
  * Run a parsed value through a zod schema, converting validation failures into
  * a typed {@link DomainError} (`kind='validation'`) so consumers never receive
  * unvalidated data and no uncaught exception escapes.
+ *
+ * Backend nulls are normalised to `undefined` first (see {@link nullToUndefined})
+ * so `.optional()` fields tolerate the explicit nulls the API emits.
  */
 function validate<T>(schema: ZodType<T>, data: unknown): T {
-  const result = schema.safeParse(data)
+  const result = schema.safeParse(nullToUndefined(data))
   if (!result.success) {
     throw new DomainError('validation', `Response validation failed: ${result.error.message}`)
   }

--- a/evalscope/web/src/api/schemas/eval.schema.ts
+++ b/evalscope/web/src/api/schemas/eval.schema.ts
@@ -48,7 +48,7 @@ export const benchmarkEntrySchema = z.object({
   total_samples: z.number(),
   few_shot_num: z.number(),
   dataset_id: z.string(),
-  paper_url: z.string().nullable(),
+  paper_url: z.string().nullish(),
   metrics: z.array(z.string()),
   meta: z.record(z.string(), z.unknown()),
   description: z.object({

--- a/evalscope/web/src/api/schemas/perf.schema.ts
+++ b/evalscope/web/src/api/schemas/perf.schema.ts
@@ -75,7 +75,7 @@ export const perfRunItemSchema = z.object({
   name: z.string(),
   parallel: z.number(),
   number: z.number(),
-  rate: z.number().nullable(),
+  rate: z.number().nullish(),
   total_requests: z.number(),
   succeed_requests: z.number(),
   success_rate: z.number(),

--- a/evalscope/web/src/api/schemas/reports.schema.test.ts
+++ b/evalscope/web/src/api/schemas/reports.schema.test.ts
@@ -65,14 +65,14 @@ describe('loadReportResponseSchema real report compatibility', () => {
     expect(result.success).toBe(true)
   })
 
-  it('accepts a reasoning block with a null reasoning_tokens, as emitted when the backend has no token count', () => {
+  it('accepts a reasoning block with an absent reasoning_tokens (backend null is normalised to undefined by the API client before validation)', () => {
     // ContentReasoning.reasoning_tokens is `Optional[int] = None` on the Python side, which
-    // serializes as an explicit JSON `null` rather than an absent key. Reasoning models that
-    // don't report a token count (e.g. via completion_tokens_details) hit this on every turn.
+    // serializes as an explicit JSON `null`. The API client's nullToUndefined() converts it
+    // to `undefined` before schema validation, so the schema only needs .optional().
     const result = chatMessageSchema.safeParse({
       role: 'assistant',
       content: [
-        { type: 'reasoning', reasoning: 'thinking it through...', reasoning_tokens: null },
+        { type: 'reasoning', reasoning: 'thinking it through...', reasoning_tokens: undefined },
         { type: 'text', text: 'final answer' },
       ],
     })

--- a/evalscope/web/src/api/schemas/reports.schema.ts
+++ b/evalscope/web/src/api/schemas/reports.schema.ts
@@ -44,8 +44,9 @@ export const metricDataSchema = z.object({
 export const percentileStatsSchema = z.object({
   mean: z.number(),
   // pandas uses sample standard deviation (ddof=1), which is undefined for a
-  // single observation. The backend serializes that NaN as JSON null.
-  std: z.number().nullable(),
+  // single observation. The backend serializes that NaN as JSON null, which the
+  // API client normalizes to undefined before validation - hence nullish.
+  std: z.number().nullish(),
   min: z.number(),
   '25%': z.number(),
   '50%': z.number(),
@@ -146,7 +147,7 @@ export const contentBlockSchema = z.object({
   type: z.enum(['text', 'reasoning', 'image', 'audio', 'video', 'data']),
   text: z.string().optional(),
   reasoning: z.string().optional(),
-  reasoning_tokens: z.number().nullable().optional(),
+  reasoning_tokens: z.number().optional(),
   image: z.string().optional(),
   audio: z.string().optional(),
   video: z.string().optional(),

--- a/evalscope/web/src/components/reports/PerfMetricsPanel.tsx
+++ b/evalscope/web/src/components/reports/PerfMetricsPanel.tsx
@@ -48,7 +48,7 @@ interface PercTableProps {
 }
 
 function PercTable({ stats, unit, accentCol = 'var(--accent)', scale = 1 }: PercTableProps) {
-  const fmt = (v: number | null) => fmtRaw(v === null ? null : v * scale, scale === 1000 ? 1 : 3)
+  const fmt = (v: number | null | undefined) => fmtRaw(v == null ? null : v * scale, scale === 1000 ? 1 : 3)
 
   const cols: { label: string; key: keyof PercentileStats; accent?: boolean }[] = [
     { label: 'Mean', key: 'mean', accent: true },
@@ -86,7 +86,7 @@ function PercTable({ stats, unit, accentCol = 'var(--accent)', scale = 1 }: Perc
                 c.accent ? 'text-[var(--text)] font-medium' : 'text-[var(--text-muted)]',
               )}
             >
-              {fmt(stats[c.key])}{stats[c.key] === null ? '' : unit}
+              {fmt(stats[c.key])}{stats[c.key] == null ? '' : unit}
             </td>
           ))}
         </tr>

--- a/evalscope/web/src/components/single/chat/MediaBlocks.tsx
+++ b/evalscope/web/src/components/single/chat/MediaBlocks.tsx
@@ -51,7 +51,7 @@ export function VideoBlock({ src, format }: { src: string; format?: string }) {
 }
 
 /** Collapsible reasoning block rendered above the main answer. */
-export function ReasoningBlock({ text, tokens }: { text: string; tokens?: number | null }) {
+export function ReasoningBlock({ text, tokens }: { text: string; tokens?: number }) {
   const { t } = useLocale()
   const [open, setOpen] = useState(false)
   return (


### PR DESCRIPTION
## Problem

The Python backend expresses "no value" as an explicit JSON `null`, not an absent key:

- Pydantic `model_dump()` ([process.py](../blob/main/evalscope/service/utils/process.py#L244), [report.py](../blob/main/evalscope/report/report.py#L181-L183)) serializes `Optional[...] = None` fields as `null`.
- pandas `DataFrame.to_json()` ([reports.py](../blob/main/evalscope/service/blueprints/reports.py#L129-L133)) — used for the `/predictions` endpoint — serializes `NaN`/`None` cells as `null` (pandas has no `exclude_none`).

The zod schemas declared these fields with `.optional()` (i.e. `T | undefined`), which rejects `null`. Since [`validate()`](../blob/main/evalscope/web/src/api/client.ts) is an all-or-nothing gate, a single unexpected `null` (a reasoning model that reports no token count, a single-observation `std`, a run without a request rate, …) fails validation and blanks the **entire** report / predictions view.

\#1563 fixed one such field (`reasoning_tokens`) by widening it to `.nullable()`. But that is a per-field treadmill: **38** `.optional()` fields are exposed today, and every new optional field is a new latent break.

## Fix — one normalization at the trust boundary

Rather than annotate every field, normalize `null → undefined` **once**, in the client's `validate()` chokepoint (all `apiValidated` / `apiDeleteValidated` / `apiPostValidated` flow through it). This makes `null` and an absent key equivalent for **every** `.optional()` field, current and future.

Why the frontend boundary and not the backend serialization:
- There are **two** producers (Pydantic `model_dump` + pandas `to_json`); pandas has no `exclude_none`, so a backend fix means two changes, one re-implementing this same recursive null-strip server-side.
- `exclude_none` can't reach nested `Dict[str, Any]` payloads (e.g. `perf_metrics.std`), and some nulls (single-observation `std`) are semantically meaningful.
- The producer is behaving correctly; the mismatch is the consumer schema's `.optional()` vs `.nullish()`. Fixing at the single consumer boundary has the smallest blast radius and doesn't change the persisted report JSON on disk.

### Changes
- `client.ts`: add `nullToUndefined()` and apply it in `validate()` before `safeParse`.
- Relax the 3 **required**-nullable fields whose `null` would otherwise become a missing-required error after normalization: `percentileStatsSchema.std`, `perfRunItemSchema.rate`, benchmark `paper_url` → `.nullish()`. (Already-optional fields need no change.)
- `PerfMetricsPanel.tsx`: `std` rendering uses `== null` so the single-observation "no unit" behavior is preserved now that `null` arrives as `undefined`.
- `client.test.ts`: covers deep-null tolerance and that a `null` on a **required** field is still rejected.

### Note / tradeoff
Normalization descends into opaque `z.unknown()` payloads (`task_config`, `metadata`, `Score`, agent `payload`), so a genuinely-`null` value inside those renders as absent rather than `"null"`. These regions already accepted `null` at validation time, so this is display-only and consistent with treating `null` as "no value" system-wide.

## Testing
- `npm run test` — 38 files / 260 tests pass
- `eslint .` — clean
- `tsc -b` — clean

Follow-up to #1563 (merged).