### PR TITLE
docs: fix stale ModelAPI docstrings (nonexistent api_key_vars / ChatUserMessage)

### DIFF
--- a/evalscope/api/model/model.py
+++ b/evalscope/api/model/model.py
@@ -35,8 +35,6 @@ class ModelAPI(abc.ABC):
            model_name (str): Model name.
            base_url (str | None): Alternate base URL for model.
            api_key (str | None): API key for model.
-           api_key_vars (list[str]): Environment variables that
-              may contain keys for this provider (used for override)
            config (GenerateConfig): Model configuration.
         """
         self.model_name = model_name
@@ -55,9 +53,7 @@ class ModelAPI(abc.ABC):
         """Generate output from the model.
 
         Args:
-          input (str | list[ChatMessage]): Chat message
-            input (if a `str` is passed it is converted
-            to a `ChatUserMessage`).
+          input (list[ChatMessage]): Chat message input.
           tools (list[ToolInfo]): Tools available for the
             model to call.
           tool_choice (ToolChoice): Directives to the model


### PR DESCRIPTION
### Description

Two stale docstrings in the `ModelAPI` base class describe an API that does not exist:

1. `ModelAPI.__init__` documents an `api_key_vars` parameter that is not in the
   signature. `grep -rn "api_key_vars"` matches only this docstring — the
   parameter does not exist anywhere in the codebase.
2. `ModelAPI.generate` documents `input` as `str | list[ChatMessage]` and claims a
   `str` is converted to a `ChatUserMessage`. But:
   - the signature is `input: List[ChatMessage]` and does not accept `str`;
   - `str` -> message conversion happens one layer up in `Model._preprocess_input`,
     not in this base class;
   - `ChatUserMessage` does not exist; the actual class is `ChatMessageUser`
     (433 occurrences), so the name in the docstring is wrong as well.

Both appear to be leftovers from the upstream inspect-ai API.

### Test

Docstring only, no behavior change.

- `make lint` equivalents pass: `ruff check evalscope/api/model/model.py` reports no new
  findings vs. the unmodified baseline; `yapf --diff` -> empty
- `python -m py_compile` passes
- No auto-generated files touched (`docs/{zh,en}/benchmarks/`, `evalscope/benchmarks/_meta/`)