### PR TITLE
fix(perf tests): repair stale local-endpoint perf tests (hang + outdated return contract)

### DIFF
--- a/tests/perf/test_perf_basic.py
+++ b/tests/perf/test_perf_basic.py
@@ -31,9 +31,9 @@ class TestPerfBasic(PerfTestBase):
         for a small number of requests (15) at parallelism 1.
         """
         task_cfg = Arguments(
-            url='http://127.0.0.1:8001/v1/chat/completions',
+            url=LOCAL_CHAT_URL,
             parallel=1,
-            model='qwen2.5',
+            model='Qwen2.5-0.5B-Instruct',
             number=15,
             api='openai',
             dataset='openqa',
@@ -131,9 +131,8 @@ class TestPerfBasic(PerfTestBase):
             tokenize_prompt=True,
             extra_args={'ignore_eos': True},
         )
-        metrics_result, percentile_result = run_perf_benchmark(task_cfg)
-        print(metrics_result)
-        print(percentile_result)
+        result = run_perf_benchmark(task_cfg)
+        print(result)
 
     # ------------------------------------------------------------------
     # Completion endpoint / multi-parallel sweep
@@ -166,9 +165,8 @@ class TestPerfBasic(PerfTestBase):
             seed=None,
             extra_args={'ignore_eos': True},
         )
-        metrics_result, percentile_result = run_perf_benchmark(task_cfg)
-        print(metrics_result)
-        print(percentile_result)
+        result = run_perf_benchmark(task_cfg)
+        print(result)
 
     def test_multi_parallel_sweep(self):
         """Multi-parallel sweep against DashScope chat/completions.
@@ -233,9 +231,8 @@ class TestPerfBasic(PerfTestBase):
             seed=None,
             extra_args={'ignore_eos': True},
         )
-        metrics_result, percentile_result = run_perf_benchmark(task_cfg)
-        print(metrics_result)
-        print(percentile_result)
+        result = run_perf_benchmark(task_cfg)
+        print(result)
 
     def test_kontext_bench_vl(self):
         """KontextBench VL dataset sweep.
@@ -260,9 +257,8 @@ class TestPerfBasic(PerfTestBase):
             seed=None,
             extra_args={'ignore_eos': True},
         )
-        metrics_result, percentile_result = run_perf_benchmark(task_cfg)
-        print(metrics_result)
-        print(percentile_result)
+        result = run_perf_benchmark(task_cfg)
+        print(result)
 
     # ------------------------------------------------------------------
     # Sequential runs / ShareGPT


### PR DESCRIPTION
Found while verifying #1571 against a real local vLLM server. Independent of that PR: these tests fail (or hang) on `main` as well.

## 1. `test_basic_openqa` hung the whole suite

It pointed at `http://127.0.0.1:8001/v1/chat/completions` — the **only** occurrence of port 8001 in the repo, while the same file already imports the shared `LOCAL_CHAT_URL` constant (`:8801`). With nothing listening on 8001, connection-refused is (correctly) treated as a retryable transport error and retried every 10s until `--total-timeout`, i.e. **6 hours by default**. So `pytest tests/perf/` did not fail — it hung.

`model='qwen2.5'` was stale as well; against the real endpoint it returns `404 The model 'qwen2.5' does not exist.` Aligned with the other local tests (`Qwen2.5-0.5B-Instruct`).

## 2. Four tests used an outdated return contract

`run_perf_benchmark()` returns `{run_key: {'metrics': ..., 'percentiles': ...}}`, but `test_local_random`, `test_completion_endpoint`, `test_random_vl` and `test_kontext_bench_vl` still unpacked it as a 2-tuple:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

The failure happens *after* the entire benchmark has run, so it wasted the full run before blowing up. Replaced with the plain `result = run_perf_benchmark(...); print(result)` form already used by the sweep tests in the same file — which is also correct for multi-run sweeps, where taking `list(results.keys())[0]` would silently drop all but the first run.

## Verification

Against a local vLLM server (`Qwen2.5-0.5B-Instruct` on `:8801`):

- `test_basic_openqa` — pass (previously: hung for hours)
- `test_local_random` — pass (previously: `ValueError`, reproduced on clean `main` at `197e0403`)
- `test_stream_openai_chat`, `test_perf_sla.py` (both cases), `test_random_multi_turn` — pass, unchanged

`make lint` clean. The DashScope-backed tests in this file are untouched apart from the return-contract fix; they still skip without `DASHSCOPE_API_KEY`.
