### PR TITLE
fix(score): prune rouge scoring function and fix en version of rouge

### DIFF
--- a/evalscope/metrics/__init__.py
+++ b/evalscope/metrics/__init__.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .math.parser import extract_answer, math_equal, strip_answer_string
     from .nlp.metrics import ExactMatch
     from .utils.functions import bleu_ngram_one_sample, exact_match, macro_mean, mean, micro_mean, simple_f1_score
-    from .utils.rouge import compute_rouge_score, compute_rouge_score_one_sample, compute_rouge_score_one_sample_zh
+    from .utils.rouge import compute_rouge_score_one_sample, compute_rouge_score_one_sample_zh
     from .utils.text_normalizer import BasicTextNormalizer, ChineseTextNormalizer, EnglishTextNormalizer
 
 else:
@@ -34,7 +34,6 @@ else:
         ],
         'utils.rouge': [
             'compute_rouge_score_one_sample_zh',
-            'compute_rouge_score',
             'compute_rouge_score_one_sample',
         ],
         'judge.llm_judge': [

--- a/evalscope/metrics/utils/rouge.py
+++ b/evalscope/metrics/utils/rouge.py
@@ -1,14 +1,10 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-from collections import defaultdict
-from statistics import mean
-from typing import List
+from typing import Dict, List
 
 import jieba
 from rouge_chinese import Rouge
-from tqdm import tqdm
 
-from evalscope.constants import MetricsConstant
 from evalscope.metrics.utils.bundled_rouge_score import rouge_scorer
 from evalscope.utils.logger import get_logger
 
@@ -25,7 +21,9 @@ def is_contains_chinese(string: str) -> bool:
     return any('\u4e00' <= c <= '\u9fa5' for c in string)
 
 
-def compute_rouge_score_one_sample_zh(predict: List[str], reference: List[str], strict: bool = False):
+def compute_rouge_score_one_sample_zh(predict: List[str],
+                                      reference: List[str],
+                                      strict: bool = False) -> Dict[str, float]:
     if isinstance(predict, str) or isinstance(reference, str):
         raise ValueError(f'Expected list of strings, but got {type(predict)} and {type(reference)}')
 
@@ -53,7 +51,7 @@ def compute_rouge_score_one_sample_zh(predict: List[str], reference: List[str], 
     return result
 
 
-def compute_rouge_score_one_sample(predict: List[str], reference: List[str], strict: bool = False):
+def compute_rouge_score_one_sample(predict: List[str], reference: List[str], strict: bool = False) -> Dict[str, float]:
     if isinstance(predict, str) or isinstance(reference, str):
         raise ValueError(f'Expected list of strings, but got {type(predict)} and {type(reference)}')
 

--- a/evalscope/metrics/utils/rouge.py
+++ b/evalscope/metrics/utils/rouge.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from statistics import mean
+from typing import List
 
 import jieba
 from rouge_chinese import Rouge
@@ -20,36 +21,17 @@ class DummyTokenizer:
         return text.split()
 
 
-def is_contains_chinese(strs):
-    for _char in strs:
-        if '\u4e00' <= _char <= '\u9fa5':
-            return True
-    return False
+def is_contains_chinese(string: str) -> bool:
+    return any('\u4e00' <= c <= '\u9fa5' for c in string)
 
 
-def compute_rouge_score(predict_l, reference_l):
-    assert len(predict_l) == len(reference_l)
-    if len(predict_l) == 0:
-        tmp_d = dict()
-        for key in MetricsConstant.ROUGE_KEYS:
-            tmp_d[key] = 0
-        return tmp_d
+def compute_rouge_score_one_sample_zh(predict: List[str], reference: List[str], strict: bool = False):
+    if isinstance(predict, str) or isinstance(reference, str):
+        raise ValueError(f'Expected list of strings, but got {type(predict)} and {type(reference)}')
 
-    result = defaultdict(list)
-    for p, r in tqdm(zip(predict_l, reference_l)):
-        one_sample = compute_rouge_score_one_sample(p, r)
-        for rouge_key in MetricsConstant.ROUGE_KEYS:
-            result[rouge_key].append(one_sample[rouge_key])
-    rlt = {}
-    for rouge_key in MetricsConstant.ROUGE_KEYS:
-        rlt[rouge_key] = (mean(result[rouge_key]) * 100 if rouge_key in result else MetricsConstant.INVALID_VALUE)
-    return rlt
-
-
-def compute_rouge_score_one_sample_zh(predict, reference):
     result = dict()
     zh_scorer = Rouge()
-    for p, r in zip(predict, reference):
+    for p, r in zip(predict, reference, strict=strict):
         p = ' '.join(jieba.cut(p)) if is_contains_chinese(p) else p
         r = ' '.join(jieba.cut(r)) if is_contains_chinese(r) else r
 
@@ -71,12 +53,15 @@ def compute_rouge_score_one_sample_zh(predict, reference):
     return result
 
 
-def compute_rouge_score_one_sample(predict, reference):
+def compute_rouge_score_one_sample(predict: List[str], reference: List[str], strict: bool = False):
+    if isinstance(predict, str) or isinstance(reference, str):
+        raise ValueError(f'Expected list of strings, but got {type(predict)} and {type(reference)}')
+
     result = dict()
     scorer = rouge_scorer.RougeScorer(['rouge1', 'rouge2', 'rougeL'], tokenizer=DummyTokenizer())
-    for p, r in zip(predict, reference):
+    for p, r in zip(predict, reference, strict=strict):
         try:
-            score = scorer.score(p, r)
+            score = scorer.score(target=r, prediction=p)
         except Exception as e:
             logger.warning(f'rouge score error: {p} {r} {e}')
             continue


### PR DESCRIPTION
## Summary

- [x] (break) remove unused, over-complicated `compute_rouge_score()`
- [x] (fix) `compute_rouge_score_one_sample()` had inverted reference and prediction.
- [x] (fix) add safeguards before Rouge functions, preventing strings from going into `zip()`
- [x] (feat) add a toggle to strictly match the lengths of `ref: list[str]` and `pred: list[str]` defaults to False, the same behavior as before.
- [x] no tests needed.
- [x] no doc updated needed.