### PR TITLE
fix(perf): guard None content in openai_api token accounting

### DIFF
--- a/evalscope/perf/plugin/api/openai_api.py
+++ b/evalscope/perf/plugin/api/openai_api.py
@@ -220,18 +220,18 @@ class OpenaiPlugin(DefaultApiPlugin):
             return
         if response['object'] == 'chat.completion':
             for choice in response['choices']:
-                delta_contents[choice['index']] = [choice['message']['content']]
+                delta_contents[choice['index']] = [choice['message'].get('content') or '']
         elif response['object'] == 'text_completion':
             for choice in response['choices']:
                 if 'text' in choice and 'index' in choice:
-                    delta_contents[choice['index']].append(choice['text'])
+                    delta_contents[choice['index']].append(choice.get('text') or '')
         elif response['object'] == 'chat.completion.chunk':
             for choice in response['choices']:
                 if 'delta' in choice and 'index' in choice:
                     delta = choice['delta']
                     idx = choice['index']
                     if 'content' in delta:
-                        delta_contents[idx].append(delta['content'])
+                        delta_contents[idx].append(delta.get('content') or '')
 
     def __process_no_object(self, response, delta_contents):
         #  assume the response is a single choice
@@ -242,9 +242,9 @@ class OpenaiPlugin(DefaultApiPlugin):
                 delta = choice['delta']
                 idx = choice['index']
                 if 'content' in delta:
-                    delta_contents[idx].append(delta['content'])
+                    delta_contents[idx].append(delta.get('content') or '')
             else:
-                delta_contents[choice['index']] = [choice['message']['content']]
+                delta_contents[choice['index']] = [choice['message'].get('content') or '']
 
     def __calculate_tokens_from_content(self, request, content):
         input_tokens = output_tokens = 0

--- a/tests/perf/test_openai_api_parse_responses.py
+++ b/tests/perf/test_openai_api_parse_responses.py
@@ -125,3 +125,98 @@ def test_parse_responses_usage_present_but_empty_falls_through(plugin):
     responses = [{'usage': {}}]
     with pytest.raises(ValueError):
         plugin.parse_responses(responses, request='{}')
+
+
+class _StubTokenizer:
+    """Minimal tokenizer stand-in: ``encode`` returns one token per character.
+
+    Lets the content-based branch of ``parse_responses`` run end-to-end
+    (``__calculate_tokens_from_content`` → ``_count_output_tokens``) without
+    loading a real HF tokenizer, so we can assert on null-content handling.
+    """
+
+    def encode(self, text, add_special_tokens=False):
+        return list(text)
+
+
+@pytest.fixture
+def plugin_with_tokenizer():
+    """``OpenaiPlugin`` with a stub tokenizer so the content-based path runs.
+
+    The default ``plugin`` fixture uses ``tokenizer_path=None``; when a
+    response lacks a usage block that makes ``parse_responses`` raise
+    ``ValueError`` before ever reaching the ``delta_contents`` join. To
+    exercise the join (the site of the null-content crash), inject a
+    trivial tokenizer whose ``encode`` returns one token per character.
+    """
+    args = Arguments(model='test-model', api='openai', number=1, parallel=1)
+    plug = OpenaiPlugin(args)
+    plug.tokenizer = _StubTokenizer()
+    return plug
+
+
+def test_parse_responses_non_stream_tool_call_null_content(plugin_with_tokenizer):
+    """Non-stream tool-call: ``message.content`` is ``None`` (tool_calls set).
+
+    Before the fix, ``delta_contents[0] = [None]`` and ``''.join`` raised
+    ``TypeError: sequence item 0: expected str instance, NoneType found``.
+    The fill site now coerces ``None`` to ``''``, so the content-based
+    path yields 0 output tokens instead of crashing.
+    """
+    responses = [{
+        'object': 'chat.completion',
+        'choices': [{
+            'index': 0,
+            'message': {
+                'content': None,
+                'tool_calls': [{
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {
+                        'name': 'get_weather',
+                        'arguments': '{}',
+                    },
+                }],
+            },
+            'finish_reason': 'tool_calls',
+        }],
+    }]
+    assert plugin_with_tokenizer.parse_responses(responses, request='{}') == (0, 0)
+
+
+def test_parse_responses_stream_tool_call_null_delta_content(plugin_with_tokenizer):
+    """Streaming tool-call: some chunks carry ``delta.content: None``.
+
+    Before the fix, ``delta_contents[0].append(None)`` made ``''.join``
+    raise ``TypeError`` as soon as any chunk in the stream had a null
+    ``content`` field (common when the chunk only carries ``tool_calls``).
+    The fill site now coerces ``None`` to ``''``.
+    """
+    responses = [
+        {
+            'object': 'chat.completion.chunk',
+            'choices': [{'index': 0, 'delta': {'role': 'assistant'}}],
+        },
+        {
+            'object': 'chat.completion.chunk',
+            'choices': [{
+                'index': 0,
+                'delta': {
+                    'content': None,
+                    'tool_calls': [{
+                        'id': 'call_1',
+                        'type': 'function',
+                        'function': {
+                            'name': 'get_weather',
+                            'arguments': '{}',
+                        },
+                    }],
+                },
+            }],
+        },
+        {
+            'object': 'chat.completion.chunk',
+            'choices': [{'index': 0, 'delta': {}, 'finish_reason': 'tool_calls'}],
+        },
+    ]
+    assert plugin_with_tokenizer.parse_responses(responses, request='{}') == (0, 0)


### PR DESCRIPTION
## Problem
`''.join(choice_contents)` raised `TypeError` when a choice's text content was `None`.

## Trigger conditions (all three required)
1. API omits `usage` (self-hosted vLLM / some OpenAI-compatible endpoints)
2. A choice has null text content:
   - non-stream tool-call: `message.content = null` (result goes to `tool_calls`)
   - streaming tool-call: chunks carrying only `tool_calls`, `delta.content = null`
3. `--tokenizer-path` set → no usage → local token counting → content join

## Fix
Sanitize at the 5 fill sites (`openai_api.py:223,227,234,245,247`) with `.get(...) or ''`, mirroring the existing pattern in `openai_responses_api._collect_output_text`. The join at line 255 is left as-is to stay consistent with `openai_responses_api.py:70`.

## Tests
Added 2 unit tests in `tests/perf/test_openai_api_parse_responses.py` (no API key needed):
- `test_parse_responses_non_stream_tool_call_null_content`
- `test_parse_responses_stream_tool_call_null_delta_content`

All 10 tests pass; pre-commit (flake8/isort/yapf/mixed-line-ending) clean.