### PR TITLE
fix(terminal_bench): reject invalid trial rewards

### DIFF
--- a/evalscope/benchmarks/terminal_bench/terminal_bench_adapter.py
+++ b/evalscope/benchmarks/terminal_bench/terminal_bench_adapter.py
@@ -1,10 +1,12 @@
 import json
+import math
 import os
 import shutil
 import uuid
 from datetime import datetime
+from numbers import Real
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from evalscope.api.agent import AgentTrace, AgentTraceEvent, EventType
 from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
@@ -332,12 +334,63 @@ class _TerminalBenchBase(AgentAdapter):
             )
         return trace, messages
 
-    def match_score(self, original_prediction, filtered_prediction, reference, task_state):
+    @staticmethod
+    def _extract_valid_reward(result: Any) -> float:
+        if not isinstance(result, dict):
+            raise RuntimeError('Terminal-Bench trial <unknown> returned an invalid result: expected an object.')
+
+        trial_uri = result.get('trial_uri') or '<unknown>'
+        exception_info = result.get('exception_info')
+        if exception_info:
+            if isinstance(exception_info, dict):
+                exc_type = exception_info.get('exception_type') or exception_info.get('type') or 'UnknownHarborError'
+                exc_msg = exception_info.get('message') or exception_info.get('exception_message')
+                exc_msg = exc_msg or 'no message provided'
+            else:
+                exc_type = type(exception_info).__name__
+                exc_msg = str(exception_info)
+            raise RuntimeError(f'Terminal-Bench trial {trial_uri} failed with {exc_type}: {exc_msg}')
+
+        verifier_result = result.get('verifier_result')
+        if verifier_result is None:
+            raise RuntimeError(
+                f'Terminal-Bench trial {trial_uri} returned an invalid result: verifier_result is missing or null.'
+            )
+        if not isinstance(verifier_result, dict):
+            raise RuntimeError(
+                f'Terminal-Bench trial {trial_uri} returned an invalid result: verifier_result must be an object.'
+            )
+
+        rewards = verifier_result.get('rewards')
+        if rewards is None:
+            raise RuntimeError(
+                f'Terminal-Bench trial {trial_uri} returned an invalid result: rewards is missing or null.'
+            )
+        if not isinstance(rewards, dict):
+            raise RuntimeError(
+                f'Terminal-Bench trial {trial_uri} returned an invalid result: rewards must be an object.'
+            )
+        if 'reward' not in rewards:
+            raise RuntimeError(f'Terminal-Bench trial {trial_uri} returned an invalid result: reward is missing.')
+
+        reward = rewards['reward']
+        if isinstance(reward, bool) or not isinstance(reward, Real):
+            raise RuntimeError(f'Terminal-Bench trial {trial_uri} returned an invalid reward: {reward!r}.')
+
+        reward = float(reward)
+        if not math.isfinite(reward) or not 0.0 <= reward <= 1.0:
+            raise RuntimeError(f'Terminal-Bench trial {trial_uri} returned an invalid reward: {reward!r}.')
+        return reward
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: Any,
+    ) -> Score:
         result = task_state.metadata.get('result', {})
-        try:
-            reward = result.get('verifier_result', {}).get('rewards', {}).get('reward', 0)
-        except Exception:
-            reward = 0
+        reward = self._extract_valid_reward(result)
         score = Score(
             extracted_prediction=filtered_prediction,
             prediction=original_prediction,

--- a/tests/benchmark/test_terminal_bench.py
+++ b/tests/benchmark/test_terminal_bench.py
@@ -1,0 +1,106 @@
+import math
+import pytest
+from types import SimpleNamespace
+from typing import Any
+
+from evalscope.api.metric import Score
+from evalscope.benchmarks.terminal_bench.terminal_bench_adapter import _TerminalBenchBase
+
+TRIAL_URI = 'file:///tmp/terminal-bench-trial'
+
+
+def _score(result: dict[str, Any]) -> Score:
+    adapter = object.__new__(_TerminalBenchBase)
+    task_state = SimpleNamespace(metadata={'result': result})
+    return adapter.match_score('raw', 'filtered', 'target', task_state)
+
+
+@pytest.mark.parametrize('reward', [0, 1])
+def test_terminal_bench_scores_valid_binary_reward(reward: int) -> None:
+    result = {
+        'trial_uri': TRIAL_URI,
+        'verifier_result': {
+            'rewards': {
+                'reward': reward
+            }
+        },
+    }
+
+    score = _score(result)
+
+    assert score.value == {'acc': float(reward)}
+    assert score.metadata == result
+
+
+@pytest.mark.parametrize(
+    ('verifier_result', 'expected_context'),
+    [
+        (None, 'verifier_result'),
+        ({}, 'rewards'),
+        ({'rewards': None}, 'rewards'),
+        ({'rewards': {}}, 'reward'),
+    ],
+)
+def test_terminal_bench_rejects_missing_reward(verifier_result: Any, expected_context: str) -> None:
+    result = {
+        'trial_uri': TRIAL_URI,
+        'verifier_result': verifier_result,
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _score(result)
+
+    assert TRIAL_URI in str(exc_info.value)
+    assert expected_context in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'reward',
+    [
+        pytest.param(None, id='null'),
+        pytest.param('1', id='string'),
+        pytest.param(True, id='bool'),
+        pytest.param(math.nan, id='nan'),
+        pytest.param(math.inf, id='infinity'),
+        pytest.param(-0.1, id='below-range'),
+        pytest.param(1.1, id='above-range'),
+    ],
+)
+def test_terminal_bench_rejects_invalid_reward(reward: Any) -> None:
+    result = {
+        'trial_uri': TRIAL_URI,
+        'verifier_result': {
+            'rewards': {
+                'reward': reward
+            }
+        },
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _score(result)
+
+    assert TRIAL_URI in str(exc_info.value)
+    assert 'invalid reward' in str(exc_info.value)
+
+
+def test_terminal_bench_rejects_trial_exception_even_with_reward() -> None:
+    result = {
+        'trial_uri': TRIAL_URI,
+        'exception_info': {
+            'exception_type': 'RewardFileNotFoundError',
+            'message': 'reward.json is missing',
+        },
+        'verifier_result': {
+            'rewards': {
+                'reward': 0
+            }
+        },
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _score(result)
+
+    error = str(exc_info.value)
+    assert TRIAL_URI in error
+    assert 'RewardFileNotFoundError' in error
+    assert 'reward.json is missing' in error


### PR DESCRIPTION
## Summary

- reject Terminal-Bench trial results that contain `exception_info`
- require `verifier_result.rewards.reward` to be a finite numeric value in `[0, 1]`
- include the trial URI and concise failure context in raised errors
- add regression coverage for missing, malformed, non-finite, and out-of-range rewards

Previously, malformed Harbor results could be silently converted to `acc=0`,
which made infrastructure and verifier failures indistinguishable from genuine
benchmark failures and polluted the aggregation denominator.

With this change, scoring raises a sample-level error instead. EvalScope can
then exclude the sample when `ignore_errors=True`.

Addresses the score-validity portion of #1608.

## Tests

- `pytest tests/benchmark/test_terminal_bench.py -q`
  - 14 passed
- `pytest tests/benchmark/test_terminal_bench.py tests/benchmark/test_deep_swe.py -q`
  - 28 passed, 1 skipped
- targeted pre-commit checks for both changed files
