### PR TITLE
refactor(benchmark): use shared media loader for BLINK images

### DIFF
--- a/evalscope/benchmarks/blink/blink_adapter.py
+++ b/evalscope/benchmarks/blink/blink_adapter.py
@@ -1,16 +1,11 @@
-import re
 from typing import Any, Dict, List
 
 from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter, VisionLanguageAdapter
 from evalscope.api.dataset import Sample
-from evalscope.api.messages import ChatMessageUser, Content, ContentImage, ContentText
+from evalscope.api.messages import ChatMessageUser, Content, ContentText
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.io_utils import bytes_to_base64
-from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import format_letter_choices
-
-logger = get_logger()
 
 MULT_CHOICE_PROMPT = r"""
 Answer the following multiple choice question. The last line of your response should be of the following format:
@@ -76,11 +71,8 @@ class BLINKAdapter(VisionLanguageAdapter, MultiChoiceAdapter):
         input_text = MULT_CHOICE_PROMPT.format(question=record['prompt'], letters=format_letter_choices(choices))
         content_list: List[Content] = [ContentText(text=input_text)]
 
-        for i in range(1, self.MAX_IMAGES + 1):
-            image = record.get(f'image_{i}')
-            if image:
-                image_base64 = bytes_to_base64(image['bytes'], format='jpeg', add_header=True)
-                content_list.append(ContentImage(image=image_base64))
+        for image in self._extract_media(record, 'image').values():
+            content_list.append(self._content_image_from_value(image))
 
         label_answer = record['answer'].strip('(').strip(')')
         return Sample(input=[ChatMessageUser(content=content_list)], choices=choices, target=label_answer)

--- a/tests/benchmark/test_blink_adapter.py
+++ b/tests/benchmark/test_blink_adapter.py
@@ -1,0 +1,40 @@
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.messages import ContentImage, ContentText
+from evalscope.benchmarks.blink.blink_adapter import BLINKAdapter
+from evalscope.config import TaskConfig
+
+
+def _adapter() -> BLINKAdapter:
+    return BLINKAdapter(
+        benchmark_meta=BenchmarkMeta(name='blink', dataset_id='evalscope/BLINK', eval_split='val'),
+        task_config=TaskConfig(datasets=['blink']),
+    )
+
+
+def test_blink_accepts_undecoded_image_bytes() -> None:
+    sample = _adapter().record_to_sample({
+        'prompt': 'Which image is brighter?',
+        'choices': ['the first image', 'the second image'],
+        'answer': '(B)',
+        'image_1': {'bytes': b'not-an-image'},
+    })
+
+    content = sample.input[0].content
+    assert isinstance(content[0], ContentText)
+    assert isinstance(content[1], ContentImage)
+    assert content[1].image.startswith('data:image/jpeg;base64,')
+    assert sample.target == 'B'
+
+
+def test_blink_accepts_plural_media_paths() -> None:
+    sample = _adapter().record_to_sample({
+        'prompt': 'Compare the images.',
+        'choices': ['same', 'different'],
+        'answer': 'A',
+        'images': [{'path': 'first.jpg'}, {'url': 'https://example.com/second.jpg'}],
+    })
+
+    content = sample.input[0].content
+    image_content = [item for item in content if isinstance(item, ContentImage)]
+    assert [item.image for item in image_content] == ['first.jpg', 'https://example.com/second.jpg']
+    assert sample.target == 'A'


### PR DESCRIPTION
### What

- Reuse `VisionLanguageAdapter` media normalization in the BLINK adapter.
- Accept undecoded image bytes, local paths, URLs, and plural `images` records.
- Add adapter tests covering byte and list-based image inputs.

### Why

BLINK previously assumed every image field was a Hugging Face byte dictionary and encoded it directly. That bypassed the shared media handling used by other vision-language benchmarks and made path, URL, and list-based records inconsistent.

### Validation

- `python -m compileall -q evalscope/benchmarks/blink/blink_adapter.py tests/benchmark/test_blink_adapter.py`
- `git diff --check`
- `pytest` was not available in the current environment; the test file is included but has not been executed here.