### PR TITLE
feat(eval): add native evaluation versioning and deterministic choices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,13 @@ Don't try to learn the architecture from this file — read these and grep:
 6. Auto-discovered by globbing `evalscope/benchmarks/*/**/*_adapter.py`.
 7. Add a smoke test.
 
+### Evaluation versioning
+
+`BenchmarkMeta.evaluation_version` is the published version of a benchmark's evaluation semantics. New benchmarks
+must declare their initial version explicitly. Raise the minor version when data, sample conversion, default prompt,
+choice/target mapping, default scoring/judge, or aggregation semantics change; raise the major version for a rename
+or task-definition replacement. Documentation, tests, and pure refactors do not change it.
+
 ## Adding a judge-scored benchmark
 
 An adapter must **never** call `self.llm_judge.judge()` or parse a judge reply itself — that debt is fenced off by `tests/api/judge/test_gates.py`, which scans every file under `evalscope/benchmarks/` (helpers included, so moving a parser into `utils.py` does not evade it). Score through the JSON output contract in `evalscope/api/judge/` instead:

--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -209,8 +209,10 @@ An invalid reply is unavailable and excluded from the metric rather than reporte
 Reports include `JudgeSummary` with coverage, failure counts, and disagreement for samples reviewed by an LLM.
 When an adapter resolves a sample through a deterministic judge short-circuit, its score metadata records
 `judge_skipped=true` and `judge_skip_reason`; the web review panel labels it as rule-based scoring instead of an
-LLM verdict. With `rerun_review=True`, predictions are reused and the review cache is atomically replaced after
-success.
+LLM verdict. Native evaluations require an exact cached evaluation identity match before reusing predictions and
+reviews. With `rerun_review=True`, predictions are reused and the review cache is atomically replaced after
+success; it is the explicit override for an identity mismatch, and the generated config records the prediction
+source under the current evaluation version.
 
 `judge_strategy` and a single mapping `judge_model_args` remain accepted only as a deprecated input migration. The
 removed `judge_worker_num` and `score_pattern` are rejected.

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -203,8 +203,9 @@ TaskConfig(
 
 对于经过 LLM 判定的样本，报告包含 `JudgeSummary`：覆盖率、失败计数与分歧。当 adapter 通过确定性的
 Judge 短路直接判定样本时，得分 metadata 会记录 `judge_skipped=true` 和 `judge_skip_reason`；Web review
-面板会将其标为规则直接判分，而非 LLM verdict。设置 `rerun_review=True` 可复用 prediction 并重算 review，
-新的 review 文件只有成功后才原子替换旧文件。
+面板会将其标为规则直接判分，而非 LLM verdict。native 评测复用 prediction 和 review 前要求缓存的评测身份完全匹配。
+设置 `rerun_review=True` 可复用 prediction 并重算 review，新的 review 文件只有成功后才原子替换旧文件；它也是身份
+不匹配时唯一的显式覆盖开关，生成的配置会在当前评测版本下记录 prediction 来源。
 
 旧 `judge_strategy` 和单个 mapping `judge_model_args` 仅保留一轮输入迁移并会告警。已删除的
 `judge_worker_num` 和 `score_pattern` 会明确报错。

--- a/evalscope/api/benchmark/adapters/default_data_adapter.py
+++ b/evalscope/api/benchmark/adapters/default_data_adapter.py
@@ -256,7 +256,9 @@ class DefaultDataAdapter(DataAdapter):
             repeats=1 if self.reformat_subset else self.repeats,  # Number of repetitions for each sample
             shuffle=self.shuffle,  # Shuffle dataset if enabled
             shuffle_choices=self.shuffle_choices,  # Shuffle choices if requested
+            seed=self.seed,
             data_source=self.dataset_hub,  # Data source configuration
+            version=self.dataset_revision,  # Remote dataset revision when pinned
             force_redownload=self.force_redownload,  # Force redownload if enabled
             dataset_dir=self.dataset_dir,  # Dataset directory
         )
@@ -289,7 +291,9 @@ class DefaultDataAdapter(DataAdapter):
             if not self.reformat_subset else None,  # Limit to specified number of few-shot examples
             shuffle=self.few_shot_random,  # Randomize selection if enabled
             shuffle_choices=self.shuffle_choices,  # Shuffle choices if requested
+            seed=self.seed,
             data_source=self.dataset_hub,  # Data source configuration
+            version=self.dataset_revision,  # Remote dataset revision when pinned
             force_redownload=self.force_redownload,  # Force redownload if enabled
             dataset_dir=self.dataset_dir,  # Dataset directory
         )

--- a/evalscope/api/benchmark/benchmark.py
+++ b/evalscope/api/benchmark/benchmark.py
@@ -39,9 +39,6 @@ class DataAdapter(LLMJudgeMixin, ABC):
         self.split_as_subset = False
         """Whether to use the split name as the dataset subsets"""
 
-        self.shuffle_choices = False
-        """Whether to shuffle the choices in the dataset"""
-
         self.use_batch_scoring = False
         """Whether to use batch scoring for metrics that support it, need to be enabled in the benchmark as well"""
 
@@ -70,6 +67,11 @@ class DataAdapter(LLMJudgeMixin, ABC):
     def to_dict(self) -> Dict[str, Any]:
         """Convert the benchmark metadata to a dictionary."""
         return self._benchmark_meta.to_string_dict()
+
+    @property
+    def benchmark_meta(self) -> 'BenchmarkMeta':
+        """Return the resolved benchmark metadata used by this adapter."""
+        return self._benchmark_meta
 
     @abstractmethod
     def load_dataset(self) -> DatasetDict:
@@ -153,6 +155,11 @@ class DataAdapter(LLMJudgeMixin, ABC):
         Set the dataset hub type for the benchmark.
         """
         self._task_config.dataset_hub = value
+
+    @property
+    def dataset_revision(self) -> Optional[str]:
+        """Return the resolved revision of the remote dataset source."""
+        return self._benchmark_meta.dataset_revision
 
     @property
     def eval_type(self) -> str:

--- a/evalscope/api/benchmark/meta.py
+++ b/evalscope/api/benchmark/meta.py
@@ -137,8 +137,16 @@ class BenchmarkMeta:
     ``'1.5gb'`` (parsed by ``parse_size``).
     Useful for avoiding 413 errors when sending multi-image payloads to APIs."""
 
+    evaluation_version: str = 'v1.0'
+    """Published evaluation semantics version used for cache compatibility."""
+
+    dataset_revision: Optional[str] = None
+    """Optional immutable revision of the remote dataset source."""
+
     def __post_init__(self):
         """Validate fields after initialization."""
+        from evalscope.evaluation_versioning import validate_evaluation_version
+        validate_evaluation_version(self.evaluation_version)
         if self.few_shot_num < 0:
             raise ValueError('few_shot_num must be >= 0')
         self._normalize_metric_list()
@@ -262,13 +270,16 @@ class BenchmarkMeta:
 
     def to_dict(self) -> dict:
         """Convert to dictionary, maintaining backward compatibility."""
-        return self._serialize_models(asdict(self))
+        result = self._serialize_models(asdict(self))
+        result.pop('evaluation_version', None)
+        return result
 
     def to_string_dict(self) -> dict:
         """Convert to string dictionary, excluding data_adapter."""
         cur_dict = copy.deepcopy(self._serialize_models(asdict(self)))
         if 'data_adapter' in cur_dict:
             del cur_dict['data_adapter']
+        cur_dict.pop('evaluation_version', None)
 
         cur_dict['extra_params'] = self.get_extra_params()
         return cur_dict
@@ -287,6 +298,11 @@ class BenchmarkMeta:
     def _update(self, args: dict):
         """Update instance with provided arguments, maintaining backward compatibility."""
         args = copy.deepcopy(args)
+
+        if 'evaluation_version' in args:
+            raise ValueError(
+                'evaluation_version must be declared by BenchmarkMeta, not overridden through dataset_args.'
+            )
 
         if args.get('local_path'):
             self.dataset_id = args['local_path']

--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -8,6 +8,13 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Unio
 
 from evalscope.api.messages import ChatMessage, messages_to_markdown
 from evalscope.api.tool import ToolInfo
+from evalscope.utils.io_utils import content_seed
+
+
+def _sample_choice_key(sample: 'Sample') -> str:
+    """Return a position-independent key for a sample's choice permutation."""
+    input_text = sample.input if isinstance(sample.input, str) else messages_to_markdown(sample.input)
+    return '\x00'.join([input_text, *sorted(sample.choices or [])])
 
 
 class Sample(BaseModel):
@@ -229,10 +236,10 @@ class MemoryDataset(Dataset):
     def shuffle_choices(self, seed: Optional[int] = None) -> None:
         from evalscope.utils.multi_choices import answer_character
 
-        rand = random.Random(seed)
         for sample in self.samples:
             if not sample.choices:
                 continue
+            rand = random.Random(content_seed(str(seed), _sample_choice_key(sample)))
             # The original positions
             positions = list(range(len(sample.choices)))
 

--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -230,15 +230,19 @@ class MemoryDataset(Dataset):
     def shuffle_choices(self, seed: Optional[int] = None) -> None:
         from evalscope.utils.multi_choices import answer_character
 
+        unseeded_random = random.Random() if seed is None else None
         for sample in self.samples:
             if not sample.choices:
                 continue
-            input_text = sample.input if isinstance(sample.input, str) else messages_to_markdown(sample.input)
-            # Derive each permutation from sample content rather than its reindexed
-            # position, so filtering one sample cannot remap any other sample's answer.
-            seed_material = '\x00'.join([str(seed), input_text, *sorted(sample.choices)])
-            choice_seed = int.from_bytes(hashlib.sha256(seed_material.encode('utf-8')).digest()[:8], 'big')
-            rand = random.Random(choice_seed)
+            if seed is None:
+                rand = unseeded_random
+            else:
+                input_text = sample.input if isinstance(sample.input, str) else messages_to_markdown(sample.input)
+                # Derive each permutation from sample content rather than its reindexed
+                # position, so filtering one sample cannot remap any other sample's answer.
+                seed_material = '\x00'.join([str(seed), input_text, *sorted(sample.choices)])
+                choice_seed = int.from_bytes(hashlib.sha256(seed_material.encode('utf-8')).digest()[:8], 'big')
+                rand = random.Random(choice_seed)
             # The original positions
             positions = list(range(len(sample.choices)))
 

--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import hashlib
 import random
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -8,13 +9,6 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Unio
 
 from evalscope.api.messages import ChatMessage, messages_to_markdown
 from evalscope.api.tool import ToolInfo
-from evalscope.utils.io_utils import content_seed
-
-
-def _sample_choice_key(sample: 'Sample') -> str:
-    """Return a position-independent key for a sample's choice permutation."""
-    input_text = sample.input if isinstance(sample.input, str) else messages_to_markdown(sample.input)
-    return '\x00'.join([input_text, *sorted(sample.choices or [])])
 
 
 class Sample(BaseModel):
@@ -239,7 +233,12 @@ class MemoryDataset(Dataset):
         for sample in self.samples:
             if not sample.choices:
                 continue
-            rand = random.Random(content_seed(str(seed), _sample_choice_key(sample)))
+            input_text = sample.input if isinstance(sample.input, str) else messages_to_markdown(sample.input)
+            # Derive each permutation from sample content rather than its reindexed
+            # position, so filtering one sample cannot remap any other sample's answer.
+            seed_material = '\x00'.join([str(seed), input_text, *sorted(sample.choices)])
+            choice_seed = int.from_bytes(hashlib.sha256(seed_material.encode('utf-8')).digest()[:8], 'big')
+            rand = random.Random(choice_seed)
             # The original positions
             positions = list(range(len(sample.choices)))
 

--- a/evalscope/api/dataset/loader.py
+++ b/evalscope/api/dataset/loader.py
@@ -169,7 +169,7 @@ class RemoteDataLoader(DataLoader):
         if self.auto_id:
             memory_dataset.reindex(group_size=self.repeats)
 
-        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices)
+        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices, self.seed)
 
         return memory_dataset
 
@@ -269,7 +269,7 @@ class LocalDataLoader(DataLoader):
         if self.auto_id:
             memory_dataset.reindex(group_size=self.repeats)
 
-        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices)
+        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices, self.seed)
 
         return memory_dataset
 
@@ -312,6 +312,6 @@ class DictDataLoader(DataLoader):
         if self.auto_id:
             memory_dataset.reindex(group_size=self.repeats)
 
-        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices)
+        shuffle_choices_if_requested(memory_dataset, self.shuffle_choices, self.seed)
 
         return memory_dataset

--- a/evalscope/api/dataset/utils.py
+++ b/evalscope/api/dataset/utils.py
@@ -123,7 +123,11 @@ def read_files(files: Optional[Any]) -> Optional[Dict[str, str]]:
         return None
 
 
-def shuffle_choices_if_requested(dataset: Dataset, shuffle_choices: Optional[Union[bool, int]]) -> None:
+def shuffle_choices_if_requested(
+    dataset: Dataset,
+    shuffle_choices: Optional[Union[bool, int]],
+    seed: Optional[int] = None,
+) -> None:
     """
     Shuffle the choices in the dataset if requested.
 
@@ -132,11 +136,16 @@ def shuffle_choices_if_requested(dataset: Dataset, shuffle_choices: Optional[Uni
     If it is a boolean, it will shuffle the choices if the value is `True`,
     and do nothing if it is `False`.
     If it is an integer, it will shuffle the choices using the integer as the seed.
+
+    Args:
+        dataset: Dataset whose choices may be shuffled.
+        shuffle_choices: Whether to shuffle, or an explicit choice-shuffle seed.
+        seed: Run seed used when ``shuffle_choices`` is ``True``.
     """
     # Note that `isinstance(x, int)` returns True if x is True or False,
     # so we need to check for both explicitly
     if shuffle_choices is True:
-        dataset.shuffle_choices()
+        dataset.shuffle_choices(seed=seed)
     elif shuffle_choices is False:
         pass
     elif isinstance(shuffle_choices, int):

--- a/evalscope/benchmarks/truthful_qa/truthful_qa_adapter.py
+++ b/evalscope/benchmarks/truthful_qa/truthful_qa_adapter.py
@@ -61,6 +61,7 @@ TruthfulQA is a benchmark designed to measure whether language models generate t
 - Important benchmark for safety and alignment research
 """,
         dataset_id='evalscope/truthful_qa',
+        evaluation_version='v1.1',
         metric_list=['multi_choice_acc'],
         subset_list=['multiple_choice'],
         shuffle_choices=True,

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -266,8 +266,11 @@ class TaskConfig(BaseArgument):
     Reuses cached predictions and reviews matched by sample_id; set None to start fresh."""
 
     rerun_review: bool = False
-    """When use_cache is set, force re-running the review/scoring step
-    (deletes existing reviews cache) while still reusing prediction cache."""
+    """When use_cache is set, force re-running review/scoring while reusing predictions.
+
+    This is also the explicit override for a native cache identity mismatch;
+    the resulting review is recorded under the current evaluation version.
+    """
 
     work_dir: str = DEFAULT_WORK_DIR
     """Root directory for evaluation outputs (predictions/, reviews/, reports/, logs/).
@@ -681,12 +684,15 @@ class TaskConfig(BaseArgument):
         fields.add('mode')
         return self.agent_config.model_dump(include=fields)
 
-    def dump_yaml(self, output_dir: str) -> None:
-        """Dump the task configuration to a YAML file."""
+    def dump_yaml(self, output_dir: str, generated_metadata: Optional[Dict[str, Any]] = None) -> None:
+        """Dump the task configuration and optional generated runtime metadata to YAML."""
         task_cfg_file = os.path.join(output_dir, f'task_config.yaml')
         try:
             logger.info(f'Dump task config to {task_cfg_file}')
-            dict_to_yaml(self.to_dict(), task_cfg_file)
+            payload = self.to_dict()
+            if generated_metadata:
+                payload.update(generated_metadata)
+            dict_to_yaml(payload, task_cfg_file)
         except Exception as e:
             logger.warning(f'Failed to dump overall task config: {e}')
 
@@ -705,13 +711,31 @@ class TaskConfig(BaseArgument):
         return result
 
 
+def _strip_generated_evaluation_metadata(task_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove output-only evaluation metadata before treating a snapshot as input."""
+    result = copy.deepcopy(task_cfg)
+    result.pop('resolved_benchmarks', None)
+    result.pop('evaluation_identity', None)
+    return result
+
+
+def load_task_config_snapshot(config_file: str) -> Optional[Dict[str, Any]]:
+    """Load a raw output task-config snapshot for cache identity validation."""
+    if not os.path.isfile(config_file):
+        return None
+    config = yaml_to_dict(config_file)
+    if not isinstance(config, dict):
+        raise ValueError(f'Invalid task config snapshot at {config_file}: expected a mapping.')
+    return config
+
+
 def parse_task_config(task_cfg) -> TaskConfig:
     """Parse task configuration from various formats into a TaskConfig object."""
     if isinstance(task_cfg, TaskConfig):
         logger.info('Args: Task config is provided with TaskConfig type.')
     elif isinstance(task_cfg, dict):
         logger.info('Args: Task config is provided with dictionary type.')
-        task_cfg = TaskConfig.from_dict(task_cfg)
+        task_cfg = TaskConfig.from_dict(_strip_generated_evaluation_metadata(task_cfg))
     elif isinstance(task_cfg, Namespace):
         logger.info('Args: Task config is provided with CommandLine type.')
         task_cfg = TaskConfig.from_args(task_cfg)
@@ -719,9 +743,9 @@ def parse_task_config(task_cfg) -> TaskConfig:
         extension = os.path.splitext(task_cfg)[-1]
         logger.info(f'Args: Task config is provided with {extension} file type.')
         if extension in ['.yaml', '.yml']:
-            task_cfg = TaskConfig.from_yaml(task_cfg)
+            task_cfg = TaskConfig.from_dict(_strip_generated_evaluation_metadata(yaml_to_dict(task_cfg)))
         elif extension == '.json':
-            task_cfg = TaskConfig.from_json(task_cfg)
+            task_cfg = TaskConfig.from_dict(_strip_generated_evaluation_metadata(json_to_dict(task_cfg)))
         else:
             raise ValueError('Args: Unsupported file extension.')
     else:

--- a/evalscope/evaluation_versioning.py
+++ b/evalscope/evaluation_versioning.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 if TYPE_CHECKING:
     from evalscope.api.benchmark import BenchmarkMeta
     from evalscope.config import TaskConfig
-    from evalscope.report import Report
 
 EVALUATION_IDENTITY_SCHEMA_VERSION = 1
 _VERSION_RE = re.compile(r'^v\d+\.\d+$')
@@ -107,14 +106,6 @@ class EvaluationIdentity(BaseModel):
 
     schema_version: int = EVALUATION_IDENTITY_SCHEMA_VERSION
     benchmarks: Dict[str, BenchmarkEvaluationIdentity] = Field(default_factory=dict)
-
-
-class BenchmarkAnalysisContext(BaseModel):
-    """Compact, structured context supplied to report analysis."""
-
-    benchmark: Dict[str, Any]
-    resolved_benchmark: ResolvedBenchmarkSpec
-    results: Dict[str, Any]
 
 
 def cache_source_for_identity(
@@ -275,27 +266,6 @@ def _identity_from_config(config: Optional[Dict[str, Any]]) -> Optional[Evaluati
         return None
 
 
-def build_analysis_context(
-    meta: 'BenchmarkMeta',
-    spec: ResolvedBenchmarkSpec,
-    identity: BenchmarkEvaluationIdentity,
-    report: 'Report',
-) -> BenchmarkAnalysisContext:
-    """Build analysis input without documentation-only metadata or perf metrics."""
-    overview, task_description = _description_sections(meta.description or '')
-    return BenchmarkAnalysisContext(
-        benchmark={
-            'name': meta.name,
-            'pretty_name': meta.pretty_name,
-            'evaluation_version': identity.evaluation_version,
-            'overview': overview,
-            'task_description': task_description,
-        },
-        resolved_benchmark=spec,
-        results=_score_summary(report),
-    )
-
-
 def _fingerprint_task_config(task_config: 'TaskConfig') -> Dict[str, Any]:
     return _fingerprint_task_mapping(task_config.to_dict())
 
@@ -336,44 +306,3 @@ def _is_secret_key(key: Any) -> bool:
     """Return whether a mapping key contains transport credentials."""
     normalized = str(key).lower().replace('_', '-')
     return normalized in _SECRET_KEYS or normalized.endswith('-api-key')
-
-
-def _description_sections(description: str) -> tuple[str, str]:
-    sections: Dict[str, list[str]] = {'Overview': [], 'Task Description': []}
-    current: Optional[str] = None
-    for line in description.splitlines():
-        heading = re.fullmatch(r'##\s+(.+?)\s*', line)
-        if heading:
-            current = heading.group(1) if heading.group(1) in sections else None
-            continue
-        if current is not None:
-            sections[current].append(line)
-    return '\n'.join(sections['Overview']).strip(), '\n'.join(sections['Task Description']).strip()
-
-
-def _score_summary(report: 'Report') -> Dict[str, Any]:
-    """Return only score aggregates relevant to a benchmark analysis."""
-    return {
-        'primary_metric_identity': (
-            report.primary_metric_identity.model_dump(mode='json') if report.primary_metric_identity else None
-        ),
-        'metrics': [{
-            'name': metric.name,
-            'identity': metric.identity.model_dump(mode='json'),
-            'num': metric.num,
-            'score': metric.score,
-            'macro_score': metric.macro_score,
-            'categories': [{
-                'name': list(category.name),
-                'num': category.num,
-                'score': category.score,
-                'macro_score': category.macro_score,
-                'subsets': [{
-                    'name': subset.name,
-                    'num': subset.num,
-                    'score': subset.score,
-                    'is_aggregate': subset.is_aggregate,
-                } for subset in category.subsets],
-            } for category in metric.categories],
-        } for metric in report.metrics],
-    }

--- a/evalscope/evaluation_versioning.py
+++ b/evalscope/evaluation_versioning.py
@@ -1,0 +1,402 @@
+"""Runtime benchmark specifications and cache identities for native evaluations."""
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+from evalscope.version import __version__
+
+if TYPE_CHECKING:
+    from evalscope.api.benchmark import BenchmarkMeta
+    from evalscope.config import TaskConfig
+    from evalscope.report import Report
+
+
+EVALUATION_IDENTITY_SCHEMA_VERSION = 1
+_VERSION_RE = re.compile(r'^v\d+\.\d+$')
+_SECRET_KEYS = {
+    'api-key',
+    'authorization',
+    'password',
+    'proxy-authorization',
+    'secret',
+    'token',
+    'x-api-key',
+    'x-auth-token',
+}
+
+
+class ResolvedBenchmarkSpec(BaseModel):
+    """The resolved benchmark settings that affect an evaluation run."""
+
+    name: str
+    dataset_id: str
+    dataset_hub: Optional[str] = None
+    dataset_revision: Optional[str] = None
+    eval_split: Optional[str] = None
+    train_split: Optional[str] = None
+    subset_list: list[str] = Field(default_factory=list)
+    default_subset: str = 'default'
+    prompt_template: Optional[str] = None
+    few_shot_prompt_template: Optional[str] = None
+    system_prompt: Optional[str] = None
+    query_template: Optional[str] = None
+    few_shot_num: int = 0
+    few_shot_random: bool = False
+    metric_list: list[Any] = Field(default_factory=list)
+    aggregation: str = 'mean'
+    primary_metric: Optional[Any] = None
+    filters: Optional[Dict[str, Any]] = None
+    shuffle: bool = False
+    shuffle_choices: bool = False
+    extra_params: Dict[str, Any] = Field(default_factory=dict)
+    sandbox_config: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_meta(cls, meta: 'BenchmarkMeta', task_config: 'TaskConfig') -> 'ResolvedBenchmarkSpec':
+        primary_metric = meta.primary_metric
+        if primary_metric is not None and hasattr(primary_metric, 'model_dump'):
+            primary_metric = primary_metric.model_dump(mode='json')
+        return cls(
+            name=meta.name,
+            dataset_id=meta.dataset_id,
+            dataset_hub=task_config.dataset_hub,
+            dataset_revision=getattr(meta, 'dataset_revision', None),
+            eval_split=meta.eval_split,
+            train_split=meta.train_split,
+            subset_list=list(meta.subset_list),
+            default_subset=meta.default_subset,
+            prompt_template=meta.prompt_template,
+            few_shot_prompt_template=meta.few_shot_prompt_template,
+            system_prompt=meta.system_prompt,
+            query_template=meta.query_template,
+            few_shot_num=meta.few_shot_num,
+            few_shot_random=meta.few_shot_random,
+            metric_list=meta.metric_list,
+            aggregation=meta.aggregation,
+            primary_metric=primary_metric,
+            filters=dict(meta.filters) if meta.filters is not None else None,
+            shuffle=meta.shuffle,
+            shuffle_choices=meta.shuffle_choices,
+            extra_params=meta.get_extra_params(),
+            sandbox_config=meta.sandbox_config,
+        )
+
+
+class CacheSource(BaseModel):
+    """The direct cache identity force-reused by ``rerun_review``."""
+
+    evaluation_version: str
+    fingerprint: str
+    inferred_legacy: bool = False
+    prediction_reused: bool = True
+    reuse_mode: str = 'rerun_review_override'
+
+
+class BenchmarkEvaluationIdentity(BaseModel):
+    """Published version and exact runtime fingerprint of one benchmark."""
+
+    evaluation_version: str
+    fingerprint: str
+    cache_source: Optional[CacheSource] = None
+
+
+class FrameworkProvenance(BaseModel):
+    """Best-effort framework provenance for auditing, excluded from fingerprints."""
+
+    evalscope_version: str
+    git_commit: Optional[str] = None
+
+
+class EvaluationIdentity(BaseModel):
+    """All generated benchmark identities persisted in ``task_config.yaml``."""
+
+    schema_version: int = EVALUATION_IDENTITY_SCHEMA_VERSION
+    framework: FrameworkProvenance
+    benchmarks: Dict[str, BenchmarkEvaluationIdentity] = Field(default_factory=dict)
+
+
+class BenchmarkAnalysisContext(BaseModel):
+    """Compact, structured context supplied to report analysis."""
+
+    benchmark: Dict[str, Any]
+    resolved_benchmark: ResolvedBenchmarkSpec
+    results: Dict[str, Any]
+
+
+def cache_source_for_identity(
+    current: BenchmarkEvaluationIdentity,
+    previous: Optional[BenchmarkEvaluationIdentity],
+    inferred_legacy: bool,
+    rerun_review: bool,
+) -> Optional[CacheSource]:
+    """Validate cache reuse and return its direct source when review is rerun.
+
+    Normal cache reuse requires a complete identity match. ``rerun_review`` is
+    the sole explicit override: it keeps old predictions and recomputes review
+    results under the current evaluation version.
+    """
+    if previous is not None and previous.fingerprint == current.fingerprint:
+        if not rerun_review:
+            return None
+        return CacheSource(
+            evaluation_version=previous.evaluation_version,
+            fingerprint=previous.fingerprint,
+            inferred_legacy=inferred_legacy,
+        )
+    if not rerun_review:
+        previous_label = previous.fingerprint if previous is not None else 'unknown'
+        raise ValueError(
+            'Cached evaluation identity does not match the current run '
+            f'(previous={previous_label}, current={current.fingerprint}). '
+            'Use rerun_review=True to explicitly reuse predictions and recompute reviews.'
+        )
+    if previous is None:
+        return CacheSource(
+            evaluation_version='unknown',
+            fingerprint='unknown',
+            inferred_legacy=True,
+        )
+    return CacheSource(
+        evaluation_version=previous.evaluation_version,
+        fingerprint=previous.fingerprint,
+        inferred_legacy=inferred_legacy,
+    )
+
+
+def validate_evaluation_version(value: str) -> str:
+    """Validate the public benchmark evaluation version."""
+    if not _VERSION_RE.fullmatch(value):
+        raise ValueError("evaluation_version must use the format 'v<major>.<minor>'")
+    return value
+
+
+def build_benchmark_identity(
+    spec: ResolvedBenchmarkSpec,
+    evaluation_version: str,
+    task_config: 'TaskConfig',
+) -> BenchmarkEvaluationIdentity:
+    """Build a stable cache identity from effective evaluation semantics."""
+    validate_evaluation_version(evaluation_version)
+    payload = {
+        'evaluation_version': evaluation_version,
+        'benchmark': spec.model_dump(mode='json'),
+        'task': _fingerprint_task_config(task_config),
+    }
+    encoded = _canonical_json(_scrub_secrets(payload)).encode('utf-8')
+    return BenchmarkEvaluationIdentity(
+        evaluation_version=evaluation_version,
+        fingerprint=f'sha256:{hashlib.sha256(encoded).hexdigest()}',
+    )
+
+
+def build_evaluation_identity(
+    specs: Dict[str, ResolvedBenchmarkSpec],
+    versions: Dict[str, str],
+    task_config: 'TaskConfig',
+) -> EvaluationIdentity:
+    """Build the generated identity block written to a native task config."""
+    return EvaluationIdentity(
+        framework=FrameworkProvenance(evalscope_version=__version__, git_commit=_git_commit()),
+        benchmarks={
+            name: build_benchmark_identity(spec, versions[name], task_config) for name, spec in specs.items()
+        },
+    )
+
+
+def build_generated_evaluation_metadata(
+    specs: Dict[str, ResolvedBenchmarkSpec],
+    identity: EvaluationIdentity,
+) -> Dict[str, Any]:
+    """Build output-only metadata stored alongside the user task configuration."""
+    return {
+        'resolved_benchmarks': {
+            name: spec.model_dump(mode='json') for name, spec in specs.items()
+        },
+        'evaluation_identity': identity.model_dump(mode='json'),
+    }
+
+
+def validate_cached_evaluation_identity(
+    previous_config: Optional[Dict[str, Any]],
+    current_identity: EvaluationIdentity,
+    rerun_review: bool,
+) -> Dict[str, CacheSource]:
+    """Validate native cache reuse and return review-rerun prediction sources.
+
+    ``previous_config`` is deliberately the raw output snapshot: generated
+    identity is audit data, not input that alters the current adapter defaults.
+    """
+    previous_identity = _identity_from_config(previous_config)
+    sources: Dict[str, CacheSource] = {}
+    for benchmark_name, current in current_identity.benchmarks.items():
+        previous = None
+        inferred_legacy = False
+        if previous_identity is not None:
+            previous = previous_identity.benchmarks.get(benchmark_name)
+        elif previous_config is not None:
+            previous = legacy_identity_from_config(previous_config, benchmark_name)
+            inferred_legacy = previous is not None
+
+        source = cache_source_for_identity(current, previous, inferred_legacy, rerun_review)
+        if source is not None:
+            sources[benchmark_name] = source
+    return sources
+
+
+def legacy_identity_from_config(
+    task_config: Dict[str, Any], benchmark_name: str
+) -> Optional[BenchmarkEvaluationIdentity]:
+    """Infer a v1.0 identity from an older full-meta task config snapshot."""
+    raw_spec = task_config.get('dataset_args', {}).get(benchmark_name)
+    if not isinstance(raw_spec, dict) or 'dataset_id' not in raw_spec:
+        return None
+    try:
+        spec = ResolvedBenchmarkSpec.model_validate({
+            **raw_spec,
+            'name': raw_spec.get('name', benchmark_name),
+            'dataset_hub': task_config.get('dataset_hub'),
+            'dataset_revision': raw_spec.get('dataset_revision'),
+        })
+    except Exception:
+        return None
+    payload = {
+        'evaluation_version': 'v1.0',
+        'benchmark': spec.model_dump(mode='json'),
+        'task': _fingerprint_task_mapping(task_config),
+    }
+    encoded = _canonical_json(_scrub_secrets(payload)).encode('utf-8')
+    return BenchmarkEvaluationIdentity(
+        evaluation_version='v1.0',
+        fingerprint=f'sha256:{hashlib.sha256(encoded).hexdigest()}',
+    )
+
+
+def _identity_from_config(config: Optional[Dict[str, Any]]) -> Optional[EvaluationIdentity]:
+    """Parse a generated identity block, treating malformed data as unknown provenance."""
+    if not config or 'evaluation_identity' not in config:
+        return None
+    try:
+        return EvaluationIdentity.model_validate(config['evaluation_identity'])
+    except Exception:
+        return None
+
+
+def build_analysis_context(
+    meta: 'BenchmarkMeta',
+    spec: ResolvedBenchmarkSpec,
+    identity: BenchmarkEvaluationIdentity,
+    report: 'Report',
+) -> BenchmarkAnalysisContext:
+    """Build analysis input without documentation-only metadata or perf metrics."""
+    overview, task_description = _description_sections(meta.description or '')
+    return BenchmarkAnalysisContext(
+        benchmark={
+            'name': meta.name,
+            'pretty_name': meta.pretty_name,
+            'evaluation_version': identity.evaluation_version,
+            'overview': overview,
+            'task_description': task_description,
+        },
+        resolved_benchmark=spec,
+        results=_score_summary(report),
+    )
+
+
+def _fingerprint_task_config(task_config: 'TaskConfig') -> Dict[str, Any]:
+    return _fingerprint_task_mapping(task_config.to_dict())
+
+
+def _fingerprint_task_mapping(task_config: Dict[str, Any]) -> Dict[str, Any]:
+    keys = (
+        'model', 'model_id', 'model_args', 'model_task', 'chat_template', 'generation_config', 'eval_type',
+        'api_url', 'limit', 'repeats', 'seed', 'judge', 'sandbox',
+    )
+    return {key: task_config.get(key) for key in keys}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(',', ':'), default=str)
+
+
+def _scrub_secrets(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _scrub_secrets(item)
+            for key, item in value.items()
+            if not _is_secret_key(key)
+        }
+    if isinstance(value, list):
+        return [_scrub_secrets(item) for item in value]
+    return value
+
+
+def _is_secret_key(key: Any) -> bool:
+    """Return whether a mapping key contains transport credentials."""
+    normalized = str(key).lower().replace('_', '-')
+    return normalized in _SECRET_KEYS or normalized.endswith('-api-key')
+
+
+def _description_sections(description: str) -> tuple[str, str]:
+    sections: Dict[str, list[str]] = {'Overview': [], 'Task Description': []}
+    current: Optional[str] = None
+    for line in description.splitlines():
+        heading = re.fullmatch(r'##\s+(.+?)\s*', line)
+        if heading:
+            current = heading.group(1) if heading.group(1) in sections else None
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return '\n'.join(sections['Overview']).strip(), '\n'.join(sections['Task Description']).strip()
+
+
+def _score_summary(report: 'Report') -> Dict[str, Any]:
+    """Return only score aggregates relevant to a benchmark analysis."""
+    return {
+        'primary_metric_identity': (
+            report.primary_metric_identity.model_dump(mode='json') if report.primary_metric_identity else None
+        ),
+        'metrics': [
+            {
+                'name': metric.name,
+                'identity': metric.identity.model_dump(mode='json'),
+                'num': metric.num,
+                'score': metric.score,
+                'macro_score': metric.macro_score,
+                'categories': [
+                    {
+                        'name': list(category.name),
+                        'num': category.num,
+                        'score': category.score,
+                        'macro_score': category.macro_score,
+                        'subsets': [
+                            {
+                                'name': subset.name,
+                                'num': subset.num,
+                                'score': subset.score,
+                                'is_aggregate': subset.is_aggregate,
+                            }
+                            for subset in category.subsets
+                        ],
+                    }
+                    for category in metric.categories
+                ],
+            }
+            for metric in report.metrics
+        ],
+    }
+
+
+def _git_commit() -> Optional[str]:
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        return subprocess.run(
+            ['git', 'rev-parse', 'HEAD'], cwd=repo_root, check=True, capture_output=True, text=True
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None

--- a/evalscope/evaluation_versioning.py
+++ b/evalscope/evaluation_versioning.py
@@ -3,12 +3,8 @@
 import hashlib
 import json
 import re
-import subprocess
-from pathlib import Path
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
-
-from evalscope.version import __version__
 
 if TYPE_CHECKING:
     from evalscope.api.benchmark import BenchmarkMeta
@@ -106,18 +102,10 @@ class BenchmarkEvaluationIdentity(BaseModel):
     cache_source: Optional[CacheSource] = None
 
 
-class FrameworkProvenance(BaseModel):
-    """Best-effort framework provenance for auditing, excluded from fingerprints."""
-
-    evalscope_version: str
-    git_commit: Optional[str] = None
-
-
 class EvaluationIdentity(BaseModel):
     """All generated benchmark identities persisted in ``task_config.yaml``."""
 
     schema_version: int = EVALUATION_IDENTITY_SCHEMA_VERSION
-    framework: FrameworkProvenance
     benchmarks: Dict[str, BenchmarkEvaluationIdentity] = Field(default_factory=dict)
 
 
@@ -202,7 +190,6 @@ def build_evaluation_identity(
 ) -> EvaluationIdentity:
     """Build the generated identity block written to a native task config."""
     return EvaluationIdentity(
-        framework=FrameworkProvenance(evalscope_version=__version__, git_commit=_git_commit()),
         benchmarks={
             name: build_benchmark_identity(spec, versions[name], task_config)
             for name, spec in specs.items()
@@ -390,12 +377,3 @@ def _score_summary(report: 'Report') -> Dict[str, Any]:
             } for category in metric.categories],
         } for metric in report.metrics],
     }
-
-
-def _git_commit() -> Optional[str]:
-    try:
-        repo_root = Path(__file__).resolve().parent.parent
-        return subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=repo_root, check=True, capture_output=True,
-                              text=True).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        return None

--- a/evalscope/evaluation_versioning.py
+++ b/evalscope/evaluation_versioning.py
@@ -5,9 +5,8 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
-
 from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from evalscope.version import __version__
 
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
     from evalscope.api.benchmark import BenchmarkMeta
     from evalscope.config import TaskConfig
     from evalscope.report import Report
-
 
 EVALUATION_IDENTITY_SCHEMA_VERSION = 1
 _VERSION_RE = re.compile(r'^v\d+\.\d+$')
@@ -54,6 +52,7 @@ class ResolvedBenchmarkSpec(BaseModel):
     filters: Optional[Dict[str, Any]] = None
     shuffle: bool = False
     shuffle_choices: bool = False
+    max_image_bytes: Optional[Union[int, str]] = None
     extra_params: Dict[str, Any] = Field(default_factory=dict)
     sandbox_config: Optional[Dict[str, Any]] = None
 
@@ -83,6 +82,7 @@ class ResolvedBenchmarkSpec(BaseModel):
             filters=dict(meta.filters) if meta.filters is not None else None,
             shuffle=meta.shuffle,
             shuffle_choices=meta.shuffle_choices,
+            max_image_bytes=meta.max_image_bytes,
             extra_params=meta.get_extra_params(),
             sandbox_config=meta.sandbox_config,
         )
@@ -204,7 +204,8 @@ def build_evaluation_identity(
     return EvaluationIdentity(
         framework=FrameworkProvenance(evalscope_version=__version__, git_commit=_git_commit()),
         benchmarks={
-            name: build_benchmark_identity(spec, versions[name], task_config) for name, spec in specs.items()
+            name: build_benchmark_identity(spec, versions[name], task_config)
+            for name, spec in specs.items()
         },
     )
 
@@ -216,7 +217,8 @@ def build_generated_evaluation_metadata(
     """Build output-only metadata stored alongside the user task configuration."""
     return {
         'resolved_benchmarks': {
-            name: spec.model_dump(mode='json') for name, spec in specs.items()
+            name: spec.model_dump(mode='json')
+            for name, spec in specs.items()
         },
         'evaluation_identity': identity.model_dump(mode='json'),
     }
@@ -249,9 +251,8 @@ def validate_cached_evaluation_identity(
     return sources
 
 
-def legacy_identity_from_config(
-    task_config: Dict[str, Any], benchmark_name: str
-) -> Optional[BenchmarkEvaluationIdentity]:
+def legacy_identity_from_config(task_config: Dict[str, Any],
+                                benchmark_name: str) -> Optional[BenchmarkEvaluationIdentity]:
     """Infer a v1.0 identity from an older full-meta task config snapshot."""
     raw_spec = task_config.get('dataset_args', {}).get(benchmark_name)
     if not isinstance(raw_spec, dict) or 'dataset_id' not in raw_spec:
@@ -314,8 +315,20 @@ def _fingerprint_task_config(task_config: 'TaskConfig') -> Dict[str, Any]:
 
 def _fingerprint_task_mapping(task_config: Dict[str, Any]) -> Dict[str, Any]:
     keys = (
-        'model', 'model_id', 'model_args', 'model_task', 'chat_template', 'generation_config', 'eval_type',
-        'api_url', 'limit', 'repeats', 'seed', 'judge', 'sandbox',
+        'model',
+        'model_id',
+        'model_args',
+        'model_task',
+        'chat_template',
+        'generation_config',
+        'eval_type',
+        'api_url',
+        'limit',
+        'repeats',
+        'seed',
+        'judge',
+        'sandbox',
+        'agent_config',
     )
     return {key: task_config.get(key) for key in keys}
 
@@ -326,11 +339,7 @@ def _canonical_json(value: Any) -> str:
 
 def _scrub_secrets(value: Any) -> Any:
     if isinstance(value, dict):
-        return {
-            key: _scrub_secrets(item)
-            for key, item in value.items()
-            if not _is_secret_key(key)
-        }
+        return {key: _scrub_secrets(item) for key, item in value.items() if not _is_secret_key(key)}
     if isinstance(value, list):
         return [_scrub_secrets(item) for item in value]
     return value
@@ -361,42 +370,32 @@ def _score_summary(report: 'Report') -> Dict[str, Any]:
         'primary_metric_identity': (
             report.primary_metric_identity.model_dump(mode='json') if report.primary_metric_identity else None
         ),
-        'metrics': [
-            {
-                'name': metric.name,
-                'identity': metric.identity.model_dump(mode='json'),
-                'num': metric.num,
-                'score': metric.score,
-                'macro_score': metric.macro_score,
-                'categories': [
-                    {
-                        'name': list(category.name),
-                        'num': category.num,
-                        'score': category.score,
-                        'macro_score': category.macro_score,
-                        'subsets': [
-                            {
-                                'name': subset.name,
-                                'num': subset.num,
-                                'score': subset.score,
-                                'is_aggregate': subset.is_aggregate,
-                            }
-                            for subset in category.subsets
-                        ],
-                    }
-                    for category in metric.categories
-                ],
-            }
-            for metric in report.metrics
-        ],
+        'metrics': [{
+            'name': metric.name,
+            'identity': metric.identity.model_dump(mode='json'),
+            'num': metric.num,
+            'score': metric.score,
+            'macro_score': metric.macro_score,
+            'categories': [{
+                'name': list(category.name),
+                'num': category.num,
+                'score': category.score,
+                'macro_score': category.macro_score,
+                'subsets': [{
+                    'name': subset.name,
+                    'num': subset.num,
+                    'score': subset.score,
+                    'is_aggregate': subset.is_aggregate,
+                } for subset in category.subsets],
+            } for category in metric.categories],
+        } for metric in report.metrics],
     }
 
 
 def _git_commit() -> Optional[str]:
     try:
         repo_root = Path(__file__).resolve().parent.parent
-        return subprocess.run(
-            ['git', 'rev-parse', 'HEAD'], cwd=repo_root, check=True, capture_output=True, text=True
-        ).stdout.strip()
+        return subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=repo_root, check=True, capture_output=True,
+                              text=True).stdout.strip()
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -20,10 +20,10 @@ from evalscope.api.judge import summarize_judge_runs
 from evalscope.api.metric import AggScore, SampleScore
 from evalscope.api.registry import register_evaluator
 from evalscope.constants import HEARTBEAT_INTERVAL_SEC, ScoreStatus
-from evalscope.evaluation_versioning import ResolvedBenchmarkSpec, build_analysis_context, build_benchmark_identity
+from evalscope.evaluation_versioning import ResolvedBenchmarkSpec, build_benchmark_identity
 from evalscope.evaluator.batch_reviewer import BatchReviewer
 from evalscope.evaluator.perf_collector import PerfCollector
-from evalscope.report import Report, gen_perf_table, gen_table
+from evalscope.report import Report, build_analysis_context, gen_perf_table, gen_table
 from evalscope.utils.function_utils import run_in_threads_with_progress
 from evalscope.utils.logger import get_logger
 

--- a/evalscope/evaluator/evaluator.py
+++ b/evalscope/evaluator/evaluator.py
@@ -20,6 +20,7 @@ from evalscope.api.judge import summarize_judge_runs
 from evalscope.api.metric import AggScore, SampleScore
 from evalscope.api.registry import register_evaluator
 from evalscope.constants import HEARTBEAT_INTERVAL_SEC, ScoreStatus
+from evalscope.evaluation_versioning import ResolvedBenchmarkSpec, build_analysis_context, build_benchmark_identity
 from evalscope.evaluator.batch_reviewer import BatchReviewer
 from evalscope.evaluator.perf_collector import PerfCollector
 from evalscope.report import Report, gen_perf_table, gen_table
@@ -542,7 +543,13 @@ class DefaultEvaluator(Evaluator):
         # Generate detailed analysis if requested in configuration
         if self.task_config.analysis_report:
             logger.info('Generating report analysis, please wait ...')
-            analysis = report.generate_analysis(self.task_config)
+            meta = self.benchmark.benchmark_meta
+            spec = ResolvedBenchmarkSpec.from_meta(meta, self.task_config)
+            identity = build_benchmark_identity(spec, meta.evaluation_version, self.task_config)
+            analysis = report.generate_analysis(
+                self.task_config,
+                build_analysis_context(meta, spec, identity, report),
+            )
             logger.info(f'Report analysis:\n{analysis}')
         else:
             logger.info('Skipping report analysis (`analysis_report=False`).')

--- a/evalscope/report/__init__.py
+++ b/evalscope/report/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .generator import ReportGenerator
     from .ref import ReportRef
     from .renderer import gen_html_report_file
-    from .report import Category, Metric, Report, ReportKey, Subset
+    from .report import BenchmarkAnalysisContext, Category, Metric, Report, ReportKey, Subset, build_analysis_context
 
 else:
     _import_structure = {
@@ -39,10 +39,12 @@ else:
         ],
         'report': [
             'Category',
+            'BenchmarkAnalysisContext',
             'Report',
             'ReportKey',
             'Subset',
             'Metric',
+            'build_analysis_context',
         ],
         'renderer': [
             'gen_html_report_file',

--- a/evalscope/report/report.py
+++ b/evalscope/report/report.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pandas as pd
+import re
 from collections import defaultdict
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_serializer, field_validator, model_validator
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -13,8 +14,9 @@ from evalscope.utils import get_logger
 from evalscope.utils.argument_utils import get_secret_value
 
 if TYPE_CHECKING:
+    from evalscope.api.benchmark import BenchmarkMeta
     from evalscope.config import TaskConfig
-    from evalscope.evaluation_versioning import BenchmarkAnalysisContext
+    from evalscope.evaluation_versioning import BenchmarkEvaluationIdentity, ResolvedBenchmarkSpec
 
 logger = get_logger()
 
@@ -44,6 +46,76 @@ Requirements:
 {analysis_context}
 ```
 """
+
+
+class BenchmarkAnalysisContext(BaseModel):
+    """Compact benchmark and score data supplied to report analysis."""
+
+    benchmark: Dict[str, Any]
+    resolved_benchmark: Dict[str, Any]
+    results: Dict[str, Any]
+
+
+def build_analysis_context(
+    meta: 'BenchmarkMeta',
+    spec: 'ResolvedBenchmarkSpec',
+    identity: 'BenchmarkEvaluationIdentity',
+    report: 'Report',
+) -> BenchmarkAnalysisContext:
+    """Build report-analysis input without documentation-only metadata or perf metrics."""
+    overview, task_description = _description_sections(meta.description or '')
+    return BenchmarkAnalysisContext(
+        benchmark={
+            'name': meta.name,
+            'pretty_name': meta.pretty_name,
+            'evaluation_version': identity.evaluation_version,
+            'overview': overview,
+            'task_description': task_description,
+        },
+        resolved_benchmark=spec.model_dump(mode='json'),
+        results=_score_summary(report),
+    )
+
+
+def _description_sections(description: str) -> tuple[str, str]:
+    sections: Dict[str, list[str]] = {'Overview': [], 'Task Description': []}
+    current: Optional[str] = None
+    for line in description.splitlines():
+        heading = re.fullmatch(r'##\s+(.+?)\s*', line)
+        if heading:
+            current = heading.group(1) if heading.group(1) in sections else None
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return '\n'.join(sections['Overview']).strip(), '\n'.join(sections['Task Description']).strip()
+
+
+def _score_summary(report: 'Report') -> Dict[str, Any]:
+    """Return only score aggregates relevant to a benchmark analysis."""
+    return {
+        'primary_metric_identity': (
+            report.primary_metric_identity.model_dump(mode='json') if report.primary_metric_identity else None
+        ),
+        'metrics': [{
+            'name': metric.name,
+            'identity': metric.identity.model_dump(mode='json'),
+            'num': metric.num,
+            'score': metric.score,
+            'macro_score': metric.macro_score,
+            'categories': [{
+                'name': list(category.name),
+                'num': category.num,
+                'score': category.score,
+                'macro_score': category.macro_score,
+                'subsets': [{
+                    'name': subset.name,
+                    'num': subset.num,
+                    'score': subset.score,
+                    'is_aggregate': subset.is_aggregate,
+                } for subset in category.subsets],
+            } for category in metric.categories],
+        } for metric in report.metrics],
+    }
 
 
 def normalize_score(score: Union[float, dict, int], keep_num: int = 4) -> Union[float, dict]:

--- a/evalscope/report/report.py
+++ b/evalscope/report/report.py
@@ -14,32 +14,34 @@ from evalscope.utils.argument_utils import get_secret_value
 
 if TYPE_CHECKING:
     from evalscope.config import TaskConfig
+    from evalscope.evaluation_versioning import BenchmarkAnalysisContext
 
 logger = get_logger()
 
-ANALYSIS_PROMPT = """You are an expert AI model evaluator. Analyze the following JSON evaluation results and produce a concise, structured analysis report.
+ANALYSIS_PROMPT = """You are an expert AI model evaluator. Analyze the benchmark context and aggregated evaluation scores below and produce a concise, structured analysis report.
 
 The report must contain exactly four sections with second-level Markdown headers (##):
 
 ## Overall Performance
-Summarize the model's general performance across all evaluated benchmarks and metrics.
+Explain the benchmark's task goal and summarize the model's performance across its reported scores.
 
 ## Key Metrics Analysis
-Break down individual metrics. If multiple metrics are present, categorize them into *Low*, *Medium*, and *High* performance tiers and present the breakdown in a Markdown table.
+Break down scores by metric, category, and subset where available. If multiple metrics are present, categorize them into *Low*, *Medium*, and *High* performance tiers and present the breakdown in a Markdown table.
 
 ## Improvement Suggestions
 Provide specific, actionable recommendations to address identified weaknesses or low-scoring areas.
 
 ## Conclusion
-Offer a concise summary of the findings and an overall assessment.
+Offer a concise summary, including material limits of the reported evaluation scope.
 
 Requirements:
 - Output only the report content itself — no preamble, commentary, or closing remarks.
 - Write the report in {language}.
 - Keep the report focused and avoid unnecessary repetition.
+- Assess only the provided evaluation scores; do not infer performance metrics or undocumented benchmark details.
 
 ```json
-{report_str}
+{analysis_context}
 ```
 """
 
@@ -338,7 +340,8 @@ class Report(BaseModel):
         df_categories.drop(columns=[ReportKey.category_name], inplace=True)
         return df_categories
 
-    def generate_analysis(self, task_config: 'TaskConfig') -> str:
+    def generate_analysis(self, task_config: 'TaskConfig', analysis_context: 'BenchmarkAnalysisContext') -> str:
+        """Generate score analysis from compact benchmark context and report aggregates."""
         from evalscope.constants import DEFAULT_LANGUAGE
         from evalscope.metrics import LLMJudge
 
@@ -358,7 +361,8 @@ class Report(BaseModel):
                     eval_type=task_config.eval_type,
                 )
 
-            prompt = ANALYSIS_PROMPT.format(language=language, report_str=self.to_json_str())
+            context_json = json.dumps(analysis_context.model_dump(mode='json'), ensure_ascii=False, indent=2)
+            prompt = ANALYSIS_PROMPT.format(language=language, analysis_context=context_json)
             from evalscope.api.messages import ChatMessageUser
 
             response = judge_llm.generate([ChatMessageUser(content=prompt)]).completion

--- a/evalscope/run.py
+++ b/evalscope/run.py
@@ -4,10 +4,16 @@ Run evaluation for LLMs.
 """
 import os
 from argparse import Namespace
-from typing import List, Optional, Union
+from typing import Dict, List, Union
 
-from evalscope.config import TaskConfig, parse_task_config
-from evalscope.constants import DEFAULT_WORK_DIR, DataCollection, EvalBackend
+from evalscope.config import TaskConfig, load_task_config_snapshot, parse_task_config
+from evalscope.constants import DEFAULT_WORK_DIR, EvalBackend
+from evalscope.evaluation_versioning import (
+    ResolvedBenchmarkSpec,
+    build_evaluation_identity,
+    build_generated_evaluation_metadata,
+    validate_cached_evaluation_identity,
+)
 from evalscope.utils.io_utils import OutputsStructure, current_time
 from evalscope.utils.logger import configure_logging, get_logger
 from evalscope.utils.model_utils import seed_everything
@@ -141,6 +147,8 @@ def evaluate_model(task_config: TaskConfig, outputs: OutputsStructure) -> dict:
     model = LazyModel(task_config=task_config)
     # Initialize evaluators for each dataset
     evaluators: List[Evaluator] = []
+    resolved_benchmarks: Dict[str, ResolvedBenchmarkSpec] = {}
+    evaluation_versions: Dict[str, str] = {}
     for dataset_name in task_config.datasets:
         # Create evaluator for each dataset
         benchmark = get_benchmark(dataset_name, task_config)
@@ -155,12 +163,29 @@ def evaluate_model(task_config: TaskConfig, outputs: OutputsStructure) -> dict:
         )
         evaluators.append(evaluator)
 
-        # Update task_config.dataset_args with benchmark metadata, except for DataCollection
-        if dataset_name != DataCollection.NAME:
-            task_config.dataset_args[dataset_name] = benchmark.to_dict()
+        meta = benchmark.benchmark_meta
+        resolved_benchmarks[dataset_name] = ResolvedBenchmarkSpec.from_meta(meta, task_config)
+        evaluation_versions[dataset_name] = meta.evaluation_version
+
+    evaluation_identity = build_evaluation_identity(resolved_benchmarks, evaluation_versions, task_config)
+    if task_config.use_cache:
+        snapshot_path = os.path.join(outputs.outputs_dir, OutputsStructure.CONFIGS_DIR, 'task_config.yaml')
+        cache_sources = validate_cached_evaluation_identity(
+            load_task_config_snapshot(snapshot_path),
+            evaluation_identity,
+            task_config.rerun_review,
+        )
+        for benchmark_name, source in cache_sources.items():
+            evaluation_identity.benchmarks[benchmark_name].cache_source = source
+            logger.warning(
+                f'Forcing prediction reuse for {benchmark_name} with rerun_review=True; '
+                f'previous identity is {source.fingerprint}.'
+            )
 
     # dump task_cfg to outputs.configs_dir after creating evaluators
-    task_config.dump_yaml(outputs.configs_dir)
+    task_config.dump_yaml(
+        outputs.configs_dir, build_generated_evaluation_metadata(resolved_benchmarks, evaluation_identity)
+    )
     logger.info(task_config)
 
     tracker_ctx = make_tracker(

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -575,12 +575,6 @@ def gen_hash(name: str, bits: int = 32) -> str:
     return hashlib.md5(name.encode(encoding='UTF-8')).hexdigest()[:bits]
 
 
-def content_seed(*parts: str) -> int:
-    """Return a stable integer seed derived from content rather than list position."""
-    content = '\x00'.join(parts).encode('utf-8')
-    return int.from_bytes(hashlib.sha256(content).digest()[:8], 'big')
-
-
 # ---------------------------------------------------------------------------
 # List utilities
 # ---------------------------------------------------------------------------

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -575,6 +575,12 @@ def gen_hash(name: str, bits: int = 32) -> str:
     return hashlib.md5(name.encode(encoding='UTF-8')).hexdigest()[:bits]
 
 
+def content_seed(*parts: str) -> int:
+    """Return a stable integer seed derived from content rather than list position."""
+    content = '\x00'.join(parts).encode('utf-8')
+    return int.from_bytes(hashlib.sha256(content).digest()[:8], 'big')
+
+
 # ---------------------------------------------------------------------------
 # List utilities
 # ---------------------------------------------------------------------------

--- a/tests/api/test_default_data_adapter.py
+++ b/tests/api/test_default_data_adapter.py
@@ -16,10 +16,14 @@ class CapturingDataLoader(DataLoader):
 
     latest_limit: ClassVar[Optional[int]] = None
     latest_repeats: ClassVar[Optional[int]] = None
+    latest_version: ClassVar[Optional[str]] = None
+    latest_seed: ClassVar[Optional[int]] = None
 
     def load(self) -> MemoryDataset:
         self.__class__.latest_limit = self.limit
         self.__class__.latest_repeats = self.repeats
+        self.__class__.latest_version = self.version
+        self.__class__.latest_seed = self.seed
 
         samples: List[Sample] = [
             Sample(input='question-1', target='answer-1', subset_key='subset-a'),
@@ -54,7 +58,10 @@ class DummyLLMJudgeAdapter(DefaultDataAdapter):
 
 
 def make_adapter(
-    repeats: int = 3, limit: Optional[int] = None, system_prompt: Optional[str] = None
+    repeats: int = 3,
+    limit: Optional[int] = None,
+    system_prompt: Optional[str] = None,
+    dataset_revision: Optional[str] = None,
 ) -> DummyReformatAdapter:
     task_config = TaskConfig(datasets=['dummy'], repeats=repeats, limit=limit)
     benchmark_meta = BenchmarkMeta(
@@ -65,6 +72,7 @@ def make_adapter(
         eval_split='test',
         prompt_template='{question}',
         system_prompt=system_prompt,
+        dataset_revision=dataset_revision,
     )
     return DummyReformatAdapter(benchmark_meta=benchmark_meta, task_config=task_config)
 
@@ -83,6 +91,37 @@ def test_reformat_subset_repeats_are_applied_once_after_grouping() -> None:
     assert CapturingDataLoader.latest_repeats == 1
     assert len(dataset_dict['subset-a']) == 6
     assert [sample.group_id for sample in dataset_dict['subset-a']] == [0, 0, 0, 1, 1, 1]
+
+
+def test_load_subset_passes_the_resolved_dataset_revision() -> None:
+    adapter = make_adapter(dataset_revision='2026-08-21')
+
+    adapter.load_subset(subset='subset-a', data_loader=CapturingDataLoader)
+
+    assert CapturingDataLoader.latest_version == '2026-08-21'
+    assert CapturingDataLoader.latest_seed == 42
+
+
+def test_shuffle_choices_configuration_survives_adapter_initialization() -> None:
+    meta = BenchmarkMeta(
+        name='choice_shuffle',
+        dataset_id='dummy',
+        eval_split='test',
+        shuffle_choices=True,
+    )
+
+    adapter = DummyReformatAdapter(benchmark_meta=meta, task_config=TaskConfig(datasets=['choice_shuffle']))
+
+    assert adapter.shuffle_choices is True
+
+    user_configured_meta = BenchmarkMeta(name='user_choice_shuffle', dataset_id='dummy', eval_split='test')
+    user_configured_meta._update({'shuffle_choices': True})
+    user_configured_adapter = DummyReformatAdapter(
+        benchmark_meta=user_configured_meta,
+        task_config=TaskConfig(datasets=['user_choice_shuffle']),
+    )
+
+    assert user_configured_adapter.shuffle_choices is True
 
 
 def test_auto_judge_strategy_uses_adapter_class_default() -> None:

--- a/tests/api/test_evaluation_versioning.py
+++ b/tests/api/test_evaluation_versioning.py
@@ -1,8 +1,7 @@
 """Tests for native evaluation snapshots, identities, and analysis context."""
 
-from types import SimpleNamespace
-
 import pytest
+from types import SimpleNamespace
 
 from evalscope.api.benchmark import BenchmarkMeta
 from evalscope.config import TaskConfig, load_task_config_snapshot, parse_task_config
@@ -20,7 +19,7 @@ from evalscope.evaluation_versioning import (
 )
 from evalscope.report import Report
 from evalscope.run import run_task
-from evalscope.utils.io_utils import dict_to_yaml
+from evalscope.utils.io_utils import dict_to_yaml, yaml_to_dict
 
 
 def _task_config(**kwargs) -> TaskConfig:
@@ -109,6 +108,10 @@ def test_identity_changes_only_for_evaluation_semantics() -> None:
     assert first.fingerprint != build_benchmark_identity(changed_prompt, 'v1.0', config).fingerprint
     changed_revision = spec.model_copy(update={'dataset_revision': '2026-08-21'})
     assert first.fingerprint != build_benchmark_identity(changed_revision, 'v1.0', config).fingerprint
+    changed_image_limit = spec.model_copy(update={'max_image_bytes': '500kb'})
+    assert first.fingerprint != build_benchmark_identity(changed_image_limit, 'v1.0', config).fingerprint
+    agent_config = _task_config(agent_config={'mode': 'native', 'max_steps': 3})
+    assert first.fingerprint != build_benchmark_identity(spec, 'v1.0', agent_config).fingerprint
 
 
 def test_cache_identity_requires_match_unless_rerun_review_is_explicit() -> None:
@@ -187,6 +190,45 @@ def test_native_cache_identity_blocks_mismatched_run_before_snapshot_overwrite(t
         run_task(TaskConfig(**base, use_cache=str(tmp_path), generation_config={'temperature': 0.7}))
 
     assert snapshot_path.read_text() == snapshot
+
+
+def test_native_rerun_review_records_the_prediction_source(tmp_path) -> None:
+    base = {
+        'model': 'mock-model',
+        'eval_type': 'mock_llm',
+        'datasets': ['general_mcq'],
+        'dataset_args': {'general_mcq': {'local_path': 'custom_eval/text/mcq', 'subset_list': ['example']}},
+        'limit': 1,
+        'no_timestamp': True,
+        'work_dir': str(tmp_path),
+    }
+    run_task(TaskConfig(**base))
+
+    snapshot_path = tmp_path / 'configs' / 'task_config.yaml'
+    previous_fingerprint = yaml_to_dict(str(snapshot_path))['evaluation_identity']['benchmarks']['general_mcq'][
+        'fingerprint']
+    prediction_path = tmp_path / 'predictions' / 'mock-model' / 'general_mcq_example.jsonl'
+    previous_prediction = prediction_path.read_text()
+
+    run_task(
+        TaskConfig(
+            **base,
+            use_cache=str(tmp_path),
+            rerun_review=True,
+            generation_config={'temperature': 0.7},
+        )
+    )
+
+    identity = yaml_to_dict(str(snapshot_path))['evaluation_identity']['benchmarks']['general_mcq']
+    assert identity['fingerprint'] != previous_fingerprint
+    assert identity['cache_source'] == {
+        'evaluation_version': 'v1.0',
+        'fingerprint': previous_fingerprint,
+        'inferred_legacy': False,
+        'prediction_reused': True,
+        'reuse_mode': 'rerun_review_override',
+    }
+    assert prediction_path.read_text() == previous_prediction
 
 
 def test_legacy_full_meta_snapshot_infers_v1_identity() -> None:

--- a/tests/api/test_evaluation_versioning.py
+++ b/tests/api/test_evaluation_versioning.py
@@ -1,0 +1,256 @@
+"""Tests for native evaluation snapshots, identities, and analysis context."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.config import TaskConfig, load_task_config_snapshot, parse_task_config
+from evalscope.evaluation_versioning import (
+    BenchmarkEvaluationIdentity,
+    EvaluationIdentity,
+    FrameworkProvenance,
+    ResolvedBenchmarkSpec,
+    build_analysis_context,
+    build_benchmark_identity,
+    build_evaluation_identity,
+    cache_source_for_identity,
+    legacy_identity_from_config,
+    validate_cached_evaluation_identity,
+)
+from evalscope.report import Report
+from evalscope.run import run_task
+from evalscope.utils.io_utils import dict_to_yaml
+
+
+def _task_config(**kwargs) -> TaskConfig:
+    return TaskConfig(
+        model='test-model',
+        eval_type='mock_llm',
+        datasets=['demo'],
+        dataset_args={'demo': {'local_path': 'custom/demo'}},
+        **kwargs,
+    )
+
+
+def _meta(**kwargs) -> BenchmarkMeta:
+    return BenchmarkMeta(
+        name='demo',
+        dataset_id='demo/data',
+        eval_split='validation',
+        metric_list=['accuracy'],
+        description=(
+            '## Overview\nA concise benchmark overview.\n\n'
+            '## Task Description\n- Task Type: Multiple choice\n\n'
+            '## Key Features\nThis must not be sent to analysis.\n\n'
+            '## Evaluation Notes\nThis must not be sent to analysis either.'
+        ),
+        **kwargs,
+    )
+
+
+def test_benchmark_evaluation_version_has_valid_default_and_is_not_doc_metadata() -> None:
+    meta = _meta()
+
+    assert meta.evaluation_version == 'v1.0'
+    assert 'evaluation_version' not in meta.to_dict()
+    assert 'evaluation_version' not in meta.to_string_dict()
+
+    with pytest.raises(ValueError, match='v<major>.<minor>'):
+        _meta(evaluation_version='1.0')
+
+    with pytest.raises(ValueError, match='declared by BenchmarkMeta'):
+        meta._update({'evaluation_version': 'v1.1'})
+
+
+def test_snapshot_dump_preserves_raw_dataset_args_and_reparses(tmp_path) -> None:
+    config = _task_config()
+    spec = ResolvedBenchmarkSpec.from_meta(_meta(), config)
+    identity = build_benchmark_identity(spec, 'v1.0', config)
+
+    config.dump_yaml(
+        str(tmp_path),
+        generated_metadata={
+            'resolved_benchmarks': {'demo': spec.model_dump(mode='json')},
+            'evaluation_identity': {
+                'schema_version': 1,
+                'framework': {'evalscope_version': 'test'},
+                'benchmarks': {'demo': identity.model_dump(mode='json')},
+            },
+        },
+    )
+
+    snapshot = (tmp_path / 'task_config.yaml').read_text()
+    reparsed = parse_task_config(str(tmp_path / 'task_config.yaml'))
+
+    assert 'resolved_benchmarks:' in snapshot
+    assert 'evaluation_identity:' in snapshot
+    assert reparsed.dataset_args == {'demo': {'local_path': 'custom/demo'}}
+
+
+def test_identity_changes_only_for_evaluation_semantics() -> None:
+    config = _task_config(
+        api_key='secret',
+        model_args={'api_key': 'nested-secret', 'headers': {'X-API-Key': 'header-secret'}},
+    )
+    spec = ResolvedBenchmarkSpec.from_meta(_meta(), config)
+    first = build_benchmark_identity(spec, 'v1.0', config)
+
+    same_without_secret = _task_config(
+        api_key='different-secret',
+        model_args={'api_key': 'other-secret', 'headers': {'X-API-Key': 'other-header-secret'}},
+    )
+    assert first.fingerprint == build_benchmark_identity(spec, 'v1.0', same_without_secret).fingerprint
+
+    assert first.fingerprint != build_benchmark_identity(spec, 'v1.1', config).fingerprint
+    assert first.fingerprint != build_benchmark_identity(spec, 'v1.0', _task_config(seed=7)).fingerprint
+    assert first.fingerprint != build_benchmark_identity(spec, 'v1.0', _task_config(limit=5)).fingerprint
+    changed_prompt = spec.model_copy(update={'prompt_template': 'Changed prompt'})
+    assert first.fingerprint != build_benchmark_identity(changed_prompt, 'v1.0', config).fingerprint
+    changed_revision = spec.model_copy(update={'dataset_revision': '2026-08-21'})
+    assert first.fingerprint != build_benchmark_identity(changed_revision, 'v1.0', config).fingerprint
+
+
+def test_cache_identity_requires_match_unless_rerun_review_is_explicit() -> None:
+    current = BenchmarkEvaluationIdentity(evaluation_version='v1.1', fingerprint='sha256:current')
+    previous = BenchmarkEvaluationIdentity(evaluation_version='v1.0', fingerprint='sha256:previous')
+
+    assert cache_source_for_identity(current, current, False, False) is None
+    exact_review_source = cache_source_for_identity(current, current, False, True)
+    assert exact_review_source is not None
+    assert exact_review_source.fingerprint == 'sha256:current'
+    with pytest.raises(ValueError, match='rerun_review=True'):
+        cache_source_for_identity(current, previous, False, False)
+
+    source = cache_source_for_identity(current, previous, True, True)
+    assert source is not None
+    assert source.evaluation_version == 'v1.0'
+    assert source.fingerprint == 'sha256:previous'
+    assert source.inferred_legacy is True
+    assert source.reuse_mode == 'rerun_review_override'
+
+
+def test_unknown_cache_requires_the_same_explicit_review_override() -> None:
+    current = BenchmarkEvaluationIdentity(evaluation_version='v1.0', fingerprint='sha256:current')
+
+    with pytest.raises(ValueError, match='previous=unknown'):
+        validate_cached_evaluation_identity(None, _identity({'demo': current}), rerun_review=False)
+
+    sources = validate_cached_evaluation_identity(None, _identity({'demo': current}), rerun_review=True)
+    assert sources['demo'].evaluation_version == 'unknown'
+    assert sources['demo'].fingerprint == 'unknown'
+
+
+def test_cache_mismatch_is_rejected_before_snapshot_is_overwritten(tmp_path) -> None:
+    meta = _meta()
+    current_config = _task_config(use_cache=str(tmp_path))
+    spec = ResolvedBenchmarkSpec.from_meta(meta, current_config)
+    current = build_evaluation_identity({'demo': spec}, {'demo': 'v1.1'}, current_config)
+    previous = build_evaluation_identity({'demo': spec}, {'demo': 'v1.0'}, current_config)
+    config_dir = tmp_path / 'configs'
+    config_dir.mkdir()
+    config_path = config_dir / 'task_config.yaml'
+    dict_to_yaml({'evaluation_identity': previous.model_dump(mode='json')}, str(config_path))
+    original_snapshot = config_path.read_text()
+
+    previous_snapshot = load_task_config_snapshot(str(config_path))
+    with pytest.raises(ValueError, match='Cached evaluation identity does not match'):
+        validate_cached_evaluation_identity(previous_snapshot, current, rerun_review=False)
+
+    assert config_path.read_text() == original_snapshot
+
+    forced_config = _task_config(use_cache=str(tmp_path), rerun_review=True)
+    forced = build_evaluation_identity({'demo': spec}, {'demo': 'v1.1'}, forced_config)
+    sources = validate_cached_evaluation_identity(previous_snapshot, forced, rerun_review=True)
+    assert sources['demo'].fingerprint == previous.benchmarks['demo'].fingerprint
+
+
+def test_native_cache_identity_blocks_mismatched_run_before_snapshot_overwrite(tmp_path) -> None:
+    base = {
+        'model': 'mock-model',
+        'eval_type': 'mock_llm',
+        'datasets': ['general_mcq'],
+        'dataset_args': {'general_mcq': {'local_path': 'custom_eval/text/mcq', 'subset_list': ['example']}},
+        'limit': 1,
+        'no_timestamp': True,
+        'work_dir': str(tmp_path),
+    }
+    run_task(TaskConfig(**base))
+    run_task(TaskConfig(**base, use_cache=str(tmp_path)))
+
+    snapshot_path = tmp_path / 'configs' / 'task_config.yaml'
+    snapshot = snapshot_path.read_text()
+    assert 'evaluation_identity:' in snapshot
+    assert 'local_path: custom_eval/text/mcq' in snapshot
+
+    with pytest.raises(ValueError, match='Cached evaluation identity does not match'):
+        run_task(TaskConfig(**base, use_cache=str(tmp_path), generation_config={'temperature': 0.7}))
+
+    assert snapshot_path.read_text() == snapshot
+
+
+def test_legacy_full_meta_snapshot_infers_v1_identity() -> None:
+    config = _task_config()
+    spec = ResolvedBenchmarkSpec.from_meta(_meta(), config)
+    previous_config = config.to_dict()
+    previous_config['dataset_args'] = {'demo': spec.model_dump(mode='json')}
+
+    identity = legacy_identity_from_config(previous_config, 'demo')
+
+    assert identity is not None
+    assert identity.evaluation_version == 'v1.0'
+    assert identity.fingerprint == build_benchmark_identity(spec, 'v1.0', config).fingerprint
+    assert validate_cached_evaluation_identity(previous_config, _identity({'demo': identity}), rerun_review=False) == {}
+
+
+def test_analysis_uses_compact_context_without_full_meta_or_perf(monkeypatch) -> None:
+    config = _task_config()
+    meta = _meta()
+    spec = ResolvedBenchmarkSpec.from_meta(meta, config)
+    identity = build_benchmark_identity(spec, meta.evaluation_version, config)
+    report = Report.from_dict({
+        'dataset_name': 'demo',
+        'dataset_description': 'full metadata must not be sent',
+        'metrics': [{
+            'name': 'mean_accuracy',
+            'score': 0.8,
+            'num': 10,
+            'categories': [],
+        }],
+    })
+    report.perf_metrics = {'latency': {'value': 42}}
+    context = build_analysis_context(meta, spec, identity, report)
+    captured = {}
+
+    class FakeJudge:
+
+        model_id = 'fake-judge'
+
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def generate(self, messages):
+            captured['prompt'] = messages[0].content
+            return SimpleNamespace(completion='analysis')
+
+    import evalscope.metrics
+    monkeypatch.setattr(evalscope.metrics, 'LLMJudge', FakeJudge)
+
+    report.generate_analysis(config, context)
+
+    prompt = captured['prompt']
+    assert 'A concise benchmark overview.' in prompt
+    assert 'Task Type: Multiple choice' in prompt
+    assert '"resolved_benchmark"' in prompt
+    assert '"score": 0.8' in prompt
+    assert 'This must not be sent to analysis.' not in prompt
+    assert 'full metadata must not be sent' not in prompt
+    assert 'latency' not in prompt
+    assert report.schema_version == 2
+
+
+def _identity(benchmarks: dict[str, BenchmarkEvaluationIdentity]) -> EvaluationIdentity:
+    return EvaluationIdentity(
+        framework=FrameworkProvenance(evalscope_version='test'),
+        benchmarks=benchmarks,
+    )

--- a/tests/api/test_evaluation_versioning.py
+++ b/tests/api/test_evaluation_versioning.py
@@ -9,14 +9,13 @@ from evalscope.evaluation_versioning import (
     BenchmarkEvaluationIdentity,
     EvaluationIdentity,
     ResolvedBenchmarkSpec,
-    build_analysis_context,
     build_benchmark_identity,
     build_evaluation_identity,
     cache_source_for_identity,
     legacy_identity_from_config,
     validate_cached_evaluation_identity,
 )
-from evalscope.report import Report
+from evalscope.report import Report, build_analysis_context
 from evalscope.run import run_task
 from evalscope.utils.io_utils import dict_to_yaml, yaml_to_dict
 

--- a/tests/api/test_evaluation_versioning.py
+++ b/tests/api/test_evaluation_versioning.py
@@ -8,7 +8,6 @@ from evalscope.config import TaskConfig, load_task_config_snapshot, parse_task_c
 from evalscope.evaluation_versioning import (
     BenchmarkEvaluationIdentity,
     EvaluationIdentity,
-    FrameworkProvenance,
     ResolvedBenchmarkSpec,
     build_analysis_context,
     build_benchmark_identity,
@@ -73,7 +72,6 @@ def test_snapshot_dump_preserves_raw_dataset_args_and_reparses(tmp_path) -> None
             'resolved_benchmarks': {'demo': spec.model_dump(mode='json')},
             'evaluation_identity': {
                 'schema_version': 1,
-                'framework': {'evalscope_version': 'test'},
                 'benchmarks': {'demo': identity.model_dump(mode='json')},
             },
         },
@@ -292,7 +290,4 @@ def test_analysis_uses_compact_context_without_full_meta_or_perf(monkeypatch) ->
 
 
 def _identity(benchmarks: dict[str, BenchmarkEvaluationIdentity]) -> EvaluationIdentity:
-    return EvaluationIdentity(
-        framework=FrameworkProvenance(evalscope_version='test'),
-        benchmarks=benchmarks,
-    )
+    return EvaluationIdentity(benchmarks=benchmarks)

--- a/tests/api/test_shuffle_determinism.py
+++ b/tests/api/test_shuffle_determinism.py
@@ -1,0 +1,66 @@
+"""Regression tests for deterministic choice shuffling."""
+
+import hashlib
+
+from evalscope.api.dataset import MemoryDataset, Sample
+from evalscope.api.dataset.utils import shuffle_choices_if_requested
+from evalscope.utils.io_utils import content_seed
+
+
+CHOICES = ['alpha', 'beta', 'gamma', 'delta']
+
+
+def _dataset(count: int) -> MemoryDataset:
+    return MemoryDataset(
+        samples=[Sample(input=f'question {index}', choices=list(CHOICES), target='A') for index in range(count)]
+    )
+
+
+def _answers_by_question(dataset: MemoryDataset) -> dict[str, tuple[tuple[str, ...], str]]:
+    return {
+        str(sample.input): (tuple(sample.choices or []), str(sample.target))
+        for sample in dataset
+    }
+
+
+def test_content_seed_is_stable() -> None:
+    expected = int.from_bytes(hashlib.sha256(b'one\x00two').digest()[:8], 'big')
+
+    assert content_seed('one', 'two') == expected
+
+
+def test_choice_shuffle_uses_the_run_seed() -> None:
+    with_42 = _dataset(8)
+    with_7 = _dataset(8)
+
+    shuffle_choices_if_requested(with_42, True, seed=42)
+    shuffle_choices_if_requested(with_7, True, seed=7)
+
+    assert _answers_by_question(with_42) != _answers_by_question(with_7)
+
+
+def test_choice_shuffle_is_reproducible_and_filter_independent() -> None:
+    all_samples = _dataset(6)
+    filtered_samples = MemoryDataset(samples=[sample for sample in _dataset(6) if sample.input != 'question 1'])
+    repeat = _dataset(6)
+
+    all_samples.shuffle_choices(seed=42)
+    filtered_samples.shuffle_choices(seed=42)
+    repeat.shuffle_choices(seed=42)
+
+    all_answers = _answers_by_question(all_samples)
+    filtered_answers = _answers_by_question(filtered_samples)
+    assert all_answers == _answers_by_question(repeat)
+    assert filtered_answers == {
+        question: answer for question, answer in all_answers.items() if question != 'question 1'
+    }
+
+
+def test_choice_shuffle_remaps_the_correct_answer() -> None:
+    dataset = _dataset(8)
+
+    dataset.shuffle_choices(seed=42)
+
+    for sample in dataset:
+        answer_index = ord(str(sample.target)) - ord('A')
+        assert sample.choices[answer_index] == 'alpha'

--- a/tests/api/test_shuffle_determinism.py
+++ b/tests/api/test_shuffle_determinism.py
@@ -1,10 +1,7 @@
 """Regression tests for deterministic choice shuffling."""
 
-import hashlib
-
 from evalscope.api.dataset import MemoryDataset, Sample
 from evalscope.api.dataset.utils import shuffle_choices_if_requested
-from evalscope.utils.io_utils import content_seed
 
 CHOICES = ['alpha', 'beta', 'gamma', 'delta']
 
@@ -20,12 +17,6 @@ def _answers_by_question(dataset: MemoryDataset) -> dict[str, tuple[tuple[str, .
         str(sample.input): (tuple(sample.choices or []), str(sample.target))
         for sample in dataset
     }
-
-
-def test_content_seed_is_stable() -> None:
-    expected = int.from_bytes(hashlib.sha256(b'one\x00two').digest()[:8], 'big')
-
-    assert content_seed('one', 'two') == expected
 
 
 def test_choice_shuffle_uses_the_run_seed() -> None:

--- a/tests/api/test_shuffle_determinism.py
+++ b/tests/api/test_shuffle_determinism.py
@@ -1,6 +1,7 @@
 """Regression tests for deterministic choice shuffling."""
 
 from evalscope.api.dataset import MemoryDataset, Sample
+from evalscope.api.dataset import dataset as dataset_module
 from evalscope.api.dataset.utils import shuffle_choices_if_requested
 
 CHOICES = ['alpha', 'beta', 'gamma', 'delta']
@@ -27,6 +28,24 @@ def test_choice_shuffle_uses_the_run_seed() -> None:
     shuffle_choices_if_requested(with_7, True, seed=7)
 
     assert _answers_by_question(with_42) != _answers_by_question(with_7)
+
+
+def test_choice_shuffle_without_seed_uses_one_random_sequence(monkeypatch) -> None:
+    calls = []
+
+    class TrackingRandom:
+
+        def __init__(self, *args) -> None:
+            calls.append(args)
+
+        def shuffle(self, values) -> None:
+            values.reverse()
+
+    monkeypatch.setattr(dataset_module.random, 'Random', TrackingRandom)
+
+    _dataset(3).shuffle_choices()
+
+    assert calls == [()]
 
 
 def test_choice_shuffle_is_reproducible_and_filter_independent() -> None:

--- a/tests/api/test_shuffle_determinism.py
+++ b/tests/api/test_shuffle_determinism.py
@@ -6,7 +6,6 @@ from evalscope.api.dataset import MemoryDataset, Sample
 from evalscope.api.dataset.utils import shuffle_choices_if_requested
 from evalscope.utils.io_utils import content_seed
 
-
 CHOICES = ['alpha', 'beta', 'gamma', 'delta']
 
 


### PR DESCRIPTION
## Summary

- Persist native resolved benchmark specifications and strict cache identities in the existing task-config snapshot, while keeping `dataset_args` as the original user input.
- Add benchmark evaluation versions, legacy v1.0 identity inference, explicit `rerun_review` cache provenance, and compact score-focused analysis context; `Report.schema_version` remains 2.
- Port the core of #1602: make choice shuffling respect the run seed and derive each permutation from sample content, so filtering/reordering cannot alter another sample's target mapping. Remove the adapter reset that disabled configured choice shuffling.
- Bump TruthfulQA to evaluation version `v1.1`, because its declared choice shuffling now takes effect.

## Validation

- `make lint`
- `pytest tests/api/test_shuffle_determinism.py tests/api/test_default_data_adapter.py tests/api/test_evaluation_versioning.py tests/api/test_benchmark_meta.py tests/report/semantics/test_report_model.py -q`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings`
