### PR TITLE
feat(web): expose output directory name in Eval/Perf task forms

### DIFF
--- a/evalscope/web/src/components/eval/EvalConfigForm.tsx
+++ b/evalscope/web/src/components/eval/EvalConfigForm.tsx
@@ -9,12 +9,12 @@ import {
   validateDatasetArgs,
   FORM_MESSAGE_KEYS,
 } from '@/domain/form/validation'
-import { ApiKeyField, ApiUrlField, ModelField } from '@/components/tasks/TaskFormFields'
+import { ApiKeyField, ApiUrlField, ModelField, OutputDirField } from '@/components/tasks/TaskFormFields'
 import TaskFormShell from '@/components/tasks/TaskFormShell'
 import { useTaskForm } from '@/components/tasks/useTaskForm'
 
 interface Props {
-  onSubmit: (config: Record<string, unknown>) => void
+  onSubmit: (config: Record<string, unknown>, outputDirName?: string) => void
   disabled?: boolean
   initialDataset?: string
   /**
@@ -50,6 +50,7 @@ const IDS = {
   sandboxImage: 'eval-sandboxImage',
   sandboxPool: 'eval-sandboxPool',
   sandboxEnable: 'eval-sandboxEnable',
+  outputDir: 'eval-outputDir',
 } as const
 
 /** DOM order of focusable fields, drives first-invalid focus on submit. */
@@ -68,6 +69,7 @@ const DOM_ORDER: string[] = [
   IDS.topK,
   IDS.datasetArgs,
   IDS.sandboxPool,
+  IDS.outputDir,
 ]
 
 /** Fields that live inside the collapsible "More Parameters" section. */
@@ -80,6 +82,7 @@ const MORE_PARAMS_IDS: string[] = [
   IDS.topK,
   IDS.datasetArgs,
   IDS.sandboxPool,
+  IDS.outputDir,
 ]
 
 export default function EvalConfigForm({ onSubmit, disabled, initialDataset, initialModel }: Props) {
@@ -103,6 +106,7 @@ export default function EvalConfigForm({ onSubmit, disabled, initialDataset, ini
   const [sandboxUrl, setSandboxUrl] = useState('')
   const [sandboxImage, setSandboxImage] = useState('')
   const [sandboxPoolSize, setSandboxPoolSize] = useState('')
+  const [outputDirName, setOutputDirName] = useState('')
 
   const { errorFor: errMsg, clearError: clearErr, showMore, toggleMore, submitHandler } = useTaskForm({
     domOrder: DOM_ORDER,
@@ -187,7 +191,7 @@ export default function EvalConfigForm({ onSubmit, disabled, initialDataset, ini
 
       config.sandbox = sandbox
     }
-    onSubmit(config)
+    onSubmit(config, outputDirName.trim() || undefined)
   }
 
   // Dataset autocomplete
@@ -335,6 +339,7 @@ export default function EvalConfigForm({ onSubmit, disabled, initialDataset, ini
             />
           )}
         </Field>
+        <OutputDirField id={IDS.outputDir} value={outputDirName} onChange={setOutputDirName} />
         <hr className="md:col-span-3 my-2" />
         <h3 className="md:col-span-3 font-semibold">{t('eval.sandbox')}</h3>
         <Field id={IDS.sandboxEnable} name="sandbox_enabled" labelKey="eval.sandboxEnable">

--- a/evalscope/web/src/components/perf/PerfConfigForm.tsx
+++ b/evalscope/web/src/components/perf/PerfConfigForm.tsx
@@ -8,12 +8,12 @@ import {
   validatePositiveIntegerList,
   FORM_MESSAGE_KEYS,
 } from '@/domain/form/validation'
-import { ApiKeyField, ApiUrlField, ModelField } from '@/components/tasks/TaskFormFields'
+import { ApiKeyField, ApiUrlField, ModelField, OutputDirField } from '@/components/tasks/TaskFormFields'
 import TaskFormShell from '@/components/tasks/TaskFormShell'
 import { useTaskForm } from '@/components/tasks/useTaskForm'
 
 interface Props {
-  onSubmit: (config: Record<string, unknown>) => void
+  onSubmit: (config: Record<string, unknown>, outputDirName?: string) => void
   disabled?: boolean
 }
 
@@ -32,6 +32,7 @@ const IDS = {
   maxPromptLen: 'perf-maxPromptLen',
   minPromptLen: 'perf-minPromptLen',
   tokenizerPath: 'perf-tokenizerPath',
+  outputDir: 'perf-outputDir',
 } as const
 
 /** DOM order of focusable fields, drives first-invalid focus on submit. */
@@ -49,10 +50,11 @@ const DOM_ORDER: string[] = [
   IDS.maxPromptLen,
   IDS.minPromptLen,
   IDS.tokenizerPath,
+  IDS.outputDir,
 ]
 
 /** Fields that live inside the collapsible "More Parameters" section. */
-const MORE_PARAMS_IDS: string[] = [IDS.tokenizerPath]
+const MORE_PARAMS_IDS: string[] = [IDS.tokenizerPath, IDS.outputDir]
 
 export default function PerfConfigForm({ onSubmit, disabled }: Props) {
   const { t } = useLocale()
@@ -69,6 +71,7 @@ export default function PerfConfigForm({ onSubmit, disabled }: Props) {
   const [maxPromptLen, setMaxPromptLen] = useState('')
   const [minPromptLen, setMinPromptLen] = useState('')
   const [tokenizerPath, setTokenizerPath] = useState('')
+  const [outputDirName, setOutputDirName] = useState('')
 
   const { errorFor: errMsg, clearError: clearErr, showMore, toggleMore, submitHandler } = useTaskForm({
     domOrder: DOM_ORDER,
@@ -114,7 +117,7 @@ export default function PerfConfigForm({ onSubmit, disabled }: Props) {
     if (maxPromptLen) config.max_prompt_length = Number(maxPromptLen)
     if (minPromptLen) config.min_prompt_length = Number(minPromptLen)
     if (tokenizerPath) config.tokenizer_path = tokenizerPath
-    onSubmit(config)
+    onSubmit(config, outputDirName.trim() || undefined)
   }
 
   return (
@@ -127,11 +130,14 @@ export default function PerfConfigForm({ onSubmit, disabled }: Props) {
       submitLabel={t('perf.task.startPerf')}
       disabled={disabled}
       moreParams={(
-        <Field id={IDS.tokenizerPath} name="tokenizer_path" labelKey="perf.task.tokenizerPath">
-          {(aria) => (
-            <input {...aria} type="text" value={tokenizerPath} onChange={(e) => setTokenizerPath(e.target.value)} className={FORM_INPUT_CLASS} placeholder="/path/to/tokenizer" />
-          )}
-        </Field>
+        <>
+          <Field id={IDS.tokenizerPath} name="tokenizer_path" labelKey="perf.task.tokenizerPath">
+            {(aria) => (
+              <input {...aria} type="text" value={tokenizerPath} onChange={(e) => setTokenizerPath(e.target.value)} className={FORM_INPUT_CLASS} placeholder="/path/to/tokenizer" />
+            )}
+          </Field>
+          <OutputDirField id={IDS.outputDir} value={outputDirName} onChange={setOutputDirName} />
+        </>
       )}
     >
       <ModelField

--- a/evalscope/web/src/components/tasks/TaskFormFields.tsx
+++ b/evalscope/web/src/components/tasks/TaskFormFields.tsx
@@ -65,3 +65,20 @@ export function ApiKeyField({ id, value, onChange }: TaskTextFieldProps) {
     </Field>
   )
 }
+
+export function OutputDirField({ id, value, onChange }: TaskTextFieldProps) {
+  return (
+    <Field id={id} name="output_dir_name" labelKey="tasks.outputDirName" autoComplete="off">
+      {(aria) => (
+        <input
+          {...aria}
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className={FORM_INPUT_CLASS}
+          placeholder="Auto-generated if left blank"
+        />
+      )}
+    </Field>
+  )
+}

--- a/evalscope/web/src/components/tasks/TaskRunnerShell.tsx
+++ b/evalscope/web/src/components/tasks/TaskRunnerShell.tsx
@@ -5,7 +5,7 @@ import Card from '@/components/ui/Card'
 import TaskMonitor from '@/components/eval/TaskMonitor'
 
 interface FormRenderProps {
-  onSubmit: (config: Record<string, unknown>) => Promise<void>
+  onSubmit: (config: Record<string, unknown>, outputDirName?: string) => Promise<void>
   disabled: boolean
 }
 
@@ -25,6 +25,17 @@ interface TaskRunnerShellProps {
 
 function createTaskId(prefix: string): string {
   return `${prefix}_${Date.now()}`
+}
+
+/**
+ * Turn a user-supplied output directory name into a task id. Filesystem- and
+ * header-safe: only word characters and dashes survive, so the result can
+ * never traverse out of the task's storage root or break the
+ * `EvalScope-Task-Id` request header.
+ */
+function taskIdFromName(prefix: string, name: string): string {
+  const cleaned = name.trim().replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 100)
+  return cleaned ? `${prefix}_${cleaned}` : createTaskId(prefix)
 }
 
 export default function TaskRunnerShell({
@@ -47,8 +58,8 @@ export default function TaskRunnerShell({
   const [logLine, setLogLine] = useState(0)
   const [progress, setProgress] = useState(0)
 
-  const handleSubmit = async (config: Record<string, unknown>) => {
-    const id = createTaskId(idPrefix)
+  const handleSubmit = async (config: Record<string, unknown>, outputDirName?: string) => {
+    const id = outputDirName ? taskIdFromName(idPrefix, outputDirName) : createTaskId(idPrefix)
     setTaskId(id)
     setRunning(true)
     setLogText('')

--- a/evalscope/web/src/i18n/translations/tasks.ts
+++ b/evalscope/web/src/i18n/translations/tasks.ts
@@ -3,9 +3,11 @@ import type { Dict } from './types'
 export const en: Dict = {
   evalTab: 'Evaluation',
   perfTab: 'Performance',
+  outputDirName: 'Output Directory Name',
 }
 
 export const zh: Dict = {
   evalTab: '模型评估',
   perfTab: '性能测试',
+  outputDirName: '输出目录名称',
 }


### PR DESCRIPTION
Lets users name a run's output directory from the Tasks tab instead of relying on the auto-generated timestamp id. The name becomes the task id (sanitized to filesystem/header-safe characters), which is what the backend already uses to derive work_dir, progress tracking, log lookup, resume, and report listing -- so no backend changes are needed and none of those flows break.