### PR TITLE
refactor(benchmark): mmmu with `_extract_media()`

### DIFF
--- a/evalscope/benchmarks/mmmu/mmmu_adapter.py
+++ b/evalscope/benchmarks/mmmu/mmmu_adapter.py
@@ -189,12 +189,13 @@ class MMMUAdapter(VisionLanguageAdapter):
         question_type = record['question_type']
 
         # Prepare image map
-        image_map: Dict[int, str] = {}
-        for i in range(MMMUAdapter.MAX_IMAGES):
-            image = record.get(f'image_{i+1}')
-            if image:
-                image_base64 = bytes_to_base64(image['bytes'], format='png', add_header=True)
-                image_map[i + 1] = image_base64
+        # image_map: Dict[int, str] = {}
+        # for i in range(MMMUAdapter.MAX_IMAGES):
+        #     image = record.get(f'image_{i+1}')
+        #     if image:
+        #         image_base64 = bytes_to_base64(image['bytes'], format='png', add_header=True)
+        #         image_map[i + 1] = image_base64
+        image_map = self._extract_media(record, media_type='image')
 
         if question_type == MULTI_CHOICE_TYPE:
             answers_list: List[str] = ast.literal_eval(record['options'])
@@ -203,11 +204,11 @@ class MMMUAdapter(VisionLanguageAdapter):
             full_text = prompt(question=record['question'], choices=answers_list, template=MULT_CHOICE_PROMPT)
 
             # Parse and replace image placeholders
-            content_list = self._parse_text_with_images(full_text, image_map)
+            content_list = self._parse_text_with_media(full_text, image_map=image_map)
 
         else:  # OPEN_TYPE
             answers_list: List[str] = []
             full_text = OPEN_PROMPT.format(question=record['question'])
-            content_list = self._parse_text_with_images(full_text, image_map)
+            content_list = self._parse_text_with_media(full_text, image_map=image_map)
 
         return content_list, answers_list

--- a/tests/benchmark/refactoring/test_mmmu.py
+++ b/tests/benchmark/refactoring/test_mmmu.py
@@ -1,0 +1,99 @@
+import ast
+import pytest
+from datasets import Dataset, Image
+from typing import Any, Dict, List
+
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.dataset.hub import DatasetHub, HubType
+from evalscope.api.messages.content import ContentImage, ContentText
+from evalscope.benchmarks.mmmu.mmmu_adapter import (
+    MULT_CHOICE_PROMPT,
+    MULTI_CHOICE_TYPE,
+    OPEN_PROMPT,
+    SUBSET_LIST,
+    MMMUAdapter,
+)
+from evalscope.config import TaskConfig
+from evalscope.utils.io_utils import bytes_to_base64
+from evalscope.utils.multi_choices import prompt
+
+MMMU_MS = 'AI-ModelScope/MMMU'
+MMMU_HF = 'MMMU/MMMU'
+
+
+def _old_create_content_and_answers(
+    record: Dict[str, Any],
+    adapter: MMMUAdapter,
+) -> tuple:
+    """Replicate the old ``create_content_and_answers_list`` exactly."""
+    question_type = record['question_type']
+    image_map: Dict[int, str] = {}
+    for i in range(MMMUAdapter.MAX_IMAGES):
+        image = record.get(f'image_{i + 1}')
+        if image:
+            image_base64 = bytes_to_base64(image['bytes'], format='png', add_header=True)
+            image_map[i + 1] = image_base64
+
+    if question_type == MULTI_CHOICE_TYPE:
+        answers_list: List[str] = ast.literal_eval(record['options'])
+        full_text = prompt(question=record['question'], choices=answers_list, template=MULT_CHOICE_PROMPT)
+        content_list = adapter._parse_text_with_images(full_text, image_map)
+    else:
+        answers_list: List[str] = []
+        full_text = OPEN_PROMPT.format(question=record['question'])
+        content_list = adapter._parse_text_with_images(full_text, image_map)
+
+    return content_list, answers_list
+
+
+def _load_mmmu_records(subject: str, limit: int) -> List[Dict[str, Any]]:
+    dataset: Dataset = DatasetHub(
+        data_id_or_path=MMMU_MS,
+        data_source=HubType.MODELSCOPE,
+    ).load(split='validation', subset=subject)
+    for colname, coltype in dataset.features.items():
+        if isinstance(coltype, Image):
+            dataset = dataset.cast_column(colname, Image(decode=False))
+    return [dict(row) for row in dataset.select(range(min(limit, len(dataset))))]
+
+
+@pytest.fixture()
+def mmmu_adapter() -> MMMUAdapter:
+    return MMMUAdapter(
+        benchmark_meta=BenchmarkMeta(
+            name='mmmu',
+            pretty_name='MMMU',
+            dataset_id=MMMU_MS,
+        ),
+        task_config=TaskConfig(datasets=['mmmu']),
+    )
+
+
+# we hope to demonstrate that the new function behaves exactly like the old one
+@pytest.mark.parametrize('subject', SUBSET_LIST)
+def test_content_and_answers_match(
+    subject: str,
+    mmmu_adapter: MMMUAdapter,
+    limit: int = 10,
+) -> None:
+    """Verify MMMU adapter maintains the exactly same data input to VLM
+    before/after ``_extract_media()`` refactoring.
+    """
+    try:
+        records = _load_mmmu_records(subject, limit=limit)
+    except Exception as e:
+        pytest.skip(f'Cannot load MMMU/{subject}: {e}')
+
+    for record in records:
+        old_content, old_answers = _old_create_content_and_answers(record, mmmu_adapter)
+        new_content, new_answers = mmmu_adapter.create_content_and_answers_list(record)
+
+        assert len(old_content) == len(new_content)
+        assert old_answers == new_answers
+
+        for old_c, new_c in zip(old_content, new_content):
+            assert isinstance(new_c, type(old_c))
+            if isinstance(old_c, ContentText):
+                assert old_c.text == new_c.text
+            elif isinstance(old_c, ContentImage):
+                assert old_c.image == new_c.image


### PR DESCRIPTION
## Summary

- [x] (break) Modify MMMU loading with `_extract_media()`. 
  Compression does not kick in because MMMU configs defaults `dataset_args.mmmu.max_image_bytes: null`, which skips compression. This can be verified by running `evalscope eval --datasets mmmu` and `outputs/timestamp/configs/task_config.yaml`
- [x] internal change, no doc needed.

## Tests

We compare the parsed inputs (the `list[ContentText | ContentImage]`s) before/after this refactoring on first 10 samples from 30 MMMU subjects.

```
pytest tests/benchmark/refactoring/test_mmmu.py
```

For #1605, score comparison is not needed for MMMU, as the inputs to VLM are **exactly identical**.


### Prediction Sample with a Mocked VLM:

```json
{
  "index": 0,
  "model": "text_generation",
  "model_output": {
    "id": null,
    "model": "mockllm",
    "choices": [
      {
        "message": {
          "id": "3b29d15d",
          "content": "Default output from mockllm/model",
          "source": "generate",
          "metadata": null,
          "internal": null,
          "perf_metrics": null,
          "role": "assistant",
          "tool_calls": null,
          "model": "mockllm"
        },
        "stop_reason": "stop",
        "logprobs": null
      }
    ],
    "usage": null,
    "time": null,
    "metadata": null,
    "error": null,
    "perf_metrics": null
  },
  "messages": [
    {
      "id": "29e1323e",
      "content": [
        {
          "internal": null,
          "type": "text",
          "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\n",
          "refusal": null
        },
        {
          "internal": null,
          "type": "image",
          "image": "data:image/png;base64,iVBORw0KGgoAAAA...(trimmed)",
          "detail": "auto"
        },
        {
          "internal": null,
          "type": "text",
          "text": " Baxter Company has a relevant range of production between 15,000 and 30,000 units. The following cost data represents average variable costs per unit for 25,000 units of production. If 30,000 units are produced, what are the per unit manufacturing overhead costs incurred?\n\nA) $6\nB) $7\nC) $8\nD) $9",
          "refusal": null
        }
      ],
      "source": null,
      "metadata": null,
      "internal": null,
      "perf_metrics": null,
      "role": "user",
      "tool_call_id": null
    },
    {
      "id": "3b29d15d",
      "content": "Default output from mockllm/model",
      "source": "generate",
      "metadata": null,
      "internal": null,
      "perf_metrics": null,
      "role": "assistant",
      "tool_calls": null,
      "model": "mockllm"
    }
  ],
  "agent_trace": null,
  "metadata": {
    "id": "validation_Accounting_1",
    "question_type": "multiple-choice",
    "subfield": "Managerial Accounting",
    "explanation": "",
    "img_type": "['Tables']",
    "topic_difficulty": "Medium"
  }
}
```