### PR TITLE
fix(perf): parse streaming usage independently of choices to fix 0 ca…

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -168,7 +168,7 @@ class DefaultApiPlugin(ApiPluginBase):
 
                                         generated_text += content
                                         output.response_messages.append(data)
-                                    elif usage := data.get('usage'):
+                                    if usage := data.get('usage'):
                                         output.prompt_tokens = usage.get('prompt_tokens')
                                         output.completion_tokens = usage.get('completion_tokens')
                                         # Extract real cached tokens from prompt_tokens_details


### PR DESCRIPTION
## Problem

`evalscope perf` in **streaming mode** (the default) always reports `KV Cache Hit Rate (%) = 0` / `Cached Prompt tok/s = 0`, even when the server reports non-zero cached tokens. The non-streaming path works correctly.

## Reproduction

```bash
evalscope perf \
  --url "https://api.deepseek.com/v1/chat/completions" \
  --api openai \
  --model deepseek-chat \
  --tokenizer-path deepseek-ai/DeepSeek-V3 \
  --api-key <YOUR_API_KEY> \
  --dataset random \
  --prefix-length 1048 \
  --min-prompt-length 2048 --max-prompt-length 2048 \
  --min-tokens 8 --max-tokens 8 \
  --parallel 1 --number 3
```

The `random` dataset shares one identical prefix across all requests, so requests 2+ hit the server prefix cache.

- Streaming (default): `Cached Prompt tok/s = 0.00`, no `Cache Hit (%)` row.
- `--no-stream`: `Cached Prompt tok/s ≈ 436` (correct).

## Root cause

`evalscope/perf/plugin/api/default_api.py`, streaming SSE branch, uses mutually-exclusive branches:

```python
if choices := data.get('choices'):
    ...                                  # content / latency
elif usage := data.get('usage'):         # only reached when choices is empty/falsy
    output.real_cached_tokens = _details.get('cached_tokens')
```

DeepSeek's **final** SSE chunk carries **both** a non-empty `choices` (the `finish_reason` delta) **and** the `usage` object:

```json
{
  "choices": [{"index": 0, "delta": {"content": "", "reasoning_content": null}, "finish_reason": "length"}],
  "usage": {"prompt_tokens": 3280, "prompt_tokens_details": {"cached_tokens": 1152}, ...}
}
```

Since `choices` is truthy, the `elif usage` branch is **never executed**, so `real_cached_tokens` is never extracted. `cached_tokens` stays `None` → `MetricsAccumulator.update()` and `WorkloadTimeline.feed()` skip it → cache hit rate is 0.

`prompt_tokens`/`completion_tokens` still look correct only because `BenchmarkData.finalize()` falls back to `parse_responses()`, but that path does **not** extract `cached_tokens`.

## Fix

Change `elif` → `if` so usage parsing is independent of `choices`, matching the non-streaming branch (which already uses a separate `if usage`).

## Impact

Any OpenAI-compatible provider that emits `usage` in the same chunk as a non-empty `choices` is affected. OpenAI itself sends a separate trailing chunk with `choices: []` (unaffected); DeepSeek and some vLLM deployments merge them and always report 0.

## Verification

On DeepSeek, streaming `Cached Prompt tok/s`: `0.00` → `285.91`, `Cache Hit (%)` = `11.7%`.

## Environment

- evalscope 1.10.0 (commit `9d052ca0`)
- Python 3.12