### PR TITLE
feat(benchmarks): add hle_tools benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ For details, please refer to [📖 Visualizing Evaluation Results](https://evals
 
 ## 🎉 What's New
 
+- 🔥 **[2026.08.26]** Added **Humanity's Last Exam with Tools** (`hle_tools`) benchmark.
 - 🔥 **[2026.08.24] v1.11.0** Introduced published evaluation versions for reproducible benchmark results; improved report semantics and incomplete-run handling; strengthened multimodal media loading and task-config validation.
 - 🔥 **[2026.08.13]** Improved evaluation reports with unified metric semantics and more reliable Agent Trace step grouping and tool-call/result linking.
 - 🔥 **[2026.08.10]** Added **AutomationBench**, **JobBench**, **MiniWoB**, **OmniDocBench-v1.6**, **PerceptionBench**, **ScreenSpot-Pro**, **PLawBench**, **PMC-VQA**, **HiPhO**, **LogicVista**, and **CC-OCR-V2** benchmarks.

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,6 +75,7 @@ EvalScope 提供交互式 Web Dashboard，支持多维度模型对比和深入�
 
 ## 🎉 内容更新
 
+- 🔥 **[2026.08.26]** 新增 **Humanity's Last Exam with Tools**（`hle_tools`）基准。
 - 🔥 **[2026.08.24] v1.11.0** 引入可发布的评测版本标识，保障基准结果可复现；优化评测报告语义与不完整运行处理，并增强多模态媒体加载和任务配置校验。
 - 🔥 **[2026.08.13]** 评测报告升级：统一指标语义，并改善 Agent Trace 步骤分组与工具调用/结果关联的可靠性。
 - 🔥 **[2026.08.10]** 新增 **AutomationBench**、**JobBench**、**MiniWoB**、**OmniDocBench-v1.6**、**PerceptionBench**、**ScreenSpot-Pro**、**PLawBench**、**PMC-VQA**、**HiPhO**、**LogicVista** 和 **CC-OCR-V2** 基准。

--- a/docs/en/benchmarks/hle_tools.md
+++ b/docs/en/benchmarks/hle_tools.md
@@ -1,0 +1,214 @@
+# Humanity's-Last-Exam-with-Tools
+
+
+## Overview
+
+Humanity's Last Exam with Tools (`hle_tools`) is the tool-use counterpart of closed-book [`hle`](hle.md). It evaluates the same 2,500 expert-level questions from CAIS / Scale AI, but drives each sample through EvalScope's Native AgentLoop so the model can call code execution and optional web tools before answering.
+
+This is a **distinct leaderboard row** from `hle`. Use `datasets=['hle']` for closed-book QA and `datasets=['hle_tools']` for the multi-turn tool-use protocol.
+
+## Task Description
+
+- **Task Type**: Expert-Level Question Answering with Tools (multi-turn AgentLoop)
+- **Input**: Question with optional image (14% multimodal), plus `python_exec` (and optional MCP fetch/search)
+- **Output**: Answer with explanation and confidence score
+- **Domains**: Mathematics (41%), Physics (9%), Biology/Medicine (11%), Computer Science/AI (10%), Humanities (9%), Engineering (4%), Chemistry (7%), Other (9%)
+
+## Key Features
+
+- Reuses the official HLE dataset (`cais/hle` on ModelScope), judge (`GRADE: C/I`), subsets, and `include_multi_modal` extra param
+- Default Native AgentLoop: `function_calling` strategy, `python_exec`, `local` environment, 30 steps
+- Optional MCP `fetch` is attached automatically when `evalscope[mcp]` (and `mcp-server-fetch`) is installed — no paid search API key required
+- Optional MCP web search (Brave, Tavily, …) can be added through `NativeAgentConfig.mcp_servers`
+- Docker is recommended for isolated production runs but is **not** required; the default `local` environment is mock-friendly
+
+## Evaluation Notes
+
+- Default evaluation uses the **test** split
+- Primary metric: **Accuracy** with the same HLE LLM judge
+- Response format includes: Explanation, Answer, and Confidence (0-100%)
+- **Note**: Set `extra_params["include_multi_modal"]` to `False` for text-only models
+- Uses GRADE: C/I format for LLM judge scoring
+- `datasets=['hle_tools']` enables tools by default. You do **not** need to set `TaskConfig.agent_config` unless you want to override the loop
+- Passing `NativeAgentConfig` merges with defaults for any field you leave unset (`tools`, `environment`, `max_steps`, `mcp_servers`)
+- `local` has no filesystem isolation; for formal runs set `environment='docker'` (see below)
+- Install web fetch with `pip install evalscope[mcp]`. Paid search MCP servers are optional
+
+## Agent Environment
+
+Default loop (applied when `agent_config` is omitted):
+
+- **Strategy**: `function_calling`
+- **Tools**: `python_exec` (built-in). `submit` is auto-injected
+- **Environment**: `local` (host subprocess). Recommended production override: `docker` + `python:3.11-slim`
+- **MCP**: `mcp-server-fetch` when the optional extra is installed
+- **max_steps**: 30
+
+Override example — Docker plus fetch, and an optional search server:
+
+```python
+import sys
+from evalscope import TaskConfig, run_task
+from evalscope.api.agent import NativeAgentConfig
+from evalscope.api.agent.mcp import MCPServerConfigStdio
+
+run_task(TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['hle_tools'],
+    dataset_args={
+        'hle_tools': {
+            'subset_list': ['Math'],
+            'extra_params': {'include_multi_modal': False},
+        }
+    },
+    agent_config=NativeAgentConfig(
+        strategy='function_calling',
+        tools=['python_exec'],
+        environment='docker',
+        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},
+        max_steps=30,
+        mcp_servers=[
+            MCPServerConfigStdio(
+                command=sys.executable,
+                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],
+                name='fetch',
+            ),
+            # Optional paid search, e.g. Brave / Tavily MCP — not required
+        ],
+    ),
+    limit=10,
+))
+```
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `hle_tools` |
+| **Dataset ID** | [cais/hle](https://modelscope.cn/datasets/cais/hle/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2501.14249) |
+| **Tags** | `Agent`, `Knowledge`, `MultiTurn`, `QA` |
+| **Metrics** | `accuracy` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 2,500 |
+| Prompt Length (Mean) | 1029.85 chars |
+| Prompt Length (Min/Max) | 234 / 21341 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `Biology/Medicine` | 280 | 1259.39 | 246 | 13702 |
+| `Chemistry` | 165 | 812.72 | 236 | 6942 |
+| `Computer Science/AI` | 241 | 1581.02 | 263 | 11529 |
+| `Engineering` | 111 | 1620.26 | 250 | 21341 |
+| `Humanities/Social Science` | 219 | 1069.39 | 256 | 7028 |
+| `Math` | 1,021 | 862.46 | 262 | 8952 |
+| `Physics` | 230 | 1027.63 | 257 | 17139 |
+| `Other` | 233 | 754.94 | 234 | 13655 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 342 |
+| Images per Sample | min: 1, max: 1, mean: 1 |
+| Resolution Range | 329x12 - 14950x2780 |
+| Formats | gif, jpeg, png, webp |
+
+
+## Sample Example
+
+**Subset**: `Biology/Medicine`
+
+```json
+{
+  "input": [
+    {
+      "id": "906a518f",
+      "content": "Your response should be in the following format:\nExplanation: {your explanation for your answer choice}\nAnswer: {your chosen answer}\nConfidence: {your confidence score between 0% and 100% for your answer}"
+    },
+    {
+      "id": "d03d8d4e",
+      "content": [
+        {
+          "text": "In a bioinformatics lab, Watterson's estimator (theta) and pi (nucleotide diversity) will be calculated from variant call files which contain human phased samples with only single nucleotide variants present, and there are no completely missi ... [TRUNCATED] ... y pi (nucleotide diversity) is biased.\nC. Both Watterson's estimator (theta) and pi (nucleotide diversity) are biased.\nD. Neither Watterson's estimator (theta) nor pi (nucleotide diversity) are biased.\nE. None of the other answers are correct"
+        }
+      ]
+    }
+  ],
+  "target": "B",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "Biology/Medicine",
+  "metadata": {
+    "uid": "66e88728ba7d8bc0d5806f3a",
+    "author_name": "Scott S",
+    "rationale": "First, we recognize that all single nucleotide variants are included somewhere in the sample. It is given that, across “all samples,” there are no “missing single nucleotide variants.” Further, since “[t]he number of samples is arbitrarily la ... [TRUNCATED] ... fferent genotypes that that position, the analysis would consider these two genomes to have the same nucleotide at the position. This reduces the estimated nucleotide diversity, pi. Therefore, pi would be biased in the circumstance described.",
+    "raw_subject": "Bioinformatics",
+    "category": "Biology/Medicine",
+    "has_image": false
+  }
+}
+```
+
+*Note: Some content was truncated for display.*
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{question}
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `include_multi_modal` | `bool` | `True` | Include multi-modal (image) questions during evaluation. |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets hle_tools \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['hle_tools'],
+    dataset_args={
+        'hle_tools': {
+            # subset_list: ['Biology/Medicine', 'Chemistry', 'Computer Science/AI']  # optional, evaluate specific subsets
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/llm.md
+++ b/docs/en/get_started/supported_dataset/llm.md
@@ -70,6 +70,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 | `hellaswag` | [HellaSwag](../../benchmarks/hellaswag.md) | `Commonsense`, `Knowledge`, `MCQ` |
 | `hellaswag_hi` | [HellaSwag-Hindi](../../benchmarks/hellaswag_hi.md) | `MCQ`, `Reasoning` |
 | `hle` | [Humanity's-Last-Exam](../../benchmarks/hle.md) | `Knowledge`, `QA` |
+| `hle_tools` | [Humanity's-Last-Exam-with-Tools](../../benchmarks/hle_tools.md) | `Agent`, `Knowledge`, `MultiTurn`, `QA` |
 | `hmmt25` | [HMMT25](../../benchmarks/hmmt25.md) | `Math`, `Reasoning` |
 | `hmmt26` | [HMMT26](../../benchmarks/hmmt26.md) | `Math`, `Reasoning` |
 | `humaneval` | [HumanEval](../../benchmarks/humaneval.md) | `Coding` |
@@ -215,6 +216,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/hellaswag.md
 ../../benchmarks/hellaswag_hi.md
 ../../benchmarks/hle.md
+../../benchmarks/hle_tools.md
 ../../benchmarks/hmmt25.md
 ../../benchmarks/hmmt26.md
 ../../benchmarks/humaneval.md

--- a/docs/zh/benchmarks/hle_tools.md
+++ b/docs/zh/benchmarks/hle_tools.md
@@ -1,0 +1,210 @@
+# Humanity's-Last-Exam-with-Tools
+
+## 概述
+
+Humanity's Last Exam with Tools（`hle_tools`）是闭卷评测集 [`hle`](hle.md) 的工具使用版本。它复用 CAIS / Scale AI 的同一批 2,500 道专家级题目，但通过 EvalScope Native AgentLoop 驱动每条样本，使模型在作答前可以调用代码执行和可选的网页工具。
+
+这是与 `hle` **不同的排行榜条目**。闭卷问答请使用 `datasets=['hle']`，多轮工具使用协议请使用 `datasets=['hle_tools']`。
+
+## 任务描述
+
+- **任务类型**：带工具的专家级问答（多轮 AgentLoop）
+- **输入**：问题（14% 为多模态，含图片），并提供 `python_exec`（以及可选的 MCP fetch/search）
+- **输出**：答案、解释及置信度分数
+- **领域分布**：数学（41%）、物理（9%）、生物/医学（11%）、计算机科学/AI（10%）、人文（9%）、工程（4%）、化学（7%）、其他（9%）
+
+## 主要特点
+
+- 复用官方 HLE 数据集（ModelScope 上的 `cais/hle`）、裁判（`GRADE: C/I`）、子集以及 `include_multi_modal` 额外参数
+- 默认 Native AgentLoop：`function_calling` 策略、`python_exec`、`local` 环境、最多 30 步
+- 安装 `evalscope[mcp]`（及 `mcp-server-fetch`）后自动挂载可选 MCP `fetch`，无需付费搜索 API Key
+- 可通过 `NativeAgentConfig.mcp_servers` 额外接入 MCP 网页搜索（Brave、Tavily 等）
+- 正式评测推荐使用 Docker 隔离，但**不是**必须；默认 `local` 环境便于本地/Mock 验证
+
+## 评估说明
+
+- 默认使用 **test** 数据划分进行评估
+- 主要指标：与 HLE 相同的 LLM 裁判 **准确率（Accuracy）**
+- 响应格式包括：解释（Explanation）、答案（Answer）和置信度（Confidence，0–100%）
+- **注意**：对于纯文本模型，请将 `extra_params["include_multi_modal"]` 设为 `False`
+- 使用 GRADE: C/I 格式进行 LLM 裁判评分
+- `datasets=['hle_tools']` 默认启用工具。除非需要覆盖循环配置，否则不必设置 `TaskConfig.agent_config`
+- 传入 `NativeAgentConfig` 时，未显式设置的字段（`tools`、`environment`、`max_steps`、`mcp_servers`）会与默认值合并
+- `local` 没有文件系统隔离；正式评测请设置 `environment='docker'`（见下文）
+- 网页抓取请安装 `pip install evalscope[mcp]`。付费搜索 MCP 为可选项
+
+## Agent 环境
+
+默认循环（未设置 `agent_config` 时生效）：
+
+- **策略**：`function_calling`
+- **工具**：内置 `python_exec`。`submit` 会自动注入
+- **环境**：`local`（宿主机子进程）。正式评测推荐覆盖为 `docker` + `python:3.11-slim`
+- **MCP**：安装可选依赖后使用 `mcp-server-fetch`
+- **max_steps**：30
+
+覆盖示例 — Docker + fetch，以及可选的搜索服务器：
+
+```python
+import sys
+from evalscope import TaskConfig, run_task
+from evalscope.api.agent import NativeAgentConfig
+from evalscope.api.agent.mcp import MCPServerConfigStdio
+
+run_task(TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['hle_tools'],
+    dataset_args={
+        'hle_tools': {
+            'subset_list': ['Math'],
+            'extra_params': {'include_multi_modal': False},
+        }
+    },
+    agent_config=NativeAgentConfig(
+        strategy='function_calling',
+        tools=['python_exec'],
+        environment='docker',
+        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},
+        max_steps=30,
+        mcp_servers=[
+            MCPServerConfigStdio(
+                command=sys.executable,
+                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],
+                name='fetch',
+            ),
+            # 可选付费搜索，例如 Brave / Tavily MCP — 非必须
+        ],
+    ),
+    limit=10,
+))
+```
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `hle_tools` |
+| **数据集ID** | [cais/hle](https://modelscope.cn/datasets/cais/hle/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2501.14249) |
+| **标签** | `Agent`, `Knowledge`, `MultiTurn`, `QA` |
+| **指标** | `accuracy` |
+| **默认示例数（Shots）** | 0-shot |
+| **评估划分** | `test` |
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 2,500 |
+| 提示词长度（平均） | 1029.85 字符 |
+| 提示词长度（最小/最大） | 234 / 21341 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |
+|--------|---------|-------------|------------|------------|
+| `Biology/Medicine` | 280 | 1259.39 | 246 | 13702 |
+| `Chemistry` | 165 | 812.72 | 236 | 6942 |
+| `Computer Science/AI` | 241 | 1581.02 | 263 | 11529 |
+| `Engineering` | 111 | 1620.26 | 250 | 21341 |
+| `Humanities/Social Science` | 219 | 1069.39 | 256 | 7028 |
+| `Math` | 1,021 | 862.46 | 262 | 8952 |
+| `Physics` | 230 | 1027.63 | 257 | 17139 |
+| `Other` | 233 | 754.94 | 234 | 13655 |
+
+**图像统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 342 |
+| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |
+| 分辨率范围 | 329x12 – 14950x2780 |
+| 图像格式 | gif, jpeg, png, webp |
+
+## 样例示例
+
+**子集**: `Biology/Medicine`
+
+```json
+{
+  "input": [
+    {
+      "id": "906a518f",
+      "content": "Your response should be in the following format:\nExplanation: {your explanation for your answer choice}\nAnswer: {your chosen answer}\nConfidence: {your confidence score between 0% and 100% for your answer}"
+    },
+    {
+      "id": "d03d8d4e",
+      "content": [
+        {
+          "text": "In a bioinformatics lab, Watterson's estimator (theta) and pi (nucleotide diversity) will be calculated from variant call files which contain human phased samples with only single nucleotide variants present, and there are no completely missi ... [TRUNCATED] ... y pi (nucleotide diversity) is biased.\nC. Both Watterson's estimator (theta) and pi (nucleotide diversity) are biased.\nD. Neither Watterson's estimator (theta) nor pi (nucleotide diversity) are biased.\nE. None of the other answers are correct"
+        }
+      ]
+    }
+  ],
+  "target": "B",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "Biology/Medicine",
+  "metadata": {
+    "uid": "66e88728ba7d8bc0d5806f3a",
+    "author_name": "Scott S",
+    "rationale": "First, we recognize that all single nucleotide variants are included somewhere in the sample. It is given that, across “all samples,” there are no “missing single nucleotide variants.” Further, since “[t]he number of samples is arbitrarily la ... [TRUNCATED] ... fferent genotypes that that position, the analysis would consider these two genomes to have the same nucleotide at the position. This reduces the estimated nucleotide diversity, pi. Therefore, pi would be biased in the circumstance described.",
+    "raw_subject": "Bioinformatics",
+    "category": "Biology/Medicine",
+    "has_image": false
+  }
+}
+```
+
+*注：部分内容因展示需要已被截断。*
+
+## 提示模板
+
+**提示模板：**
+```text
+{question}
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `include_multi_modal` | `bool` | `True` | 评估时是否包含多模态（图像）问题。 |
+
+## 使用方法
+
+### 通过命令行（CLI）
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets hle_tools \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 通过 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['hle_tools'],
+    dataset_args={
+        'hle_tools': {
+            # subset_list: ['Biology/Medicine', 'Chemistry', 'Computer Science/AI']  # 可选，用于评估特定子集
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/llm.md
+++ b/docs/zh/get_started/supported_dataset/llm.md
@@ -70,6 +70,7 @@
 | `hellaswag` | [HellaSwag](../../benchmarks/hellaswag.md) | `Commonsense`, `Knowledge`, `MCQ` |
 | `hellaswag_hi` | [HellaSwag-Hindi](../../benchmarks/hellaswag_hi.md) | `MCQ`, `Reasoning` |
 | `hle` | [Humanity's-Last-Exam](../../benchmarks/hle.md) | `Knowledge`, `QA` |
+| `hle_tools` | [Humanity's-Last-Exam-with-Tools](../../benchmarks/hle_tools.md) | `Agent`, `Knowledge`, `MultiTurn`, `QA` |
 | `hmmt25` | [HMMT25](../../benchmarks/hmmt25.md) | `Math`, `Reasoning` |
 | `hmmt26` | [HMMT26](../../benchmarks/hmmt26.md) | `Math`, `Reasoning` |
 | `humaneval` | [HumanEval](../../benchmarks/humaneval.md) | `Coding` |
@@ -215,6 +216,7 @@
 ../../benchmarks/hellaswag.md
 ../../benchmarks/hellaswag_hi.md
 ../../benchmarks/hle.md
+../../benchmarks/hle_tools.md
 ../../benchmarks/hmmt25.md
 ../../benchmarks/hmmt26.md
 ../../benchmarks/humaneval.md

--- a/evalscope/benchmarks/_meta/hle_tools.json
+++ b/evalscope/benchmarks/_meta/hle_tools.json
@@ -1,0 +1,473 @@
+{
+  "meta": {
+    "pretty_name": "Humanity's-Last-Exam-with-Tools",
+    "dataset_id": "cais/hle",
+    "paper_url": "https://arxiv.org/abs/2501.14249",
+    "tags": [
+      "Knowledge",
+      "QA",
+      "Agent",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "accuracy"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "Biology/Medicine",
+      "Chemistry",
+      "Computer Science/AI",
+      "Engineering",
+      "Humanities/Social Science",
+      "Math",
+      "Physics",
+      "Other"
+    ],
+    "description": "\n## Overview\n\nHumanity's Last Exam with Tools (`hle_tools`) is the tool-use counterpart of closed-book [`hle`](hle.md). It evaluates the same 2,500 expert-level questions from CAIS / Scale AI, but drives each sample through EvalScope's Native AgentLoop so the model can call code execution and optional web tools before answering.\n\nThis is a **distinct leaderboard row** from `hle`. Use `datasets=['hle']` for closed-book QA and `datasets=['hle_tools']` for the multi-turn tool-use protocol.\n\n## Task Description\n\n- **Task Type**: Expert-Level Question Answering with Tools (multi-turn AgentLoop)\n- **Input**: Question with optional image (14% multimodal), plus `python_exec` (and optional MCP fetch/search)\n- **Output**: Answer with explanation and confidence score\n- **Domains**: Mathematics (41%), Physics (9%), Biology/Medicine (11%), Computer Science/AI (10%), Humanities (9%), Engineering (4%), Chemistry (7%), Other (9%)\n\n## Key Features\n\n- Reuses the official HLE dataset (`cais/hle` on ModelScope), judge (`GRADE: C/I`), subsets, and `include_multi_modal` extra param\n- Default Native AgentLoop: `function_calling` strategy, `python_exec`, `local` environment, 30 steps\n- Optional MCP `fetch` is attached automatically when `evalscope[mcp]` (and `mcp-server-fetch`) is installed — no paid search API key required\n- Optional MCP web search (Brave, Tavily, …) can be added through `NativeAgentConfig.mcp_servers`\n- Docker is recommended for isolated production runs but is **not** required; the default `local` environment is mock-friendly\n\n## Evaluation Notes\n\n- Default evaluation uses the **test** split\n- Primary metric: **Accuracy** with the same HLE LLM judge\n- Response format includes: Explanation, Answer, and Confidence (0-100%)\n- **Note**: Set `extra_params[\"include_multi_modal\"]` to `False` for text-only models\n- Uses GRADE: C/I format for LLM judge scoring\n- `datasets=['hle_tools']` enables tools by default. You do **not** need to set `TaskConfig.agent_config` unless you want to override the loop\n- Passing `NativeAgentConfig` merges with defaults for any field you leave unset (`tools`, `environment`, `max_steps`, `mcp_servers`)\n- `local` has no filesystem isolation; for formal runs set `environment='docker'` (see below)\n- Install web fetch with `pip install evalscope[mcp]`. Paid search MCP servers are optional\n\n## Agent Environment\n\nDefault loop (applied when `agent_config` is omitted):\n\n- **Strategy**: `function_calling`\n- **Tools**: `python_exec` (built-in). `submit` is auto-injected\n- **Environment**: `local` (host subprocess). Recommended production override: `docker` + `python:3.11-slim`\n- **MCP**: `mcp-server-fetch` when the optional extra is installed\n- **max_steps**: 30\n\nOverride example — Docker plus fetch, and an optional search server:\n\n```python\nimport sys\nfrom evalscope import TaskConfig, run_task\nfrom evalscope.api.agent import NativeAgentConfig\nfrom evalscope.api.agent.mcp import MCPServerConfigStdio\n\nrun_task(TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['hle_tools'],\n    dataset_args={\n        'hle_tools': {\n            'subset_list': ['Math'],\n            'extra_params': {'include_multi_modal': False},\n        }\n    },\n    agent_config=NativeAgentConfig(\n        strategy='function_calling',\n        tools=['python_exec'],\n        environment='docker',\n        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},\n        max_steps=30,\n        mcp_servers=[\n            MCPServerConfigStdio(\n                command=sys.executable,\n                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],\n                name='fetch',\n            ),\n            # Optional paid search, e.g. Brave / Tavily MCP — not required\n        ],\n    ),\n    limit=10,\n))\n```\n",
+    "prompt_template": "{question}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "include_multi_modal": {
+        "type": "bool",
+        "description": "Include multi-modal (image) questions during evaluation.",
+        "value": true
+      }
+    },
+    "sandbox_config": {},
+    "category": "llm"
+  },
+  "statistics": {
+    "total_samples": 2500,
+    "subset_stats": [
+      {
+        "name": "Biology/Medicine",
+        "sample_count": 280,
+        "prompt_length_mean": 1259.39,
+        "prompt_length_min": 246,
+        "prompt_length_max": 13702,
+        "prompt_length_std": 1344.62,
+        "target_length_mean": 7.74,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 58,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1024x768",
+              "1050x1400",
+              "107x99",
+              "1200x729",
+              "1230x450",
+              "1246x759",
+              "1336x1022",
+              "1418x1078",
+              "1535x858",
+              "1600x670"
+            ],
+            "resolution_range": {
+              "min": "107x99",
+              "max": "2784x2484"
+            },
+            "formats": [
+              "gif",
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Chemistry",
+        "sample_count": 165,
+        "prompt_length_mean": 812.72,
+        "prompt_length_min": 236,
+        "prompt_length_max": 6942,
+        "prompt_length_std": 848.77,
+        "target_length_mean": 19.62,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 64,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1022x439",
+              "1051x1055",
+              "1063x183",
+              "1080x783",
+              "1211x200",
+              "1280x720",
+              "1420x688",
+              "1600x900",
+              "1652x422",
+              "1665x587"
+            ],
+            "resolution_range": {
+              "min": "200x200",
+              "max": "2278x2179"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Computer Science/AI",
+        "sample_count": 241,
+        "prompt_length_mean": 1581.02,
+        "prompt_length_min": 263,
+        "prompt_length_max": 11529,
+        "prompt_length_std": 1655.36,
+        "target_length_mean": 9.22,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 17,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1121x969",
+              "1365x513",
+              "1581x961",
+              "168x168",
+              "2496x1422",
+              "270x360",
+              "329x12",
+              "337x178",
+              "390x480",
+              "560x407"
+            ],
+            "resolution_range": {
+              "min": "329x12",
+              "max": "2496x1422"
+            },
+            "formats": [
+              "gif",
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Engineering",
+        "sample_count": 111,
+        "prompt_length_mean": 1620.26,
+        "prompt_length_min": 250,
+        "prompt_length_max": 21341,
+        "prompt_length_std": 2595.85,
+        "target_length_mean": 15.95,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 47,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1007x754",
+              "1008x871",
+              "1085x1022",
+              "1185x648",
+              "1188x802",
+              "1222x1098",
+              "1252x674",
+              "1260x746",
+              "1262x787",
+              "1284x758"
+            ],
+            "resolution_range": {
+              "min": "503x373",
+              "max": "4405x1418"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Humanities/Social Science",
+        "sample_count": 219,
+        "prompt_length_mean": 1069.39,
+        "prompt_length_min": 256,
+        "prompt_length_max": 7028,
+        "prompt_length_std": 1066.43,
+        "target_length_mean": 9.98,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 26,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1089x970",
+              "1091x1602",
+              "1152x816",
+              "118x204",
+              "132x46",
+              "1757x1456",
+              "1860x525",
+              "1996x592",
+              "2000x1882",
+              "2200x1544"
+            ],
+            "resolution_range": {
+              "min": "132x46",
+              "max": "2000x1882"
+            },
+            "formats": [
+              "gif",
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Math",
+        "sample_count": 1021,
+        "prompt_length_mean": 862.46,
+        "prompt_length_min": 262,
+        "prompt_length_max": 8952,
+        "prompt_length_std": 780.95,
+        "target_length_mean": 11.2,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 45,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1000x700",
+              "1000x990",
+              "1051x380",
+              "1152x1212",
+              "1167x975",
+              "1188x760",
+              "1200x562",
+              "1385x1388",
+              "1430x1000",
+              "1430x1080"
+            ],
+            "resolution_range": {
+              "min": "415x381",
+              "max": "14950x2780"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Physics",
+        "sample_count": 230,
+        "prompt_length_mean": 1027.63,
+        "prompt_length_min": 257,
+        "prompt_length_max": 17139,
+        "prompt_length_std": 1301.6,
+        "target_length_mean": 14.67,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 28,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1096x420",
+              "1141x823",
+              "1251x833",
+              "1264x868",
+              "1600x276",
+              "1608x1009",
+              "1667x439",
+              "1667x445",
+              "1667x815",
+              "1920x1440"
+            ],
+            "resolution_range": {
+              "min": "216x126",
+              "max": "2242x1876"
+            },
+            "formats": [
+              "jpeg",
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Other",
+        "sample_count": 233,
+        "prompt_length_mean": 754.94,
+        "prompt_length_min": 234,
+        "prompt_length_max": 13655,
+        "prompt_length_std": 988.31,
+        "target_length_mean": 10.89,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 57,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1018x550",
+              "1024x1024",
+              "1070x766",
+              "1080x1078",
+              "1089x568",
+              "1159x642",
+              "1180x625",
+              "1260x1300",
+              "1266x1022",
+              "1279x1687"
+            ],
+            "resolution_range": {
+              "min": "82x110",
+              "max": "3508x4961"
+            },
+            "formats": [
+              "jpeg",
+              "png",
+              "webp"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 1029.85,
+      "min": 234,
+      "max": 21341,
+      "std": 1214.66
+    },
+    "target_length_mean": 11.57,
+    "computed_at": "2026-01-28T11:14:01.956484",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 342,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "resolutions": [
+          "1000x700",
+          "1000x990",
+          "1007x754",
+          "1008x871",
+          "1018x550",
+          "1022x439",
+          "1024x1024",
+          "1024x768",
+          "1050x1400",
+          "1051x1055"
+        ],
+        "resolution_range": {
+          "min": "329x12",
+          "max": "14950x2780"
+        },
+        "formats": [
+          "gif",
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "906a518f",
+          "content": "Your response should be in the following format:\nExplanation: {your explanation for your answer choice}\nAnswer: {your chosen answer}\nConfidence: {your confidence score between 0% and 100% for your answer}"
+        },
+        {
+          "id": "d03d8d4e",
+          "content": [
+            {
+              "text": "In a bioinformatics lab, Watterson's estimator (theta) and pi (nucleotide diversity) will be calculated from variant call files which contain human phased samples with only single nucleotide variants present, and there are no completely missi ... [TRUNCATED] ... y pi (nucleotide diversity) is biased.\nC. Both Watterson's estimator (theta) and pi (nucleotide diversity) are biased.\nD. Neither Watterson's estimator (theta) nor pi (nucleotide diversity) are biased.\nE. None of the other answers are correct"
+            }
+          ]
+        }
+      ],
+      "target": "B",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "Biology/Medicine",
+      "metadata": {
+        "uid": "66e88728ba7d8bc0d5806f3a",
+        "author_name": "Scott S",
+        "rationale": "First, we recognize that all single nucleotide variants are included somewhere in the sample. It is given that, across “all samples,” there are no “missing single nucleotide variants.” Further, since “[t]he number of samples is arbitrarily la ... [TRUNCATED] ... fferent genotypes that that position, the analysis would consider these two genomes to have the same nucleotide at the position. This reduces the estimated nucleotide diversity, pi. Therefore, pi would be biased in the circumstance described.",
+        "raw_subject": "Bioinformatics",
+        "category": "Biology/Medicine",
+        "has_image": false
+      }
+    },
+    "subset": "Biology/Medicine",
+    "truncated": true
+  },
+  "readme": {
+    "en": "# Humanity's-Last-Exam-with-Tools\n\n\n## Overview\n\nHumanity's Last Exam with Tools (`hle_tools`) is the tool-use counterpart of closed-book [`hle`](hle.md). It evaluates the same 2,500 expert-level questions from CAIS / Scale AI, but drives each sample through EvalScope's Native AgentLoop so the model can call code execution and optional web tools before answering.\n\nThis is a **distinct leaderboard row** from `hle`. Use `datasets=['hle']` for closed-book QA and `datasets=['hle_tools']` for the multi-turn tool-use protocol.\n\n## Task Description\n\n- **Task Type**: Expert-Level Question Answering with Tools (multi-turn AgentLoop)\n- **Input**: Question with optional image (14% multimodal), plus `python_exec` (and optional MCP fetch/search)\n- **Output**: Answer with explanation and confidence score\n- **Domains**: Mathematics (41%), Physics (9%), Biology/Medicine (11%), Computer Science/AI (10%), Humanities (9%), Engineering (4%), Chemistry (7%), Other (9%)\n\n## Key Features\n\n- Reuses the official HLE dataset (`cais/hle` on ModelScope), judge (`GRADE: C/I`), subsets, and `include_multi_modal` extra param\n- Default Native AgentLoop: `function_calling` strategy, `python_exec`, `local` environment, 30 steps\n- Optional MCP `fetch` is attached automatically when `evalscope[mcp]` (and `mcp-server-fetch`) is installed — no paid search API key required\n- Optional MCP web search (Brave, Tavily, …) can be added through `NativeAgentConfig.mcp_servers`\n- Docker is recommended for isolated production runs but is **not** required; the default `local` environment is mock-friendly\n\n## Evaluation Notes\n\n- Default evaluation uses the **test** split\n- Primary metric: **Accuracy** with the same HLE LLM judge\n- Response format includes: Explanation, Answer, and Confidence (0-100%)\n- **Note**: Set `extra_params[\"include_multi_modal\"]` to `False` for text-only models\n- Uses GRADE: C/I format for LLM judge scoring\n- `datasets=['hle_tools']` enables tools by default. You do **not** need to set `TaskConfig.agent_config` unless you want to override the loop\n- Passing `NativeAgentConfig` merges with defaults for any field you leave unset (`tools`, `environment`, `max_steps`, `mcp_servers`)\n- `local` has no filesystem isolation; for formal runs set `environment='docker'` (see below)\n- Install web fetch with `pip install evalscope[mcp]`. Paid search MCP servers are optional\n\n## Agent Environment\n\nDefault loop (applied when `agent_config` is omitted):\n\n- **Strategy**: `function_calling`\n- **Tools**: `python_exec` (built-in). `submit` is auto-injected\n- **Environment**: `local` (host subprocess). Recommended production override: `docker` + `python:3.11-slim`\n- **MCP**: `mcp-server-fetch` when the optional extra is installed\n- **max_steps**: 30\n\nOverride example — Docker plus fetch, and an optional search server:\n\n```python\nimport sys\nfrom evalscope import TaskConfig, run_task\nfrom evalscope.api.agent import NativeAgentConfig\nfrom evalscope.api.agent.mcp import MCPServerConfigStdio\n\nrun_task(TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['hle_tools'],\n    dataset_args={\n        'hle_tools': {\n            'subset_list': ['Math'],\n            'extra_params': {'include_multi_modal': False},\n        }\n    },\n    agent_config=NativeAgentConfig(\n        strategy='function_calling',\n        tools=['python_exec'],\n        environment='docker',\n        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},\n        max_steps=30,\n        mcp_servers=[\n            MCPServerConfigStdio(\n                command=sys.executable,\n                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],\n                name='fetch',\n            ),\n            # Optional paid search, e.g. Brave / Tavily MCP — not required\n        ],\n    ),\n    limit=10,\n))\n```\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `hle_tools` |\n| **Dataset ID** | [cais/hle](https://modelscope.cn/datasets/cais/hle/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2501.14249) |\n| **Tags** | `Agent`, `Knowledge`, `MultiTurn`, `QA` |\n| **Metrics** | `accuracy` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 2,500 |\n| Prompt Length (Mean) | 1029.85 chars |\n| Prompt Length (Min/Max) | 234 / 21341 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `Biology/Medicine` | 280 | 1259.39 | 246 | 13702 |\n| `Chemistry` | 165 | 812.72 | 236 | 6942 |\n| `Computer Science/AI` | 241 | 1581.02 | 263 | 11529 |\n| `Engineering` | 111 | 1620.26 | 250 | 21341 |\n| `Humanities/Social Science` | 219 | 1069.39 | 256 | 7028 |\n| `Math` | 1,021 | 862.46 | 262 | 8952 |\n| `Physics` | 230 | 1027.63 | 257 | 17139 |\n| `Other` | 233 | 754.94 | 234 | 13655 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 342 |\n| Images per Sample | min: 1, max: 1, mean: 1 |\n| Resolution Range | 329x12 - 14950x2780 |\n| Formats | gif, jpeg, png, webp |\n\n\n## Sample Example\n\n**Subset**: `Biology/Medicine`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"906a518f\",\n      \"content\": \"Your response should be in the following format:\\nExplanation: {your explanation for your answer choice}\\nAnswer: {your chosen answer}\\nConfidence: {your confidence score between 0% and 100% for your answer}\"\n    },\n    {\n      \"id\": \"d03d8d4e\",\n      \"content\": [\n        {\n          \"text\": \"In a bioinformatics lab, Watterson's estimator (theta) and pi (nucleotide diversity) will be calculated from variant call files which contain human phased samples with only single nucleotide variants present, and there are no completely missi ... [TRUNCATED] ... y pi (nucleotide diversity) is biased.\\nC. Both Watterson's estimator (theta) and pi (nucleotide diversity) are biased.\\nD. Neither Watterson's estimator (theta) nor pi (nucleotide diversity) are biased.\\nE. None of the other answers are correct\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"B\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"Biology/Medicine\",\n  \"metadata\": {\n    \"uid\": \"66e88728ba7d8bc0d5806f3a\",\n    \"author_name\": \"Scott S\",\n    \"rationale\": \"First, we recognize that all single nucleotide variants are included somewhere in the sample. It is given that, across “all samples,” there are no “missing single nucleotide variants.” Further, since “[t]he number of samples is arbitrarily la ... [TRUNCATED] ... fferent genotypes that that position, the analysis would consider these two genomes to have the same nucleotide at the position. This reduces the estimated nucleotide diversity, pi. Therefore, pi would be biased in the circumstance described.\",\n    \"raw_subject\": \"Bioinformatics\",\n    \"category\": \"Biology/Medicine\",\n    \"has_image\": false\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{question}\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `include_multi_modal` | `bool` | `True` | Include multi-modal (image) questions during evaluation. |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets hle_tools \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['hle_tools'],\n    dataset_args={\n        'hle_tools': {\n            # subset_list: ['Biology/Medicine', 'Chemistry', 'Computer Science/AI']  # optional, evaluate specific subsets\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# Humanity's-Last-Exam-with-Tools\n\n## 概述\n\nHumanity's Last Exam with Tools（`hle_tools`）是闭卷评测集 [`hle`](hle.md) 的工具使用版本。它复用 CAIS / Scale AI 的同一批 2,500 道专家级题目，但通过 EvalScope Native AgentLoop 驱动每条样本，使模型在作答前可以调用代码执行和可选的网页工具。\n\n这是与 `hle` **不同的排行榜条目**。闭卷问答请使用 `datasets=['hle']`，多轮工具使用协议请使用 `datasets=['hle_tools']`。\n\n## 任务描述\n\n- **任务类型**：带工具的专家级问答（多轮 AgentLoop）\n- **输入**：问题（14% 为多模态，含图片），并提供 `python_exec`（以及可选的 MCP fetch/search）\n- **输出**：答案、解释及置信度分数\n- **领域分布**：数学（41%）、物理（9%）、生物/医学（11%）、计算机科学/AI（10%）、人文（9%）、工程（4%）、化学（7%）、其他（9%）\n\n## 主要特点\n\n- 复用官方 HLE 数据集（ModelScope 上的 `cais/hle`）、裁判（`GRADE: C/I`）、子集以及 `include_multi_modal` 额外参数\n- 默认 Native AgentLoop：`function_calling` 策略、`python_exec`、`local` 环境、最多 30 步\n- 安装 `evalscope[mcp]`（及 `mcp-server-fetch`）后自动挂载可选 MCP `fetch`，无需付费搜索 API Key\n- 可通过 `NativeAgentConfig.mcp_servers` 额外接入 MCP 网页搜索（Brave、Tavily 等）\n- 正式评测推荐使用 Docker 隔离，但**不是**必须；默认 `local` 环境便于本地/Mock 验证\n\n## 评估说明\n\n- 默认使用 **test** 数据划分进行评估\n- 主要指标：与 HLE 相同的 LLM 裁判 **准确率（Accuracy）**\n- 响应格式包括：解释（Explanation）、答案（Answer）和置信度（Confidence，0–100%）\n- **注意**：对于纯文本模型，请将 `extra_params[\"include_multi_modal\"]` 设为 `False`\n- 使用 GRADE: C/I 格式进行 LLM 裁判评分\n- `datasets=['hle_tools']` 默认启用工具。除非需要覆盖循环配置，否则不必设置 `TaskConfig.agent_config`\n- 传入 `NativeAgentConfig` 时，未显式设置的字段（`tools`、`environment`、`max_steps`、`mcp_servers`）会与默认值合并\n- `local` 没有文件系统隔离；正式评测请设置 `environment='docker'`（见下文）\n- 网页抓取请安装 `pip install evalscope[mcp]`。付费搜索 MCP 为可选项\n\n## Agent 环境\n\n默认循环（未设置 `agent_config` 时生效）：\n\n- **策略**：`function_calling`\n- **工具**：内置 `python_exec`。`submit` 会自动注入\n- **环境**：`local`（宿主机子进程）。正式评测推荐覆盖为 `docker` + `python:3.11-slim`\n- **MCP**：安装可选依赖后使用 `mcp-server-fetch`\n- **max_steps**：30\n\n覆盖示例 — Docker + fetch，以及可选的搜索服务器：\n\n```python\nimport sys\nfrom evalscope import TaskConfig, run_task\nfrom evalscope.api.agent import NativeAgentConfig\nfrom evalscope.api.agent.mcp import MCPServerConfigStdio\n\nrun_task(TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['hle_tools'],\n    dataset_args={\n        'hle_tools': {\n            'subset_list': ['Math'],\n            'extra_params': {'include_multi_modal': False},\n        }\n    },\n    agent_config=NativeAgentConfig(\n        strategy='function_calling',\n        tools=['python_exec'],\n        environment='docker',\n        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},\n        max_steps=30,\n        mcp_servers=[\n            MCPServerConfigStdio(\n                command=sys.executable,\n                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],\n                name='fetch',\n            ),\n            # 可选付费搜索，例如 Brave / Tavily MCP — 非必须\n        ],\n    ),\n    limit=10,\n))\n```\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `hle_tools` |\n| **数据集ID** | [cais/hle](https://modelscope.cn/datasets/cais/hle/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2501.14249) |\n| **标签** | `Agent`, `Knowledge`, `MultiTurn`, `QA` |\n| **指标** | `accuracy` |\n| **默认示例数（Shots）** | 0-shot |\n| **评估划分** | `test` |\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 2,500 |\n| 提示词长度（平均） | 1029.85 字符 |\n| 提示词长度（最小/最大） | 234 / 21341 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |\n|--------|---------|-------------|------------|------------|\n| `Biology/Medicine` | 280 | 1259.39 | 246 | 13702 |\n| `Chemistry` | 165 | 812.72 | 236 | 6942 |\n| `Computer Science/AI` | 241 | 1581.02 | 263 | 11529 |\n| `Engineering` | 111 | 1620.26 | 250 | 21341 |\n| `Humanities/Social Science` | 219 | 1069.39 | 256 | 7028 |\n| `Math` | 1,021 | 862.46 | 262 | 8952 |\n| `Physics` | 230 | 1027.63 | 257 | 17139 |\n| `Other` | 233 | 754.94 | 234 | 13655 |\n\n**图像统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 342 |\n| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |\n| 分辨率范围 | 329x12 – 14950x2780 |\n| 图像格式 | gif, jpeg, png, webp |\n\n## 样例示例\n\n**子集**: `Biology/Medicine`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"906a518f\",\n      \"content\": \"Your response should be in the following format:\\nExplanation: {your explanation for your answer choice}\\nAnswer: {your chosen answer}\\nConfidence: {your confidence score between 0% and 100% for your answer}\"\n    },\n    {\n      \"id\": \"d03d8d4e\",\n      \"content\": [\n        {\n          \"text\": \"In a bioinformatics lab, Watterson's estimator (theta) and pi (nucleotide diversity) will be calculated from variant call files which contain human phased samples with only single nucleotide variants present, and there are no completely missi ... [TRUNCATED] ... y pi (nucleotide diversity) is biased.\\nC. Both Watterson's estimator (theta) and pi (nucleotide diversity) are biased.\\nD. Neither Watterson's estimator (theta) nor pi (nucleotide diversity) are biased.\\nE. None of the other answers are correct\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"B\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"Biology/Medicine\",\n  \"metadata\": {\n    \"uid\": \"66e88728ba7d8bc0d5806f3a\",\n    \"author_name\": \"Scott S\",\n    \"rationale\": \"First, we recognize that all single nucleotide variants are included somewhere in the sample. It is given that, across “all samples,” there are no “missing single nucleotide variants.” Further, since “[t]he number of samples is arbitrarily la ... [TRUNCATED] ... fferent genotypes that that position, the analysis would consider these two genomes to have the same nucleotide at the position. This reduces the estimated nucleotide diversity, pi. Therefore, pi would be biased in the circumstance described.\",\n    \"raw_subject\": \"Bioinformatics\",\n    \"category\": \"Biology/Medicine\",\n    \"has_image\": false\n  }\n}\n```\n\n*注：部分内容因展示需要已被截断。*\n\n## 提示模板\n\n**提示模板：**\n```text\n{question}\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `include_multi_modal` | `bool` | `True` | 评估时是否包含多模态（图像）问题。 |\n\n## 使用方法\n\n### 通过命令行（CLI）\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets hle_tools \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 通过 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['hle_tools'],\n    dataset_args={\n        'hle_tools': {\n            # subset_list: ['Biology/Medicine', 'Chemistry', 'Computer Science/AI']  # 可选，用于评估特定子集\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```\n",
+    "content_hash": "cc30c1a507c76370f4bf01c6466bc215",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-26T05:12:31.386035",
+  "translation_updated_at": "2026-08-26T05:13:21.277390"
+}

--- a/evalscope/benchmarks/hle_tools/hle_tools_adapter.py
+++ b/evalscope/benchmarks/hle_tools/hle_tools_adapter.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from typing import Any, Dict, List, Optional
+
+from evalscope.agent.external.config import ExternalAgentConfig
+from evalscope.agent.tools.python_exec import PYTHON_EXEC_TOOL_INFO
+from evalscope.api.agent import NativeAgentConfig
+from evalscope.api.agent.mcp import MCPServerConfig, MCPServerConfigStdio
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import InferenceReturn
+from evalscope.api.model import Model
+from evalscope.api.registry import register_benchmark
+from evalscope.benchmarks.hle.hle_adapter import SUBSET_LIST, HLEAdapter
+from evalscope.constants import Tags
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+_DEFAULT_MAX_STEPS = 30
+_DEFAULT_TOOLS = ['python_exec']
+_DEFAULT_ENVIRONMENT = 'local'
+
+TOOL_USE_HINT = (
+    '\n\nYou may use the python_exec tool to compute or verify results. '
+    'If fetch or search tools are available, use them to look up information. '
+    'When you are finished, give your final answer in the required format.'
+)
+
+_DESCRIPTION = """
+## Overview
+
+Humanity's Last Exam with Tools (`hle_tools`) is the tool-use counterpart of closed-book [`hle`](hle.md). It evaluates the same 2,500 expert-level questions from CAIS / Scale AI, but drives each sample through EvalScope's Native AgentLoop so the model can call code execution and optional web tools before answering.
+
+This is a **distinct leaderboard row** from `hle`. Use `datasets=['hle']` for closed-book QA and `datasets=['hle_tools']` for the multi-turn tool-use protocol.
+
+## Task Description
+
+- **Task Type**: Expert-Level Question Answering with Tools (multi-turn AgentLoop)
+- **Input**: Question with optional image (14% multimodal), plus `python_exec` (and optional MCP fetch/search)
+- **Output**: Answer with explanation and confidence score
+- **Domains**: Mathematics (41%), Physics (9%), Biology/Medicine (11%), Computer Science/AI (10%), Humanities (9%), Engineering (4%), Chemistry (7%), Other (9%)
+
+## Key Features
+
+- Reuses the official HLE dataset (`cais/hle` on ModelScope), judge (`GRADE: C/I`), subsets, and `include_multi_modal` extra param
+- Default Native AgentLoop: `function_calling` strategy, `python_exec`, `local` environment, 30 steps
+- Optional MCP `fetch` is attached automatically when `evalscope[mcp]` (and `mcp-server-fetch`) is installed — no paid search API key required
+- Optional MCP web search (Brave, Tavily, …) can be added through `NativeAgentConfig.mcp_servers`
+- Docker is recommended for isolated production runs but is **not** required; the default `local` environment is mock-friendly
+
+## Evaluation Notes
+
+- Default evaluation uses the **test** split
+- Primary metric: **Accuracy** with the same HLE LLM judge
+- Response format includes: Explanation, Answer, and Confidence (0-100%)
+- **Note**: Set `extra_params["include_multi_modal"]` to `False` for text-only models
+- Uses GRADE: C/I format for LLM judge scoring
+- `datasets=['hle_tools']` enables tools by default. You do **not** need to set `TaskConfig.agent_config` unless you want to override the loop
+- Passing `NativeAgentConfig` merges with defaults for any field you leave unset (`tools`, `environment`, `max_steps`, `mcp_servers`)
+- `local` has no filesystem isolation; for formal runs set `environment='docker'` (see below)
+- Install web fetch with `pip install evalscope[mcp]`. Paid search MCP servers are optional
+
+## Agent Environment
+
+Default loop (applied when `agent_config` is omitted):
+
+- **Strategy**: `function_calling`
+- **Tools**: `python_exec` (built-in). `submit` is auto-injected
+- **Environment**: `local` (host subprocess). Recommended production override: `docker` + `python:3.11-slim`
+- **MCP**: `mcp-server-fetch` when the optional extra is installed
+- **max_steps**: 30
+
+Override example — Docker plus fetch, and an optional search server:
+
+```python
+import sys
+from evalscope import TaskConfig, run_task
+from evalscope.api.agent import NativeAgentConfig
+from evalscope.api.agent.mcp import MCPServerConfigStdio
+
+run_task(TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['hle_tools'],
+    dataset_args={
+        'hle_tools': {
+            'subset_list': ['Math'],
+            'extra_params': {'include_multi_modal': False},
+        }
+    },
+    agent_config=NativeAgentConfig(
+        strategy='function_calling',
+        tools=['python_exec'],
+        environment='docker',
+        environment_extra={'sandbox_config': {'image': 'python:3.11-slim'}},
+        max_steps=30,
+        mcp_servers=[
+            MCPServerConfigStdio(
+                command=sys.executable,
+                args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],
+                name='fetch',
+            ),
+            # Optional paid search, e.g. Brave / Tavily MCP — not required
+        ],
+    ),
+    limit=10,
+))
+```
+"""
+
+
+def default_hle_tools_mcp_servers() -> List[MCPServerConfig]:
+    """Return the default fetch MCP server when the optional extra is installed."""
+    if importlib.util.find_spec('mcp') is None or importlib.util.find_spec('mcp_server_fetch') is None:
+        return []
+    return [
+        MCPServerConfigStdio(
+            command=sys.executable,
+            args=['-m', 'mcp_server_fetch', '--ignore-robots-txt'],
+            name='fetch',
+        )
+    ]
+
+
+def default_hle_tools_agent_config() -> NativeAgentConfig:
+    """Return the built-in Native AgentLoop defaults for ``hle_tools``."""
+    return NativeAgentConfig(
+        strategy='function_calling',
+        tools=list(_DEFAULT_TOOLS),
+        environment=_DEFAULT_ENVIRONMENT,
+        max_steps=_DEFAULT_MAX_STEPS,
+        mcp_servers=default_hle_tools_mcp_servers(),
+    )
+
+
+def merge_hle_tools_agent_config(agent_config: Optional[NativeAgentConfig]) -> NativeAgentConfig:
+    """Fill unset NativeAgentConfig fields with ``hle_tools`` defaults."""
+    if agent_config is None:
+        return default_hle_tools_agent_config()
+
+    updates: Dict[str, Any] = {}
+    if not agent_config.tools:
+        updates['tools'] = list(_DEFAULT_TOOLS)
+    if agent_config.environment is None:
+        updates['environment'] = _DEFAULT_ENVIRONMENT
+    if 'max_steps' not in agent_config.model_fields_set:
+        updates['max_steps'] = _DEFAULT_MAX_STEPS
+    if 'mcp_servers' not in agent_config.model_fields_set:
+        updates['mcp_servers'] = default_hle_tools_mcp_servers()
+    if not updates:
+        return agent_config
+    return agent_config.model_copy(update=updates)
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='hle_tools',
+        pretty_name="Humanity's-Last-Exam-with-Tools",
+        tags=[Tags.KNOWLEDGE, Tags.QA, Tags.AGENT, Tags.MULTI_TURN],
+        description=_DESCRIPTION,
+        dataset_id='cais/hle',
+        paper_url='https://arxiv.org/abs/2501.14249',
+        subset_list=SUBSET_LIST,
+        metric_list=['acc'],
+        eval_split='test',
+        prompt_template='{question}',
+        evaluation_version='v1.0',
+        extra_params={
+            'include_multi_modal': {
+                'type': 'bool',
+                'description': 'Include multi-modal (image) questions during evaluation.',
+                'value': True
+            }
+        }
+    )
+)
+class HLEToolsAdapter(HLEAdapter):
+    """HLE with a default Native AgentLoop (``python_exec`` + optional MCP fetch)."""
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        sample = super().record_to_sample(record)
+        sample.tools = [PYTHON_EXEC_TOOL_INFO]
+        messages = sample.input
+        if isinstance(messages, list) and messages:
+            system_message = messages[0]
+            if getattr(system_message, 'role', None) == 'system':
+                system_message.text = f'{system_message.text}{TOOL_USE_HINT}'
+        return sample
+
+    def _effective_agent_config(self) -> NativeAgentConfig:
+        ac = self._task_config.agent_config if self._task_config is not None else None
+        if isinstance(ac, NativeAgentConfig):
+            return merge_hle_tools_agent_config(ac)
+        return default_hle_tools_agent_config()
+
+    def _on_inference(self, model: Model, sample: Sample) -> InferenceReturn:
+        """Always run the Native AgentLoop, using benchmark defaults when unset.
+
+        A TaskConfig copy is used so a shared ``agent_config`` is not mutated for
+        sibling datasets in the same task (e.g. ``['hle', 'hle_tools']``).
+        """
+        if self._task_config is None:
+            return super()._on_inference(model, sample)
+
+        ac = self._task_config.agent_config
+        if isinstance(ac, ExternalAgentConfig):
+            return self._on_external_agent_inference(model, sample)
+
+        from evalscope.agent.runner import run_native_agent
+
+        task_config = self._task_config.model_copy(update={'agent_config': self._effective_agent_config()})
+        mcp_names = [
+            getattr(server, 'name', None) or getattr(server, 'command', None)
+            for server in task_config.agent_config.mcp_servers
+        ]
+        logger.info(
+            f'hle_tools agent_config: strategy={task_config.agent_config.strategy} '
+            f'tools={task_config.agent_config.tools} environment={task_config.agent_config.environment} '
+            f'max_steps={task_config.agent_config.max_steps} mcp_servers={mcp_names}'
+        )
+        return run_native_agent(
+            task_config=task_config,
+            model=model,
+            sample=sample,
+            build_sandbox_config=self.build_sandbox_config,
+            extract_final_answer=self._extract_final_answer,
+        )

--- a/tests/benchmark/test_eval.py
+++ b/tests/benchmark/test_eval.py
@@ -373,6 +373,28 @@ class TestNativeBenchmark(TestBenchmark):
         }
         self._run_dataset_test('hle', dataset_args)
 
+    def test_hle_tools(self):
+        """Test HLE-with-tools dataset (mock-safe local AgentLoop)."""
+        dataset_args = {
+            'subset_list': ['Math', 'Other'],
+            'extra_params': {
+                'include_multi_modal': False
+            }
+        }
+        # Empty mcp_servers + local env: no docker and no network in CI.
+        self._run_dataset_test(
+            'hle_tools',
+            dataset_args,
+            agent_config={
+                'mode': 'native',
+                'strategy': 'function_calling',
+                'tools': ['python_exec'],
+                'environment': 'local',
+                'max_steps': 3,
+                'mcp_servers': [],
+            },
+        )
+
     def test_process_bench(self):
         """Test ProcessBench dataset."""
         dataset_args = {


### PR DESCRIPTION
## Summary

Add one new benchmark, the tool-use counterpart of closed-book `hle`:

- **Humanity's-Last-Exam-with-Tools** (`hle_tools`, dataset id `cais/hle`) — same 2,500 CAIS / Scale AI questions as `hle`, evaluated through EvalScope Native AgentLoop so the model can call tools before answering. This is a distinct leaderboard row from closed-book `hle`.

Dataset stays on ModelScope (`cais/hle`), same source as `hle`.

## Changes

- Add thin `HLEToolsAdapter` subclassing `HLEAdapter` (same judge, subsets, `include_multi_modal`, scoring)
- Default Native AgentLoop when `agent_config` is omitted: `function_calling`, `python_exec`, `local`, `max_steps=30`; optional MCP `fetch` if `evalscope[mcp]` is installed
- Add `test_hle_tools` next to `test_hle` (mock-safe local loop, no docker/network)
- Generate bilingual docs (EN/ZH) and `_meta` JSON
- Changelog entries in `README.md` / `README_zh.md`

## Test plan

- [x] Register `hle_tools` with `dataset_id=cais/hle`
- [x] Load 1 sample from ModelScope (`Other`, `include_multi_modal=False`)
- [x] Mock AgentLoop + HLE judge path
- [x] Live 1-sample eval on `deepseek-chat` via official API: pipeline completed (Accuracy 0% on that item — model miss, not a harness failure)
- [ ] CI `test_hle_tools`

## Notes

`datasets=['hle']` remains closed-book. `datasets=['hle_tools']` enables tools by default; passing `NativeAgentConfig` only overrides fields you set. Default environment is `local` for smoke tests; use `environment='docker'` for isolated formal runs. Web search is optional via MCP, not required for the default `python_exec` path.
