### PR TITLE
fix(benchmark): load OmniDocBench v1.6 from snapshot

### DIFF
--- a/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
+++ b/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Type
 
 from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
-from evalscope.api.dataset import DataLoader, Dataset, DictDataLoader, Sample, download_dataset_file
+from evalscope.api.dataset import DataLoader, Dataset, DictDataLoader, Sample, resolve_snapshot_or_local_path
 from evalscope.api.evaluator import TaskState
 from evalscope.api.messages import ChatMessageUser, Content, ContentImage, ContentText
 from evalscope.api.metric import AggScore, SampleScore, Score
@@ -88,18 +88,12 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
         self.add_overall_metric = False
+        self._snapshot_dir: Path | None = None
 
     def load_subset(self, subset: str, data_loader: Type[DataLoader]) -> Dataset:
-        """Load the v1.6 annotation and delegate selection to the standard loader."""
-        annotation_path = Path(
-            download_dataset_file(
-                data_id_or_path=self.dataset_id,
-                file_path='OmniDocBench.json',
-                data_source=self.dataset_hub,
-                force_redownload=self.force_redownload,
-                cache_dir=self.dataset_dir,
-            )
-        )
+        """Load the v1.6 snapshot and delegate selection to the standard loader."""
+        self._snapshot_dir = Path(resolve_snapshot_or_local_path(self)).resolve()
+        annotation_path = self._snapshot_dir / 'OmniDocBench.json'
         records = json.loads(annotation_path.read_text(encoding='utf-8'))
         return DictDataLoader(
             dict_list=records,
@@ -113,16 +107,13 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
         ).load()
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        if self._snapshot_dir is None:
+            raise RuntimeError('OmniDocBench v1.6 snapshot must be loaded before converting records.')
         image_name = record['page_info']['image_path']
-        image_path = Path(
-            download_dataset_file(
-                data_id_or_path=self.dataset_id,
-                file_path=f'images/{image_name}',
-                data_source=self.dataset_hub,
-                force_redownload=self.force_redownload,
-                cache_dir=self.dataset_dir,
-            )
-        )
+        image_dir = (self._snapshot_dir / 'images').resolve()
+        image_path = (image_dir / image_name).resolve()
+        if not image_path.is_relative_to(image_dir):
+            raise ValueError(f'Invalid OmniDocBench v1.6 image path: {image_name}')
         image_format = image_path.suffix.lower().lstrip('.') or 'png'
         image_uri = self._image_bytes_to_base64(image_path.read_bytes(), default_format=image_format)
         content: List[Content] = [

--- a/tests/benchmark/test_omnidoc_bench.py
+++ b/tests/benchmark/test_omnidoc_bench.py
@@ -1,9 +1,38 @@
+import json
 import pytest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+from evalscope.api.dataset import DictDataLoader
 from evalscope.api.metric import MetricSelector, SampleScore, Score
+from evalscope.api.registry import get_benchmark
 from evalscope.benchmarks.omnidoc_bench.legacy.omnidoc_bench_adapter import OmniDocBenchAdapter
+from evalscope.config import TaskConfig
+
+
+def test_v16_loads_snapshot_once_and_reads_images_locally(tmp_path: Path) -> None:
+    image_names = ['page.png', 'long_' + '页面' * 36 + '.png']
+    records = [{'page_info': {'image_path': image_name}} for image_name in image_names]
+    (tmp_path / 'OmniDocBench.json').write_text(json.dumps(records), encoding='utf-8')
+    image_dir = tmp_path / 'images'
+    image_dir.mkdir()
+    for image_name in image_names:
+        (image_dir / image_name).write_bytes(b'image')
+
+    adapter = get_benchmark(
+        'omni_doc_bench_v1_6',
+        TaskConfig(datasets=['omni_doc_bench_v1_6']),
+    )
+    with mock.patch(
+        'evalscope.benchmarks.omnidoc_bench.v1_6.omnidoc_bench_v1_6_adapter.resolve_snapshot_or_local_path',
+        return_value=str(tmp_path),
+    ) as resolve_snapshot:
+        dataset = adapter.load_subset('default', DictDataLoader)
+
+    resolve_snapshot.assert_called_once_with(adapter)
+    assert [sample.metadata['image_name'] for sample in dataset] == image_names
+    assert all(sample.input[0].content[0].image.startswith('data:image/png;base64,') for sample in dataset)
 
 
 def test_legacy_omnidoc_aggregates_canonical_metrics() -> None:


### PR DESCRIPTION
## Summary

- resolve the OmniDocBench v1.6 dataset snapshot once during subset loading
- read annotations and page images directly from the local snapshot
- preserve image path containment checks and remove per-record hub downloads
- add focused coverage for one snapshot resolution and long Unicode image names

Related to #1622.

## Tests

- `./.venv/bin/pytest tests/api/test_dataset_hub.py tests/benchmark/test_omnidoc_bench.py -q`
- `./.venv/bin/pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -s -p no:warnings`
- `./.venv/bin/pre-commit run --all-files`
