### PR TITLE
docs(api): fix message and tool documentation typos

### DIFF
--- a/evalscope/api/messages/chat_message.py
+++ b/evalscope/api/messages/chat_message.py
@@ -13,7 +13,7 @@ class ChatMessageBase(BaseModel):
     """Base class for chat messages."""
 
     id: Optional[str] = Field(default=None)
-    """Unique identifer for message."""
+    """Unique identifier for message."""
 
     content: Union[str, List[Content]]
     """Content (simple string or list of content objects)"""

--- a/evalscope/api/tool/tool_info.py
+++ b/evalscope/api/tool/tool_info.py
@@ -118,7 +118,7 @@ def parse_tool_info(func: Callable[..., Any]) -> ToolInfo:
         if param_name in type_hints:
             tool_param = json_schema(type_hints[param_name])
         # as a fallback try to parse it from the docstring
-        # (this is minimally necessary for backwards compatiblity
+        # (this is minimally necessary for backwards compatibility
         #  with tools gen1 type parsing, which only used docstrings)
         elif 'docstring_type' in docstring_info:
             json_type = python_type_to_json_type(docstring_info['docstring_type'])

--- a/evalscope/api/tool/utils.py
+++ b/evalscope/api/tool/utils.py
@@ -13,8 +13,8 @@ def parse_tool_call(id: str, function: str, arguments: str, tools: Optional[List
     """Parse a tool call from a JSON payload.
 
     Note that this function doesn't know about internal tool names so the caller
-    should ammend the returned `ToolCall` by mapping the parsed `function` field from
-    an internal name to an tool name and fixing up the `ToolCall` object
+    should amend the returned `ToolCall` by mapping the parsed `function` field from
+    an internal name to a tool name and fixing up the `ToolCall` object
     as required to reflect this change.
     """
     error: Optional[str] = None


### PR DESCRIPTION
## Summary

- Correct the `ChatMessageBase.id` field documentation.
- Fix a spelling error in the tool type compatibility comment.
- Improve spelling and grammar in the `parse_tool_call` docstring.

No runtime behavior is changed.

## Validation

- `git diff --check`
- Python AST parsing for all three modified files
- Targeted `codespell` using the repository configuration
- `python -m flake8` on all three modified files