### PR TITLE
fix(perf): abort request generation when a plugin returns None for the whole dataset

### DIFF
--- a/evalscope/perf/benchmark.py
+++ b/evalscope/perf/benchmark.py
@@ -89,12 +89,25 @@ async def get_requests(args: Arguments, api_plugin: 'ApiPluginBase') -> AsyncGen
         dataset_index = 0
         num_messages = len(dataset_messages)
 
+        # Guard against an infinite loop: if build_request returns None for a whole
+        # pass over the dataset, no request will ever be produced, so abort instead
+        # of spinning forever (count would never advance).
+        consecutive_skips = 0
+
         while count < total_count:
             messages = dataset_messages[dataset_index]
             request = api_plugin.build_request(messages)
             if request is not None:
                 yield request, count < warmup_count
                 count += 1
+                consecutive_skips = 0
+            else:
+                consecutive_skips += 1
+                if consecutive_skips >= num_messages:
+                    raise ValueError(
+                        f'{type(api_plugin).__name__}.build_request() returned None for every one of '
+                        f'the {num_messages} dataset message(s); no request could be generated.'
+                    )
             dataset_index = (dataset_index + 1) % num_messages
 
     # Dispatch based on arguments.

--- a/tests/perf/test_request_generation.py
+++ b/tests/perf/test_request_generation.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import numpy as np
+import pytest
 from pytest import MonkeyPatch
 from typing import Dict, Iterator, List, Optional, Tuple
 
@@ -45,6 +46,23 @@ class _FakeApiPlugin:
 
     def build_request(self, messages: str) -> Dict[str, str]:
         return {'payload': messages}
+
+
+class _NoneApiPlugin:
+    """Simulates a plugin that returns None for every message (unusable input)."""
+
+    def build_request(self, messages: str) -> Optional[Dict[str, str]]:
+        return None
+
+
+class _SerialDatasetPlugin(DatasetPluginBase):
+
+    def build_messages(self) -> Iterator[str]:
+        for index in range(3):
+            yield f'message-{index}'
+
+    def supports_parallel_message_generation(self, total_count: Optional[int] = None) -> bool:
+        return False
 
 
 async def _collect_requests(args: Arguments) -> List:
@@ -95,6 +113,23 @@ def test_parallel_dataset_generation_hook_preserves_order_and_warmup() -> None:
         ({'payload': 'message-2'}, False),
         ({'payload': 'message-3'}, False),
     ]
+
+
+def test_all_none_requests_abort_instead_of_hanging() -> None:
+    """If build_request returns None for a whole dataset pass, get_requests must abort.
+
+    Reproduces the residual #1565 risk: count never advances, so the serial cycle
+    would otherwise spin forever without yielding.
+    """
+    DatasetRegistry.register('unit_serial_dataset', _SerialDatasetPlugin)
+    args = _make_args(dataset='unit_serial_dataset', num_workers=0)
+
+    async def _drain() -> None:
+        async for _ in get_requests(args, _NoneApiPlugin()):
+            pass
+
+    with pytest.raises(ValueError, match='returned None for every one of'):
+        asyncio.run(_drain())
 
 
 def test_dataset_generation_worker_auto_respects_cpu_affinity(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Follow-up to #1571 (issue #1565). That PR fixed the swallow-to-`None` path in `OpenaiPlugin`, but left one residual hang untouched, as noted in the #1565 discussion.

## Problem

`get_requests()._generate_from_dataset()` cycles the dataset and only advances `count` when `build_request()` returns a request:

```python
while count < total_count:
    request = api_plugin.build_request(dataset_messages[dataset_index])
    if request is not None:
        yield request, count < warmup_count
        count += 1
    dataset_index = (dataset_index + 1) % num_messages
```

If a plugin returns `None` for **every** message, `count` never advances and the loop has no `await` — it starves the event loop forever. The other four API plugins (embedding / rerank / custom / dashscope) still legitimately return `None` for unusable/empty input, so this is reachable.

## Fix

Guard the loop with a full-pass invariant: if a whole cycle over the dataset yields no request, raise with the plugin name instead of spinning.

```python
consecutive_skips += 1
if consecutive_skips >= num_messages:
    raise ValueError(f'{type(api_plugin).__name__}.build_request() returned None for every one of the {num_messages} dataset message(s); no request could be generated.')
```

## Verification

New test `test_all_none_requests_abort_instead_of_hanging`:
- **without** the guard it hangs (`pytest-timeout` fires at `benchmark.py:95`),
- **with** the guard it raises `ValueError` fast.

`tests/perf/test_request_generation.py`: 14 passed. `make lint` clean.
