### PR TITLE
perf(service): memoize report-list metadata and support conditional GET

### DIFF
--- a/evalscope/service/blueprints/reports.py
+++ b/evalscope/service/blueprints/reports.py
@@ -12,18 +12,26 @@ import plotly.graph_objects as go
 import shutil
 from datetime import datetime
 from flask import Blueprint, jsonify, request, send_file
+from flask.typing import ResponseReturnValue
 from pydantic import ValidationError
 from typing import List, Optional, Tuple
 
 from evalscope.constants import PLOTLY_CDN_URL, PLOTLY_THEME
 from evalscope.metrics.semantics import PrimaryMetricRef
-from evalscope.report import ReportKey, ReportRef, get_data_frame
+from evalscope.report import ReportKey, ReportRef, get_data_frame, get_report_list
 from evalscope.report.report import Report
 from evalscope.report.visualization import (
     plot_multi_report_radar,
     plot_single_dataset_scores,
     plot_single_report_scores,
     plot_single_report_sunburst,
+)
+from evalscope.service.report_meta_cache import (
+    Fingerprint,
+    build_report_meta_cached,
+    list_etag,
+    prune_report_meta_cache,
+    report_ref_fingerprint,
 )
 from evalscope.utils.data_utils import (
     get_acc_report_df,
@@ -36,6 +44,7 @@ from evalscope.utils.data_utils import (
     load_multi_report_groups,
     load_report_bundle,
     normalize_score,
+    report_model_dir,
     scan_report_refs,
 )
 from evalscope.utils.io_utils import OutputsStructure
@@ -78,7 +87,7 @@ _MEDIA_EXTENSIONS = {
 
 
 @bp_reports.route('/media/file', methods=['GET'])
-def serve_media_file():
+def serve_media_file() -> ResponseReturnValue:
     """Serve a local media file (image / audio / video) via HTTP.
 
     This proxy endpoint allows the browser to load server-side local file
@@ -171,9 +180,13 @@ def _extract_timestamp(ref: ReportRef, root: str) -> str:
 
 
 def _build_report_meta(ref: ReportRef, root: str) -> Optional[dict]:
-    """Load a report and return lightweight metadata for the list endpoint."""
+    """Load a report and return lightweight metadata for the list endpoint.
+
+    Reads only the report JSON files, never the run's YAML config: the list needs
+    none of the config, and requiring it dropped config-less report directories.
+    """
     try:
-        report_list, _, _ = load_report_bundle(root, ref)
+        report_list = get_report_list([report_model_dir(root, ref)])
     except Exception:
         return None
 
@@ -247,9 +260,68 @@ def _refresh_html_report(reports_dir: str) -> None:
 # Endpoints
 # ------------------------------------------------------------------
 
+_SORT_KEYS = {
+    'model': lambda x: x['model_name'].lower(),
+    'dataset': lambda x: x['dataset_name'].lower(),
+    'time': lambda x: x['timestamp'],
+}
+
+
+def _load_report_metas(root: str) -> Tuple[List[dict], List[Tuple[str, Fingerprint]]]:
+    """Load list metadata for every report under ``root``, memoized by fingerprint."""
+    fingerprints: List[Tuple[str, Fingerprint]] = []
+    items: List[dict] = []
+    for ref in scan_report_refs(root):
+        fingerprint = report_ref_fingerprint(root, ref)
+        fingerprints.append((ref.key, fingerprint))
+        meta = build_report_meta_cached(root, ref, fingerprint, _build_report_meta)
+        if meta is not None:
+            items.append(meta)
+    prune_report_meta_cache(root, (ref_key for ref_key, _ in fingerprints))
+    return items, fingerprints
+
+
+def _apply_report_filters(items: List[dict], search: str, models_filter: str, datasets_filter: str) -> List[dict]:
+    """Narrow the metadata list by fuzzy search, model set and dataset set."""
+    if search:
+        items = [
+            it for it in items if search in it['model_name'].lower() or search in it['dataset_name'].lower()
+            or search in it['dataset_pretty_name'].lower()
+        ]
+    if models_filter:
+        model_set = {m.strip().lower() for m in models_filter.split(';') if m.strip()}
+        items = [it for it in items if it['model_name'].lower() in model_set]
+    if datasets_filter:
+        ds_set = {d.strip().lower() for d in datasets_filter.split(';') if d.strip()}
+        items = [it for it in items if any(d.lower() in ds_set for d in it['_datasets'])]
+    return items
+
+
+def _list_response(
+    page_items: List[dict], total: int, page: int, page_size: int, available_models: List[str],
+    available_datasets: List[str], fingerprints: List[Tuple[str, Fingerprint]], query_parts: List[str]
+) -> ResponseReturnValue:
+    """Serialize the page with an ETag so unchanged responses revalidate as 304."""
+    # Project internal keys into fresh dicts: meta objects are shared with the
+    # cache, so mutating them here would corrupt later requests.
+    response_reports = [{k: v for k, v in it.items() if k != '_datasets'} for it in page_items]
+    resp = jsonify({
+        'reports': response_reports,
+        'total': total,
+        'page': page,
+        'page_size': page_size,
+        'filters': {
+            'available_models': available_models,
+            'available_datasets': available_datasets,
+        },
+    })
+    resp.set_etag(list_etag(fingerprints, query_parts))
+    resp.headers['Cache-Control'] = 'no-cache'
+    return resp.make_conditional(request)
+
 
 @bp_reports.route('', methods=['GET'])
-def list_reports():
+def list_reports() -> ResponseReturnValue:
     """Return a filterable, paginated list of reports with metadata.
 
     Query params:
@@ -262,90 +334,58 @@ def list_reports():
         page       (int):   page number (default: 1)
         page_size  (int):   items per page (default: 20)
     """
+    root = _root_path()
+    if not root or not os.path.isdir(root):
+        return jsonify({'error': 'root_path is required and must be an existing directory'}), 400
+
+    removed_score_params = sorted({'score_min', 'score_max'} & set(request.args))
+    if removed_score_params:
+        return jsonify({'error': f"unsupported query parameters: {', '.join(removed_score_params)}"}), 400
+    sort_by = request.args.get('sort_by', 'time')
+    sort_order = request.args.get('sort_order', 'desc')
+    if sort_by not in _SORT_KEYS:
+        return jsonify({'error': f'unsupported sort_by: {sort_by}'}), 400
+    if sort_order not in {'asc', 'desc'}:
+        return jsonify({'error': f'unsupported sort_order: {sort_order}'}), 400
+
     try:
-        root = _root_path()
-        if not root or not os.path.isdir(root):
-            return jsonify({'error': 'root_path is required and must be an existing directory'}), 400
+        items, fingerprints = _load_report_metas(root)
 
-        removed_score_params = sorted({'score_min', 'score_max'} & set(request.args))
-        sort_by = request.args.get('sort_by', 'time')
-        sort_order = request.args.get('sort_order', 'desc')
-        if removed_score_params:
-            return jsonify({'error': f"unsupported query parameters: {', '.join(removed_score_params)}"}), 400
-        if sort_by not in {'model', 'dataset', 'time'}:
-            return jsonify({'error': f'unsupported sort_by: {sort_by}'}), 400
-        if sort_order not in {'asc', 'desc'}:
-            return jsonify({'error': f'unsupported sort_order: {sort_order}'}), 400
-
-        # --- Scan & load metadata ---
-        items = []
-        for ref in scan_report_refs(root):
-            meta = _build_report_meta(ref, root)
-            if meta is not None:
-                items.append(meta)
-
-        # Collect available filter values before filtering
+        # Filter values are offered from the unfiltered set.
         available_models = sorted({it['model_name'] for it in items})
         available_datasets = sorted({ds for it in items for ds in it['_datasets']})
 
-        # --- Filters ---
         search = request.args.get('search', '').strip().lower()
-        if search:
-            items = [
-                it for it in items if search in it['model_name'].lower() or search in it['dataset_name'].lower()
-                or search in it['dataset_pretty_name'].lower()
-            ]
-
         models_filter = request.args.get('models', '').strip()
-        if models_filter:
-            model_set = {m.strip().lower() for m in models_filter.split(';') if m.strip()}
-            items = [it for it in items if it['model_name'].lower() in model_set]
-
         datasets_filter = request.args.get('datasets', '').strip()
-        if datasets_filter:
-            ds_set = {d.strip().lower() for d in datasets_filter.split(';') if d.strip()}
-            items = [it for it in items if any(d.lower() in ds_set for d in it['_datasets'])]
+        items = _apply_report_filters(items, search, models_filter, datasets_filter)
 
-        # --- Sort ---
-        reverse = sort_order == 'desc'
+        items.sort(key=_SORT_KEYS[sort_by], reverse=sort_order == 'desc')
 
-        sort_key_map = {
-            'model': lambda x: x['model_name'].lower(),
-            'dataset': lambda x: x['dataset_name'].lower(),
-            'time': lambda x: x['timestamp'],
-        }
-        key_fn = sort_key_map[sort_by]
-        items.sort(key=key_fn, reverse=reverse)
-
-        # --- Paginate ---
         page = max(1, request.args.get('page', 1, type=int))
         page_size = max(1, min(100, request.args.get('page_size', 20, type=int)))
         total = len(items)
-        start = (page - 1) * page_size
-        page_items = items[start:start + page_size]
+        page_items = items[(page - 1) * page_size:(page - 1) * page_size + page_size]
 
-        # Strip internal keys before returning
-        for it in page_items:
-            it.pop('_datasets', None)
-
-        return jsonify({
-            'reports': page_items,
-            'total': total,
-            'page': page,
-            'page_size': page_size,
-            'filters': {
-                'available_models': available_models,
-                'available_datasets': available_datasets,
-            },
-        }), 200
-
-    except Exception as e:
-        logger.error(f'Failed to list reports: {e}')
-        return jsonify({'error': str(e)}), 500
+        query_parts = [
+            f'search={search}',
+            f'models={models_filter}',
+            f'datasets={datasets_filter}',
+            f'sort_by={sort_by}',
+            f'sort_order={sort_order}',
+            f'page={page}',
+            f'page_size={page_size}',
+        ]
+        return _list_response(
+            page_items, total, page, page_size, available_models, available_datasets, fingerprints, query_parts
+        )
+    except Exception:
+        logger.error('Failed to list reports', exc_info=True)
+        return jsonify({'error': 'Failed to list reports'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>', methods=['DELETE'])
-def delete_report(run_id: str, model_id: str):
+def delete_report(run_id: str, model_id: str) -> ResponseReturnValue:
     """Delete one evaluation report (its per-model artefacts) from disk.
 
     Removes ``<run_id>/{reports,predictions,reviews}/<model_id>``. When no other
@@ -394,13 +434,13 @@ def delete_report(run_id: str, model_id: str):
             _refresh_html_report(reports_dir)
         logger.info(f'Deleted eval report {ref.key} under {run_dir}')
         return jsonify({'success': True, 'run_id': ref.run_id, 'model_id': ref.model_id}), 200
-    except Exception as e:
-        logger.error(f'Failed to delete report {ref.key}: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error(f'Failed to delete report {ref.key}', exc_info=True)
+        return jsonify({'error': 'Failed to delete report'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>', methods=['GET'])
-def load_report(run_id: str, model_id: str):
+def load_report(run_id: str, model_id: str) -> ResponseReturnValue:
     """Load one model report of one run.
 
     Query params:
@@ -421,13 +461,13 @@ def load_report(run_id: str, model_id: str):
     except FileNotFoundError as e:
         logger.warning(f'Report {ref.key} not found: {e}')
         return jsonify({'error': f'Report not found: {ref.key}'}), 404
-    except Exception as e:
-        logger.error(f'Failed to load report {ref.key}: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error(f'Failed to load report {ref.key}', exc_info=True)
+        return jsonify({'error': 'Failed to load report'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>/table', methods=['GET'])
-def get_dataframe(run_id: str, model_id: str):
+def get_dataframe(run_id: str, model_id: str) -> ResponseReturnValue:
     """Get report data as a flat JSON table.
 
     Query params:
@@ -462,13 +502,13 @@ def get_dataframe(run_id: str, model_id: str):
             'columns': list(df.columns),
             'data': _df_to_records(df),
         }), 200
-    except Exception as e:
-        logger.error(f'Failed to get dataframe: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to get report table', exc_info=True)
+        return jsonify({'error': 'Failed to get report table'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>/predictions', methods=['GET'])
-def get_predictions(run_id: str, model_id: str):
+def get_predictions(run_id: str, model_id: str) -> ResponseReturnValue:
     """Get model predictions for a given subset.
 
     Query params:
@@ -492,13 +532,13 @@ def get_predictions(run_id: str, model_id: str):
         return jsonify({
             'predictions': _df_to_records(df),
         }), 200
-    except Exception as e:
-        logger.error(f'Failed to get predictions: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to get predictions', exc_info=True)
+        return jsonify({'error': 'Failed to get predictions'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>/analysis', methods=['GET'])
-def get_analysis(run_id: str, model_id: str):
+def get_analysis(run_id: str, model_id: str) -> ResponseReturnValue:
     """Get the AI analysis text for a dataset.
 
     Query params:
@@ -518,13 +558,13 @@ def get_analysis(run_id: str, model_id: str):
         report_list, _, _ = load_report_bundle(_root_path(), ref)
         analysis = get_report_analysis(report_list, dataset_name)
         return jsonify({'analysis': analysis}), 200
-    except Exception as e:
-        logger.error(f'Failed to get analysis: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to get analysis', exc_info=True)
+        return jsonify({'error': 'Failed to get analysis'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/html', methods=['GET'])
-def get_html_report(run_id: str):
+def get_html_report(run_id: str) -> ResponseReturnValue:
     """Serve the generated HTML report of a run.
 
     The HTML report covers every model of the run, so it is addressed by run alone.
@@ -549,9 +589,9 @@ def get_html_report(run_id: str):
             }), 404
 
         return send_file(report_html, mimetype='text/html')
-    except Exception as e:
-        logger.error(f'Failed to get HTML report: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to get HTML report', exc_info=True)
+        return jsonify({'error': 'Failed to get HTML report'}), 500
 
 
 def _render_chart_html(fig: Optional[go.Figure]) -> Tuple[str, int, dict]:
@@ -569,7 +609,7 @@ def _render_chart_html(fig: Optional[go.Figure]) -> Tuple[str, int, dict]:
 
 
 @bp_reports.route('/charts/<chart_type>', methods=['GET'])
-def get_compare_chart(chart_type: str):
+def get_compare_chart(chart_type: str) -> ResponseReturnValue:
     """Generate a multi-report comparison chart as standalone HTML.
 
     Query params:
@@ -621,13 +661,13 @@ def get_compare_chart(chart_type: str):
                 plot_bgcolor='rgba(0,0,0,0)',
             )
         return _render_chart_html(fig)
-    except Exception as e:
-        logger.error(f'Failed to generate comparison chart: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to generate comparison chart', exc_info=True)
+        return jsonify({'error': 'Failed to generate comparison chart'}), 500
 
 
 @bp_reports.route('/runs/<run_id>/models/<model_id>/charts/<chart_type>', methods=['GET'])
-def get_chart(run_id: str, model_id: str, chart_type: str):
+def get_chart(run_id: str, model_id: str, chart_type: str) -> ResponseReturnValue:
     """Generate a single-report chart as standalone HTML.
 
     Path params:
@@ -688,6 +728,6 @@ def get_chart(run_id: str, model_id: str, chart_type: str):
                 return jsonify({'error': f'Unknown chart type: {chart_type}'}), 400
 
         return _render_chart_html(fig)
-    except Exception as e:
-        logger.error(f'Failed to generate chart: {e}')
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.error('Failed to generate chart', exc_info=True)
+        return jsonify({'error': 'Failed to generate chart'}), 500

--- a/evalscope/service/blueprints/reports.py
+++ b/evalscope/service/blueprints/reports.py
@@ -188,6 +188,7 @@ def _build_report_meta(ref: ReportRef, root: str) -> Optional[dict]:
     try:
         report_list = get_report_list([report_model_dir(root, ref)])
     except Exception:
+        logger.warning(f'Skipping report {ref.key}: failed to load', exc_info=True)
         return None
 
     if not report_list:

--- a/evalscope/service/report_meta_cache.py
+++ b/evalscope/service/report_meta_cache.py
@@ -3,8 +3,8 @@
 The report-list endpoint derives a small metadata dict from each report by
 reading its JSON files. Those files are immutable audit records once written
 (a rerun rewrites them, changing their mtime; a delete removes the directory),
-so a fingerprint over the files' ``(path, mtime, size)`` is a sound version key:
-an unchanged fingerprint guarantees unchanged derived metadata.
+so a fingerprint over the files' ``(path, mtime, ctime, size)`` and the run
+mtime is a lightweight version key for the metadata inputs.
 
 This lets every list request stat the report files (cheap) while reading and
 parsing them (expensive) only for references that are new or have changed since
@@ -21,18 +21,15 @@ from evalscope.constants import DataCollection
 from evalscope.report import ReportRef
 from evalscope.utils.data_utils import report_model_dir
 
-# Per-file identity: relative path, mtime (ns) and size. The tuple of these over
-# a reference's JSON files is its version key.
-Fingerprint = Tuple[Tuple[str, int, int], ...]
+# Per-path identity: relative path, mtime (ns), ctime (ns), and size.
+Fingerprint = Tuple[Tuple[str, int, int, int], ...]
 
-# cache key -> (fingerprint, meta_or_None). One entry per (root, reference),
+# cache key -> (fingerprint, metadata). One entry per (root, reference),
 # replaced when the fingerprint changes. Per root the cache is bounded by the
 # report directories on disk and pruned every request; across roots it grows
 # with the number of distinct outputs roots the process serves, which is small
 # and stable in practice (the endpoint only lists existing directories).
-# ``None`` metadata (an unreadable report) is cached too, so a broken report is
-# not re-read on every request.
-_CACHE: Dict[str, Tuple[Fingerprint, Optional[dict]]] = {}
+_CACHE: Dict[str, Tuple[Fingerprint, dict]] = {}
 _LOCK = threading.Lock()
 
 # Type of the callable that reads a report and builds its metadata.
@@ -49,14 +46,16 @@ def _cache_key(root: str, ref: ReportRef) -> str:
 
 
 def report_ref_fingerprint(root: str, ref: ReportRef) -> Fingerprint:
-    """Version key for one report reference: its files' paths, mtimes and sizes.
-
-    Stat-only, no file is read. The collection report is skipped to match
-    ``get_report_list``'s own exclusion, so the fingerprint tracks exactly the
-    files the metadata is derived from.
-    """
+    """Version key for the report JSONs and timestamp fallback inputs."""
     model_dir = report_model_dir(root, ref)
-    entries: List[Tuple[str, int, int]] = []
+    entries: List[Tuple[str, int, int, int]] = []
+    run_dir = os.path.join(root, ref.run_id)
+    try:
+        run_stat = os.stat(run_dir)
+        entries.append(('@run', run_stat.st_mtime_ns, run_stat.st_ctime_ns, run_stat.st_size))
+    except OSError:
+        pass
+
     for file_path in glob.glob(os.path.join(model_dir, '**', '*.json'), recursive=True):
         if os.path.basename(file_path) == DataCollection.REPORT_NAME:
             continue
@@ -64,7 +63,7 @@ def report_ref_fingerprint(root: str, ref: ReportRef) -> Fingerprint:
             st = os.stat(file_path)
         except OSError:
             continue
-        entries.append((os.path.relpath(file_path, model_dir), st.st_mtime_ns, st.st_size))
+        entries.append((os.path.relpath(file_path, model_dir), st.st_mtime_ns, st.st_ctime_ns, st.st_size))
     entries.sort()
     return tuple(entries)
 
@@ -79,16 +78,18 @@ def build_report_meta_cached(root: str, ref: ReportRef, fingerprint: Fingerprint
     """
     key = _cache_key(root, ref)
     with _LOCK:
-        cached = _CACHE.get(key)
-        if cached is not None and cached[0] == fingerprint:
-            return cached[1]
+        observed = _CACHE.get(key)
+        if observed is not None and observed[0] == fingerprint:
+            return observed[1]
 
-    # Computed outside the lock to keep file I/O off it; a rare double-compute on
-    # concurrent misses is harmless because the result is idempotent.
     meta = compute(ref, root)
+    if meta is None:
+        return None
 
     with _LOCK:
-        _CACHE[key] = (fingerprint, meta)
+        current = _CACHE.get(key)
+        if current is observed or current is None or current[0] == fingerprint:
+            _CACHE[key] = (fingerprint, meta)
     return meta
 
 

--- a/evalscope/service/report_meta_cache.py
+++ b/evalscope/service/report_meta_cache.py
@@ -26,9 +26,12 @@ from evalscope.utils.data_utils import report_model_dir
 Fingerprint = Tuple[Tuple[str, int, int], ...]
 
 # cache key -> (fingerprint, meta_or_None). One entry per (root, reference),
-# replaced when the fingerprint changes, so the cache is bounded by the number
-# of report directories on disk. ``None`` metadata (an unreadable report) is
-# cached too, so a broken report is not re-read on every request.
+# replaced when the fingerprint changes. Per root the cache is bounded by the
+# report directories on disk and pruned every request; across roots it grows
+# with the number of distinct outputs roots the process serves, which is small
+# and stable in practice (the endpoint only lists existing directories).
+# ``None`` metadata (an unreadable report) is cached too, so a broken report is
+# not re-read on every request.
 _CACHE: Dict[str, Tuple[Fingerprint, Optional[dict]]] = {}
 _LOCK = threading.Lock()
 
@@ -107,11 +110,15 @@ def list_etag(fingerprints: Sequence[Tuple[str, Fingerprint]], query_parts: Sequ
 
     ``fingerprints`` is the ``(ref.key, fingerprint)`` pairs gathered while
     serving the list, so this adds no file reads. ``query_parts`` folds in the
-    filter/sort/page values that also shape the response.
+    filter/sort/page values that also shape the response. The digest is built
+    incrementally so no O(N) intermediate payload is allocated.
     """
-    parts: List[str] = sorted(f'{key}:{fp}' for key, fp in fingerprints)
-    parts.extend(f'q:{part}' for part in query_parts)
-    return hashlib.sha256('\n'.join(parts).encode('utf-8')).hexdigest()
+    digest = hashlib.sha256()
+    for key, fingerprint in sorted(fingerprints):
+        digest.update(f'{key}:{fingerprint}\n'.encode('utf-8'))
+    for part in query_parts:
+        digest.update(f'q:{part}\n'.encode('utf-8'))
+    return digest.hexdigest()
 
 
 def clear_report_meta_cache() -> None:

--- a/evalscope/service/report_meta_cache.py
+++ b/evalscope/service/report_meta_cache.py
@@ -1,0 +1,120 @@
+"""Process-local memoization of report-list metadata.
+
+The report-list endpoint derives a small metadata dict from each report by
+reading its JSON files. Those files are immutable audit records once written
+(a rerun rewrites them, changing their mtime; a delete removes the directory),
+so a fingerprint over the files' ``(path, mtime, size)`` is a sound version key:
+an unchanged fingerprint guarantees unchanged derived metadata.
+
+This lets every list request stat the report files (cheap) while reading and
+parsing them (expensive) only for references that are new or have changed since
+the last request. Entries are keyed by ``(root, ref)`` so switching the outputs
+root never makes one root's entries evict or shadow another's.
+"""
+import glob
+import hashlib
+import os
+import threading
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from evalscope.constants import DataCollection
+from evalscope.report import ReportRef
+from evalscope.utils.data_utils import report_model_dir
+
+# Per-file identity: relative path, mtime (ns) and size. The tuple of these over
+# a reference's JSON files is its version key.
+Fingerprint = Tuple[Tuple[str, int, int], ...]
+
+# cache key -> (fingerprint, meta_or_None). One entry per (root, reference),
+# replaced when the fingerprint changes, so the cache is bounded by the number
+# of report directories on disk. ``None`` metadata (an unreadable report) is
+# cached too, so a broken report is not re-read on every request.
+_CACHE: Dict[str, Tuple[Fingerprint, Optional[dict]]] = {}
+_LOCK = threading.Lock()
+
+# Type of the callable that reads a report and builds its metadata.
+MetaBuilder = Callable[[ReportRef, str], Optional[dict]]
+
+
+def _cache_key_prefix(root: str) -> str:
+    """Namespace for one outputs root, so entries never cross between roots."""
+    return f'{os.path.realpath(root)}\x00'
+
+
+def _cache_key(root: str, ref: ReportRef) -> str:
+    return f'{_cache_key_prefix(root)}{ref.key}'
+
+
+def report_ref_fingerprint(root: str, ref: ReportRef) -> Fingerprint:
+    """Version key for one report reference: its files' paths, mtimes and sizes.
+
+    Stat-only, no file is read. The collection report is skipped to match
+    ``get_report_list``'s own exclusion, so the fingerprint tracks exactly the
+    files the metadata is derived from.
+    """
+    model_dir = report_model_dir(root, ref)
+    entries: List[Tuple[str, int, int]] = []
+    for file_path in glob.glob(os.path.join(model_dir, '**', '*.json'), recursive=True):
+        if os.path.basename(file_path) == DataCollection.REPORT_NAME:
+            continue
+        try:
+            st = os.stat(file_path)
+        except OSError:
+            continue
+        entries.append((os.path.relpath(file_path, model_dir), st.st_mtime_ns, st.st_size))
+    entries.sort()
+    return tuple(entries)
+
+
+def build_report_meta_cached(root: str, ref: ReportRef, fingerprint: Fingerprint,
+                             compute: MetaBuilder) -> Optional[dict]:
+    """Return the cached metadata for ``ref`` or compute and store it.
+
+    ``fingerprint`` is supplied by the caller (which already needs it for the
+    list ETag) so the file stat is not repeated here. A hit reuses the stored
+    metadata; a miss calls ``compute`` and writes the result back.
+    """
+    key = _cache_key(root, ref)
+    with _LOCK:
+        cached = _CACHE.get(key)
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+
+    # Computed outside the lock to keep file I/O off it; a rare double-compute on
+    # concurrent misses is harmless because the result is idempotent.
+    meta = compute(ref, root)
+
+    with _LOCK:
+        _CACHE[key] = (fingerprint, meta)
+    return meta
+
+
+def prune_report_meta_cache(root: str, valid_ref_keys: Iterable[str]) -> None:
+    """Drop entries for ``root`` whose reference is no longer present on disk.
+
+    Other roots' entries are left untouched, so alternating between roots does
+    not evict either one's warm cache.
+    """
+    prefix = _cache_key_prefix(root)
+    keep = {f'{prefix}{ref_key}' for ref_key in valid_ref_keys}
+    with _LOCK:
+        for key in [k for k in _CACHE if k.startswith(prefix) and k not in keep]:
+            del _CACHE[key]
+
+
+def list_etag(fingerprints: Sequence[Tuple[str, Fingerprint]], query_parts: Sequence[str]) -> str:
+    """Digest identifying a list response: the scanned set plus the query.
+
+    ``fingerprints`` is the ``(ref.key, fingerprint)`` pairs gathered while
+    serving the list, so this adds no file reads. ``query_parts`` folds in the
+    filter/sort/page values that also shape the response.
+    """
+    parts: List[str] = sorted(f'{key}:{fp}' for key, fp in fingerprints)
+    parts.extend(f'q:{part}' for part in query_parts)
+    return hashlib.sha256('\n'.join(parts).encode('utf-8')).hexdigest()
+
+
+def clear_report_meta_cache() -> None:
+    """Drop all cached entries. Intended for tests."""
+    with _LOCK:
+        _CACHE.clear()

--- a/tests/report/test_report_endpoints.py
+++ b/tests/report/test_report_endpoints.py
@@ -11,6 +11,9 @@ from unittest import mock
 
 flask = pytest.importorskip('flask')  # noqa: F841  (service extra not installed → skip)
 
+from evalscope.report import ReportRef  # noqa: E402
+from evalscope.service.report_meta_cache import clear_report_meta_cache  # noqa: E402
+
 
 class TestReportEndpoints(unittest.TestCase):
 
@@ -19,6 +22,7 @@ class TestReportEndpoints(unittest.TestCase):
 
         self.tmp = tempfile.mkdtemp()
         self.client = create_app().test_client()
+        clear_report_meta_cache()
 
     def tearDown(self):
         import shutil
@@ -100,13 +104,20 @@ class TestReportEndpoints(unittest.TestCase):
 
         for sort_by, sort_order, expected in cases:
             case_items = [{**item, '_datasets': list(item['_datasets'])} for item in items]
+            refs = [
+                ReportRef(run_id='20260101_120000', model_id='m1'),
+                ReportRef(run_id='20260102_120000', model_id='m2'),
+            ]
             with self.subTest(sort_by=sort_by, sort_order=sort_order), \
-                    mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=range(2)), \
+                    mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=refs), \
                     mock.patch('evalscope.service.blueprints.reports._build_report_meta', side_effect=case_items):
+                clear_report_meta_cache()
                 res = self.client.get(
                     '/api/v1/reports',
                     query_string={
-                        'root_path': self.tmp, 'sort_by': sort_by, 'sort_order': sort_order
+                        'root_path': self.tmp,
+                        'sort_by': sort_by,
+                        'sort_order': sort_order
                     },
                 )
 
@@ -123,12 +134,103 @@ class TestReportEndpoints(unittest.TestCase):
 
     def test_report_list_response_omits_score_comparability_fields(self):
         item = self._report_meta('model')
-        with mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=range(1)), \
+        ref = ReportRef(run_id='20260101_120000', model_id='model')
+        with mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=[ref]), \
                 mock.patch('evalscope.service.blueprints.reports._build_report_meta', return_value=item):
             body = self.client.get('/api/v1/reports', query_string={'root_path': self.tmp}).get_json()
 
         self.assertNotIn('score_comparable', body['filters'])
         self.assertNotIn('quality_ratio', body['reports'][0])
+
+    def _seed_report_dir(self, run='20260101_120000', model='m', filename='gsm8k.json'):
+        model_dir = Path(self.tmp) / run / 'reports' / model
+        model_dir.mkdir(parents=True, exist_ok=True)
+        report_file = model_dir / filename
+        report_file.write_text('{}', encoding='utf-8')
+        return report_file
+
+    @staticmethod
+    def _fake_report():
+        return mock.Mock(
+            dataset_name='gsm8k',
+            dataset_pretty_name='GSM8K',
+            num=5,
+            model_name='m',
+            primary_metric=None,
+        )
+
+    def test_report_list_includes_report_without_config_yaml(self):
+        # Layer 0: the list reads only report JSONs, so a run with no
+        # configs/*.yaml (which load_report_bundle rejects) still appears.
+        self._seed_report_dir()
+        with mock.patch(
+            'evalscope.service.blueprints.reports.get_report_list',
+            return_value=[self._fake_report()],
+        ):
+            res = self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual([it['model_name'] for it in res.get_json()['reports']], ['m'])
+
+    def test_report_meta_cache_reuses_unchanged_reports(self):
+        # Layer A: a repeated request over unchanged files recomputes nothing;
+        # editing a file busts that reference's entry.
+        report_file = self._seed_report_dir()
+        with mock.patch(
+            'evalscope.service.blueprints.reports.get_report_list',
+            return_value=[self._fake_report()],
+        ) as get_list:
+            self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+            self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+            reused = get_list.call_count
+            report_file.write_text('{"changed": true}', encoding='utf-8')
+            self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+
+        self.assertEqual(reused, 1)
+        self.assertEqual(get_list.call_count, 2)
+
+    def test_report_meta_cache_drops_deleted_reports(self):
+        # Layer A: a reference that leaves the scan is pruned, so its return is a
+        # fresh computation rather than a stale cache hit.
+        self._seed_report_dir()
+        ref = ReportRef(run_id='20260101_120000', model_id='m')
+        with mock.patch(
+            'evalscope.service.blueprints.reports.get_report_list',
+            return_value=[self._fake_report()],
+        ) as get_list:
+            with mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=[ref]):
+                self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+            with mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=[]):
+                self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+            with mock.patch('evalscope.service.blueprints.reports.scan_report_refs', return_value=[ref]):
+                self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+
+        self.assertEqual(get_list.call_count, 2)
+
+    def test_report_list_supports_conditional_get(self):
+        # Layer B: unchanged data revalidates as 304; changed data returns 200.
+        report_file = self._seed_report_dir()
+        with mock.patch(
+            'evalscope.service.blueprints.reports.get_report_list',
+            return_value=[self._fake_report()],
+        ):
+            first = self.client.get('/api/v1/reports', query_string={'root_path': self.tmp})
+            etag = first.headers.get('ETag')
+            self.assertTrue(etag)
+            cached = self.client.get(
+                '/api/v1/reports',
+                query_string={'root_path': self.tmp},
+                headers={'If-None-Match': etag},
+            )
+            self.assertEqual(cached.status_code, 304)
+            report_file.write_text('{"x": 1}', encoding='utf-8')
+            changed = self.client.get(
+                '/api/v1/reports',
+                query_string={'root_path': self.tmp},
+                headers={'If-None-Match': etag},
+            )
+
+        self.assertEqual(changed.status_code, 200)
 
     @staticmethod
     def _report_meta(model_id, dataset='dataset', timestamp='2026-01-01T00:00:00'):

--- a/tests/report/test_report_meta_cache.py
+++ b/tests/report/test_report_meta_cache.py
@@ -1,0 +1,75 @@
+import os
+import threading
+from pathlib import Path
+from typing import Optional
+
+from evalscope.report import ReportRef
+from evalscope.service.report_meta_cache import (
+    build_report_meta_cached,
+    clear_report_meta_cache,
+    report_ref_fingerprint,
+)
+
+
+def setup_function() -> None:
+    clear_report_meta_cache()
+
+
+def test_fingerprint_tracks_run_directory_mtime(tmp_path: Path) -> None:
+    ref = ReportRef(run_id='custom-run', model_id='model')
+    model_dir = tmp_path / ref.run_id / 'reports' / ref.model_id
+    model_dir.mkdir(parents=True)
+    (model_dir / 'report.json').write_text('{}', encoding='utf-8')
+
+    before = report_ref_fingerprint(str(tmp_path), ref)
+    run_dir = tmp_path / ref.run_id
+    stat = run_dir.stat()
+    os.utime(run_dir, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+
+    assert report_ref_fingerprint(str(tmp_path), ref) != before
+
+
+def test_newer_concurrent_result_is_not_overwritten(tmp_path: Path) -> None:
+    ref = ReportRef(run_id='run', model_id='model')
+    old_fingerprint = (('report.json', 1, 1, 1), )
+    new_fingerprint = (('report.json', 2, 2, 2), )
+    started = threading.Event()
+    release = threading.Event()
+
+    def compute_old(_ref: ReportRef, _root: str) -> dict:
+        started.set()
+        release.wait(timeout=2)
+        return {'version': 'old'}
+
+    worker = threading.Thread(
+        target=build_report_meta_cached,
+        args=(str(tmp_path), ref, old_fingerprint, compute_old),
+    )
+    worker.start()
+    assert started.wait(timeout=2)
+
+    assert build_report_meta_cached(
+        str(tmp_path), ref, new_fingerprint, lambda _ref, _root: {'version': 'new'}
+    ) == {'version': 'new'}
+    release.set()
+    worker.join(timeout=2)
+
+    def fail_compute(_ref: ReportRef, _root: str) -> dict:
+        raise AssertionError('newer cached result was overwritten')
+
+    assert build_report_meta_cached(str(tmp_path), ref, new_fingerprint, fail_compute) == {'version': 'new'}
+
+
+def test_failed_metadata_is_retried(tmp_path: Path) -> None:
+    ref = ReportRef(run_id='run', model_id='model')
+    fingerprint = (('report.json', 1, 1, 1), )
+    attempts = 0
+
+    def compute(_ref: ReportRef, _root: str) -> Optional[dict]:
+        nonlocal attempts
+        attempts += 1
+        return None if attempts == 1 else {'ok': True}
+
+    assert build_report_meta_cached(str(tmp_path), ref, fingerprint, compute) is None
+    assert build_report_meta_cached(str(tmp_path), ref, fingerprint, compute) == {'ok': True}
+    assert attempts == 2

--- a/tests/report/test_service_charts.py
+++ b/tests/report/test_service_charts.py
@@ -55,8 +55,8 @@ def test_build_report_meta_exposes_primary_metric_identity(monkeypatch) -> None:
         primary_metric_identity=identity,
     )
     monkeypatch.setattr(
-        'evalscope.service.blueprints.reports.load_report_bundle',
-        lambda _root, _ref: ([report], ['throughput_suite'], {}),
+        'evalscope.service.blueprints.reports.get_report_list',
+        lambda _paths: [report],
     )
 
     metadata = _build_report_meta(ReportRef(run_id='run', model_id='test-model'), '/tmp')
@@ -100,8 +100,8 @@ def test_build_report_meta_picks_the_primary_identity_not_the_first_metric(monke
         primary_metric_identity=normalized_identity,
     )
     monkeypatch.setattr(
-        'evalscope.service.blueprints.reports.load_report_bundle',
-        lambda _root, _ref: ([report], ['document_suite'], {}),
+        'evalscope.service.blueprints.reports.get_report_list',
+        lambda _paths: [report],
     )
 
     metadata = _build_report_meta(ReportRef(run_id='run', model_id='test-model'), '/tmp')
@@ -121,8 +121,8 @@ def test_build_report_meta_does_not_rank_multiple_datasets(monkeypatch) -> None:
         _semantic_report('f1', 0.6, 'quality.f1.ratio'),
     ]
     monkeypatch.setattr(
-        'evalscope.service.blueprints.reports.load_report_bundle',
-        lambda _root, _ref: (reports, ['accuracy', 'f1'], {}),
+        'evalscope.service.blueprints.reports.get_report_list',
+        lambda _paths: reports,
     )
 
     metadata = _build_report_meta(ReportRef(run_id='run', model_id='test-model'), '/tmp')


### PR DESCRIPTION
## Motivation

The `GET /api/v1/reports` endpoint read and parsed **every** report's JSON (plus each run's YAML config) on **every** request, then sliced the result to a single page. That is `O(all reports)` of disk + parse work behind a paginated contract, repeated on every call with no caching — the frontend consuming one page never saved the backend that cost.

The paginated API contract is correct; only the work behind it was wasteful. This PR fixes the work, leaving the contract (and the frontend) unchanged.

## Changes

**Layer 0 — read only what the list needs**
- `_build_report_meta` now builds list metadata from the report JSONs alone, dropping the unused `load_report_bundle` (which also parsed the run's YAML).
- Fixes a real bug: a report directory with no `configs/*.yaml` was silently dropped from the list, because `load_report_bundle` raised `FileNotFoundError` and the error was swallowed.

**Layer A — memoize per-reference metadata (`report_meta_cache.py`)**
- Cache keyed by a stat-only file fingerprint `(relpath, mtime_ns, size)`. Reports are immutable audit records (a rerun rewrites files → mtime changes; a delete removes the dir), so an unchanged fingerprint guarantees unchanged metadata — invalidation is free.
- Keyed by `(outputs root, reference)` so switching `root_path` never evicts or shadows another root's warm cache; entries for a vanished reference are pruned.
- Each request now stats all references but reads/parses only the new or changed ones.

**Layer B — conditional GET**
- The list response carries an `ETag` (over the scanned fingerprints + query params) and `Cache-Control: no-cache`. Browsers revalidate and reuse an unchanged page as a `304`. No frontend change: the client only ever sees `200` + body (the browser serves the cached body transparently).

**Housekeeping**
- Split `list_reports` into focused helpers (`_load_report_metas`, `_apply_report_filters`, `_list_response`).
- Exception handlers now capture stack traces (`exc_info=True`) and return a generic message instead of echoing raw exception text to clients.
- Added return-type annotations to the view functions.

## Notes / scope

- Response JSON shape is **unchanged**; this is purely a backend improvement. No frontend files touched.
- A full persistent index (sidecar/SQLite) was intentionally **not** added — the remaining per-request cost is a cheap stat-scan, and an index would be premature for the current scale.
- This lands the backend groundwork for a future view-layer "group by model" feature (#1599), which will build on this cheap metadata path.

## Testing

- `tests/report/` — all green except one pre-existing failure on `main` (`olmocr_bench_adapter` `unit_test_pass_rate` vocabulary), unrelated to this change.
- Added endpoint tests: config-less report is listed (Layer 0), cache hit / fingerprint invalidation / prune (Layer A), and conditional `304` (Layer B).
- Verified end-to-end against a real outputs directory, both via the Flask test client and a live `app.run` server: `200` + `ETag` + `Cache-Control` on first request, `304` (empty body) on `If-None-Match`, multi-root alternation stays warm, filters/sort intact, bad params rejected with `400`.