### PR TITLE
fix(cmmmu): normalize image media inputs

### DIFF
--- a/evalscope/benchmarks/cmmmu/cmmmu_adapter.py
+++ b/evalscope/benchmarks/cmmmu/cmmmu_adapter.py
@@ -7,7 +7,6 @@ from evalscope.api.messages import ChatMessageUser, Content
 from evalscope.api.metric.scorer import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.io_utils import bytes_to_base64
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -102,6 +101,7 @@ CMMU (Chinese Massive Multi-discipline Multimodal Understanding) includes manual
         subset_list=SUBSET_LIST,
         metric_list=['acc'],
         eval_split='val',
+        evaluation_version='v1.1',
     )
 )
 class CMMMUAdapter(VisionLanguageAdapter):
@@ -205,15 +205,11 @@ class CMMMUAdapter(VisionLanguageAdapter):
             current_example = current_example_template.format(question)
             final_input_prompt = task_instructions[2] + '\n\n' + current_example
 
-        # Prepare image map
-        image_map: Dict[int, str] = {}
         for i in range(1, CMMMUAdapter.MAX_IMAGES + 1):
             final_input_prompt = final_input_prompt.replace(f'<img="{record[f"image_{i}_filename"]}">', f'<image {i}>')
-            image = record.get(f'image_{i}')
-            if image:
-                image_base64 = bytes_to_base64(image['bytes'], format='png', add_header=True)
-                image_map[i] = image_base64
+
+        image_map = self._extract_media(record, 'image')
 
         # Parse and replace image placeholders
-        content_list = self._parse_text_with_images(final_input_prompt, image_map)
+        content_list = self._parse_text_with_media(final_input_prompt, image_map=image_map)
         return content_list

--- a/tests/benchmark/test_cmmmu_adapter.py
+++ b/tests/benchmark/test_cmmmu_adapter.py
@@ -1,0 +1,80 @@
+import base64
+import pytest
+from io import BytesIO
+from pathlib import Path
+from PIL import Image
+from typing import Any, Dict
+
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.messages import ContentImage, ContentText
+from evalscope.benchmarks.cmmmu.cmmmu_adapter import CMMMUAdapter
+from evalscope.config import TaskConfig
+
+
+@pytest.fixture
+def adapter() -> CMMMUAdapter:
+    return CMMMUAdapter(
+        benchmark_meta=BenchmarkMeta(name='cmmmu', dataset_id='dummy', eval_split='val'),
+        task_config=TaskConfig(datasets=['cmmmu']),
+    )
+
+
+def _record(question: str, **overrides: Any) -> Dict[str, Any]:
+    record = {
+        'question': question,
+        'type': '选择',
+        'option1': '甲',
+        'option2': '乙',
+        'option3': '丙',
+        'option4': '丁',
+        **{f'image_{index}_filename': '' for index in range(1, CMMMUAdapter.MAX_IMAGES + 1)},
+    }
+    record.update(overrides)
+    return record
+
+
+def _image_bytes(image_format: str) -> bytes:
+    buffer = BytesIO()
+    Image.new('RGB', (2, 2), color='white').save(buffer, format=image_format)
+    return buffer.getvalue()
+
+
+def test_create_content_list_supports_undecoded_path_image(adapter: CMMMUAdapter, tmp_path: Path) -> None:
+    image_path = tmp_path / 'diagram.png'
+    Image.new('RGB', (2, 2), color='white').save(image_path)
+    record = _record(
+        '观察<img="diagram.png">，选择正确答案。',
+        image_1={'path': str(image_path), 'bytes': None},
+        image_1_filename='diagram.png',
+    )
+
+    content_list = adapter.create_content_list(record)
+
+    images = [content for content in content_list if isinstance(content, ContentImage)]
+    assert [content.image for content in images] == [str(image_path)]
+
+
+def test_create_content_list_preserves_image_order_and_detects_mime_type(adapter: CMMMUAdapter) -> None:
+    png_bytes = _image_bytes('PNG')
+    jpeg_bytes = _image_bytes('JPEG')
+    record = _record(
+        '比较<img="left.png">与<img="right.jpg">，选择正确答案。',
+        image_1={'path': 'left.png', 'bytes': png_bytes},
+        image_1_filename='left.png',
+        image_2={'path': 'right.jpg', 'bytes': jpeg_bytes},
+        image_2_filename='right.jpg',
+    )
+
+    content_list = adapter.create_content_list(record)
+
+    assert [type(content) for content in content_list] == [
+        ContentText,
+        ContentImage,
+        ContentText,
+        ContentImage,
+        ContentText,
+    ]
+    images = [content for content in content_list if isinstance(content, ContentImage)]
+    expected_png = f'data:image/png;base64,{base64.b64encode(png_bytes).decode()}'
+    assert images[0].image == expected_png
+    assert images[1].image.startswith('data:image/jpeg;base64,')


### PR DESCRIPTION
## Summary

- migrate CMMMU image loading to the shared `_extract_media` path
- support path-backed Hugging Face image dictionaries and detect image MIME types from bytes
- bump the CMMMU evaluation version to `v1.1`
- add regression coverage for path-backed and ordered multi-image inputs

## Problem

The CMMMU adapter reads `image_<n>["bytes"]` directly and labels every image data URI as PNG. A valid undecoded image value with `bytes=None` and a usable `path` therefore raises `TypeError`, while JPEG bytes are sent with an incorrect PNG MIME type.

## Validation

- `pytest -q tests/benchmark/test_cmmmu_adapter.py tests/api/test_vision_language_adapter.py tests/benchmark/test_general_vmcq_adapter.py` — 25 passed
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings` — 1 passed
- pre-commit hooks passed for both changed files
- checked 100 records and 111 images from the official CMMMU validation Parquet: content shape, text, image order, and Base64 payloads matched the legacy path; 43 incorrect PNG MIME headers were corrected

Part of #1605.