### PR TITLE
feat(io): unify undecoding behavior and support overlong images list

### DIFF
--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -12,7 +12,7 @@ The following environment variables can be set before launch to control global d
 | `EVALSCOPE_LANGUAGE` | Global default language, affects output language for reports, etc. (`en` or `zh`) | `en` |
 | `EVALSCOPE_HEARTBEAT_INTERVAL` | Heartbeat reporting interval (seconds) | `60` |
 | `MODELSCOPE_CACHE` | Root cache directory for ModelScope models and datasets | `~/.cache/modelscope/hub` |
-| `DATASET_TF_BATCH_SIZE` | Batch size for dataset transformation | `1000` |
+| `DATASET_TF_BATCH_SIZE` | Batch size for dataset transformation | `100` |
 
 ## Model Parameters
 

--- a/docs/en/get_started/parameters.md
+++ b/docs/en/get_started/parameters.md
@@ -12,6 +12,7 @@ The following environment variables can be set before launch to control global d
 | `EVALSCOPE_LANGUAGE` | Global default language, affects output language for reports, etc. (`en` or `zh`) | `en` |
 | `EVALSCOPE_HEARTBEAT_INTERVAL` | Heartbeat reporting interval (seconds) | `60` |
 | `MODELSCOPE_CACHE` | Root cache directory for ModelScope models and datasets | `~/.cache/modelscope/hub` |
+| `DATASET_TF_BATCH_SIZE` | Batch size for dataset transformation | `1000` |
 
 ## Model Parameters
 

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -12,7 +12,7 @@
 | `EVALSCOPE_LANGUAGE` | 全局默认语言，影响报告等输出语言（`en` 或 `zh`） | `en` |
 | `EVALSCOPE_HEARTBEAT_INTERVAL` | 评测进度心跳上报间隔（秒） | `60` |
 | `MODELSCOPE_CACHE` | ModelScope 模型与数据集缓存根目录 | `~/.cache/modelscope/hub` |
-| `DATASET_TF_BATCH_SIZE` | 数据集转换的批处理大小 | `1000` |
+| `DATASET_TF_BATCH_SIZE` | 数据集转换的批处理大小 | `100` |
 
 ## 模型参数
 

--- a/docs/zh/get_started/parameters.md
+++ b/docs/zh/get_started/parameters.md
@@ -12,6 +12,7 @@
 | `EVALSCOPE_LANGUAGE` | 全局默认语言，影响报告等输出语言（`en` 或 `zh`） | `en` |
 | `EVALSCOPE_HEARTBEAT_INTERVAL` | 评测进度心跳上报间隔（秒） | `60` |
 | `MODELSCOPE_CACHE` | ModelScope 模型与数据集缓存根目录 | `~/.cache/modelscope/hub` |
+| `DATASET_TF_BATCH_SIZE` | 数据集转换的批处理大小 | `1000` |
 
 ## 模型参数
 

--- a/evalscope/api/dataset/loader.py
+++ b/evalscope/api/dataset/loader.py
@@ -9,7 +9,15 @@ from typing import Callable, Dict, List, Optional, Union
 from evalscope.api.dataset.utils import record_to_sample_fn
 from evalscope.constants import DEFAULT_EVALSCOPE_CACHE_DIR, HubType
 from evalscope.utils import get_logger
-from evalscope.utils.io_utils import csv_to_list, gen_hash, jsonl_to_list, parquet_to_list, safe_filename, tsv_to_list
+from evalscope.utils.io_utils import (
+    csv_to_list,
+    gen_hash,
+    jsonl_to_list,
+    parquet_to_list,
+    safe_filename,
+    tsv_to_list,
+    undecode_media,
+)
 from .dataset import Dataset, FieldSpec, MemoryDataset, Sample
 from .hub import DatasetHub
 from .utils import data_to_samples, shuffle_choices_if_requested
@@ -123,16 +131,7 @@ class RemoteDataLoader(DataLoader):
                 dataset.save_to_disk(dataset_cache_dir)
 
         # Disable auto-decoding for Image/Audio to keep raw bytes format (compat with datasets >= 3.0)
-        from datasets.features import Sequence
-        for col, feat in list(dataset.features.items()):
-            if isinstance(feat, Image):
-                dataset = dataset.cast_column(col, Image(decode=False))
-            elif isinstance(feat, Audio):
-                dataset = dataset.cast_column(col, Audio(decode=False))
-            elif isinstance(feat, Sequence) and isinstance(feat.feature, Image):
-                dataset = dataset.cast_column(col, Sequence(Image(decode=False)))
-            elif isinstance(feat, Sequence) and isinstance(feat.feature, Audio):
-                dataset = dataset.cast_column(col, Sequence(Audio(decode=False)))
+        dataset = undecode_media(dataset, media_type=['image', 'audio'])
 
         # shuffle if requested
         if self.shuffle:

--- a/evalscope/constants.py
+++ b/evalscope/constants.py
@@ -19,7 +19,7 @@ DEFAULT_ROOT_CACHE_DIR = DEFAULT_DATASET_CACHE_DIR  # compatible with old versio
 DEFAULT_EVALSCOPE_CACHE_DIR = os.path.expanduser(
     os.getenv('EVALSCOPE_CACHE', '~/.cache/evalscope')
 )  # ~/.cache/evalscope
-DATASET_TRANSFORM_BATCH_SIZE = int(os.getenv('DATASET_TF_BATCH_SIZE', '1000'))
+DATASET_TRANSFORM_BATCH_SIZE = int(os.getenv('DATASET_TF_BATCH_SIZE', '100'))
 HEARTBEAT_INTERVAL_SEC = int(os.getenv('EVALSCOPE_HEARTBEAT_INTERVAL', '60'))  # 60 seconds
 DEFAULT_LANGUAGE = os.getenv('EVALSCOPE_LANGUAGE', 'en')  # default language: 'en' or 'zh'
 USE_OSS = os.getenv('USE_OSS', '0') == '1'  # whether to use OSS/FUSE-mounted filesystem

--- a/evalscope/constants.py
+++ b/evalscope/constants.py
@@ -19,6 +19,7 @@ DEFAULT_ROOT_CACHE_DIR = DEFAULT_DATASET_CACHE_DIR  # compatible with old versio
 DEFAULT_EVALSCOPE_CACHE_DIR = os.path.expanduser(
     os.getenv('EVALSCOPE_CACHE', '~/.cache/evalscope')
 )  # ~/.cache/evalscope
+DATASET_TRANSFORM_BATCH_SIZE = int(os.getenv('DATASET_TF_BATCH_SIZE', '1000'))
 HEARTBEAT_INTERVAL_SEC = int(os.getenv('EVALSCOPE_HEARTBEAT_INTERVAL', '60'))  # 60 seconds
 DEFAULT_LANGUAGE = os.getenv('EVALSCOPE_LANGUAGE', 'en')  # default language: 'en' or 'zh'
 USE_OSS = os.getenv('USE_OSS', '0') == '1'  # whether to use OSS/FUSE-mounted filesystem

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -17,7 +17,7 @@ from io import BytesIO
 from PIL import Image
 from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Union
 
-from evalscope.constants import BEIJING_TZ, USE_OSS, DumpMode
+from evalscope.constants import BEIJING_TZ, DATASET_TRANSFORM_BATCH_SIZE, USE_OSS, DumpMode
 from evalscope.utils.logger import get_logger
 
 logger = get_logger()
@@ -143,7 +143,11 @@ class OutputsStructure:
 # ---------------------------------------------------------------------------
 
 
-def undecode_media(dataset: 'Dataset', media_type: List[Literal['image', 'audio', 'video']]) -> 'Dataset':
+def undecode_media(
+    dataset: 'Dataset',
+    media_type: List[Literal['image', 'audio', 'video']],
+    batch_size: Optional[int] = None
+) -> 'Dataset':
     from datasets.features import Audio, Image, Sequence, Video
 
     if not isinstance(dataset, Dataset):
@@ -175,7 +179,7 @@ def undecode_media(dataset: 'Dataset', media_type: List[Literal['image', 'audio'
         return dataset
 
     # if there are updates, do casting
-    dataset = dataset.cast(features, batch_size=100)
+    dataset = dataset.cast(features, batch_size=batch_size or DATASET_TRANSFORM_BATCH_SIZE)
     return dataset
 
 

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -14,7 +14,7 @@ import yaml
 from datetime import datetime
 from io import BytesIO
 from PIL import Image
-from typing import IO, Any, Dict, List, Optional, Tuple, Union
+from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from evalscope.constants import BEIJING_TZ, USE_OSS, DumpMode
 from evalscope.utils.logger import get_logger
@@ -142,25 +142,43 @@ class OutputsStructure:
 # ---------------------------------------------------------------------------
 
 
-def parquet_to_list(parquet_file: str) -> List[Dict[str, Any]]:
+def undecode_media(dataset, media_type: List[Literal['image', 'audio', 'video']]):
     from datasets import Dataset
     from datasets.features import Audio, Image, Sequence, Video
 
-    dataset = Dataset.from_parquet(parquet_file)
+    if not isinstance(dataset, Dataset):
+        raise TypeError(f'Expected a datasets.Dataset object, got {type(dataset)} instead.')
+    # for type checking
+    dataset = cast(Dataset, dataset)
 
-    for col, feat in list(dataset.features.items()):
-        if isinstance(feat, Image):
-            dataset = dataset.cast_column(col, Image(decode=False))
-        elif isinstance(feat, Audio):
-            dataset = dataset.cast_column(col, Audio(decode=False))
-        elif isinstance(feat, Video):
-            dataset = dataset.cast_column(col, Video(decode=False))
-        elif isinstance(feat, Sequence) and isinstance(feat.feature, Image):
-            dataset = dataset.cast_column(col, Sequence(Image(decode=False)))
-        elif isinstance(feat, Sequence) and isinstance(feat.feature, Audio):
-            dataset = dataset.cast_column(col, Sequence(Audio(decode=False)))
-        elif isinstance(feat, Sequence) and isinstance(feat.feature, Video):
-            dataset = dataset.cast_column(col, Sequence(Video(decode=False)))
+    # we did not use cast_column here, because cast_column() does not support batch_size,
+    # the default batch_size=1000 may cause OOM for large datasets
+    # see https://github.com/huggingface/datasets/pull/7910
+    features = dataset.features
+    for col, feat in dataset.features.items():
+        if 'image' in media_type and isinstance(feat, Image):
+            features[col] = Image(decode=False)
+        elif 'audio' in media_type and isinstance(feat, Audio):
+            features[col] = Audio(decode=False)
+        elif 'video' in media_type and isinstance(feat, Video):
+            features[col] = Video(decode=False)
+        elif 'image' in media_type and isinstance(feat, Sequence) and isinstance(feat.feature, Image):
+            features[col] = Sequence(Image(decode=False))
+        elif 'audio' in media_type and isinstance(feat, Sequence) and isinstance(feat.feature, Audio):
+            features[col] = Sequence(Audio(decode=False))
+        elif 'video' in media_type and isinstance(feat, Sequence) and isinstance(feat.feature, Video):
+            features[col] = Sequence(Video(decode=False))
+
+    dataset = dataset.cast(features, batch_size=100)
+    return dataset
+
+
+def parquet_to_list(parquet_file: str) -> List[Dict[str, Any]]:
+    from datasets import Dataset
+
+    dataset = Dataset.from_parquet(parquet_file)
+    dataset = undecode_media(dataset, media_type=['image', 'audio', 'video'])
+
     return dataset.to_list()
 
 

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -11,10 +11,11 @@ import re
 import string
 import unicodedata
 import yaml
+from datasets import Dataset
 from datetime import datetime
 from io import BytesIO
 from PIL import Image
-from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from evalscope.constants import BEIJING_TZ, USE_OSS, DumpMode
 from evalscope.utils.logger import get_logger
@@ -142,19 +143,17 @@ class OutputsStructure:
 # ---------------------------------------------------------------------------
 
 
-def undecode_media(dataset, media_type: List[Literal['image', 'audio', 'video']]):
-    from datasets import Dataset
+def undecode_media(dataset: 'Dataset', media_type: List[Literal['image', 'audio', 'video']]) -> 'Dataset':
     from datasets.features import Audio, Image, Sequence, Video
 
     if not isinstance(dataset, Dataset):
         raise TypeError(f'Expected a datasets.Dataset object, got {type(dataset)} instead.')
-    # for type checking
-    dataset = cast(Dataset, dataset)
 
     # we did not use cast_column here, because cast_column() does not support batch_size,
     # the default batch_size=1000 may cause OOM for large datasets
     # see https://github.com/huggingface/datasets/pull/7910
     features = dataset.features
+    noupdate = True
     for col, feat in dataset.features.items():
         if 'image' in media_type and isinstance(feat, Image):
             features[col] = Image(decode=False)
@@ -168,7 +167,14 @@ def undecode_media(dataset, media_type: List[Literal['image', 'audio', 'video']]
             features[col] = Sequence(Audio(decode=False))
         elif 'video' in media_type and isinstance(feat, Sequence) and isinstance(feat.feature, Video):
             features[col] = Sequence(Video(decode=False))
+        else:
+            continue
+        noupdate = False
 
+    if noupdate:
+        return dataset
+
+    # if there are updates, do casting
     dataset = dataset.cast(features, batch_size=100)
     return dataset
 

--- a/tests/api/test_io_utils.py
+++ b/tests/api/test_io_utils.py
@@ -1,7 +1,9 @@
 import io
 import numpy as np
+import pyarrow as pa
 import pytest
-from datasets import Audio, Dataset, Features, Image, Sequence, Video, concatenate_datasets
+from datasets import Audio, Dataset, DatasetInfo, Features, Image, Sequence, Video, concatenate_datasets
+from datasets.table import InMemoryTable
 from PIL import Image as PILImage
 
 from evalscope.utils.io_utils import undecode_media
@@ -27,17 +29,19 @@ def gen_dataset(
     for col_name, (media_bytes, inner_feat, count) in media_factory.items():
         if count == 1:
             features[col_name] = inner_feat
-            row[col_name] = {'bytes': media_bytes}
+            row[col_name] = {'bytes': media_bytes, 'path': None}
         else:
             features[col_name] = Sequence(inner_feat)
-            row[col_name] = [{'bytes': media_bytes}] * count
+            row[col_name] = [{'bytes': media_bytes, 'path': None}] * count
 
     # inject non-media cols
     if extra_dict:
         features |= Dataset.from_list([extra_dict]).features
         row.update(extra_dict)
 
-    single_row = Dataset.from_list([row], features=Features(features))
+    dataset_features = Features(features)
+    table = pa.Table.from_pylist([row], schema=dataset_features.arrow_schema)
+    single_row = Dataset(InMemoryTable(table), info=DatasetInfo(features=dataset_features))
     return concatenate_datasets([single_row] * num_rows)
 
 
@@ -53,12 +57,12 @@ class TestArrowOffsetOverflow:
 
     @pytest.mark.parametrize(
         'dim, batch_size',
-        [(512, 100), (1024, 10)],
+        [(512, None), (1024, 10)],
     )
     def test_default_batch_overflows_but_small_batch_succeeds(
         self,
         dim: int,
-        batch_size: int,
+        batch_size: int | None,
     ):
         ds = gen_dataset(
             media_factory={'images': (_generate_jpeg_bytes(dim), Image(decode=True), self.IMAGES_PER_ROW)},
@@ -69,9 +73,12 @@ class TestArrowOffsetOverflow:
         with pytest.raises(ValueError, match='offset'):
             undecode_media(ds, media_type=['image'], batch_size=1000)
 
-        # we cap len exactly as batch_size to make test faster
-        # smaller batch size avoids the overflow
-        undecode_media(ds.select(range(batch_size)), media_type=['image'], batch_size=batch_size)
+        # A smaller batch size avoids the overflow. One full batch is sufficient to verify the boundary.
+        safe_batch_size = batch_size or 100
+        result = undecode_media(
+            ds.select(range(safe_batch_size)), media_type=['image'], batch_size=batch_size
+        )
+        assert result.features['images'].feature.decode is False
 
 
 class TestUndecodeMediaIntegration:
@@ -119,7 +126,7 @@ class TestUndecodeMediaIntegration:
                 id='plain_Audio',
             ),
             pytest.param(
-                {'audios': (b'dummy', Audio(decode=True), 1)},
+                {'audios': (b'dummy', Audio(decode=True), 2)},
                 {'text': 'playlist'},
                 id='Sequence_Audio',
             ),
@@ -129,7 +136,7 @@ class TestUndecodeMediaIntegration:
                 id='plain_Video',
             ),
             pytest.param(
-                {'videos': (b'dummy', Video(decode=True), 1)},
+                {'videos': (b'dummy', Video(decode=True), 2)},
                 {'text': 'clips'},
                 id='Sequence_Video',
             ),

--- a/tests/api/test_io_utils.py
+++ b/tests/api/test_io_utils.py
@@ -67,14 +67,11 @@ class TestArrowOffsetOverflow:
 
         # expected overflow with default batch size (1k)
         with pytest.raises(ValueError, match='offset'):
-            ds.cast(Features(images=Sequence(Image(decode=True))))
+            undecode_media(ds, media_type=['image'], batch_size=1000)
 
         # we cap len exactly as batch_size to make test faster
         # smaller batch size avoids the overflow
-        ds.select(range(batch_size)).cast(
-            Features(images=Sequence(Image(decode=True))),
-            batch_size=batch_size,
-        )
+        undecode_media(ds.select(range(batch_size)), media_type=['image'], batch_size=batch_size)
 
 
 class TestUndecodeMediaIntegration:
@@ -169,7 +166,7 @@ class TestUndecodeMediaIntegration:
                 assert media_feat.decode is False
 
         for other_col in non_media_data:
-            assert other_col in result.features, f"Column {other_col} missing"
+            assert other_col in result.features, f'Column {other_col} missing'
             assert result.features[other_col] == ds.features[other_col]
 
         original_row = ds.to_list()[0]

--- a/tests/api/test_io_utils.py
+++ b/tests/api/test_io_utils.py
@@ -1,0 +1,178 @@
+import io
+import numpy as np
+import pytest
+from datasets import Audio, Dataset, Features, Image, Sequence, Video, concatenate_datasets
+from PIL import Image as PILImage
+
+from evalscope.utils.io_utils import undecode_media
+
+
+def _generate_jpeg_bytes(dim: int, quality: int = 80) -> bytes:
+    """Return a square random-noise JPEG as raw bytes."""
+    img = PILImage.fromarray(np.random.randint(0, 256, (dim, dim, 3), dtype=np.uint8))
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG', quality=quality)
+    return buf.getvalue()
+
+
+def gen_dataset(
+    media_factory: dict,
+    extra_dict: dict | None = None,
+    num_rows: int = 1,
+) -> Dataset:
+    features = {}
+    row = {}
+
+    # make media cols
+    for col_name, (media_bytes, inner_feat, count) in media_factory.items():
+        if count == 1:
+            features[col_name] = inner_feat
+            row[col_name] = {'bytes': media_bytes}
+        else:
+            features[col_name] = Sequence(inner_feat)
+            row[col_name] = [{'bytes': media_bytes}] * count
+
+    # inject non-media cols
+    if extra_dict:
+        features |= Dataset.from_list([extra_dict]).features
+        row.update(extra_dict)
+
+    single_row = Dataset.from_list([row], features=Features(features))
+    return concatenate_datasets([single_row] * num_rows)
+
+
+class TestArrowOffsetOverflow:
+    """The default ``batch_size=1000`` in ``datasets`` can overflow Arrow's
+    32-bit offset when a dataset contains many large images per row.
+
+    These tests reproduce the overflow and confirm that a smaller batch
+    size avoids it.
+    """
+
+    IMAGES_PER_ROW = 100
+
+    @pytest.mark.parametrize(
+        'dim, batch_size',
+        [(512, 100), (1024, 10)],
+    )
+    def test_default_batch_overflows_but_small_batch_succeeds(
+        self,
+        dim: int,
+        batch_size: int,
+    ):
+        ds = gen_dataset(
+            media_factory={'images': (_generate_jpeg_bytes(dim), Image(decode=True), self.IMAGES_PER_ROW)},
+            num_rows=1000,
+        )
+
+        # expected overflow with default batch size (1k)
+        with pytest.raises(ValueError, match='offset'):
+            ds.cast(Features(images=Sequence(Image(decode=True))))
+
+        # we cap len exactly as batch_size to make test faster
+        # smaller batch size avoids the overflow
+        ds.select(range(batch_size)).cast(
+            Features(images=Sequence(Image(decode=True))),
+            batch_size=batch_size,
+        )
+
+
+class TestUndecodeMediaIntegration:
+    """End-to-end tests for ``undecode_media``.
+
+    Every test verifies that:
+    • target media columns get ``decode=False``
+    • non-media columns keep their original feature type and data
+    """
+
+    @pytest.mark.parametrize(
+        'example',
+        [
+            {'text': 'hello', 'label': 0},
+            {'messages': [{'role': 'user', 'content': 'world'}], 'answer': [1]},
+            {'tokens': [1, 2, 3, 4], 'answer': {'text': 'hello'}},
+        ],
+    )
+    def test_leave_non_media_columns_unchanged(self, example: dict):
+        """Given a dataset with only text / numeric columns,
+        when undecode_media is called,
+        then the original object is returned and features are preserved."""
+        ds = Dataset.from_list([example])
+        undecoded_ds = undecode_media(ds, media_type=['image', 'audio', 'video'])
+
+        assert undecoded_ds.features == ds.features
+        assert undecoded_ds[0] == example
+
+    @pytest.mark.parametrize(
+        'media_factory, non_media_data',
+        [
+            pytest.param(
+                {'image': (_generate_jpeg_bytes(40), Image(decode=True), 1)},
+                {'text': 'cat'},
+                id='plain_Image',
+            ),
+            pytest.param(
+                {'images': (_generate_jpeg_bytes(20), Image(decode=True), 4)},
+                {'text': 'album'},
+                id='Sequence_Image',
+            ),
+            pytest.param(
+                {'audio': (b'dummy', Audio(decode=True), 1)},
+                {'text': 'recording'},
+                id='plain_Audio',
+            ),
+            pytest.param(
+                {'audios': (b'dummy', Audio(decode=True), 1)},
+                {'text': 'playlist'},
+                id='Sequence_Audio',
+            ),
+            pytest.param(
+                {'video': (b'dummy', Video(decode=True), 1)},
+                {'text': 'clip'},
+                id='plain_Video',
+            ),
+            pytest.param(
+                {'videos': (b'dummy', Video(decode=True), 1)},
+                {'text': 'clips'},
+                id='Sequence_Video',
+            ),
+            pytest.param(
+                {
+                    'image': (_generate_jpeg_bytes(40), Image(decode=True), 1),
+                    'audio': (b'dummy', Audio(decode=True), 1),
+                },
+                {'text': 'multi'},
+                id='multiple_media_types',
+            ),
+        ],
+    )
+    def test_it_disables_decode_on_media_columns_and_preserves_others(
+        self,
+        media_factory: dict,
+        non_media_data: dict,
+    ):
+        """Given a dataset with a media column (decode=True) and a text column,
+        when undecode_media is called with the relevant media_type(s),
+        then the media column's decode flag is set to False,
+        and the text column is untouched."""
+        ds = gen_dataset(media_factory, extra_dict=non_media_data)
+        result = undecode_media(ds, media_type=['image', 'audio', 'video'])
+
+        # -- Media columns: decode must be False --
+        for col_name in media_factory:
+            media_feat = result.features[col_name]
+            if isinstance(media_feat, Sequence):
+                assert isinstance(media_feat.feature, (Image, Audio, Video))
+                assert media_feat.feature.decode is False
+            else:
+                assert isinstance(media_feat, (Image, Audio, Video))
+                assert media_feat.decode is False
+
+        for other_col in non_media_data:
+            assert other_col in result.features, f"Column {other_col} missing"
+            assert result.features[other_col] == ds.features[other_col]
+
+        original_row = ds.to_list()[0]
+        result_row = result.to_list()[0]
+        for other_col in non_media_data:
+            assert result_row[other_col] == original_row[other_col]


### PR DESCRIPTION
## Summary

- [x] (feat) add function `undecode_media` in `io_utils`, with a no-op bypass when nothing to do. It takes an optional batch_size which defaults to env var `DATASET_TF_BATCH_SIZE` or 1000.
- [x] (break) migrate `parquet_to_list` to use `undecode_media` for binary media
- [x] (break) migrate remote loading `RemoteLoader` to use `undecode_media` for binary media
- [x] (test) add tests to: 
  - [x] 1. non-media columns will maintain and keeps origianl values. 
  - [x] 2. regression tests to show why supporting `batch_size`: default `1000` may fail in extreme cases.
- [x] (doc) update env var docs.

## Tests

```sh
pytest tests/benchmark/test_general_vqa_adapter.py
pytest tests/benchmark/test_general_vmcq_adapter.py
pytest tests/api/test_io_utils.py
```