### PR TITLE
fix(agent): limit SWE-bench toolcall nudge to once

### DIFF
--- a/evalscope/agent/strategies/swe_bench/swe_bench_toolcall.py
+++ b/evalscope/agent/strategies/swe_bench/swe_bench_toolcall.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from evalscope.api.agent import AgentContext, AgentLoopResult, AgentStrategy, ParsedAction, ToolSchemaMode
+from evalscope.api.agent.constants import NUDGE_PROMPT
 from evalscope.api.messages import ChatMessage, ChatMessageTool
 from evalscope.api.model import ModelOutput
 from evalscope.api.registry import register_strategy
@@ -85,10 +86,8 @@ class SweBenchToolcallStrategy(AgentStrategy):
         return parsed.final_answer is not None
 
     def should_nudge(self, parsed: ParsedAction, ctx: AgentContext) -> bool:
-        # Allow at most one nudge; matches the ``FunctionCallingStrategy``
-        # philosophy but with a distinct marker so the two don't share state.
-        marker = 'No bash tool was called'
-        nudge_count = sum(1 for m in ctx.messages if m.role == 'user' and marker in str(m.content))
+        # Allow at most one nudge by matching the reminder appended by AgentLoop.
+        nudge_count = sum(1 for m in ctx.messages if m.role == 'user' and str(m.content) == NUDGE_PROMPT)
         return nudge_count < 1
 
     def tool_schema_mode(self) -> ToolSchemaMode:

--- a/tests/agent/test_strategy_parsers.py
+++ b/tests/agent/test_strategy_parsers.py
@@ -238,6 +238,23 @@ class TestSweBenchToolcallParseOutput(unittest.TestCase):
         self.assertIsNone(parsed.final_answer)
         self.assertEqual(parsed.raw_text, 'just thinking')
 
+    def test_should_nudge_when_no_previous_nudge(self):
+        ctx = _make_ctx()
+        parsed = ParsedAction(raw_text='thinking')
+        self.assertTrue(self.strategy.should_nudge(parsed, ctx))
+
+    def test_should_not_nudge_after_reminder(self):
+        from evalscope.api.agent.constants import NUDGE_PROMPT
+
+        ctx = _make_ctx(messages=[ChatMessageUser(content=NUDGE_PROMPT)])
+        parsed = ParsedAction(raw_text='still thinking')
+        self.assertFalse(self.strategy.should_nudge(parsed, ctx))
+
+    def test_unrelated_user_message_does_not_consume_nudge(self):
+        ctx = _make_ctx(messages=[ChatMessageUser(content='No bash tool was called')])
+        parsed = ParsedAction(raw_text='thinking')
+        self.assertTrue(self.strategy.should_nudge(parsed, ctx))
+
 
 class TestSweBenchToolcallFormatObservation(unittest.TestCase):
     """``format_observation`` is the sentinel interception point."""


### PR DESCRIPTION
## Summary

- make `SweBenchToolcallStrategy.should_nudge()` count the reminder that `AgentLoop` actually injects
- prevent repeated nudges when the model continues to return no bash tool calls
- add deterministic regression coverage for the single-nudge behavior

Closes #1577

## Root cause

`SweBenchToolcallStrategy.should_nudge()` currently counts user messages containing `No bash tool was called`.

However, `AgentLoop._try_nudge()` appends the shared `NUDGE_PROMPT`, whose content starts with `No tool was called`.

Because the strategy marker never appears in the injected reminder, `nudge_count` remains zero and `should_nudge()` continues returning `True` on every no-tool turn until the loop reaches its step limit.

## Fix

The SWE-bench toolcall strategy now counts the actual `NUDGE_PROMPT` stored in the message history.

The comparison is exact so unrelated user content does not accidentally consume the one allowed nudge.

The shared AgentLoop behavior and reminder text remain unchanged.

## Tests

Added regression coverage for:

- allowing the first nudge
- declining a second nudge after `NUDGE_PROMPT` has been injected
- ignoring unrelated user messages when counting nudges

## Validation

- `python -m pytest tests/agent/test_strategy_parsers.py -q`
- `python -m pytest tests/agent -q`
- `pre-commit run --all-files`