### PR TITLE
fix(perf): preserve Unicode line separators in SSE payloads

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -38,7 +38,9 @@ class StreamedResponseHandler:
         drop continuation lines.
         """
         data_values: list[str] = []
-        for line in message.strip().splitlines():
+        # SSE lines use CR/LF only; splitlines() also splits valid JSON characters
+        # such as U+0085, U+2028, and U+2029.
+        for line in message.strip().split('\n'):
             if line.startswith('data:'):
                 data_values.append(line.removeprefix('data:').lstrip(' '))
 

--- a/evalscope/perf/plugin/api/openai_responses_api.py
+++ b/evalscope/perf/plugin/api/openai_responses_api.py
@@ -258,7 +258,8 @@ _DELTA_EVENT_TYPES = {
 
 def _extract_sse_data(message: str) -> str:
     data_lines = []
-    for line in message.splitlines():
+    # SSE lines use CR/LF only; preserve other Unicode line separators in JSON.
+    for line in message.split('\n'):
         line = line.strip()
         if not line or line.startswith(':'):
             continue

--- a/tests/perf/test_perf_streaming.py
+++ b/tests/perf/test_perf_streaming.py
@@ -70,6 +70,22 @@ class TestStreamedResponseHandler(unittest.TestCase):
         self.assertEqual(handler.add_chunk(b'data: {"choices":'), [])
         self.assertEqual(handler.add_chunk(b' []}'), ['data: {"choices": []}'])
 
+    def test_preserves_unicode_line_separators_in_json_payload(self) -> None:
+        for separator in ('\x85', '\u2028', '\u2029'):
+            expected = {'choices': [{'text': f'before{separator}after'}]}
+            payload = json.dumps(expected, ensure_ascii=False)
+            event = f'data: {payload}\n\n'.encode()
+
+            for split_at in range(len(event) + 1):
+                with self.subTest(separator=repr(separator), split_at=split_at):
+                    handler = StreamedResponseHandler()
+                    messages = handler.add_chunk(event[:split_at])
+                    messages.extend(handler.add_chunk(event[split_at:]))
+
+                    self.assertEqual(messages, [f'data: {payload}'])
+                    self.assertEqual(json.loads(messages[0].removeprefix('data:').strip()), expected)
+                    self.assertEqual(_extract_sse_data(messages[0]), payload)
+
 
 class TestPerfStreaming(PerfTestBase):
     """Streaming (SSE) performance benchmarks."""


### PR DESCRIPTION
## Summary
- parse SSE fields only on LF instead of `str.splitlines()`
- preserve U+0085, U+2028, and U+2029 inside JSON payloads
- add fragmented-stream regression coverage for both SSE parsers

## Testing
- targeted streaming handler tests (7 passed)
- pre-commit checks on changed files

Fixes #1638