### PR TITLE
fix(gpqa): seed choice shuffle from the question so rerun-review is reproducible

### DIFF
--- a/evalscope/benchmarks/gpqa/gpqa_adapter.py
+++ b/evalscope/benchmarks/gpqa/gpqa_adapter.py
@@ -1,5 +1,6 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
+import hashlib
 import os
 import random
 from typing import Any, Dict
@@ -102,7 +103,13 @@ class GPQAAdapter(MultiChoiceAdapter):
             preprocess(input_d['Incorrect Answer 3']),
             preprocess(input_d['Correct Answer']),
         ]
-        random.shuffle(choices)
+        # Derive the shuffle order from the question so this method stays a pure
+        # function. With the unseeded global RNG the option order changed on every
+        # dataset build, so `--rerun-review` paired cached predictions with a freshly
+        # shuffled answer key and accuracy collapsed to chance. Hashing per question
+        # keeps the position-bias protection while making the mapping reproducible.
+        seed = int.from_bytes(hashlib.sha256(preprocess(input_d['Question']).encode('utf-8')).digest()[:8], 'big')
+        random.Random(seed).shuffle(choices)
         correct_answer_index = choices.index(preprocess(input_d['Correct Answer']))
 
         return {

--- a/tests/benchmark/test_gpqa_determinism.py
+++ b/tests/benchmark/test_gpqa_determinism.py
@@ -1,0 +1,62 @@
+"""Regression tests for GPQA choice shuffling determinism (issue #1579).
+
+``record_to_sample`` must be a pure function: an unseeded shuffle made the
+option order differ on every dataset build, so ``--rerun-review`` scored
+cached predictions against a freshly shuffled answer key.
+"""
+
+import random
+from typing import Any, Dict, List
+
+from evalscope.api.registry import get_benchmark
+
+
+def _record(question: str) -> Dict[str, Any]:
+    return {
+        'Question': question,
+        'Correct Answer': '10^-4 eV',
+        'Incorrect Answer 1': '10^-8 eV',
+        'Incorrect Answer 2': '10^-9 eV',
+        'Incorrect Answer 3': '10^-11 eV',
+    }
+
+
+QUESTIONS: List[str] = [
+    'Two quantum states with energies E1 and E2 have a lifetime of 10^-9 sec and 10^-8 sec.',
+    'Which of the following is the energy difference that can be clearly resolved?',
+    'A different graduate-level physics question about spectral line widths.',
+]
+
+
+def test_record_to_sample_is_deterministic_across_calls() -> None:
+    adapter = get_benchmark('gpqa_diamond')
+    record = _record(QUESTIONS[0])
+
+    samples = []
+    for seed in range(8):
+        # Perturb the global RNG the way a real run does (dataset shuffle, other
+        # adapters, model sampling) to prove the choice order does not depend on it.
+        random.seed(seed)
+        samples.append(adapter.record_to_sample(record))
+
+    targets = {str(sample.target) for sample in samples}
+    orders = {tuple(sample.choices) for sample in samples}
+    assert len(targets) == 1, f'answer letter drifted across rebuilds: {targets}'
+    assert len(orders) == 1, f'choice order drifted across rebuilds: {orders}'
+
+
+def test_target_still_points_at_the_correct_answer() -> None:
+    adapter = get_benchmark('gpqa_diamond')
+
+    for question in QUESTIONS:
+        sample = adapter.record_to_sample(_record(question))
+        letter_index = ord(str(sample.target)) - ord('A')
+        assert sample.choices[letter_index] == '10^-4 eV'
+
+
+def test_shuffle_still_varies_between_questions() -> None:
+    """Position-bias protection must survive the switch to a seeded RNG."""
+    adapter = get_benchmark('gpqa_diamond')
+
+    orders = {tuple(adapter.record_to_sample(_record(question)).choices) for question in QUESTIONS}
+    assert len(orders) > 1, 'every question produced the same option order'


### PR DESCRIPTION
## Problem

`--rerun-review` on `gpqa_diamond` reports ~25% accuracy (chance level for four
options) instead of reproducing the original score. Reported in #1579, with the
reporter correctly pointing at the shuffle in `gpqa_adapter.py`.

`_process_input` shuffled the four options through the unseeded global RNG, so
`record_to_sample` was not a pure function — the option order, and therefore the
target letter, changed on every dataset build:

```python
random.shuffle(choices)
correct_answer_index = choices.index(preprocess(input_d['Correct Answer']))
```

On a rerun the dataset is rebuilt from scratch while predictions are restored
from the cache. `ModelResult.to_task_state` looks the sample up as
`dataset[self.index]`, so the cached completion — produced under the *original*
option order — is scored against an answer key derived from a *new* shuffle.
The reporter's example (`target: "A"` on the first run, `target: "C"` on the
rerun, same question and same prompt) is exactly this.

## Change

Derive the shuffle order from `sha256(question)`, so `_process_input` becomes a
pure function:

- same question always produces the same option order and target letter;
- different questions still get different orders, so the position-bias
  protection the shuffle exists for is preserved;
- the result no longer depends on global RNG state (dataset shuffling, other
  adapters, model sampling).

`gpqa_diamond` was the only adapter shuffling choices this way — everything
else goes through the framework-level `shuffle_choices` path, which already
accepts a seed.

## Tests

New `tests/benchmark/test_gpqa_determinism.py` (no network, no model):

- `test_record_to_sample_is_deterministic_across_calls` — reseeds the global RNG
  between calls and asserts the target letter and option order do not drift.
- `test_target_still_points_at_the_correct_answer` — the letter still indexes the
  correct option.
- `test_shuffle_still_varies_between_questions` — shuffling is still applied
  across questions.

Verification:

- Red→green confirmed: on the previous code the first test fails with the target
  drifting across `{'A', 'C', 'D'}` for a single question, matching the report.
- End to end: `mock_llm` on `gpqa_diamond --limit 8` scored 12.5%, and
  `--use-cache <dir> --rerun-review` reproduced 12.5% exactly.
- `make lint` passes.

## Known limitation

Predictions cached by earlier versions cannot be recovered: the original option
order was never persisted, so a rerun-review over old caches still mismatches.
Those runs need a fresh generation pass. Persisting the target inside the cached
`ModelResult` would make old caches self-describing, but that changes the cache
schema and is left out of this fix.

Closes #1579
