### PR TITLE
feat(benchmark): add PhyX physical reasoning benchmark (phyx_mc, phyx_oe)

### DIFF
--- a/docs/en/benchmarks/phyx_mc.md
+++ b/docs/en/benchmarks/phyx_mc.md
@@ -1,0 +1,159 @@
+# PhyX-MC
+
+
+## Overview
+
+PhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded
+scenarios. This is its multiple-choice variant: each university-level physics problem is presented
+with a figure and four answer options, and the model has to name the correct option letter.
+
+## Task Description
+
+- **Task Type**: Visual multiple-choice physics problem solving
+- **Input**: A figure plus the problem description, question and four labelled options
+- **Output**: A single option letter (A, B, C or D)
+- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,
+  optics, modern physics)
+
+## Key Features
+
+- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed
+  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.
+- Every problem is grounded in a figure that carries information the text does not restate, so the
+  model must combine visual cues with implicit physical laws.
+- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,
+  numerical, predictive and implicit condition reasoning).
+- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description
+  plus the question, with the figure attached.
+
+- The official prompt is reproduced verbatim, including its instruction to answer with the option
+  letter only, so scores stay comparable with the published numbers.
+
+## Evaluation Notes
+
+- Primary metric: `acc`, mean over problems, reported overall and per domain.
+- Default scoring is the official string-level match: the chosen letter is extracted from the reply
+  and compared with the ground truth, accepting replies that mark the correct option the way the
+  prompt prints it (`D:`) or emphasises it (`**D**`).
+- Setting `judge_strategy='llm'` (with `judge_model_args`) reproduces the official LLM-judged mode.
+  The judge is only consulted for replies whose option letter could not be extracted, matching
+  upstream.
+- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`
+  if the served model enforces a smaller per-image limit.
+- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)
+  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `phyx_mc` |
+| **Dataset ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2505.15929) |
+| **Tags** | `MCQ`, `MultiModal`, `Reasoning` |
+| **Metrics** | `accuracy` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 3,000 |
+| Prompt Length (Mean) | 487.19 chars |
+| Prompt Length (Min/Max) | 178 / 2039 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `mechanics` | 550 | 471.63 | 203 | 1364 |
+| `electromagnetism` | 550 | 466.88 | 189 | 1125 |
+| `thermodynamics` | 500 | 498.81 | 178 | 1283 |
+| `waves_acoustics` | 500 | 492.87 | 196 | 1880 |
+| `optics` | 500 | 478.61 | 194 | 1376 |
+| `modern_physics` | 400 | 525.59 | 199 | 2039 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 3,000 |
+| Images per Sample | min: 1, max: 1, mean: 1 |
+| Resolution Range | 215x46 - 5712x4953 |
+| Formats | jpeg, png |
+
+
+## Sample Example
+
+**Subset**: `mechanics`
+
+```json
+{
+  "input": [
+    {
+      "id": "4334f3a0",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~35.6KB]"
+        },
+        {
+          "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be?Please directly answer the question and provide the correct OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N"
+        }
+      ]
+    }
+  ],
+  "target": "A",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": "0",
+    "category": "Mechanics",
+    "subfield": "Statics",
+    "reasoning_type": [
+      "Spatial Relation Reasoning"
+    ]
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets phyx_mc \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['phyx_mc'],
+    dataset_args={
+        'phyx_mc': {
+            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/benchmarks/phyx_oe.md
+++ b/docs/en/benchmarks/phyx_oe.md
@@ -1,0 +1,161 @@
+# PhyX-OE
+
+
+## Overview
+
+PhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded
+scenarios. This is its open-ended variant: no options are shown, so the model has to derive the
+answer of a university-level physics problem from the figure and state it.
+
+## Task Description
+
+- **Task Type**: Visual open-ended physics problem solving
+- **Input**: A figure plus the problem description and question
+- **Output**: A step-by-step derivation ending in the final answer (value with unit or a formula)
+- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,
+  optics, modern physics)
+
+## Key Features
+
+- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed
+  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.
+- Every problem is grounded in a figure that carries information the text does not restate, so the
+  model must combine visual cues with implicit physical laws.
+- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,
+  numerical, predictive and implicit condition reasoning).
+- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description
+  plus the question, with the figure attached.
+
+- The official prompt is reproduced verbatim, including its request for step-by-step reasoning, so
+  scores stay comparable with the published numbers.
+
+## Evaluation Notes
+
+- Primary metric: `acc`, mean over problems, reported overall and per domain.
+- The final answer is read from `\boxed{...}`, else from a 'final answer:' / 'correct answer:'
+  statement, else the whole reply is compared. A reply truncated before its answer therefore scores
+  0 for reasons unrelated to physics ability; give the model a generous `generation_config.max_tokens`.
+- Answers are free-form values with units, so an LLM judge is used by default (the official
+  recommendation): run with `judge_strategy='auto'` or `'llm'` and provide `judge_model_args`. The
+  judge is only consulted when the answer does not already match as a string.
+- `judge_strategy='rule'` falls back to the official string-level mode, which understates accuracy
+  because equivalent spellings (`0.5 m` vs `50 cm`) do not match literally.
+- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`
+  if the served model enforces a smaller per-image limit.
+- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)
+  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `phyx_oe` |
+| **Dataset ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2505.15929) |
+| **Tags** | `MultiModal`, `QA`, `Reasoning` |
+| **Metrics** | `accuracy` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 3,000 |
+| Prompt Length (Mean) | 364.68 chars |
+| Prompt Length (Min/Max) | 93 / 1874 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `mechanics` | 550 | 356.92 | 124 | 1273 |
+| `electromagnetism` | 550 | 326.73 | 107 | 1032 |
+| `thermodynamics` | 500 | 390.86 | 93 | 1174 |
+| `waves_acoustics` | 500 | 379.95 | 101 | 1731 |
+| `optics` | 500 | 361.15 | 109 | 1215 |
+| `modern_physics` | 400 | 380.12 | 106 | 1874 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 3,000 |
+| Images per Sample | min: 1, max: 1, mean: 1 |
+| Resolution Range | 215x46 - 5712x4953 |
+| Formats | jpeg, png |
+
+
+## Sample Example
+
+**Subset**: `mechanics`
+
+```json
+{
+  "input": [
+    {
+      "id": "508a6723",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~35.6KB]"
+        },
+        {
+          "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be? Please answer the question with step by step reasoning."
+        }
+      ]
+    }
+  ],
+  "target": "7.55N",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": "0",
+    "category": "Mechanics",
+    "subfield": "Statics",
+    "reasoning_type": [
+      "Spatial Relation Reasoning"
+    ]
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets phyx_oe \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['phyx_oe'],
+    dataset_args={
+        'phyx_oe': {
+            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -52,6 +52,8 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `omni_doc_bench` | [OmniDocBench](../../benchmarks/omni_doc_bench.md) | `Knowledge`, `MultiModal`, `QA` |
 | `omni_doc_bench_v1_6` | [OmniDocBench-v1.6](../../benchmarks/omni_doc_bench_v1_6.md) | `Knowledge`, `MultiModal`, `QA` |
 | `perception_bench` | [PerceptionBench](../../benchmarks/perception_bench.md) | `MultiModal`, `QA` |
+| `phyx_mc` | [PhyX-MC](../../benchmarks/phyx_mc.md) | `MCQ`, `MultiModal`, `Reasoning` |
+| `phyx_oe` | [PhyX-OE](../../benchmarks/phyx_oe.md) | `MultiModal`, `QA`, `Reasoning` |
 | `pmc_vqa` | [PMC-VQA](../../benchmarks/pmc_vqa.md) | `MCQ`, `Medical`, `MultiModal` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
@@ -122,6 +124,8 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/omni_doc_bench.md
 ../../benchmarks/omni_doc_bench_v1_6.md
 ../../benchmarks/perception_bench.md
+../../benchmarks/phyx_mc.md
+../../benchmarks/phyx_oe.md
 ../../benchmarks/pmc_vqa.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md

--- a/docs/zh/benchmarks/phyx_mc.md
+++ b/docs/zh/benchmarks/phyx_mc.md
@@ -1,0 +1,145 @@
+# PhyX-MC
+
+
+## 概述
+
+PhyX 是首个面向现实、视觉接地场景中物理推理的大规模基准测试。这是其多项选择题（multiple-choice）变体：每个大学水平的物理问题均附带一张图和四个选项，模型需输出正确选项对应的字母。
+
+## 任务描述
+
+- **任务类型**：视觉多项选择物理问题求解
+- **输入**：一张图像，以及问题描述、提问和四个带标签的选项
+- **输出**：单个选项字母（A、B、C 或 D）
+- **领域**：大学水平物理（力学、电磁学、热力学、波动/声学、光学、现代物理）
+
+## 核心特性
+
+- 包含 3,000 道大学水平题目（`test`），覆盖 6 个核心领域和 25 个子领域，每个领域作为独立子集提供；设置 `eval_split='test_mini'` 可选用官方 1,000 题的 testmini 测试集。
+- 每道题均基于一张图像，其中包含文本未重复说明的关键信息，因此模型必须结合视觉线索与隐含的物理定律进行推理。
+- 涵盖 6 种推理类型（物理模型接地、多公式、空间关系、数值、预测性及隐含条件推理）。
+- 采用论文默认的 *Text-DeRedundancy* 输入格式：简化后的问题描述加提问，并附上图像。
+
+- 官方提示词被逐字复现，包括要求仅输出选项字母的指令，以确保评估结果与已发表数据具有可比性。
+
+## 评估说明
+
+- 主要指标：`acc`（准确率），对所有题目取平均值，并分别报告整体及各领域的得分。
+- 默认评分方式为官方字符串级匹配：从模型回复中提取选项字母并与标准答案比较，接受如 `D:` 或 `**D**` 等符合提示格式的正确选项标记形式。
+- 设置 `judge_strategy='llm'`（配合 `judge_model_args`）可复现官方 LLM 判定模式。仅当无法从回复中提取选项字母时，才调用判别模型，与上游实现一致。
+- 图像以内联 base64 形式发送，最大约 5 MB；若所用模型对单张图像有更小的大小限制，请在 `dataset_args` 中设置 `max_image_bytes`。
+- 资源链接：[论文](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX) | [项目主页](https://killthefullmoon.github.io/projects/PhyX/index.html)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `phyx_mc` |
+| **数据集ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2505.15929) |
+| **标签** | `MCQ`, `MultiModal`, `Reasoning` |
+| **指标** | `accuracy` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 3,000 |
+| 提示词长度（平均） | 487.19 字符 |
+| 提示词长度（最小/最大） | 178 / 2039 字符 |
+
+**各子集统计：**
+
+| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |
+|--------|---------|-------------|------------|------------|
+| `mechanics` | 550 | 471.63 | 203 | 1364 |
+| `electromagnetism` | 550 | 466.88 | 189 | 1125 |
+| `thermodynamics` | 500 | 498.81 | 178 | 1283 |
+| `waves_acoustics` | 500 | 492.87 | 196 | 1880 |
+| `optics` | 500 | 478.61 | 194 | 1376 |
+| `modern_physics` | 400 | 525.59 | 199 | 2039 |
+
+**图像统计：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 3,000 |
+| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |
+| 分辨率范围 | 215x46 - 5712x4953 |
+| 格式 | jpeg, png |
+
+
+## 样例示例
+
+**子集**: `mechanics`
+
+```json
+{
+  "input": [
+    {
+      "id": "4334f3a0",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~35.6KB]"
+        },
+        {
+          "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be?Please directly answer the question and provide the correct OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N"
+        }
+      ]
+    }
+  ],
+  "target": "A",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": "0",
+    "category": "Mechanics",
+    "subfield": "Statics",
+    "reasoning_type": [
+      "Spatial Relation Reasoning"
+    ]
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets phyx_mc \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['phyx_mc'],
+    dataset_args={
+        'phyx_mc': {
+            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/benchmarks/phyx_oe.md
+++ b/docs/zh/benchmarks/phyx_oe.md
@@ -1,0 +1,146 @@
+# PhyX-OE
+
+
+## 概述
+
+PhyX 是首个面向现实、视觉接地场景中物理推理的大规模基准测试。这是其开放式变体：不提供选项，模型必须从图示中推导出大学水平物理问题的答案并直接陈述。
+
+## 任务描述
+
+- **任务类型**：视觉开放式物理问题求解
+- **输入**：一张图示，加上问题描述和提问
+- **输出**：包含逐步推导过程并以最终答案（带单位的数值或公式）结尾的解答
+- **领域**：大学水平物理（力学、电磁学、热力学、波动/声学、光学、现代物理）
+
+## 核心特性
+
+- 包含 3,000 道大学水平题目（`test`），覆盖 6 个核心领域和 25 个子领域，每个领域作为独立子集提供；使用 `eval_split='test_mini'` 可选择官方指定的 1,000 题 testmini 测试集。
+- 每道题均基于一张图示，其中包含文本未重复说明的信息，因此模型必须结合视觉线索与隐含的物理定律进行推理。
+- 涵盖 6 种推理类型（物理模型接地、多公式、空间关系、数值、预测性及隐含条件推理）。
+- 采用论文默认的 *Text-DeRedundancy* 输入风格：简化后的问题描述加提问，并附上图示。
+
+- 官方提示词被逐字复现，包括对逐步推理的要求，以确保评分结果与已发表数据具有可比性。
+
+## 评估说明
+
+- 主要指标：`acc`，即各题目的平均准确率，整体及按领域分别报告。
+- 最终答案从 `\boxed{...}` 中提取；若无，则从 'final answer:' / 'correct answer:' 语句中提取；否则将整个回复内容用于比对。若回复在给出答案前被截断，则得分为 0（此情况与模型物理能力无关）；请为模型设置足够大的 `generation_config.max_tokens`。
+- 答案为自由格式的带单位数值，因此默认使用 LLM 评判器（官方推荐）：运行时设置 `judge_strategy='auto'` 或 `'llm'` 并提供 `judge_model_args`。仅当答案字符串不完全匹配时才调用评判器。
+- 若使用 `judge_strategy='rule'`，则回退到官方的字符串级匹配模式，但由于等效写法（如 `0.5 m` 与 `50 cm`）无法字面匹配，会导致准确率被低估。
+- 图像以内联 base64 形式发送，最大约 5 MB；若所用模型对单张图像有更小的大小限制，请在 `dataset_args` 中设置 `max_image_bytes`。
+- 资源链接：[论文](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX) | [项目主页](https://killthefullmoon.github.io/projects/PhyX/index.html)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `phyx_oe` |
+| **数据集ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2505.15929) |
+| **标签** | `MultiModal`, `QA`, `Reasoning` |
+| **指标** | `accuracy` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 3,000 |
+| 提示词长度（平均） | 364.68 字符 |
+| 提示词长度（最小/最大） | 93 / 1874 字符 |
+
+**各子集统计：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `mechanics` | 550 | 356.92 | 124 | 1273 |
+| `electromagnetism` | 550 | 326.73 | 107 | 1032 |
+| `thermodynamics` | 500 | 390.86 | 93 | 1174 |
+| `waves_acoustics` | 500 | 379.95 | 101 | 1731 |
+| `optics` | 500 | 361.15 | 109 | 1215 |
+| `modern_physics` | 400 | 380.12 | 106 | 1874 |
+
+**图像统计：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 3,000 |
+| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |
+| 分辨率范围 | 215x46 - 5712x4953 |
+| 格式 | jpeg, png |
+
+
+## 样例示例
+
+**子集**: `mechanics`
+
+```json
+{
+  "input": [
+    {
+      "id": "508a6723",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~35.6KB]"
+        },
+        {
+          "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be? Please answer the question with step by step reasoning."
+        }
+      ]
+    }
+  ],
+  "target": "7.55N",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": "0",
+    "category": "Mechanics",
+    "subfield": "Statics",
+    "reasoning_type": [
+      "Spatial Relation Reasoning"
+    ]
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets phyx_oe \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['phyx_oe'],
+    dataset_args={
+        'phyx_oe': {
+            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -52,6 +52,8 @@
 | `omni_doc_bench` | [OmniDocBench](../../benchmarks/omni_doc_bench.md) | `Knowledge`, `MultiModal`, `QA` |
 | `omni_doc_bench_v1_6` | [OmniDocBench-v1.6](../../benchmarks/omni_doc_bench_v1_6.md) | `Knowledge`, `MultiModal`, `QA` |
 | `perception_bench` | [PerceptionBench](../../benchmarks/perception_bench.md) | `MultiModal`, `QA` |
+| `phyx_mc` | [PhyX-MC](../../benchmarks/phyx_mc.md) | `MCQ`, `MultiModal`, `Reasoning` |
+| `phyx_oe` | [PhyX-OE](../../benchmarks/phyx_oe.md) | `MultiModal`, `QA`, `Reasoning` |
 | `pmc_vqa` | [PMC-VQA](../../benchmarks/pmc_vqa.md) | `MCQ`, `Medical`, `MultiModal` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
@@ -122,6 +124,8 @@
 ../../benchmarks/omni_doc_bench.md
 ../../benchmarks/omni_doc_bench_v1_6.md
 ../../benchmarks/perception_bench.md
+../../benchmarks/phyx_mc.md
+../../benchmarks/phyx_oe.md
 ../../benchmarks/pmc_vqa.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md

--- a/evalscope/benchmarks/_meta/phyx_mc.json
+++ b/evalscope/benchmarks/_meta/phyx_mc.json
@@ -1,0 +1,368 @@
+{
+  "meta": {
+    "pretty_name": "PhyX-MC",
+    "dataset_id": "evalscope/PhyX",
+    "paper_url": "https://arxiv.org/abs/2505.15929",
+    "tags": [
+      "MultiModal",
+      "Reasoning",
+      "MCQ"
+    ],
+    "metrics": [
+      "accuracy"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "mechanics",
+      "electromagnetism",
+      "thermodynamics",
+      "waves_acoustics",
+      "optics",
+      "modern_physics"
+    ],
+    "description": "\n## Overview\n\nPhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded\nscenarios. This is its multiple-choice variant: each university-level physics problem is presented\nwith a figure and four answer options, and the model has to name the correct option letter.\n\n## Task Description\n\n- **Task Type**: Visual multiple-choice physics problem solving\n- **Input**: A figure plus the problem description, question and four labelled options\n- **Output**: A single option letter (A, B, C or D)\n- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,\n  optics, modern physics)\n\n## Key Features\n\n- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed\n  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.\n- Every problem is grounded in a figure that carries information the text does not restate, so the\n  model must combine visual cues with implicit physical laws.\n- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,\n  numerical, predictive and implicit condition reasoning).\n- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description\n  plus the question, with the figure attached.\n\n- The official prompt is reproduced verbatim, including its instruction to answer with the option\n  letter only, so scores stay comparable with the published numbers.\n\n## Evaluation Notes\n\n- Primary metric: `acc`, mean over problems, reported overall and per domain.\n- Default scoring is the official string-level match: the chosen letter is extracted from the reply\n  and compared with the ground truth, accepting replies that mark the correct option the way the\n  prompt prints it (`D:`) or emphasises it (`**D**`).\n- Setting `judge_strategy='llm'` (with `judge_model_args`) reproduces the official LLM-judged mode.\n  The judge is only consulted for replies whose option letter could not be extracted, matching\n  upstream.\n- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`\n  if the served model enforces a smaller per-image limit.\n- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)\n  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm"
+  },
+  "statistics": {
+    "total_samples": 3000,
+    "subset_stats": [
+      {
+        "name": "mechanics",
+        "sample_count": 550,
+        "prompt_length_mean": 471.63,
+        "prompt_length_min": 203,
+        "prompt_length_max": 1364,
+        "prompt_length_std": 147.61,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 550,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x262",
+              "1002x974",
+              "1016x420",
+              "1016x484",
+              "1024x541",
+              "1024x787",
+              "1024x980",
+              "1028x394",
+              "1030x588",
+              "1034x544"
+            ],
+            "resolution_range": {
+              "min": "90x213",
+              "max": "1132x1044"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "electromagnetism",
+        "sample_count": 550,
+        "prompt_length_mean": 466.88,
+        "prompt_length_min": 189,
+        "prompt_length_max": 1125,
+        "prompt_length_std": 159.4,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 550,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1016x916",
+              "1019x620",
+              "1024x464",
+              "1066x554",
+              "115x144",
+              "1214x434",
+              "1232x568",
+              "123x152",
+              "1240x392",
+              "1274x584"
+            ],
+            "resolution_range": {
+              "min": "215x46",
+              "max": "1016x916"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "thermodynamics",
+        "sample_count": 500,
+        "prompt_length_mean": 498.81,
+        "prompt_length_min": 178,
+        "prompt_length_max": 1283,
+        "prompt_length_std": 162.39,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1008x477",
+              "1012x610",
+              "1023x309",
+              "1028x329",
+              "1028x498",
+              "1030x673",
+              "1031x761",
+              "1034x688",
+              "1038x188",
+              "1038x636"
+            ],
+            "resolution_range": {
+              "min": "196x216",
+              "max": "1242x1420"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "waves_acoustics",
+        "sample_count": 500,
+        "prompt_length_mean": 492.87,
+        "prompt_length_min": 196,
+        "prompt_length_max": 1880,
+        "prompt_length_std": 183.54,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1002x472",
+              "1005x481",
+              "1006x230",
+              "1011x285",
+              "1012x220",
+              "1012x423",
+              "1016x356",
+              "1020x510",
+              "1027x213",
+              "1035x175"
+            ],
+            "resolution_range": {
+              "min": "168x110",
+              "max": "1536x1024"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "optics",
+        "sample_count": 500,
+        "prompt_length_mean": 478.61,
+        "prompt_length_min": 194,
+        "prompt_length_max": 1376,
+        "prompt_length_std": 182.36,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1004x574",
+              "1026x338",
+              "1032x304",
+              "1042x262",
+              "1048x332",
+              "1048x370",
+              "1162x620",
+              "1202x874",
+              "1210x366",
+              "1242x686"
+            ],
+            "resolution_range": {
+              "min": "130x166",
+              "max": "5712x4953"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "modern_physics",
+        "sample_count": 400,
+        "prompt_length_mean": 525.59,
+        "prompt_length_min": 199,
+        "prompt_length_max": 2039,
+        "prompt_length_std": 201.34,
+        "target_length_mean": 1,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 400,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x698",
+              "1004x490",
+              "1015x617",
+              "1022x598",
+              "1034x1506",
+              "1060x236",
+              "1062x1046",
+              "1074x716",
+              "1084x790",
+              "1086x298"
+            ],
+            "resolution_range": {
+              "min": "284x116",
+              "max": "1940x1792"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 487.19,
+      "min": 178,
+      "max": 2039,
+      "std": 172.97
+    },
+    "target_length_mean": 1,
+    "computed_at": "2026-08-17T18:10:05.737068",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 3000,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "resolutions": [
+          "1000x262",
+          "1000x698",
+          "1002x472",
+          "1002x974",
+          "1004x490",
+          "1004x574",
+          "1005x481",
+          "1006x230",
+          "1008x477",
+          "1011x285"
+        ],
+        "resolution_range": {
+          "min": "215x46",
+          "max": "5712x4953"
+        },
+        "formats": [
+          "jpeg",
+          "png"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "4334f3a0",
+          "content": [
+            {
+              "image": "[BASE64_IMAGE: png, ~35.6KB]"
+            },
+            {
+              "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be?Please directly answer the question and provide the correct OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N"
+            }
+          ]
+        }
+      ],
+      "target": "A",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "index": "0",
+        "category": "Mechanics",
+        "subfield": "Statics",
+        "reasoning_type": [
+          "Spatial Relation Reasoning"
+        ]
+      }
+    },
+    "subset": "mechanics",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# PhyX-MC\n\n\n## Overview\n\nPhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded\nscenarios. This is its multiple-choice variant: each university-level physics problem is presented\nwith a figure and four answer options, and the model has to name the correct option letter.\n\n## Task Description\n\n- **Task Type**: Visual multiple-choice physics problem solving\n- **Input**: A figure plus the problem description, question and four labelled options\n- **Output**: A single option letter (A, B, C or D)\n- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,\n  optics, modern physics)\n\n## Key Features\n\n- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed\n  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.\n- Every problem is grounded in a figure that carries information the text does not restate, so the\n  model must combine visual cues with implicit physical laws.\n- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,\n  numerical, predictive and implicit condition reasoning).\n- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description\n  plus the question, with the figure attached.\n\n- The official prompt is reproduced verbatim, including its instruction to answer with the option\n  letter only, so scores stay comparable with the published numbers.\n\n## Evaluation Notes\n\n- Primary metric: `acc`, mean over problems, reported overall and per domain.\n- Default scoring is the official string-level match: the chosen letter is extracted from the reply\n  and compared with the ground truth, accepting replies that mark the correct option the way the\n  prompt prints it (`D:`) or emphasises it (`**D**`).\n- Setting `judge_strategy='llm'` (with `judge_model_args`) reproduces the official LLM-judged mode.\n  The judge is only consulted for replies whose option letter could not be extracted, matching\n  upstream.\n- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`\n  if the served model enforces a smaller per-image limit.\n- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)\n  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `phyx_mc` |\n| **Dataset ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2505.15929) |\n| **Tags** | `MCQ`, `MultiModal`, `Reasoning` |\n| **Metrics** | `accuracy` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 3,000 |\n| Prompt Length (Mean) | 487.19 chars |\n| Prompt Length (Min/Max) | 178 / 2039 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `mechanics` | 550 | 471.63 | 203 | 1364 |\n| `electromagnetism` | 550 | 466.88 | 189 | 1125 |\n| `thermodynamics` | 500 | 498.81 | 178 | 1283 |\n| `waves_acoustics` | 500 | 492.87 | 196 | 1880 |\n| `optics` | 500 | 478.61 | 194 | 1376 |\n| `modern_physics` | 400 | 525.59 | 199 | 2039 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 3,000 |\n| Images per Sample | min: 1, max: 1, mean: 1 |\n| Resolution Range | 215x46 - 5712x4953 |\n| Formats | jpeg, png |\n\n\n## Sample Example\n\n**Subset**: `mechanics`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"4334f3a0\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~35.6KB]\"\n        },\n        {\n          \"text\": \"A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\\\vec{A}$ and $\\\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be?Please directly answer the question and provide the correct OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"A\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": \"0\",\n    \"category\": \"Mechanics\",\n    \"subfield\": \"Statics\",\n    \"reasoning_type\": [\n      \"Spatial Relation Reasoning\"\n    ]\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets phyx_mc \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['phyx_mc'],\n    dataset_args={\n        'phyx_mc': {\n            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# PhyX-MC\n\n\n## 概述\n\nPhyX 是首个面向现实、视觉接地场景中物理推理的大规模基准测试。这是其多项选择题（multiple-choice）变体：每个大学水平的物理问题均附带一张图和四个选项，模型需输出正确选项对应的字母。\n\n## 任务描述\n\n- **任务类型**：视觉多项选择物理问题求解\n- **输入**：一张图像，以及问题描述、提问和四个带标签的选项\n- **输出**：单个选项字母（A、B、C 或 D）\n- **领域**：大学水平物理（力学、电磁学、热力学、波动/声学、光学、现代物理）\n\n## 核心特性\n\n- 包含 3,000 道大学水平题目（`test`），覆盖 6 个核心领域和 25 个子领域，每个领域作为独立子集提供；设置 `eval_split='test_mini'` 可选用官方 1,000 题的 testmini 测试集。\n- 每道题均基于一张图像，其中包含文本未重复说明的关键信息，因此模型必须结合视觉线索与隐含的物理定律进行推理。\n- 涵盖 6 种推理类型（物理模型接地、多公式、空间关系、数值、预测性及隐含条件推理）。\n- 采用论文默认的 *Text-DeRedundancy* 输入格式：简化后的问题描述加提问，并附上图像。\n\n- 官方提示词被逐字复现，包括要求仅输出选项字母的指令，以确保评估结果与已发表数据具有可比性。\n\n## 评估说明\n\n- 主要指标：`acc`（准确率），对所有题目取平均值，并分别报告整体及各领域的得分。\n- 默认评分方式为官方字符串级匹配：从模型回复中提取选项字母并与标准答案比较，接受如 `D:` 或 `**D**` 等符合提示格式的正确选项标记形式。\n- 设置 `judge_strategy='llm'`（配合 `judge_model_args`）可复现官方 LLM 判定模式。仅当无法从回复中提取选项字母时，才调用判别模型，与上游实现一致。\n- 图像以内联 base64 形式发送，最大约 5 MB；若所用模型对单张图像有更小的大小限制，请在 `dataset_args` 中设置 `max_image_bytes`。\n- 资源链接：[论文](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX) | [项目主页](https://killthefullmoon.github.io/projects/PhyX/index.html)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `phyx_mc` |\n| **数据集ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2505.15929) |\n| **标签** | `MCQ`, `MultiModal`, `Reasoning` |\n| **指标** | `accuracy` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 3,000 |\n| 提示词长度（平均） | 487.19 字符 |\n| 提示词长度（最小/最大） | 178 / 2039 字符 |\n\n**各子集统计：**\n\n| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |\n|--------|---------|-------------|------------|------------|\n| `mechanics` | 550 | 471.63 | 203 | 1364 |\n| `electromagnetism` | 550 | 466.88 | 189 | 1125 |\n| `thermodynamics` | 500 | 498.81 | 178 | 1283 |\n| `waves_acoustics` | 500 | 492.87 | 196 | 1880 |\n| `optics` | 500 | 478.61 | 194 | 1376 |\n| `modern_physics` | 400 | 525.59 | 199 | 2039 |\n\n**图像统计：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 3,000 |\n| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |\n| 分辨率范围 | 215x46 - 5712x4953 |\n| 格式 | jpeg, png |\n\n\n## 样例示例\n\n**子集**: `mechanics`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"4334f3a0\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~35.6KB]\"\n        },\n        {\n          \"text\": \"A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\\\vec{A}$ and $\\\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be?Please directly answer the question and provide the correct OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"A\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": \"0\",\n    \"category\": \"Mechanics\",\n    \"subfield\": \"Statics\",\n    \"reasoning_type\": [\n      \"Spatial Relation Reasoning\"\n    ]\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets phyx_mc \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['phyx_mc'],\n    dataset_args={\n        'phyx_mc': {\n            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "80ee6a1fafe0c7ef19320236c4f93994",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-17T18:10:17.672873",
+  "translation_updated_at": "2026-08-17T18:10:23"
+}

--- a/evalscope/benchmarks/_meta/phyx_oe.json
+++ b/evalscope/benchmarks/_meta/phyx_oe.json
@@ -1,0 +1,368 @@
+{
+  "meta": {
+    "pretty_name": "PhyX-OE",
+    "dataset_id": "evalscope/PhyX",
+    "paper_url": "https://arxiv.org/abs/2505.15929",
+    "tags": [
+      "MultiModal",
+      "Reasoning",
+      "QA"
+    ],
+    "metrics": [
+      "accuracy"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "mechanics",
+      "electromagnetism",
+      "thermodynamics",
+      "waves_acoustics",
+      "optics",
+      "modern_physics"
+    ],
+    "description": "\n## Overview\n\nPhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded\nscenarios. This is its open-ended variant: no options are shown, so the model has to derive the\nanswer of a university-level physics problem from the figure and state it.\n\n## Task Description\n\n- **Task Type**: Visual open-ended physics problem solving\n- **Input**: A figure plus the problem description and question\n- **Output**: A step-by-step derivation ending in the final answer (value with unit or a formula)\n- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,\n  optics, modern physics)\n\n## Key Features\n\n- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed\n  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.\n- Every problem is grounded in a figure that carries information the text does not restate, so the\n  model must combine visual cues with implicit physical laws.\n- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,\n  numerical, predictive and implicit condition reasoning).\n- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description\n  plus the question, with the figure attached.\n\n- The official prompt is reproduced verbatim, including its request for step-by-step reasoning, so\n  scores stay comparable with the published numbers.\n\n## Evaluation Notes\n\n- Primary metric: `acc`, mean over problems, reported overall and per domain.\n- The final answer is read from `\\boxed{...}`, else from a 'final answer:' / 'correct answer:'\n  statement, else the whole reply is compared. A reply truncated before its answer therefore scores\n  0 for reasons unrelated to physics ability; give the model a generous `generation_config.max_tokens`.\n- Answers are free-form values with units, so an LLM judge is used by default (the official\n  recommendation): run with `judge_strategy='auto'` or `'llm'` and provide `judge_model_args`. The\n  judge is only consulted when the answer does not already match as a string.\n- `judge_strategy='rule'` falls back to the official string-level mode, which understates accuracy\n  because equivalent spellings (`0.5 m` vs `50 cm`) do not match literally.\n- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`\n  if the served model enforces a smaller per-image limit.\n- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)\n  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm"
+  },
+  "statistics": {
+    "total_samples": 3000,
+    "subset_stats": [
+      {
+        "name": "mechanics",
+        "sample_count": 550,
+        "prompt_length_mean": 356.92,
+        "prompt_length_min": 124,
+        "prompt_length_max": 1273,
+        "prompt_length_std": 141.32,
+        "target_length_mean": 12.44,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 550,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x262",
+              "1002x974",
+              "1016x420",
+              "1016x484",
+              "1024x541",
+              "1024x787",
+              "1024x980",
+              "1028x394",
+              "1030x588",
+              "1034x544"
+            ],
+            "resolution_range": {
+              "min": "90x213",
+              "max": "1132x1044"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "electromagnetism",
+        "sample_count": 550,
+        "prompt_length_mean": 326.73,
+        "prompt_length_min": 107,
+        "prompt_length_max": 1032,
+        "prompt_length_std": 141.95,
+        "target_length_mean": 19.0,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 550,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1016x916",
+              "1019x620",
+              "1024x464",
+              "1066x554",
+              "115x144",
+              "1214x434",
+              "1232x568",
+              "123x152",
+              "1240x392",
+              "1274x584"
+            ],
+            "resolution_range": {
+              "min": "215x46",
+              "max": "1016x916"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "thermodynamics",
+        "sample_count": 500,
+        "prompt_length_mean": 390.86,
+        "prompt_length_min": 93,
+        "prompt_length_max": 1174,
+        "prompt_length_std": 153.2,
+        "target_length_mean": 10.77,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1008x477",
+              "1012x610",
+              "1023x309",
+              "1028x329",
+              "1028x498",
+              "1030x673",
+              "1031x761",
+              "1034x688",
+              "1038x188",
+              "1038x636"
+            ],
+            "resolution_range": {
+              "min": "196x216",
+              "max": "1242x1420"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "waves_acoustics",
+        "sample_count": 500,
+        "prompt_length_mean": 379.95,
+        "prompt_length_min": 101,
+        "prompt_length_max": 1731,
+        "prompt_length_std": 171.12,
+        "target_length_mean": 11.9,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1002x472",
+              "1005x481",
+              "1006x230",
+              "1011x285",
+              "1012x220",
+              "1012x423",
+              "1016x356",
+              "1020x510",
+              "1027x213",
+              "1035x175"
+            ],
+            "resolution_range": {
+              "min": "168x110",
+              "max": "1536x1024"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "optics",
+        "sample_count": 500,
+        "prompt_length_mean": 361.15,
+        "prompt_length_min": 109,
+        "prompt_length_max": 1215,
+        "prompt_length_std": 161.19,
+        "target_length_mean": 13.38,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 500,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1004x574",
+              "1026x338",
+              "1032x304",
+              "1042x262",
+              "1048x332",
+              "1048x370",
+              "1162x620",
+              "1202x874",
+              "1210x366",
+              "1242x686"
+            ],
+            "resolution_range": {
+              "min": "130x166",
+              "max": "5712x4953"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "modern_physics",
+        "sample_count": 400,
+        "prompt_length_mean": 380.12,
+        "prompt_length_min": 106,
+        "prompt_length_max": 1874,
+        "prompt_length_std": 182.77,
+        "target_length_mean": 20.05,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 400,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x698",
+              "1004x490",
+              "1015x617",
+              "1022x598",
+              "1034x1506",
+              "1060x236",
+              "1062x1046",
+              "1074x716",
+              "1084x790",
+              "1086x298"
+            ],
+            "resolution_range": {
+              "min": "284x116",
+              "max": "1940x1792"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 364.68,
+      "min": 93,
+      "max": 1874,
+      "std": 159.22
+    },
+    "target_length_mean": 14.45,
+    "computed_at": "2026-08-17T18:09:59.435764",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 3000,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "resolutions": [
+          "1000x262",
+          "1000x698",
+          "1002x472",
+          "1002x974",
+          "1004x490",
+          "1004x574",
+          "1005x481",
+          "1006x230",
+          "1008x477",
+          "1011x285"
+        ],
+        "resolution_range": {
+          "min": "215x46",
+          "max": "5712x4953"
+        },
+        "formats": [
+          "jpeg",
+          "png"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "508a6723",
+          "content": [
+            {
+              "image": "[BASE64_IMAGE: png, ~35.6KB]"
+            },
+            {
+              "text": "A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be? Please answer the question with step by step reasoning."
+            }
+          ]
+        }
+      ],
+      "target": "7.55N",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "index": "0",
+        "category": "Mechanics",
+        "subfield": "Statics",
+        "reasoning_type": [
+          "Spatial Relation Reasoning"
+        ]
+      }
+    },
+    "subset": "mechanics",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# PhyX-OE\n\n\n## Overview\n\nPhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded\nscenarios. This is its open-ended variant: no options are shown, so the model has to derive the\nanswer of a university-level physics problem from the figure and state it.\n\n## Task Description\n\n- **Task Type**: Visual open-ended physics problem solving\n- **Input**: A figure plus the problem description and question\n- **Output**: A step-by-step derivation ending in the final answer (value with unit or a formula)\n- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,\n  optics, modern physics)\n\n## Key Features\n\n- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed\n  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.\n- Every problem is grounded in a figure that carries information the text does not restate, so the\n  model must combine visual cues with implicit physical laws.\n- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,\n  numerical, predictive and implicit condition reasoning).\n- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description\n  plus the question, with the figure attached.\n\n- The official prompt is reproduced verbatim, including its request for step-by-step reasoning, so\n  scores stay comparable with the published numbers.\n\n## Evaluation Notes\n\n- Primary metric: `acc`, mean over problems, reported overall and per domain.\n- The final answer is read from `\\boxed{...}`, else from a 'final answer:' / 'correct answer:'\n  statement, else the whole reply is compared. A reply truncated before its answer therefore scores\n  0 for reasons unrelated to physics ability; give the model a generous `generation_config.max_tokens`.\n- Answers are free-form values with units, so an LLM judge is used by default (the official\n  recommendation): run with `judge_strategy='auto'` or `'llm'` and provide `judge_model_args`. The\n  judge is only consulted when the answer does not already match as a string.\n- `judge_strategy='rule'` falls back to the official string-level mode, which understates accuracy\n  because equivalent spellings (`0.5 m` vs `50 cm`) do not match literally.\n- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`\n  if the served model enforces a smaller per-image limit.\n- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)\n  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `phyx_oe` |\n| **Dataset ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2505.15929) |\n| **Tags** | `MultiModal`, `QA`, `Reasoning` |\n| **Metrics** | `accuracy` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 3,000 |\n| Prompt Length (Mean) | 364.68 chars |\n| Prompt Length (Min/Max) | 93 / 1874 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `mechanics` | 550 | 356.92 | 124 | 1273 |\n| `electromagnetism` | 550 | 326.73 | 107 | 1032 |\n| `thermodynamics` | 500 | 390.86 | 93 | 1174 |\n| `waves_acoustics` | 500 | 379.95 | 101 | 1731 |\n| `optics` | 500 | 361.15 | 109 | 1215 |\n| `modern_physics` | 400 | 380.12 | 106 | 1874 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 3,000 |\n| Images per Sample | min: 1, max: 1, mean: 1 |\n| Resolution Range | 215x46 - 5712x4953 |\n| Formats | jpeg, png |\n\n\n## Sample Example\n\n**Subset**: `mechanics`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"508a6723\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~35.6KB]\"\n        },\n        {\n          \"text\": \"A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\\\vec{A}$ and $\\\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be? Please answer the question with step by step reasoning.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"7.55N\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": \"0\",\n    \"category\": \"Mechanics\",\n    \"subfield\": \"Statics\",\n    \"reasoning_type\": [\n      \"Spatial Relation Reasoning\"\n    ]\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets phyx_oe \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['phyx_oe'],\n    dataset_args={\n        'phyx_oe': {\n            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# PhyX-OE\n\n\n## 概述\n\nPhyX 是首个面向现实、视觉接地场景中物理推理的大规模基准测试。这是其开放式变体：不提供选项，模型必须从图示中推导出大学水平物理问题的答案并直接陈述。\n\n## 任务描述\n\n- **任务类型**：视觉开放式物理问题求解\n- **输入**：一张图示，加上问题描述和提问\n- **输出**：包含逐步推导过程并以最终答案（带单位的数值或公式）结尾的解答\n- **领域**：大学水平物理（力学、电磁学、热力学、波动/声学、光学、现代物理）\n\n## 核心特性\n\n- 包含 3,000 道大学水平题目（`test`），覆盖 6 个核心领域和 25 个子领域，每个领域作为独立子集提供；使用 `eval_split='test_mini'` 可选择官方指定的 1,000 题 testmini 测试集。\n- 每道题均基于一张图示，其中包含文本未重复说明的信息，因此模型必须结合视觉线索与隐含的物理定律进行推理。\n- 涵盖 6 种推理类型（物理模型接地、多公式、空间关系、数值、预测性及隐含条件推理）。\n- 采用论文默认的 *Text-DeRedundancy* 输入风格：简化后的问题描述加提问，并附上图示。\n\n- 官方提示词被逐字复现，包括对逐步推理的要求，以确保评分结果与已发表数据具有可比性。\n\n## 评估说明\n\n- 主要指标：`acc`，即各题目的平均准确率，整体及按领域分别报告。\n- 最终答案从 `\\boxed{...}` 中提取；若无，则从 'final answer:' / 'correct answer:' 语句中提取；否则将整个回复内容用于比对。若回复在给出答案前被截断，则得分为 0（此情况与模型物理能力无关）；请为模型设置足够大的 `generation_config.max_tokens`。\n- 答案为自由格式的带单位数值，因此默认使用 LLM 评判器（官方推荐）：运行时设置 `judge_strategy='auto'` 或 `'llm'` 并提供 `judge_model_args`。仅当答案字符串不完全匹配时才调用评判器。\n- 若使用 `judge_strategy='rule'`，则回退到官方的字符串级匹配模式，但由于等效写法（如 `0.5 m` 与 `50 cm`）无法字面匹配，会导致准确率被低估。\n- 图像以内联 base64 形式发送，最大约 5 MB；若所用模型对单张图像有更小的大小限制，请在 `dataset_args` 中设置 `max_image_bytes`。\n- 资源链接：[论文](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX) | [项目主页](https://killthefullmoon.github.io/projects/PhyX/index.html)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `phyx_oe` |\n| **数据集ID** | [evalscope/PhyX](https://modelscope.cn/datasets/evalscope/PhyX/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2505.15929) |\n| **标签** | `MultiModal`, `QA`, `Reasoning` |\n| **指标** | `accuracy` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 3,000 |\n| 提示词长度（平均） | 364.68 字符 |\n| 提示词长度（最小/最大） | 93 / 1874 字符 |\n\n**各子集统计：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `mechanics` | 550 | 356.92 | 124 | 1273 |\n| `electromagnetism` | 550 | 326.73 | 107 | 1032 |\n| `thermodynamics` | 500 | 390.86 | 93 | 1174 |\n| `waves_acoustics` | 500 | 379.95 | 101 | 1731 |\n| `optics` | 500 | 361.15 | 109 | 1215 |\n| `modern_physics` | 400 | 380.12 | 106 | 1874 |\n\n**图像统计：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 3,000 |\n| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |\n| 分辨率范围 | 215x46 - 5712x4953 |\n| 格式 | jpeg, png |\n\n\n## 样例示例\n\n**子集**: `mechanics`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"508a6723\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~35.6KB]\"\n        },\n        {\n          \"text\": \"A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. The pulls $\\\\vec{A}$ and $\\\\vec{B} must combine to produce an outward traction force of 12.8 N on the patient’s arm. How large should these pulls be? Please answer the question with step by step reasoning.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"7.55N\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": \"0\",\n    \"category\": \"Mechanics\",\n    \"subfield\": \"Statics\",\n    \"reasoning_type\": [\n      \"Spatial Relation Reasoning\"\n    ]\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets phyx_oe \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['phyx_oe'],\n    dataset_args={\n        'phyx_oe': {\n            # subset_list: ['mechanics', 'electromagnetism', 'thermodynamics']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "50a31f2db9c1c06125cf7eda836f2ec4",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-17T18:10:10.919722",
+  "translation_updated_at": "2026-08-17T18:10:23"
+}

--- a/evalscope/benchmarks/phyx/phyx_adapter.py
+++ b/evalscope/benchmarks/phyx/phyx_adapter.py
@@ -16,6 +16,7 @@ from evalscope.api.metric import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
 from .utils import (
+    OPTION_LABELS,
     build_mc_judge_prompt,
     build_mc_question,
     build_oe_judge_prompt,
@@ -121,13 +122,14 @@ class PhyXAdapter(VisionLanguageAdapter):
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
         """Build a multimodal Sample from one physics problem."""
         options = parse_options(record['options'])
-        if record['answer'] not in options:
-            # Dropping the problem instead would leave the run reporting fewer problems per domain
-            # than PhyX defines, and a partially parsed option string would put an incomplete
+        if set(options) != set(OPTION_LABELS) or record['answer'] not in options:
+            # Every PhyX problem offers exactly A-D, so a short or relabelled parse means the option
+            # string was only partially read. Dropping the problem would leave the run reporting
+            # fewer problems per domain than PhyX defines, and continuing would put an incomplete
             # question in front of the model.
             raise ValueError(
-                f'PhyX problem {record["index"]}: answer {record["answer"]!r} is not among its '
-                f'parsed options {sorted(options)}.'
+                f'PhyX problem {record["index"]}: parsed option labels {sorted(options)} with answer '
+                f'{record["answer"]!r}, expected exactly {list(OPTION_LABELS)}.'
             )
 
         content: List[Content] = [
@@ -241,10 +243,16 @@ class PhyXMCAdapter(PhyXAdapter):
     def llm_match_score(
         self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
     ) -> Score:
-        """Score with the official judge, which only arbitrates replies without a clear letter."""
-        if match_mc_answer(filtered_prediction, original_prediction, reference):
+        """Score with the official judge, which only arbitrates replies without a clear letter.
+
+        The pre-check is plain equality rather than the lenient ``match_mc_answer`` used in rule
+        mode: upstream keeps the ``D:`` / ``**D**`` fallbacks out of its judged path, and accepting
+        them here would credit a reply that committed to one letter while merely quoting the
+        correct option's text.
+        """
+        if reference.strip().lower() == filtered_prediction.strip().lower():
             return self._build_score(original_prediction, filtered_prediction, True, 'string match')
-        if filtered_prediction.strip() in ('A', 'B', 'C', 'D'):
+        if filtered_prediction.strip() in OPTION_LABELS:
             # The reply committed to a different option; there is nothing for the judge to weigh.
             return self._build_score(original_prediction, filtered_prediction, False, 'string match')
 

--- a/evalscope/benchmarks/phyx/phyx_adapter.py
+++ b/evalscope/benchmarks/phyx/phyx_adapter.py
@@ -1,0 +1,334 @@
+# flake8: noqa: E501
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
+from evalscope.api.dataset import (
+    DatasetDict,
+    Sample,
+    build_dataset_dict_from_record_map,
+    resolve_snapshot_or_local_path,
+)
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageUser, Content, ContentImage, ContentText
+from evalscope.api.metric import Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from .utils import (
+    build_mc_judge_prompt,
+    build_mc_question,
+    build_oe_judge_prompt,
+    build_oe_question,
+    extract_mc_answer,
+    extract_oe_answer,
+    match_mc_answer,
+    match_oe_answer,
+    parse_judge_verdict,
+    parse_options,
+)
+
+# The benchmark ships as one JSONL of problems plus a flat directory of figures.
+DATA_DIR = 'test'
+RECORD_FILE = 'PhyX_test.jsonl'
+IMAGE_DIR = 'test_image'
+
+# ``test`` is the full 3,000-problem set; the official ``testmini`` is its first 1,000 problems.
+FULL_SPLIT = 'test'
+MINI_SPLIT = 'test_mini'
+MINI_SIZE = 1000
+
+# One subset per core physics domain, keyed by the record ``category`` field. The subset names are
+# file-safe identifiers because they become part of the prediction/review file names, which rules
+# out the dataset's own 'Waves/Acoustics' spelling.
+CATEGORY_TO_SUBSET = {
+    'Mechanics': 'mechanics',
+    'Electromagnetism': 'electromagnetism',
+    'Thermodynamics': 'thermodynamics',
+    'Waves/Acoustics': 'waves_acoustics',
+    'Optics': 'optics',
+    'Modern Physics': 'modern_physics',
+}
+SUBSET_LIST = list(CATEGORY_TO_SUBSET.values())
+
+_SHARED_FEATURES = """
+- 3,000 university-level problems (`test`) over 6 core domains and 25 sub-domains, each domain exposed
+  as its own subset; `eval_split='test_mini'` selects the official 1,000-problem testmini set.
+- Every problem is grounded in a figure that carries information the text does not restate, so the
+  model must combine visual cues with implicit physical laws.
+- 6 reasoning types are represented (physical model grounding, multi-formula, spatial relation,
+  numerical, predictive and implicit condition reasoning).
+- Uses the default *Text-DeRedundancy* input style of the paper: the simplified problem description
+  plus the question, with the figure attached.
+"""
+
+
+class PhyXAdapter(VisionLanguageAdapter):
+    """Shared loading for PhyX.
+
+    The dataset is distributed as a JSONL of problems next to a directory of figures, so the records
+    are read from the snapshot instead of a tabular split. Subclasses decide how a problem is asked
+    (multiple-choice or open-ended) and how a reply is scored.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        # Set during load(); record_to_sample resolves figures relative to it.
+        self.image_root: Optional[str] = None
+
+    def load(self) -> Tuple[DatasetDict, None]:
+        """Read the problem records and their figures from the snapshot."""
+        if self.eval_split not in (FULL_SPLIT, MINI_SPLIT):
+            raise ValueError(
+                f"Unknown PhyX eval_split '{self.eval_split}'. Use '{FULL_SPLIT}' for the full "
+                f"3,000-problem set or '{MINI_SPLIT}' for the official testmini subset."
+            )
+        unknown = [subset for subset in self.subset_list if subset not in SUBSET_LIST]
+        if unknown:
+            raise ValueError(f'Unknown PhyX subsets {unknown}. Valid subsets are: {SUBSET_LIST}')
+
+        # Only fetch the problem file and its figures; the repository also holds ~1 GB of
+        # pre-rendered parquet/TSV exports that this adapter does not use.
+        snapshot_dir = resolve_snapshot_or_local_path(
+            self, allow_file_pattern=[f'{DATA_DIR}/{RECORD_FILE}', f'{DATA_DIR}/{IMAGE_DIR}/*']
+        )
+        data_root = os.path.join(snapshot_dir, DATA_DIR)
+        self.image_root = os.path.join(data_root, IMAGE_DIR)
+
+        record_map: Dict[str, List[Dict[str, Any]]] = {subset: [] for subset in self.subset_list}
+        with open(os.path.join(data_root, RECORD_FILE), 'r', encoding='utf-8') as f:
+            for line in f:
+                record = json.loads(line)
+                # The official testmini is the first 1,000 problems of the test set.
+                if self.eval_split == MINI_SPLIT and int(record['index']) >= MINI_SIZE:
+                    continue
+                subset = CATEGORY_TO_SUBSET.get(record['category'])
+                if subset is None:
+                    raise ValueError(f'PhyX problem {record["index"]} has unknown category {record["category"]!r}.')
+                if subset in record_map:
+                    record_map[subset].append(record)
+
+        return build_dataset_dict_from_record_map(
+            record_map=record_map,
+            sample_fields=self.record_to_sample,
+            location=self.dataset_id,
+            limit=self.limit,
+            repeats=self.repeats,
+            shuffle=self.shuffle,
+            seed=self.seed,
+        ), None
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        """Build a multimodal Sample from one physics problem."""
+        options = parse_options(record['options'])
+        if record['answer'] not in options:
+            # Dropping the problem instead would leave the run reporting fewer problems per domain
+            # than PhyX defines, and a partially parsed option string would put an incomplete
+            # question in front of the model.
+            raise ValueError(
+                f'PhyX problem {record["index"]}: answer {record["answer"]!r} is not among its '
+                f'parsed options {sorted(options)}.'
+            )
+
+        content: List[Content] = [
+            ContentImage(image=self._load_figure(record['image'])),
+            ContentText(text=self.build_question(record, options)),
+        ]
+        return Sample(
+            input=[ChatMessageUser(content=content)],
+            target=self.build_target(record, options),
+            metadata={
+                'index': record['index'],
+                'category': record['category'],
+                'subfield': record['subfield'],
+                'reasoning_type': record['reasoning_type'],
+            },
+        )
+
+    def _load_figure(self, image_name: str) -> str:
+        """Read a figure from the snapshot and return it as a base64 data URI.
+
+        The name comes from the dataset record, so it stays confined to the figure directory. Some
+        figures carry JPEG data under a .png name (49 of the 3,000 released ones), so the MIME type
+        is sniffed from the bytes rather than taken from the extension.
+        """
+        normalized = os.path.normpath(image_name)
+        if os.path.isabs(normalized) or normalized.split(os.sep)[0] == os.pardir:
+            raise ValueError(f'PhyX figure path escapes the dataset directory: {image_name}')
+        with open(os.path.join(self.image_root, normalized), 'rb') as f:
+            return self._image_bytes_to_base64(f.read(), default_format='png', guess_mimetype=True)
+
+    def build_question(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        """Render the problem statement in the format this benchmark asks for."""
+        raise NotImplementedError
+
+    def build_target(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        """Return the ground-truth answer in the format this benchmark scores against."""
+        raise NotImplementedError
+
+    def _build_score(self, prediction: str, extracted: str, correct: bool, explanation: str) -> Score:
+        score = Score(prediction=prediction, extracted_prediction=extracted)
+        score.value = {'acc': float(correct)}
+        score.main_score_name = 'acc'
+        score.explanation = explanation
+        return score
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='phyx_mc',
+        pretty_name='PhyX-MC',
+        dataset_id='evalscope/PhyX',
+        tags=[Tags.MULTI_MODAL, Tags.REASONING, Tags.MULTIPLE_CHOICE],
+        description=f"""
+## Overview
+
+PhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded
+scenarios. This is its multiple-choice variant: each university-level physics problem is presented
+with a figure and four answer options, and the model has to name the correct option letter.
+
+## Task Description
+
+- **Task Type**: Visual multiple-choice physics problem solving
+- **Input**: A figure plus the problem description, question and four labelled options
+- **Output**: A single option letter (A, B, C or D)
+- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,
+  optics, modern physics)
+
+## Key Features
+{_SHARED_FEATURES}
+- The official prompt is reproduced verbatim, including its instruction to answer with the option
+  letter only, so scores stay comparable with the published numbers.
+
+## Evaluation Notes
+
+- Primary metric: `acc`, mean over problems, reported overall and per domain.
+- Default scoring is the official string-level match: the chosen letter is extracted from the reply
+  and compared with the ground truth, accepting replies that mark the correct option the way the
+  prompt prints it (`D:`) or emphasises it (`**D**`).
+- Setting `judge_strategy='llm'` (with `judge_model_args`) reproduces the official LLM-judged mode.
+  The judge is only consulted for replies whose option letter could not be extracted, matching
+  upstream.
+- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`
+  if the served model enforces a smaller per-image limit.
+- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)
+  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)
+""",
+        paper_url='https://arxiv.org/abs/2505.15929',
+        subset_list=SUBSET_LIST,
+        metric_list=['acc'],
+        eval_split=FULL_SPLIT,
+    )
+)
+class PhyXMCAdapter(PhyXAdapter):
+    """PhyX in multiple-choice mode, scored by matching the chosen option letter."""
+
+    def build_question(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        return build_mc_question(record['question_simply'], record['question'], options)
+
+    def build_target(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        return record['answer']
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        return extract_mc_answer(prediction)
+
+    def match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        correct = match_mc_answer(filtered_prediction, original_prediction, reference)
+        return self._build_score(original_prediction, filtered_prediction, correct, 'string match')
+
+    def llm_match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        """Score with the official judge, which only arbitrates replies without a clear letter."""
+        if match_mc_answer(filtered_prediction, original_prediction, reference):
+            return self._build_score(original_prediction, filtered_prediction, True, 'string match')
+        if filtered_prediction.strip() in ('A', 'B', 'C', 'D'):
+            # The reply committed to a different option; there is nothing for the judge to weigh.
+            return self._build_score(original_prediction, filtered_prediction, False, 'string match')
+
+        judge_response = self.llm_judge.judge(build_mc_judge_prompt(filtered_prediction, reference))
+        correct = parse_judge_verdict(judge_response)
+        return self._build_score(original_prediction, filtered_prediction, correct, f'LLM judge: {judge_response}')
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='phyx_oe',
+        pretty_name='PhyX-OE',
+        dataset_id='evalscope/PhyX',
+        tags=[Tags.MULTI_MODAL, Tags.REASONING, Tags.QA],
+        description=f"""
+## Overview
+
+PhyX is the first large-scale benchmark for physical reasoning in realistic, visually grounded
+scenarios. This is its open-ended variant: no options are shown, so the model has to derive the
+answer of a university-level physics problem from the figure and state it.
+
+## Task Description
+
+- **Task Type**: Visual open-ended physics problem solving
+- **Input**: A figure plus the problem description and question
+- **Output**: A step-by-step derivation ending in the final answer (value with unit or a formula)
+- **Domain**: University-level physics (mechanics, electromagnetism, thermodynamics, wave/acoustics,
+  optics, modern physics)
+
+## Key Features
+{_SHARED_FEATURES}
+- The official prompt is reproduced verbatim, including its request for step-by-step reasoning, so
+  scores stay comparable with the published numbers.
+
+## Evaluation Notes
+
+- Primary metric: `acc`, mean over problems, reported overall and per domain.
+- The final answer is read from `\\boxed{{...}}`, else from a 'final answer:' / 'correct answer:'
+  statement, else the whole reply is compared. A reply truncated before its answer therefore scores
+  0 for reasons unrelated to physics ability; give the model a generous `generation_config.max_tokens`.
+- Answers are free-form values with units, so an LLM judge is used by default (the official
+  recommendation): run with `judge_strategy='auto'` or `'llm'` and provide `judge_model_args`. The
+  judge is only consulted when the answer does not already match as a string.
+- `judge_strategy='rule'` falls back to the official string-level mode, which understates accuracy
+  because equivalent spellings (`0.5 m` vs `50 cm`) do not match literally.
+- Figures are sent inline as base64 and the largest is ~5 MB; set `max_image_bytes` in `dataset_args`
+  if the served model enforces a smaller per-image limit.
+- Resources: [Paper](https://arxiv.org/abs/2505.15929) | [GitHub](https://github.com/NastyMarcus/PhyX)
+  | [Project page](https://killthefullmoon.github.io/projects/PhyX/index.html)
+""",
+        paper_url='https://arxiv.org/abs/2505.15929',
+        subset_list=SUBSET_LIST,
+        metric_list=['acc'],
+        eval_split=FULL_SPLIT,
+    )
+)
+class PhyXOEAdapter(PhyXAdapter):
+    """PhyX in open-ended mode, scored by comparing the final answer with the ground truth."""
+
+    llm_judge_default = True
+
+    def build_question(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        return build_oe_question(record['question_simply'], record['question'])
+
+    def build_target(self, record: Dict[str, Any], options: Dict[str, str]) -> str:
+        # The open-ended ground truth is the text of the correct option.
+        return options[record['answer']]
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        return extract_oe_answer(prediction)
+
+    def match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        correct = match_oe_answer(filtered_prediction, original_prediction, reference)
+        return self._build_score(original_prediction, filtered_prediction, correct, 'string match')
+
+    def llm_match_score(
+        self, original_prediction: str, filtered_prediction: str, reference: str, task_state: TaskState
+    ) -> Score:
+        """Score with the official judge, which decides whether the answers are equivalent."""
+        if reference.strip().lower() == filtered_prediction.strip().lower():
+            return self._build_score(original_prediction, filtered_prediction, True, 'string match')
+
+        judge_response = self.llm_judge.judge(build_oe_judge_prompt(filtered_prediction, reference))
+        correct = parse_judge_verdict(judge_response)
+        return self._build_score(original_prediction, filtered_prediction, correct, f'LLM judge: {judge_response}')

--- a/evalscope/benchmarks/phyx/utils.py
+++ b/evalscope/benchmarks/phyx/utils.py
@@ -17,6 +17,9 @@ MC_INSTRUCTION = (
 )
 OE_INSTRUCTION = ' Please answer the question with step by step reasoning.'
 
+# Every PhyX problem offers exactly these four labels.
+OPTION_LABELS = ('A', 'B', 'C', 'D')
+
 # Options ship as a single string, ``A:"...",B:"...",...``. Values are matched non-greedily up to the
 # quote that precedes the next label (or the end), because option text legitimately contains commas
 # and may end in a backslash. ``ast.literal_eval`` cannot be used: a value ending in a backslash
@@ -33,8 +36,12 @@ _FINAL_ANSWER_RE = re.compile(
 )
 
 # A letter the model committed to, e.g. 'The correct option is D': the first capital A-D following
-# one of the answer-announcing words.
-_MC_ANSWER_RE = re.compile(r'\b(?:correct|answer|option|Answer|Option|Correct)\b[\s\S]*?([A-D])')
+# one of the answer-announcing words. Upstream enumerates the lower-case and capitalised spellings;
+# the all-caps forms are added here because 'ANSWER: C' otherwise falls through to the raw reply and
+# scores 0. Case-insensitivity is deliberately not expressed with a flag: ``re.IGNORECASE`` would
+# also let ``[A-D]`` match the 'd' in 'derived' and invent a choice the model never made.
+_ANSWER_WORDS = 'correct|answer|option|Correct|Answer|Option|CORRECT|ANSWER|OPTION'
+_MC_ANSWER_RE = re.compile(rf'\b(?:{_ANSWER_WORDS})\b[\s\S]*?([A-D])')
 
 # Replies that echo the option list instead of announcing a choice, e.g. 'B: 5.2 mW/cm^2'.
 _MC_LABEL_RE = re.compile(r'([ABCD]):')
@@ -208,7 +215,13 @@ def extract_mc_answer(prediction: str) -> str:
 
 
 def match_oe_answer(extracted: str, prediction: str, reference: str) -> bool:
-    """Official string-level match for open-ended answers."""
+    """Official string-level match for open-ended answers.
+
+    The reference is stripped before the containment test, which upstream does not do. 175 of the
+    3,000 ground-truth values carry a trailing space, and requiring the model to reproduce it would
+    reject a reply that ends in exactly the right value. The containment test stays case-sensitive:
+    physical units are case-bearing, so folding case would equate ``7.55N`` with ``7.55n``.
+    """
     reference = reference.strip()
     return (
         reference.lower() == extracted.strip().lower() or reference.lower() == prediction.strip().lower()

--- a/evalscope/benchmarks/phyx/utils.py
+++ b/evalscope/benchmarks/phyx/utils.py
@@ -1,0 +1,261 @@
+# flake8: noqa: E501
+"""Prompt building, answer extraction and judge helpers ported from the official PhyX evaluation.
+
+Reference: https://github.com/NastyMarcus/PhyX (``vlmeval/dataset/utils/phyx.py``).
+"""
+import re
+from typing import Dict, List, Optional
+
+from evalscope.metrics.judge.llm_judge import JUDGE_ERROR_PREFIX
+
+# The official instruction suffixes, appended verbatim to the problem statement. The multiple-choice
+# suffix is concatenated without a separator and the open-ended one with a leading space, matching
+# the released ``PhyX_MC.tsv`` / ``PhyX_OE.tsv`` question strings exactly.
+MC_INSTRUCTION = (
+    'Please directly answer the question and provide the correct OPTION LETTER ONLY, '
+    'e.g., A, B, C, D. OPTION: '
+)
+OE_INSTRUCTION = ' Please answer the question with step by step reasoning.'
+
+# Options ship as a single string, ``A:"...",B:"...",...``. Values are matched non-greedily up to the
+# quote that precedes the next label (or the end), because option text legitimately contains commas
+# and may end in a backslash. ``ast.literal_eval`` cannot be used: a value ending in a backslash
+# (e.g. ``A:"1.54 \text{ m/s}^2\"``) escapes its own closing quote.
+_OPTION_RE = re.compile(r'([A-Z])\s*:\s*"(.*?)"(?=\s*,\s*[A-Z]\s*:\s*"|\s*$)', re.DOTALL)
+
+# The first ``\boxed{`` of a reply, whose content is read with brace counting rather than a regex.
+_BOXED_MARKER = r'\boxed{'
+
+# Fallback for replies that state their result in prose instead of a box.
+_FINAL_ANSWER_RE = re.compile(
+    r'\b(?:final\s+answer|correct\s+answer)\b[^:：]*[:：]\s*(.*?)(?=\n\n\n|\Z)',
+    re.IGNORECASE | re.DOTALL,
+)
+
+# A letter the model committed to, e.g. 'The correct option is D': the first capital A-D following
+# one of the answer-announcing words.
+_MC_ANSWER_RE = re.compile(r'\b(?:correct|answer|option|Answer|Option|Correct)\b[\s\S]*?([A-D])')
+
+# Replies that echo the option list instead of announcing a choice, e.g. 'B: 5.2 mW/cm^2'.
+_MC_LABEL_RE = re.compile(r'([ABCD]):')
+
+# A standalone 0 or 1 verdict. The lookarounds reject digits inside a number so that a judge reply
+# discussing values ('0.49 vs 0.5') cannot be read as a verdict; the last occurrence wins because
+# the judge prompt asks for the verdict at the end.
+_VERDICT_RE = re.compile(r'(?<![\w.])([01])(?![\w.])')
+
+# LaTeX spellings normalised before string comparison, as the official evaluator does. Applied to the
+# prediction only -- the ground truth is left untouched, matching upstream.
+_LATEX_SUBSTITUTIONS = {r'\dfrac': r'\frac', r'\pi': '3.14'}
+
+_ICE_EXAMPLES_OE = [
+    """
+Ground truth answer: 502 \n
+Predicted answer: The mass of block (B) is:
+[
+\\boxed{ 50 \\sqrt{101} }
+] \n
+Judegement: 1
+""",
+    """
+Ground truth answer: 46.3 kN \n
+Predicted answer: The tension ( T_B ) in the cable is approximately:
+[
+\\boxed{46300 }
+] \n
+Judegement: 1
+""",
+    """
+Ground truth answer: 12 m/s \n
+Predicted answer: The speed of the box after 2.00 seconds is:
+[
+\\boxed{11.3, \\text{m/s}}
+] \n
+Judegement: 0
+""",
+    """
+Ground truth answer: 36.00 kg \n
+Predicted answer: The mass of the hanging block ( m_2 ) must be approximately:
+[
+\\boxed{36.1, \\text\\{kg\\}}
+] \n
+Judegement: 1
+""",
+    """
+Ground truth answer: 3.2 m \n
+Predicted answer: The stuntman and villain slide approximately \\frac\\{10\\}{3.1415} meters**.
+Judegement: 1
+""",
+]
+
+_ICE_EXAMPLES_MC = [
+    """
+Ground truth answer: A \n
+Predicted answer: A \n
+Judegement: 1
+""",
+    """
+Ground truth answer: B \n
+Predicted answer: A \n
+Judegement: 0
+""",
+    """
+Ground truth answer: C \n
+Predicted answer: ### Step 1: Calculate ( l_1 )
+The lightbulb is ( 2.50, \\text\\{m\\}) above the floor, and the bottom of the mirror is (0.50, \\text\\{m\\}) above the floor. The vertical distance from the lightbulb to the bottom of the mirror is:
+[
+\\Delta y_1 = 2.50, \\text\\{m\\} - 0.50, \\text\\{m\\} = 2.00, \\text\\{m\\}.
+] \n
+Judegement: 0
+""",
+    """
+Ground truth answer: D \n
+Predicted answer: The correct option is D. \n
+Judegement: 1
+""",
+]
+
+_OE_JUDGE_TASK = """
+Please read the following example. Given predicted answer and ground truth answer,
+compare the these two answers, then ONLY output judegement 1/0 for matched/unmatched at the end of the prompt.
+If the meaning is expressed in the same way, it is also considered consistent, for example, 0.5m and 50cm.
+If the given predicted mentions "approximately", then allow the Approximation Error, such as 0.49 and approximately 0.5, 0.81 and approximately 0.8. \n
+"""
+
+_MC_JUDGE_TASK = """
+Please read the following example. Given predicted answer and ground truth answer for Multi-Choice question.
+The ground truth answer would be A/B/C/D. The predicted answer would be some words containing A/B/C/D.
+Please compare the these two answers, then ONLY output judegement 1/0 for matched/unmatched at the end of the prompt. \n
+"""
+
+
+def parse_options(raw_options: str) -> Dict[str, str]:
+    """Parse the raw ``A:"...",B:"..."`` option string into a label -> text mapping."""
+    return dict(_OPTION_RE.findall(raw_options.strip()))
+
+
+def build_mc_question(description: str, question: str, options: Dict[str, str]) -> str:
+    """Build the official multiple-choice prompt: description, question, instruction, options."""
+    rendered_options = ' '.join(f'{label}: {text}' for label, text in options.items())
+    return f'{description} {question}{MC_INSTRUCTION}{rendered_options}'
+
+
+def build_oe_question(description: str, question: str) -> str:
+    """Build the official open-ended prompt: description, question, reasoning instruction."""
+    return f'{description} {question}{OE_INSTRUCTION}'
+
+
+def _normalize_latex(text: str) -> str:
+    """Apply the official LaTeX spelling substitutions used before string comparison."""
+    for old, new in _LATEX_SUBSTITUTIONS.items():
+        text = text.replace(old, new)
+    return text
+
+
+def extract_boxed_content(text: str) -> Optional[str]:
+    """Return the content of the first ``\\boxed{...}``, or None when there is none.
+
+    An unterminated ``\\boxed{`` yields None rather than the remainder of the reply: a truncated
+    box carries no complete answer, and returning its prefix would score a partial expression.
+    """
+    start = text.find(_BOXED_MARKER)
+    if start == -1:
+        return None
+    rest = text[start + len(_BOXED_MARKER):]
+    depth = 0
+    for index, char in enumerate(rest):
+        if char == '{':
+            depth += 1
+        elif char == '}':
+            if depth == 0:
+                return rest[:index]
+            depth -= 1
+    return None
+
+
+def extract_oe_answer(prediction: str) -> str:
+    """Extract the final answer of an open-ended reply.
+
+    Prefers a boxed answer, then a 'final answer:' / 'correct answer:' statement. A reply doing
+    neither is returned unchanged, which is what the official evaluator compares against.
+    """
+    prediction = prediction.strip()
+    boxed = extract_boxed_content(prediction)
+    if boxed is not None:
+        return _normalize_latex(boxed).strip()
+
+    match = _FINAL_ANSWER_RE.search(prediction)
+    if match:
+        return _normalize_latex(match.group(1)).strip()
+    return prediction
+
+
+def extract_mc_answer(prediction: str) -> str:
+    """Extract the chosen option label of a multiple-choice reply.
+
+    A reply that announces no label is returned unchanged, so that the substring fallbacks in
+    ``match_mc_answer`` still see the full text.
+    """
+    prediction = prediction.strip()
+    match = _MC_ANSWER_RE.search(prediction)
+    if match:
+        return match.group(1)
+
+    labels = _MC_LABEL_RE.findall(prediction)
+    if labels:
+        return labels[-1]
+    return prediction
+
+
+def match_oe_answer(extracted: str, prediction: str, reference: str) -> bool:
+    """Official string-level match for open-ended answers."""
+    reference = reference.strip()
+    return (
+        reference.lower() == extracted.strip().lower() or reference.lower() == prediction.strip().lower()
+        or reference in prediction
+    )
+
+
+def match_mc_answer(extracted: str, prediction: str, reference: str) -> bool:
+    """Official string-level match for multiple-choice answers.
+
+    Besides the extracted label, the reply is accepted when it marks the correct label the way the
+    options are printed (``D:``) or emphasised (``**D``), covering replies that restate the option
+    instead of announcing a letter.
+    """
+    reference = reference.strip()
+    if reference.lower() == extracted.strip().lower():
+        return True
+    return f'{reference}:' in prediction or f'{reference}**' in prediction or f'**{reference}' in prediction
+
+
+def build_oe_judge_prompt(prediction: str, reference: str) -> str:
+    """Build the official open-ended judge prompt (in-context examples + the pair to compare)."""
+    return _build_judge_prompt(_OE_JUDGE_TASK, _ICE_EXAMPLES_OE, prediction, reference)
+
+
+def build_mc_judge_prompt(prediction: str, reference: str) -> str:
+    """Build the official multiple-choice judge prompt."""
+    return _build_judge_prompt(_MC_JUDGE_TASK, _ICE_EXAMPLES_MC, prediction, reference)
+
+
+def _build_judge_prompt(task_description: str, examples: List[str], prediction: str, reference: str) -> str:
+    prompt = task_description
+    for example in examples:
+        prompt += example + '\n'
+    prompt += f'Ground truth answer: {reference} \n'
+    prompt += f'Predicted answer: {prediction} \n'
+    prompt += 'Judegement:'
+    return prompt
+
+
+def parse_judge_verdict(response: str) -> bool:
+    """Read the judge's 1/0 verdict.
+
+    A failed judge request fails closed: ``LLMJudge.judge`` reports errors as an ``[ERROR] ...``
+    string whose embedded digits would otherwise be parsed as a verdict.
+    """
+    if not response or response.startswith(JUDGE_ERROR_PREFIX):
+        return False
+    matches = _VERDICT_RE.findall(response)
+    return bool(matches) and matches[-1] == '1'

--- a/tests/benchmark/test_phyx.py
+++ b/tests/benchmark/test_phyx.py
@@ -1,0 +1,133 @@
+"""Unit tests for the PhyX option parser, answer extraction and judge verdict reading.
+
+PhyX ships its options as one quoted string and its answers as free-form physics values, so a
+regression in `parse_options`, `extract_*_answer` or `parse_judge_verdict` silently mis-scores
+replies instead of raising. The expected prompt/answer strings below are taken verbatim from the
+official `PhyX_MC.tsv` / `PhyX_OE.tsv` releases.
+"""
+from evalscope.benchmarks.phyx.utils import (
+    build_mc_question,
+    build_oe_question,
+    extract_boxed_content,
+    extract_mc_answer,
+    extract_oe_answer,
+    match_mc_answer,
+    match_oe_answer,
+    parse_judge_verdict,
+    parse_options,
+)
+
+# Record index 0 of the released test set.
+DESCRIPTION = ('A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. '
+               'The pulls $\\vec{A}$ and $\\vec{B} must combine to produce an outward traction force of '
+               '12.8 N on the patient’s arm.')
+QUESTION = 'How large should these pulls be?'
+RAW_OPTIONS = 'A:"7.55N",B:"5.55N",C:"7.65N",D:"6.65N"'
+
+
+def test_options_are_parsed_into_a_label_map() -> None:
+    assert parse_options(RAW_OPTIONS) == {'A': '7.55N', 'B': '5.55N', 'C': '7.65N', 'D': '6.65N'}
+
+
+def test_option_values_ending_in_a_backslash_are_kept_whole() -> None:
+    """`ast.literal_eval` cannot read these: the trailing backslash escapes the closing quote.
+
+    Record index 53 of the released set; the official TSV renders the same trailing backslash.
+    """
+    raw = ('A:"1.54 \\text{ m/s}^2\\",B:"1.84 \\text{ m/s}^2\\",'
+           'C:"2.54 \\text{ m/s}^2\\",D:"2.84 \\text{ m/s}^2\\"')
+    assert parse_options(raw) == {
+        'A': '1.54 \\text{ m/s}^2\\',
+        'B': '1.84 \\text{ m/s}^2\\',
+        'C': '2.54 \\text{ m/s}^2\\',
+        'D': '2.84 \\text{ m/s}^2\\',
+    }
+
+
+def test_option_values_containing_commas_and_apostrophes_are_kept_whole() -> None:
+    """Splitting on ',' or "'" truncates LaTeX; record indices 507 and 193 rely on this."""
+    assert parse_options('A:"\\( \\frac{v}{c^2} I\'a\'b\'e, \\)",B:"x",C:"y",D:"z"')['A'] == (
+        '\\( \\frac{v}{c^2} I\'a\'b\'e, \\)'
+    )
+    assert parse_options('A: "20\\ \\Omega\\", B: "80\\ \\Omega\\"') == {'A': '20\\ \\Omega\\', 'B': '80\\ \\Omega\\'}
+
+
+def test_mc_question_matches_the_official_rendering() -> None:
+    expected = (f'{DESCRIPTION} {QUESTION}Please directly answer the question and provide the correct '
+                'OPTION LETTER ONLY, e.g., A, B, C, D. OPTION: A: 7.55N B: 5.55N C: 7.65N D: 6.65N')
+    assert build_mc_question(DESCRIPTION, QUESTION, parse_options(RAW_OPTIONS)) == expected
+
+
+def test_oe_question_matches_the_official_rendering() -> None:
+    expected = f'{DESCRIPTION} {QUESTION} Please answer the question with step by step reasoning.'
+    assert build_oe_question(DESCRIPTION, QUESTION) == expected
+
+
+def test_boxed_content_reads_nested_braces() -> None:
+    assert extract_boxed_content('so \\boxed{\\frac{1}{2} \\text{ m}} follows') == '\\frac{1}{2} \\text{ m}'
+
+
+def test_unterminated_box_yields_no_answer() -> None:
+    """A reply truncated inside its box must not be scored on the partial expression."""
+    assert extract_boxed_content('the answer is \\boxed{50 \\sqrt{101') is None
+    assert extract_boxed_content('no box here') is None
+
+
+def test_oe_answer_prefers_the_box_and_normalizes_latex() -> None:
+    assert extract_oe_answer('Thus T = \\boxed{46300}.') == '46300'
+    assert extract_oe_answer('\\boxed{\\dfrac{1}{2}}') == '\\frac{1}{2}'
+    assert extract_oe_answer('\\boxed{2\\pi r}') == '23.14 r'
+
+
+def test_oe_answer_falls_back_to_a_stated_final_answer() -> None:
+    assert extract_oe_answer('Step 1 ...\nFinal answer: 7.55 N') == '7.55 N'
+    assert extract_oe_answer('The correct answer is: 12 m/s') == '12 m/s'
+
+
+def test_oe_answer_without_a_marker_is_returned_unchanged() -> None:
+    """The official evaluator compares the whole reply when it announces no answer."""
+    assert extract_oe_answer('  roughly 7.5 newtons  ') == 'roughly 7.5 newtons'
+
+
+def test_mc_answer_reads_an_announced_label() -> None:
+    assert extract_mc_answer('The correct option is D.') == 'D'
+    assert extract_mc_answer('Answer: C') == 'C'
+    assert extract_mc_answer('A') == 'A'
+
+
+def test_mc_answer_falls_back_to_the_last_echoed_label() -> None:
+    """Replies that restate the option list end with the one they picked."""
+    assert extract_mc_answer('Comparing the values, B: 5.55N') == 'B'
+
+
+def test_oe_match_accepts_equal_and_contained_answers() -> None:
+    assert match_oe_answer('7.55N', 'Thus \\boxed{7.55N}', '7.55N')
+    assert match_oe_answer('roughly 7.55N', 'roughly 7.55N', '7.55N')
+    assert not match_oe_answer('6.65N', 'Thus \\boxed{6.65N}', '7.55N')
+
+
+def test_mc_match_accepts_the_label_as_printed_or_emphasised() -> None:
+    assert match_mc_answer('D', 'The correct option is D.', 'D')
+    assert match_mc_answer('the value is 6.65N', 'the value is D: 6.65N', 'D')
+    assert match_mc_answer('the value is 6.65N', 'the value is **D**', 'D')
+    assert not match_mc_answer('B', 'The correct option is B.', 'D')
+
+
+def test_judge_verdict_reads_the_trailing_flag() -> None:
+    assert parse_judge_verdict('1')
+    assert parse_judge_verdict('Judegement: 1')
+    assert not parse_judge_verdict('0')
+    assert not parse_judge_verdict('Judegement: 0')
+
+
+def test_judge_verdict_ignores_digits_inside_discussed_values() -> None:
+    """A judge that reasons about '0.49 vs 0.5' must not have those digits read as its verdict."""
+    assert parse_judge_verdict('The prediction 0.49 approximates 0.5, so 1')
+    assert not parse_judge_verdict('The prediction 1.5 differs from 1.2, so 0')
+
+
+def test_failed_judge_request_scores_zero() -> None:
+    """`LLMJudge.judge` reports failures as an '[ERROR] ...' string containing digits."""
+    assert not parse_judge_verdict('[ERROR] Error occurred during qwen3-max@http://host:1 evaluation')
+    assert not parse_judge_verdict('')
+    assert not parse_judge_verdict('unable to compare')

--- a/tests/benchmark/test_phyx.py
+++ b/tests/benchmark/test_phyx.py
@@ -5,6 +5,13 @@ regression in `parse_options`, `extract_*_answer` or `parse_judge_verdict` silen
 replies instead of raising. The expected prompt/answer strings below are taken verbatim from the
 official `PhyX_MC.tsv` / `PhyX_OE.tsv` releases.
 """
+import pytest
+from typing import List, Tuple
+
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.model import ModelOutput
+from evalscope.api.registry import get_benchmark
 from evalscope.benchmarks.phyx.utils import (
     build_mc_question,
     build_oe_question,
@@ -16,6 +23,8 @@ from evalscope.benchmarks.phyx.utils import (
     parse_judge_verdict,
     parse_options,
 )
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeStrategy
 
 # Record index 0 of the released test set.
 DESCRIPTION = ('A patient with a dislocated shoulder is put into a traction apparatus as shown in figure. '
@@ -95,6 +104,23 @@ def test_mc_answer_reads_an_announced_label() -> None:
     assert extract_mc_answer('A') == 'A'
 
 
+def test_mc_answer_reads_an_all_caps_answer_marker() -> None:
+    """'ANSWER: C' must not fall through to the raw reply and score 0.
+
+    Upstream enumerates only the lower-case and capitalised announcing words; the all-caps spelling
+    is added. It cannot be expressed as `re.IGNORECASE` because that would also let the letter class
+    match lower-case text.
+    """
+    assert extract_mc_answer('ANSWER: C') == 'C'
+    assert extract_mc_answer('FINAL OPTION: B') == 'B'
+
+
+def test_lower_case_prose_does_not_yield_an_invented_letter() -> None:
+    """A reply whose reasoning contains 'derived'/'because' must not be read as choice B or D."""
+    assert extract_mc_answer('the value is derived from the diagram') == 'the value is derived from the diagram'
+    assert extract_mc_answer('answer: derived below, so 22.3 degrees') != 'D'
+
+
 def test_mc_answer_falls_back_to_the_last_echoed_label() -> None:
     """Replies that restate the option list end with the one they picked."""
     assert extract_mc_answer('Comparing the values, B: 5.55N') == 'B'
@@ -131,3 +157,104 @@ def test_failed_judge_request_scores_zero() -> None:
     assert not parse_judge_verdict('[ERROR] Error occurred during qwen3-max@http://host:1 evaluation')
     assert not parse_judge_verdict('')
     assert not parse_judge_verdict('unable to compare')
+
+
+class _StubJudge:
+    """Records whether the judge was consulted and with which prompt."""
+
+    model_id = 'stub-judge'
+
+    def __init__(self, response: str = '1') -> None:
+        self.response = response
+        self.prompts: List[str] = []
+
+    def judge(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.response
+
+
+def _judged_score(name: str, prediction: str, target: str, response: str = '1') -> Tuple[float, _StubJudge]:
+    """Run one prediction through the benchmark's judged scoring path."""
+    adapter = get_benchmark(name, TaskConfig(model='mock', datasets=[name], judge_strategy=JudgeStrategy.LLM))
+    judge = _StubJudge(response)
+    adapter.llm_judge = judge
+    state = TaskState(
+        model='mock',
+        sample=Sample(input='q', target=target),
+        output=ModelOutput.from_content('mock', prediction),
+    )
+    extracted = adapter.extract_answer(prediction, state)
+    score = adapter.llm_match_score(prediction, extracted, target, state)
+    return score.value['acc'], judge
+
+
+def test_mc_judge_is_not_consulted_when_the_reply_names_a_letter() -> None:
+    """Upstream settles a committed letter by string comparison and never pays for a judge call."""
+    acc, judge = _judged_score('phyx_mc', 'C', 'C')
+    assert (acc, judge.prompts) == (1.0, [])
+
+    acc, judge = _judged_score('phyx_mc', 'B', 'C')
+    assert (acc, judge.prompts) == (0.0, [])
+
+
+def test_mc_judge_arbitrates_only_replies_without_a_letter() -> None:
+    """A reply that states the option text instead of its label is handed to the judge."""
+    prediction = 'The refracted beam bends to 22.3 degrees from the normal.'
+    acc, judge = _judged_score('phyx_mc', prediction, 'C')
+    assert acc == 1.0
+    assert len(judge.prompts) == 1
+    assert 'Ground truth answer: C' in judge.prompts[0]
+
+
+def test_mc_judged_mode_does_not_credit_a_quoted_option() -> None:
+    """A reply committing to A while quoting 'D: ...' must not score.
+
+    Upstream's judged path applies plain equality, not the `D:` / `**D**` fallbacks of rule mode.
+    """
+    prediction = 'Answer: A. For reference the other choices were D: 6.65N and B: 5.55N.'
+    acc, judge = _judged_score('phyx_mc', prediction, 'D')
+    assert (acc, judge.prompts) == (0.0, [])
+
+
+def test_oe_judge_settles_answers_that_do_not_match_literally() -> None:
+    acc, judge = _judged_score('phyx_oe', 'Thus \\boxed{50 cm}', '0.5 m')
+    assert acc == 1.0
+    assert 'Ground truth answer: 0.5 m' in judge.prompts[0]
+    assert 'Predicted answer: 50 cm' in judge.prompts[0]
+
+    acc, judge = _judged_score('phyx_oe', 'Thus \\boxed{0.5 m}', '0.5 m')
+    assert (acc, judge.prompts) == (1.0, [])  # settled by string equality, no judge call
+
+
+def test_oe_judge_error_does_not_award_credit() -> None:
+    acc, _ = _judged_score('phyx_oe', 'Thus \\boxed{12 m/s}', '9.8 m/s', response='[ERROR] request failed for model 1')
+    assert acc == 0.0
+
+
+def test_partially_parsed_options_are_rejected() -> None:
+    """A record whose option string yields fewer than the four labels must not reach the model.
+
+    Presenting an incomplete choice list would silently corrupt the measurement, and skipping the
+    record would under-report the domain's problem count.
+    """
+    adapter = get_benchmark('phyx_mc', TaskConfig(model='mock', datasets=['phyx_mc']))
+    adapter.image_root = '/nonexistent'
+    record = {
+        'index': '7',
+        'question': 'q',
+        'question_simply': 'd',
+        'options': 'A:"7.55N",B:"5.55N"',
+        'answer': 'A',
+        'image': '7.png',
+        'category': 'Mechanics',
+        'subfield': 'Statics',
+        'reasoning_type': [],
+    }
+    with pytest.raises(ValueError, match='expected exactly'):
+        adapter.record_to_sample(record)
+
+    # A full parse whose answer names a label outside A-D is rejected on the same path.
+    record['options'] = 'A:"1",B:"2",C:"3",D:"4"'
+    record['answer'] = 'E'
+    with pytest.raises(ValueError, match='expected exactly'):
+        adapter.record_to_sample(record)

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -573,3 +573,34 @@ class TestVLMBenchmark(TestBenchmark):
     def test_count_qa_mock(self):
         """Test CountQA with mock LLM."""
         self._run_dataset_test('count_qa', limit=5, use_mock=True)
+
+    def test_phyx_mc(self):
+        """Test PhyX multiple-choice physical reasoning benchmark."""
+        dataset_args = {'subset_list': ['optics', 'modern_physics']}
+        self._run_dataset_test('phyx_mc', dataset_args=dataset_args, limit=5)
+
+    def test_phyx_mc_mock(self):
+        """Test PhyX-MC with mock LLM."""
+        dataset_args = {'subset_list': ['optics']}
+        self._run_dataset_test('phyx_mc', dataset_args=dataset_args, limit=5, use_mock=True)
+
+    def test_phyx_oe(self):
+        """Test PhyX open-ended physical reasoning benchmark (LLM-judged)."""
+        dataset_args = {'subset_list': ['optics', 'modern_physics']}
+        self._run_dataset_test('phyx_oe', dataset_args=dataset_args, limit=5)
+
+    def test_phyx_oe_mock(self):
+        """Test PhyX-OE with a mock model and a mock judge."""
+        dataset_args = {'subset_list': ['optics']}
+        self._run_dataset_test(
+            'phyx_oe',
+            dataset_args=dataset_args,
+            limit=5,
+            use_mock=True,
+            judge_model_args={'model_id': 'mock-judge', 'eval_type': EvalType.MOCK_LLM},
+        )
+
+    def test_phyx_oe_testmini(self):
+        """Test the official PhyX testmini split selection."""
+        dataset_args = {'subset_list': ['optics'], 'eval_split': 'test_mini'}
+        self._run_dataset_test('phyx_oe', dataset_args=dataset_args, limit=5)


### PR DESCRIPTION
## What

Adds [PhyX](https://arxiv.org/abs/2505.15929) — 3,000 visually grounded university-level physics problems across 6 domains (mechanics, electromagnetism, thermodynamics, wave/acoustics, optics, modern physics) — as two native VLM benchmarks:

| Benchmark | Form | Default scoring |
|---|---|---|
| `phyx_mc` | Multiple choice, four options | Official string-level letter match (no judge needed) |
| `phyx_oe` | Open ended, free-form answer | LLM judge (`llm_judge_default`), per the official recommendation |

Each domain is a subset. `eval_split='test_mini'` selects the official 1,000-problem testmini set (verified to be exactly indices 0–999).

```bash
evalscope eval --model qwen-vl-plus --datasets phyx_mc --limit 10
```

## Why two benchmarks rather than one with a mode flag

They share only the figures and problem text. The prompt, ground truth (`C` vs `\( 22.3^{\circ} \)`), answer extraction, match rule, judge prompt and judge default all differ, and MC scores run ~20 points above OE — so a single `phyx: 50%` report line would not say which protocol produced it. Common loading lives in a shared, non-registered `PhyXAdapter` base; `cc_bench`/`mm_bench` and `drivelology` are the existing precedent for this shape.

PhyX's official `valid_type: STR | LLM` modes map exactly onto `match_score` / `llm_match_score`, so `judge_strategy` picks between them and **no new configuration parameter was added**.

## Two upstream data problems worth knowing about

- **Every parquet config of the dataset is lossy.** Option values are truncated at `\,`, so `A: 5.7\,\text{mW}/\text{cm}^2` becomes `A: 5.7\` — incomplete choices in front of the model. The adapter reads the raw `test/PhyX_test.jsonl` instead, which also avoids downloading ~1 GB of unused parquet/TSV exports.
- **Options cannot be parsed with `ast.literal_eval`** (upstream's own helper fails on 19 of 3,000): a value ending in a backslash escapes its own closing quote. A lookahead regex parses 3,000/3,000.

## Verification

**Prompt fidelity** — reconstructed prompts compared against all six released official TSV variants: MC 2,988/3,000 and OE 3,000/3,000 byte-identical; answers 3,000/3,000. The 12 differences are records where *the official TSV is itself truncated* at an apostrophe (`\theta'`, `p'_1`), so this rendering is the complete one.

**Scoring** — 160 real `qwen-vl-plus` samples with every score re-derived independently from the raw prediction: **0 score mismatches, 0 extraction mismatches, 0 unparseable replies**, per-subset counts summing correctly. `phyx_mc` 50–54%, `phyx_oe` 30–34%, reproducing the paper's MC > OE gap. The thermodynamics OE 0/10 subset was hand-checked sample by sample — genuinely wrong physics, not a harness bug.

**Tests** — `tests/benchmark/test_phyx.py` (17 unit tests over option parsing, answer extraction and judge verdict reading), plus mock and real e2e cases in `test_vlm.py`. `make lint` and `tests/cli/test_all.py::TestRun::test_ci_lite` pass.

## Two deliberate deviations from upstream

Both prevent silent mis-scoring:

1. **Judge verdict parsing** rejects `[ERROR]` responses and reads the last *standalone* 0/1 token. Upstream's `"1" in res` awards full credit to any verdict text containing a stray `1` (same bug class as #1576).
2. **Figures are read as bytes** through `_image_bytes_to_base64(guess_mimetype=True)`. 49 of the 3,000 files hold JPEG data under a `.png` name, so a path-based `ContentImage` would declare the wrong MIME type from the extension, and would also bypass `max_image_bytes` for the 5 MB figures.

One thing I deliberately did **not** change: the official MC extraction regex takes the first `A`–`D` after an answer word, so a reply echoing the prompt's "e.g., A, B, C, D" would extract `A`. Kept faithful because published PhyX numbers depend on this parser and real replies are bare single letters (60/60 of length 1); documented rather than silently "improved".

Malformed records raise with the problem index instead of being skipped — PhyX publishes exact per-domain counts (550/550/500/500/500/400), so a silently smaller run would report a wrong number.
