### PR TITLE
feat(metrics): Wilson CI + paired McNemar helpers

### DIFF
--- a/evalscope/metrics/__init__.py
+++ b/evalscope/metrics/__init__.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from .judge.llm_judge import DEFAULT_NUMERIC_SCORE_TEMPLATE, DEFAULT_PROMPT_TEMPLATE, LLMJudge
     from .math.parser import extract_answer, math_equal, strip_answer_string
     from .nlp.metrics import ExactMatch
-    from .utils.functions import bleu_ngram_one_sample, exact_match, macro_mean, mean, micro_mean, simple_f1_score
+    from .utils.functions import bleu_ngram_one_sample, exact_match, macro_mean, mean, micro_mean, paired_mcnemar, simple_f1_score, wilson_ci
     from .utils.rouge import compute_rouge_score, compute_rouge_score_one_sample, compute_rouge_score_one_sample_zh
     from .utils.text_normalizer import BasicTextNormalizer, ChineseTextNormalizer, EnglishTextNormalizer
 
@@ -20,7 +20,9 @@ else:
             'macro_mean',
             'mean',
             'micro_mean',
+            'paired_mcnemar',
             'simple_f1_score',
+            'wilson_ci',
         ],
         'aggregators.aggregators': [
             'Mean',

--- a/evalscope/metrics/__init__.py
+++ b/evalscope/metrics/__init__.py
@@ -8,7 +8,16 @@ if TYPE_CHECKING:
     from .judge.llm_judge import DEFAULT_NUMERIC_SCORE_TEMPLATE, DEFAULT_PROMPT_TEMPLATE, LLMJudge
     from .math.parser import extract_answer, math_equal, strip_answer_string
     from .nlp.metrics import ExactMatch
-    from .utils.functions import bleu_ngram_one_sample, exact_match, macro_mean, mean, micro_mean, paired_mcnemar, simple_f1_score, wilson_ci
+    from .utils.functions import (
+        bleu_ngram_one_sample,
+        exact_match,
+        macro_mean,
+        mean,
+        micro_mean,
+        paired_mcnemar,
+        simple_f1_score,
+        wilson_ci,
+    )
     from .utils.rouge import compute_rouge_score, compute_rouge_score_one_sample, compute_rouge_score_one_sample_zh
     from .utils.text_normalizer import BasicTextNormalizer, ChineseTextNormalizer, EnglishTextNormalizer
 

--- a/evalscope/metrics/utils/functions.py
+++ b/evalscope/metrics/utils/functions.py
@@ -49,7 +49,6 @@ def macro_mean(items):
         return 0.0
 
 
-
 def wilson_ci(successes: int, n: int, z: float = 1.96) -> tuple:
     """Return the (lower, upper) Wilson score interval for a proportion.
 
@@ -81,6 +80,7 @@ def paired_mcnemar(a_only: int, b_only: int, two_sided: bool = True) -> float:
     for i in range(k + 1):
         tail += math.comb(n, i) / (2 ** n)
     return min(1.0, 2 * tail) if two_sided else tail
+
 
 def bleu_ngram_one_sample(predict: str, reference: str):
     """

--- a/evalscope/metrics/utils/functions.py
+++ b/evalscope/metrics/utils/functions.py
@@ -49,6 +49,39 @@ def macro_mean(items):
         return 0.0
 
 
+
+def wilson_ci(successes: int, n: int, z: float = 1.96) -> tuple:
+    """Return the (lower, upper) Wilson score interval for a proportion.
+
+    Unlike the normal approximation, the Wilson interval stays within [0, 1]
+    and behaves well for extreme pass rates, which is common on fixed-item
+    leaderboards.
+    """
+    if n <= 0:
+        return (0.0, 0.0)
+    p = successes / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    margin = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def paired_mcnemar(a_only: int, b_only: int, two_sided: bool = True) -> float:
+    """Exact binomial p-value for the paired McNemar test.
+
+    ``a_only`` is the number of items solved by A but not B; ``b_only`` the
+    reverse. Under the null hypothesis the discordant items split 50/50, so
+    the test is a binomial test on the smaller discordant count.
+    """
+    n = a_only + b_only
+    if n == 0:
+        return 1.0
+    k = min(a_only, b_only)
+    tail = 0.0
+    for i in range(k + 1):
+        tail += math.comb(n, i) / (2 ** n)
+    return min(1.0, 2 * tail) if two_sided else tail
+
 def bleu_ngram_one_sample(predict: str, reference: str):
     """
     Calculate BLEU-1, BLEU-2, BLEU-3, and BLEU-4 scores

--- a/tests/metrics/test_uncertainty.py
+++ b/tests/metrics/test_uncertainty.py
@@ -1,0 +1,41 @@
+"""Unit tests for the fixed-item statistics helpers in evalscope.metrics.
+
+These lock in the Wilson score interval and the exact paired McNemar test
+used for comparing models on the same fixed item set.
+"""
+
+from evalscope.metrics.utils.functions import paired_mcnemar, wilson_ci
+
+
+class TestWilsonCi:
+
+    def test_center_is_p(self) -> None:
+        lo, hi = wilson_ci(50, 100)
+        assert abs((lo + hi) / 2 - 0.5) < 1e-9
+        assert lo < 0.5 < hi
+
+    def test_extreme_rates_stay_in_unit_interval(self) -> None:
+        lo, hi = wilson_ci(0, 10)
+        assert lo == 0.0
+        lo, hi = wilson_ci(10, 10)
+        assert hi == 1.0
+
+    def test_reference_interval(self) -> None:
+        # Wilson 95% interval for 50/100 is (0.404, 0.596) to 3 decimals.
+        lo, hi = wilson_ci(50, 100)
+        assert abs(lo - 0.404) < 0.001
+        assert abs(hi - 0.596) < 0.001
+
+
+class TestPairedMcNemar:
+
+    def test_classic_discordant_pair(self) -> None:
+        # The textbook (1, 9) discordant pair yields a two-sided p of ~0.0215.
+        p = paired_mcnemar(1, 9)
+        assert abs(p - 0.02148) < 0.0001
+
+    def test_no_discordance(self) -> None:
+        assert paired_mcnemar(0, 0) == 1.0
+
+    def test_one_sided(self) -> None:
+        assert paired_mcnemar(1, 9, two_sided=False) < 0.011


### PR DESCRIPTION
## Summary

Adds stdlib-only statistical helpers for fixed-item leaderboard reporting to `evalscope.metrics`:

- `wilson_ci(successes, n)` — 95% Wilson score interval for pass rates; well behaved near 0/1, unlike the normal approximation
- `paired_mcnemar(a_only, b_only)` — exact binomial two-sided p-value for comparing two models on the same fixed item set

Both are exported from `evalscope.metrics` and covered by unit tests in `tests/metrics/test_uncertainty.py`.

## Motivation

On fixed item sets (e.g. SWE-bench-style leaderboards), strict rank order overstates differences: the honest question for a #1-vs-#k gap is the paired McNemar test, and every aggregate should carry an uncertainty measure. These helpers make that reporting possible without new dependencies.

## Testing

- Helper values verified locally against reference values (Wilson 50/100 → (0.404, 0.596); McNemar (1,9) → p=0.0215); flake8 (project config) and isort are clean
- `pytest tests/metrics/test_uncertainty.py` — the repo's eager package init pulls the full framework dependency stack, so the local environment could only verify the helper values in isolation; the full test run is executed by upstream CI
- CI status: checks are pending on the head commit — no upstream Actions run has executed yet (fork-PR/first-contributor approval). This PR does not claim a green CI run.
