### PR TITLE
fix(judge): fail closed on [ERROR] judge responses and surface silent extraction paths

### DIFF
--- a/evalscope/metrics/judge/llm_judge.py
+++ b/evalscope/metrics/judge/llm_judge.py
@@ -9,6 +9,11 @@ from .score_extractors import NumericScoreExtractor, PatternScoreExtractor, Scor
 
 logger = get_logger()
 
+# Sentinel that ``judge`` returns instead of raising on a failed request.
+# Consumers must fail closed on it (score 0, never full credit) — the same
+# contract as ``evalscope/benchmarks/hipho/utils.py#JUDGE_ERROR_PREFIX``.
+JUDGE_ERROR_PREFIX = '[ERROR]'
+
 DEFAULT_PROMPT_TEMPLATE = """Your job is to look at a question, a gold target, and a predicted answer, and return a letter "A" or "B" to indicate whether the predicted answer is correct or incorrect.
 
 [Question]
@@ -159,7 +164,7 @@ class LLMJudge(BaseJudge):
         except Exception as e:
             error_message = f'Error occurred during {self.model_id}@{self.api_url} LLM judge evaluation: {e}'
             logger.error(error_message)
-            return f'[ERROR] {error_message}'
+            return f'{JUDGE_ERROR_PREFIX} {error_message}'
 
     def build_prompt(self, pred: str, gold: str, question: Optional[str] = None) -> str:
         if question is None:
@@ -186,5 +191,12 @@ class LLMJudge(BaseJudge):
             float: The numeric score extracted from the response
         """
         if response is None:
+            return 0.0
+        # A failed judge request must score 0, never full credit: ``judge`` reports
+        # failures as an ``[ERROR] ...`` string whose embedded digits (model id,
+        # endpoint, HTTP code) could otherwise be parsed as a score by a loose
+        # pattern. Same guard as ``benchmarks/hipho/utils.py``.
+        if response.startswith(JUDGE_ERROR_PREFIX):
+            logger.warning(f'LLM judge failed; returning 0.0. Response: {response}')
             return 0.0
         return self._score_extractor.extract(response)

--- a/evalscope/metrics/judge/score_extractors.py
+++ b/evalscope/metrics/judge/score_extractors.py
@@ -1,3 +1,4 @@
+import math
 import re
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
@@ -58,6 +59,12 @@ class NumericScoreExtractor(ScoreExtractor):
 
         def _clamped(val: float) -> float:
             """Clamp to [clamp_min, clamp_max], warning when the raw value was out of range."""
+            # NaN compares false against every bound, so it would slip through the range
+            # check below and propagate into aggregation, turning the whole metric into
+            # NaN. Fail closed at clamp_min instead, as documented for [ERROR] responses.
+            if math.isnan(val):
+                logger.warning(f'Score NaN is not a usable rating, returning {self.clamp_min} in response: {response}')
+                return self.clamp_min
             if val < self.clamp_min or val > self.clamp_max:
                 clamped = max(self.clamp_min, min(self.clamp_max, val))
                 logger.warning(

--- a/evalscope/metrics/judge/score_extractors.py
+++ b/evalscope/metrics/judge/score_extractors.py
@@ -28,7 +28,13 @@ class PatternScoreExtractor(ScoreExtractor):
         match = re.search(self.pattern, response, re.MULTILINE)
         if match:
             answer = match.group(1) if match.lastindex else match.group(0).strip()
-            return self.score_mapping.get(answer, 0.0)
+            if answer not in self.score_mapping:
+                logger.warning(
+                    f"Matched '{answer}' for pattern '{self.pattern}' but no score mapping exists; "
+                    f'returning 0.0. Response: {response}'
+                )
+                return 0.0
+            return self.score_mapping[answer]
         else:
             logger.warning(f"No match found for pattern '{self.pattern}' in response: {response}")
             return 0.0
@@ -50,6 +56,17 @@ class NumericScoreExtractor(ScoreExtractor):
             logger.warning(f"No match found for pattern '{self.pattern}' in response: {response}")
             return 0.0
 
+        def _clamped(val: float) -> float:
+            """Clamp to [clamp_min, clamp_max], warning when the raw value was out of range."""
+            if val < self.clamp_min or val > self.clamp_max:
+                clamped = max(self.clamp_min, min(self.clamp_max, val))
+                logger.warning(
+                    f'Score {val} out of range [{self.clamp_min}, {self.clamp_max}], '
+                    f'clamped to {clamped} in response: {response}'
+                )
+                return clamped
+            return val
+
         # iterate from last to first to pick the final rating
         for match in reversed(matches):
             # prefer captured groups
@@ -57,14 +74,12 @@ class NumericScoreExtractor(ScoreExtractor):
                 if group is None:
                     continue
                 try:
-                    val = float(group)
-                    return max(self.clamp_min, min(self.clamp_max, val))
+                    return _clamped(float(group))
                 except (ValueError, TypeError):
                     continue
             # fallback: try entire match if groups fail
             try:
-                val = float(match.group(0))
-                return max(self.clamp_min, min(self.clamp_max, val))
+                return _clamped(float(match.group(0)))
             except (ValueError, TypeError):
                 continue
 

--- a/tests/metrics/judge/test_score_extractors.py
+++ b/tests/metrics/judge/test_score_extractors.py
@@ -11,6 +11,7 @@ from evalscope.metrics.judge.score_extractors import NumericScoreExtractor, Patt
 
 
 class TestPatternScoreExtractor:
+
     def test_mapped_answer_returns_mapping_value(self) -> None:
         extractor = PatternScoreExtractor(pattern=r'\b([AB])\b', score_mapping={'A': 1.0, 'B': 0.5})
         assert extractor.extract('The answer is A.') == 1.0
@@ -32,6 +33,7 @@ class TestPatternScoreExtractor:
 
 
 class TestNumericScoreExtractor:
+
     def test_in_range_value_passes_through(self) -> None:
         extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
         assert extractor.extract('[[0.5]]') == 0.5
@@ -45,12 +47,26 @@ class TestNumericScoreExtractor:
         extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
         assert extractor.extract('[[-1]]') == 0.0
 
+    def test_nan_fails_closed_to_min(self) -> None:
+        # float() accepts 'nan', and NaN compares false against both bounds, so without an
+        # explicit check it escapes clamping. One NaN sample would poison every aggregate
+        # built on this metric, since nothing downstream filters it.
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('[[nan]]') == 0.0
+        assert extractor.extract('[[NaN]]') == 0.0
+
+    def test_infinity_clamps_to_bounds(self) -> None:
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('[[inf]]') == 1.0
+        assert extractor.extract('[[-inf]]') == 0.0
+
     def test_no_match_returns_zero(self) -> None:
         extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
         assert extractor.extract('no brackets here') == 0.0
 
 
 class TestLLMJudgeErrorGuard:
+
     def make_judge(self, score_type: str, **kwargs) -> LLMJudge:
         return LLMJudge(score_type=score_type, **kwargs)
 
@@ -76,6 +92,7 @@ class TestLLMJudgeErrorGuard:
         judge = self.make_judge('pattern', score_pattern=r'\b([AB])\b')
 
         class _FailingModel:
+
             def generate(self, messages):
                 raise RuntimeError('connection refused')
 

--- a/tests/metrics/judge/test_score_extractors.py
+++ b/tests/metrics/judge/test_score_extractors.py
@@ -1,0 +1,84 @@
+"""Unit tests for LLM-judge score extraction strategies.
+
+These lock in the documented fail-close contract: a failed judge request
+(``[ERROR] ...`` responses) and any unmatched/unmapped extraction must score
+0, never full credit. Covers ``PatternScoreExtractor``, ``NumericScoreExtractor``
+and the ``[ERROR]`` guard in ``LLMJudge.get_score``.
+"""
+
+from evalscope.metrics.judge.llm_judge import JUDGE_ERROR_PREFIX, LLMJudge
+from evalscope.metrics.judge.score_extractors import NumericScoreExtractor, PatternScoreExtractor
+
+
+class TestPatternScoreExtractor:
+    def test_mapped_answer_returns_mapping_value(self) -> None:
+        extractor = PatternScoreExtractor(pattern=r'\b([AB])\b', score_mapping={'A': 1.0, 'B': 0.5})
+        assert extractor.extract('The answer is A.') == 1.0
+        assert extractor.extract('The answer is B.') == 0.5
+
+    def test_no_match_returns_zero(self) -> None:
+        extractor = PatternScoreExtractor(pattern=r'\b([AB])\b')
+        assert extractor.extract('The answer is C.') == 0.0
+
+    def test_matched_but_unmapped_returns_zero(self) -> None:
+        # 'B' matches the pattern but is not in the mapping: fail closed at 0.0
+        extractor = PatternScoreExtractor(pattern=r'\b([AB])\b', score_mapping={'A': 1.0})
+        assert extractor.extract('The answer is B.') == 0.0
+
+    def test_error_response_returns_zero_for_letter_pattern(self) -> None:
+        # An [ERROR] response carries no letter token; extraction fails closed.
+        extractor = PatternScoreExtractor(pattern=r'\b([AB])\b')
+        assert extractor.extract(f'{JUDGE_ERROR_PREFIX} Qwen3-235B@http://127.0.0.1:8000/v1/ HTTP 500') == 0.0
+
+
+class TestNumericScoreExtractor:
+    def test_in_range_value_passes_through(self) -> None:
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('[[0.5]]') == 0.5
+
+    def test_out_of_range_high_clamps_to_max(self) -> None:
+        # A 0-100-scale judge reporting [[90]] must not become full credit silently.
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('[[90]]') == 1.0
+
+    def test_out_of_range_low_clamps_to_min(self) -> None:
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('[[-1]]') == 0.0
+
+    def test_no_match_returns_zero(self) -> None:
+        extractor = NumericScoreExtractor(pattern=r'\[\[(.*?)\]\]')
+        assert extractor.extract('no brackets here') == 0.0
+
+
+class TestLLMJudgeErrorGuard:
+    def make_judge(self, score_type: str, **kwargs) -> LLMJudge:
+        return LLMJudge(score_type=score_type, **kwargs)
+
+    def test_none_response_returns_zero(self) -> None:
+        judge = self.make_judge('pattern', score_pattern=r'\b([AB])\b')
+        assert judge.get_score(None) == 0.0
+
+    def test_error_response_returns_zero_even_with_loose_numeric_pattern(self) -> None:
+        # Without the [ERROR] guard, a loose numeric pattern would parse the
+        # embedded digits (500, 8000, 127) from a failed judge response and clamp
+        # them to full credit — the opposite of the fail-close contract.
+        judge = self.make_judge('numeric', score_pattern=r'(\d+)')
+        response = f'{JUDGE_ERROR_PREFIX} Qwen3-235B@http://127.0.0.1:8000/v1/ HTTP 500'
+        assert judge.get_score(response) == 0.0
+
+    def test_normal_response_still_extracts(self) -> None:
+        judge = self.make_judge('numeric', score_pattern=r'\[\[(.*?)\]\]')
+        assert judge.get_score('[[0.75]]') == 0.75
+
+    def test_judge_returns_error_prefix_when_generate_raises(self) -> None:
+        # Locks the producer contract: on a failed request, ``judge`` returns a
+        # ``JUDGE_ERROR_PREFIX``-prefixed string that ``get_score`` then fails closed on.
+        judge = self.make_judge('pattern', score_pattern=r'\b([AB])\b')
+
+        class _FailingModel:
+            def generate(self, messages):
+                raise RuntimeError('connection refused')
+
+        judge.model = _FailingModel()
+        result = judge.judge(prompt='question')
+        assert result.startswith(JUDGE_ERROR_PREFIX)


### PR DESCRIPTION
## Summary

Ports the **fail-close `[ERROR]` guard** that `evalscope/benchmarks/hipho/utils.py` already ships into the **shared** LLM-judge scoring path (`LLMJudge.get_score` → `ScoreExtractor`). When a judge API request fails, `LLMJudge.judge()` returns an `[ERROR] ...` string that embeds the model id, endpoint and HTTP code — under a loose numeric `score_pattern` (e.g. `(\d+)`) the shared extractor can parse those digits and clamp them to **full credit**, the exact thing the documented contract forbids ("A failed judge request must score 0, never full credit").

Also surfaces two **silent** paths in `score_extractors.py` with `logger.warning`, matching the observability the no-match branches already have:
- `PatternScoreExtractor`: a matched-but-unmapped answer returned `0.0` with no warning (inconsistent with the no-match branch one line below).
- `NumericScoreExtractor`: an out-of-range value (e.g. `[[90]]` from a 0–100-scale judge) was clamped to `[0, 1]` with no warning.

Adds unit tests locking in the documented fail-close contract (failed judge → `0.0`, never full credit). See issue #1575 for the audit that motivated this; the semantic question of *excluding* failed samples with a visible count stays open there.

## Changes

1. `evalscope/metrics/judge/llm_judge.py` — module constant `JUDGE_ERROR_PREFIX = '[ERROR]'`; `judge()` builds the failure sentinel from it; `get_score()` fails closed (logs + returns `0.0`) when the response starts with the prefix, before any regex extraction.
2. `evalscope/metrics/judge/score_extractors.py` — warning on matched-but-unmapped pattern answers; warning when a numeric value is clamped (clamp behavior itself unchanged).
3. `tests/metrics/judge/test_score_extractors.py` — 12 tests covering the fail-close contract, clamp behavior, the `[ERROR]` guard (with a loose pattern that would otherwise yield full credit) and the producer contract (`judge()` returns a prefix-prefixed string when `generate` raises).

## Behavior compatibility

For the **default** patterns (`^\s*([AB])\s*$` and `\[\[(\d+(?:\.\d+)?)\]\]`), `[ERROR]` responses already failed closed via the no-match path, so `get_score` output is unchanged — the guard only changes behavior for loose/custom patterns, which is the intended fix. Verified by execution.

## Tests

```
tests/metrics/judge/test_score_extractors.py ................ 12 passed
tests/api/test_default_data_adapter.py ......................... 5 passed
tests/benchmark/test_researchrubrics.py .......... 11 passed, 2 failed*
tests/benchmark/test_wide_search.py + tests/api/test_gdpval_benchmark.py + tests/perf/test_arguments_secrets.py ... 28 passed, 9 failed*
```

\* The 11 failures are **pre-existing environment issues** (missing optional deps such as `dateparser`, docker-related mocks) — confirmed identical on a clean `main` checkout (`git stash` + rerun → same 9/2 failures), unrelated to this change.
