### PR TITLE
fix(multi-choice): parse the last valid answer label instead of the first

### DIFF
--- a/evalscope/utils/multi_choices.py
+++ b/evalscope/utils/multi_choices.py
@@ -165,8 +165,7 @@ _BRACKETED_LABEL_RE = re.compile(r'[\(\[（【]\s*([A-Za-z\d](?:\s*[,，]\s*[A-Z
 _PLAIN_LABEL_RE = re.compile(r'([A-Za-z\d][A-Za-z\d ,]*)')
 _PLAIN_LABEL_ZH_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9,，]*)')
 
-_LABEL_SEPARATOR = r'[,，]|\s+and\s+|\s+'
-_LABEL_SEPARATOR_ZH = r'[,，]|\s+和\s+'
+_LABEL_TOKEN_RE = re.compile(r'[A-Za-z\d]+')
 
 
 def _fallback_parse_answer(completion: str, allowed_options: set[str]) -> Optional[set[str]]:
@@ -180,21 +179,28 @@ def _fallback_parse_answer(completion: str, allowed_options: set[str]) -> Option
     return None
 
 
-def _is_label_shaped(capture: str, separator: str, allowed_options: set[str]) -> bool:
-    """Whether a capture holds nothing but labels of the current sample."""
-    capture = capture.strip().rstrip('。.')
-    listed = {part.strip() for part in re.split(separator, capture) if part.strip()}
-    if listed and listed.issubset(allowed_options):
-        return True
-    run = set(capture)
-    return bool(run) and run.issubset(allowed_options)
+def _label_prefix(capture: str, allowed_options: set[str]) -> str:
+    """Leading part of a capture that holds nothing but labels of the current sample.
+
+    Models routinely justify the choice in the same breath ('ANSWER: B, not C'), and a
+    capture rejected as a whole loses the label with the prose: the reply then reaches
+    `_fallback_parse_answer`, which answers with the last capital - typically a distractor
+    named in that justification.
+    """
+    end = 0
+    for token in _LABEL_TOKEN_RE.finditer(capture):
+        word = token.group(0)
+        if word in allowed_options or set(word).issubset(allowed_options):
+            end = token.end()
+            continue
+        break
+    return capture[:end]
 
 
 def _last_labelled_answer(
     text: str,
     marker_re: re.Pattern,
     plain_label_re: re.Pattern,
-    separator: str,
     allowed_options: set[str],
 ) -> Optional[str]:
     """Label of the last answer marker that is actually followed by one.
@@ -206,8 +212,11 @@ def _last_labelled_answer(
         tail = text[marker.end():]
         for label_re in (_BRACKETED_LABEL_RE, plain_label_re):
             label = label_re.match(tail)
-            if label is not None and _is_label_shaped(label.group(1), separator, allowed_options):
-                return label.group(1)
+            if label is None:
+                continue
+            prefix = _label_prefix(label.group(1), allowed_options)
+            if prefix:
+                return prefix
     return None
 
 
@@ -233,7 +242,7 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
-    matched = _last_labelled_answer(text, _ANSWER_MARKER_RE, _PLAIN_LABEL_RE, _LABEL_SEPARATOR, allowed_options)
+    matched = _last_labelled_answer(text, _ANSWER_MARKER_RE, _PLAIN_LABEL_RE, allowed_options)
 
     if matched is None:
         return _fallback_parse_answer(text, allowed_options) or set()
@@ -292,9 +301,7 @@ def parse_answers_zh(state: TaskState, multiple_correct: bool = False, completio
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
-    matched = _last_labelled_answer(
-        text, _ANSWER_MARKER_ZH_RE, _PLAIN_LABEL_ZH_RE, _LABEL_SEPARATOR_ZH, allowed_options
-    )
+    matched = _last_labelled_answer(text, _ANSWER_MARKER_ZH_RE, _PLAIN_LABEL_ZH_RE, allowed_options)
 
     if matched is None:
         return _fallback_parse_answer(text, allowed_options) or set()

--- a/evalscope/utils/multi_choices.py
+++ b/evalscope/utils/multi_choices.py
@@ -152,17 +152,21 @@ def format_example(
     return f'{question}\n{choices_text}\nANSWER: {answer.text}'
 
 
+# The answer marker itself.  Locating markers separately from the label keeps a greedy label
+# pattern from swallowing the next marker, which would hide it from the scan below.
+_ANSWER_MARKER_RE = re.compile(r'(?i)ANSWER\s*:\s*\**\s*')
+_ANSWER_MARKER_ZH_RE = re.compile(r'答案\s*[:：]\s*\**\s*')
+
 # A label the model may wrap the way the options are printed, optionally listing several labels:
 # '(A)', '[A]', '(A, C)'.  Only label-shaped content is accepted, so bracketed prose such as
 # '(see the diagram above)' and an echoed '[LETTER]' placeholder stay unparseable.
-_BRACKETED_LABEL = r'[\(\[（【]\s*([A-Za-z\d](?:\s*[,，]\s*[A-Za-z\d])*)\s*[\)\]）】]'
+_BRACKETED_LABEL_RE = re.compile(r'[\(\[（【]\s*([A-Za-z\d](?:\s*[,，]\s*[A-Za-z\d])*)\s*[\)\]）】]')
 
-# Models frequently give the label in that wrapped form and then append the option text, e.g.
-# 'ANSWER: (A) 36'.  Neither the strict nor the loose pattern accepts a leading bracket, so
-# without this pattern such a reply reaches `_fallback_parse_answer` and is answered with an
-# arbitrary capital letter taken from the reasoning.
-_BRACKETED_ANSWER_RE = re.compile(rf'(?i)ANSWER\s*:\s*\**\s*{_BRACKETED_LABEL}')
-_BRACKETED_ANSWER_ZH_RE = re.compile(rf'答案\s*[:：]\s*\**\s*{_BRACKETED_LABEL}')
+_PLAIN_LABEL_RE = re.compile(r'([A-Za-z\d][A-Za-z\d ,]*)')
+_PLAIN_LABEL_ZH_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9,，]*)')
+
+_LABEL_SEPARATOR = r'[,，]|\s+and\s+|\s+'
+_LABEL_SEPARATOR_ZH = r'[,，]|\s+和\s+'
 
 
 def _fallback_parse_answer(completion: str, allowed_options: set[str]) -> Optional[set[str]]:
@@ -173,6 +177,37 @@ def _fallback_parse_answer(completion: str, allowed_options: set[str]) -> Option
             # returning it would record an answer the model never gave.  Reporting no answer
             # scores the same (an invalid label never equals the target) and stays diagnosable.
             return {letter} if letter in allowed_options else None
+    return None
+
+
+def _is_label_shaped(capture: str, separator: str, allowed_options: set[str]) -> bool:
+    """Whether a capture holds nothing but labels of the current sample."""
+    capture = capture.strip().rstrip('。.')
+    listed = {part.strip() for part in re.split(separator, capture) if part.strip()}
+    if listed and listed.issubset(allowed_options):
+        return True
+    run = set(capture)
+    return bool(run) and run.issubset(allowed_options)
+
+
+def _last_labelled_answer(
+    text: str,
+    marker_re: re.Pattern,
+    plain_label_re: re.Pattern,
+    separator: str,
+    allowed_options: set[str],
+) -> Optional[str]:
+    """Label of the last answer marker that is actually followed by one.
+
+    Reasoning models restate the required format and revise themselves mid-thought, so an
+    earlier marker may carry an echoed placeholder or a choice the model went on to reject.
+    """
+    for marker in reversed(list(marker_re.finditer(text))):
+        tail = text[marker.end():]
+        for label_re in (_BRACKETED_LABEL_RE, plain_label_re):
+            label = label_re.match(tail)
+            if label is not None and _is_label_shaped(label.group(1), separator, allowed_options):
+                return label.group(1)
     return None
 
 
@@ -198,61 +233,10 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
-    def _labels_are_valid(labels: set[str]) -> bool:
-        return bool(labels) and labels.issubset(allowed_options)
+    matched = _last_labelled_answer(text, _ANSWER_MARKER_RE, _PLAIN_LABEL_RE, _LABEL_SEPARATOR, allowed_options)
 
-    def _valid_label(capture: str) -> set[str]:
-        """Return the labels parsed from a capture group, or an empty set if invalid."""
-        capture = capture.strip().rstrip('。.')
-        # Multiple labels may be separated by commas/spaces/`and`, or run together (`AB`).
-        separated = {part.strip() for part in re.split(r'[,，]|\s+and\s+|\s+', capture) if part.strip()}
-        if _labels_are_valid(separated):
-            return separated
-        if _labels_are_valid(set(capture)):
-            return set(capture)
-        return set()
-
-    # First check whether the string strictly ends with the expected answer
-    # In this case, we're looking for a single line which contains the expected
-    # ANSWER: <answer> string with only whitespace or a period/full stop at the end.
-    # Note: the capture group must start with an alphanumeric character, otherwise a
-    # placeholder the model echoed from the prompt (e.g. `ANSWER: [LETTER]`) matches
-    # with a whitespace-only capture and shadows the real answer that follows.
-    match = None
-    strict = re.search(
-        r'(?i)^ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)\s*(?:$|\n|\.)',
-        text,
-        flags=re.MULTILINE,
-    )
-    if strict is not None and _valid_label(strict.group(1)):
-        match = strict
-
-    # The alphanumeric-start rule above also rejects a label the model wrapped in brackets,
-    # so try that form explicitly before giving up on the answer marker.
-    if match is None:
-        bracketed = _BRACKETED_ANSWER_RE.search(text)
-        if bracketed is not None and _valid_label(bracketed.group(1)):
-            match = bracketed
-
-    # If we couldn't match the strict version, we can try the less strict
-    # version for backward compatibility.
-    # Reasoning models often restate the required format (e.g. `ANSWER: [LETTER]`) and
-    # hedge with sentences like `Final answer: ANSWER: D` before the real answer, so the
-    # first `ANSWER:` marker may capture a placeholder or a partial word instead of the
-    # final choice.  The actual answer is the LAST marker, so iterate all matches and
-    # keep the last one whose capture looks like a valid label.
-    if match is None:
-        for candidate in re.finditer(
-            r'(?i)ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)(?:[^\w]|\n|$|\.)',
-            text,
-        ):
-            if _valid_label(candidate.group(1)):
-                match = candidate
-
-    if match is None:
+    if matched is None:
         return _fallback_parse_answer(text, allowed_options) or set()
-
-    matched = match.group(1)
 
     # Strip trailing period / full stop
     matched = matched.strip()
@@ -308,26 +292,14 @@ def parse_answers_zh(state: TaskState, multiple_correct: bool = False, completio
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
-    # Simple pattern to capture answers with optional bold markdown.
-    # Keep the LAST marker whose capture looks like a valid label: reasoning models may
-    # restate the required format or hedge with `答案：X` multiple times, and only the
-    # final `答案：<label>` is the actual answer (see `parse_answers` for details).
-    pattern = r'答案\s*[:：]\s*\**\s*([A-Za-z0-9,，]+)'
-    match = None
-    for candidate in re.finditer(pattern, text, flags=re.MULTILINE):
-        label = candidate.group(1).strip().rstrip('。.')
-        labels = {part.strip() for part in re.split(r'[,，]|\s+和\s+', label) if part.strip()}
-        if labels.issubset(allowed_options) and labels:
-            match = candidate
+    matched = _last_labelled_answer(
+        text, _ANSWER_MARKER_ZH_RE, _PLAIN_LABEL_ZH_RE, _LABEL_SEPARATOR_ZH, allowed_options
+    )
 
-    # The pattern above cannot start on a bracket, so try a wrapped label explicitly.
-    if match is None:
-        match = _BRACKETED_ANSWER_ZH_RE.search(text)
-
-    if match is None:
+    if matched is None:
         return _fallback_parse_answer(text, allowed_options) or set()
 
-    matched = match.group(1).strip().rstrip('。.')
+    matched = matched.strip().rstrip('。.')
 
     if multiple_correct:
         # Handle comma-separated or continuous letters

--- a/evalscope/utils/multi_choices.py
+++ b/evalscope/utils/multi_choices.py
@@ -198,30 +198,56 @@ def parse_answers(state: TaskState, multiple_correct: bool = False, completion: 
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
+    def _labels_are_valid(labels: set[str]) -> bool:
+        return bool(labels) and labels.issubset(allowed_options)
+
+    def _valid_label(capture: str) -> set[str]:
+        """Return the labels parsed from a capture group, or an empty set if invalid."""
+        capture = capture.strip().rstrip('。.')
+        # Multiple labels may be separated by commas/spaces/`and`, or run together (`AB`).
+        separated = {part.strip() for part in re.split(r'[,，]|\s+and\s+|\s+', capture) if part.strip()}
+        if _labels_are_valid(separated):
+            return separated
+        if _labels_are_valid(set(capture)):
+            return set(capture)
+        return set()
+
     # First check whether the string strictly ends with the expected answer
     # In this case, we're looking for a single line which contains the expected
     # ANSWER: <answer> string with only whitespace or a period/full stop at the end.
     # Note: the capture group must start with an alphanumeric character, otherwise a
     # placeholder the model echoed from the prompt (e.g. `ANSWER: [LETTER]`) matches
     # with a whitespace-only capture and shadows the real answer that follows.
-    match = re.search(
+    match = None
+    strict = re.search(
         r'(?i)^ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)\s*(?:$|\n|\.)',
         text,
         flags=re.MULTILINE,
     )
+    if strict is not None and _valid_label(strict.group(1)):
+        match = strict
 
     # The alphanumeric-start rule above also rejects a label the model wrapped in brackets,
     # so try that form explicitly before giving up on the answer marker.
     if match is None:
-        match = _BRACKETED_ANSWER_RE.search(text)
+        bracketed = _BRACKETED_ANSWER_RE.search(text)
+        if bracketed is not None and _valid_label(bracketed.group(1)):
+            match = bracketed
 
     # If we couldn't match the strict version, we can try the less strict
-    # version for backward compatibility
+    # version for backward compatibility.
+    # Reasoning models often restate the required format (e.g. `ANSWER: [LETTER]`) and
+    # hedge with sentences like `Final answer: ANSWER: D` before the real answer, so the
+    # first `ANSWER:` marker may capture a placeholder or a partial word instead of the
+    # final choice.  The actual answer is the LAST marker, so iterate all matches and
+    # keep the last one whose capture looks like a valid label.
     if match is None:
-        match = re.search(
+        for candidate in re.finditer(
             r'(?i)ANSWER\s*:\s*\**\s*([A-Za-z\d][A-Za-z\d ,]*)(?:[^\w]|\n|$|\.)',
             text,
-        )
+        ):
+            if _valid_label(candidate.group(1)):
+                match = candidate
 
     if match is None:
         return _fallback_parse_answer(text, allowed_options) or set()
@@ -282,9 +308,17 @@ def parse_answers_zh(state: TaskState, multiple_correct: bool = False, completio
 
     allowed_options = set(answer_character(i) for i in range(len(state.choices)))
 
-    # Simple pattern to capture answers with optional bold markdown
+    # Simple pattern to capture answers with optional bold markdown.
+    # Keep the LAST marker whose capture looks like a valid label: reasoning models may
+    # restate the required format or hedge with `答案：X` multiple times, and only the
+    # final `答案：<label>` is the actual answer (see `parse_answers` for details).
     pattern = r'答案\s*[:：]\s*\**\s*([A-Za-z0-9,，]+)'
-    match = re.search(pattern, text, flags=re.MULTILINE)
+    match = None
+    for candidate in re.finditer(pattern, text, flags=re.MULTILINE):
+        label = candidate.group(1).strip().rstrip('。.')
+        labels = {part.strip() for part in re.split(r'[,，]|\s+和\s+', label) if part.strip()}
+        if labels.issubset(allowed_options) and labels:
+            match = candidate
 
     # The pattern above cannot start on a bracket, so try a wrapped label explicitly.
     if match is None:

--- a/tests/test_multi_choices.py
+++ b/tests/test_multi_choices.py
@@ -116,6 +116,23 @@ def test_parse_answers_placeholder_only_yields_no_valid_option() -> None:
     assert parse_answers(_make_state(completion)).isdisjoint({'A', 'B', 'C', 'D'})
 
 
+def test_parse_answers_keeps_last_valid_label() -> None:
+    """Reasoning models may emit several `ANSWER:` markers (format restatements,
+    hedges like `Final answer: ANSWER: X`, or a letter leaked into the chain of
+    thought) before the real answer.  The LAST marker whose capture is a valid
+    label is the model's final choice, not the first one.
+    """
+    # `Final answer: ANSWER: D` makes the first marker capture the word `ANSWER`;
+    # the actual label `D` only appears in the final marker.
+    assert parse_answers(_make_state('Final answer: ANSWER: D</think>ANSWER: D')) == {'D'}
+    # A wrong letter inside the reasoning must not shadow the final answer.
+    assert parse_answers(_make_state('ANSWER: A is wrong.</think>ANSWER: B')) == {'B'}
+    # Placeholder restated in the reasoning, real answer at the end.
+    assert parse_answers(_make_state("format 'ANSWER: [LETTER]'. So B.</think>ANSWER: B")) == {'B'}
+    # Chinese counterpart.
+    assert parse_answers_zh(_make_state('推理：答案：A 不对。</think>答案：B')) == {'B'}
+
+
 def test_completion_argument_overrides_raw_model_output() -> None:
     """An explicit `completion` must be parsed instead of the raw model output.
 
@@ -123,11 +140,11 @@ def test_completion_argument_overrides_raw_model_output() -> None:
     pass the filtered text so the discarded reasoning cannot win the match.
     """
     state = _make_state('If I answer ANSWER: A that is wrong.</think>ANSWER: B')
-    assert parse_answers(state) == set()
+    assert parse_answers(state) == {'B'}
     assert parse_answers(state, completion='ANSWER: B') == {'B'}
 
     zh_state = _make_state('如果答案：A 就错了。</think>答案：B')
-    assert parse_answers_zh(zh_state) == {'A'}
+    assert parse_answers_zh(zh_state) == {'B'}
     assert parse_answers_zh(zh_state, completion='答案：B') == {'B'}
 
 

--- a/tests/test_multi_choices.py
+++ b/tests/test_multi_choices.py
@@ -133,19 +133,48 @@ def test_parse_answers_keeps_last_valid_label() -> None:
     assert parse_answers_zh(_make_state('推理：答案：A 不对。</think>答案：B')) == {'B'}
 
 
+def test_parse_answers_last_marker_wins_in_every_label_form() -> None:
+    """The last-marker rule must not depend on the form the label is written in.
+
+    A per-form cascade (bare label first, wrapped label second) answers a revised
+    reply with the discarded choice whenever the two markers use different forms.
+    """
+    assert parse_answers(_make_state('ANSWER: A\nANSWER: B')) == {'B'}
+    assert parse_answers(_make_state('ANSWER: (A)</think>ANSWER: (B)')) == {'B'}
+    assert parse_answers(_make_state('ANSWER: A\nreasoning\nANSWER: (B) 300')) == {'B'}
+    assert parse_answers_zh(_make_state('答案：(A)</think>答案：（B）')) == {'B'}
+
+
+def test_parse_answers_finds_a_marker_that_follows_prose_on_one_line() -> None:
+    """Regression test: a greedy label pattern used to run past the next `ANSWER:`.
+
+    The second marker was then never examined, so a revision stated on the same line
+    was scored as the discarded choice, or lost to the last-capital fallback.
+    """
+    assert parse_answers(_make_state('ANSWER: A is not right, ANSWER: B. Hope this helps.')) == {'B'}
+    assert parse_answers(_make_state('I first said ANSWER: A but ANSWER: C is correct.')) == {'C'}
+    assert parse_answers(_make_state('ANSWER: A,B then ANSWER: C,D'), multiple_correct=True) == {'C', 'D'}
+    assert parse_answers_zh(_make_state('先写答案：A，再改为答案：C。')) == {'C'}
+
+
+def test_parse_answers_skips_a_trailing_marker_without_a_label() -> None:
+    """A placeholder echoed after the real answer must not discard it."""
+    assert parse_answers(_make_state('ANSWER: B</think>ANSWER: [LETTER]')) == {'B'}
+
+
 def test_completion_argument_overrides_raw_model_output() -> None:
     """An explicit `completion` must be parsed instead of the raw model output.
 
-    Reasoning models can leak a wrong letter into their chain of thought; callers
-    pass the filtered text so the discarded reasoning cannot win the match.
+    Asserted with a `completion` that resolves differently from the raw output, so the
+    argument cannot appear to be honoured while the raw text is what actually got parsed.
     """
     state = _make_state('If I answer ANSWER: A that is wrong.</think>ANSWER: B')
     assert parse_answers(state) == {'B'}
-    assert parse_answers(state, completion='ANSWER: B') == {'B'}
+    assert parse_answers(state, completion='ANSWER: A') == {'A'}
 
     zh_state = _make_state('如果答案：A 就错了。</think>答案：B')
     assert parse_answers_zh(zh_state) == {'B'}
-    assert parse_answers_zh(zh_state, completion='答案：B') == {'B'}
+    assert parse_answers_zh(zh_state, completion='答案：A') == {'A'}
 
 
 def test_configured_filter_reaches_multi_choice_extraction() -> None:

--- a/tests/test_multi_choices.py
+++ b/tests/test_multi_choices.py
@@ -162,6 +162,44 @@ def test_parse_answers_skips_a_trailing_marker_without_a_label() -> None:
     assert parse_answers(_make_state('ANSWER: B</think>ANSWER: [LETTER]')) == {'B'}
 
 
+JUSTIFIED_ANSWERS = [
+    'ANSWER: B because it fits',
+    'ANSWER: B is the correct choice',
+    'ANSWER: B second option',
+    'ANSWER: B - energy is conserved',
+    'ANSWER: B; energy is conserved',
+    'ANSWER: B because Energy is conserved',
+    'ANSWER: B is correct per Newton',
+    'ANSWER: B because option A is wrong',
+    'ANSWER: B, not C',
+    'ANSWER: B is correct, D is a distractor',
+]
+
+
+def test_parse_answers_reads_a_label_that_is_justified_in_the_same_breath() -> None:
+    """A label must be read from its own token, not from the whole trailing sentence.
+
+    Regression test: the capture used to be validated as a whole, so the label was
+    discarded together with the justification and the reply fell through to the
+    last-capital fallback - which answers with whichever distractor the justification
+    happens to name last.
+    """
+    for completion in JUSTIFIED_ANSWERS:
+        assert parse_answers(_make_state(completion)) == {'B'}, completion
+
+
+def test_parse_answers_zh_reads_a_label_that_is_justified_in_the_same_breath() -> None:
+    for completion in ['答案：B，因为能量守恒', '答案：B，因为A是错的', '答案：B是正确的，D是干扰项']:
+        assert parse_answers_zh(_make_state(completion)) == {'B'}, completion
+
+
+def test_parse_answers_still_rejects_prose_that_names_no_label() -> None:
+    """Reading a label prefix must not turn an unparseable reply into an answer."""
+    assert parse_answers(_make_state('ANSWER: None of the above')) == set()
+    assert parse_answers(_make_state('ANSWER: A B C D are all plausible')) == set()
+    assert parse_answers_zh(_make_state('答案：无法确定')) == set()
+
+
 def test_completion_argument_overrides_raw_model_output() -> None:
     """An explicit `completion` must be parsed instead of the raw model output.
 


### PR DESCRIPTION
## Description

Fixes multi-choice answer extraction when a reasoning model emits several `ANSWER:` markers before the final answer.

**Problem:** `parse_answers()` used `re.search` and kept the **first** `ANSWER:` match. Reasoning models often restate the required format (`'ANSWER: [LETTER]'`) or hedge with sentences like `Final answer: ANSWER: D` before giving the real answer. The first marker can then capture a placeholder or a partial word (e.g. `ANSWER` from `answer: ANSWER: D`), causing the sample to be scored as a miss even though the model's final choice is present later in the output.

**Fix:** iterate over **all** `ANSWER:` markers and keep the **last** one whose capture is a valid label; the same rule is applied to the Chinese parser (`parse_answers_zh`). A wrong letter leaked into the chain of thought can no longer shadow the final answer.

## Verification

- New regression tests cover: placeholder restated in reasoning, `Final answer: ANSWER: D` hedges, leaked letters inside the chain of thought, and the Chinese counterpart.
- `tests/test_multi_choices.py`: 15 passed.
- On a real LongBench-v2 run, this restores 13/25 previously-empty samples (accuracy 57.0% → 64.2%).
- `flake8`, `isort`, `yapf` all clean.

## Related

Fixes answer extraction failures observed with verbose reasoning-model outputs (e.g. DeepSeek-V4-Flash).
