### PR TITLE
fix(perf): ignore metadata-only chunks in TTFT and ITL

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -120,12 +120,12 @@ class DefaultApiPlugin(ApiPluginBase):
         data = json.dumps(body, ensure_ascii=False)  # serialize to JSON
 
         output = BenchmarkData()
-        ttft = 0.0
         generated_text = ''
         st = time.perf_counter()
         output.start_time = st
         output.request = data
         most_recent_timestamp = st
+        last_output_timestamp: float | None = None
         try:
             async with client_session.post(url=url, data=data, headers=headers) as response:
                 content_type = response.headers.get('Content-Type', '')
@@ -160,14 +160,16 @@ class DefaultApiPlugin(ApiPluginBase):
                                             content = (delta.get('content') or '') + (
                                                 delta.get('reasoning_content') or ''
                                             )
-                                        # First token
-                                        if ttft == 0.0:
-                                            ttft = timestamp - st
-                                            output.first_chunk_latency = ttft
+                                        if content:
+                                            # First token
+                                            if last_output_timestamp is None:
+                                                output.first_chunk_latency = timestamp - st
 
-                                        # Decoding phase
-                                        else:
-                                            output.inter_chunk_latency.append(timestamp - most_recent_timestamp)
+                                            # Decoding phase
+                                            else:
+                                                output.inter_chunk_latency.append(timestamp - last_output_timestamp)
+
+                                            last_output_timestamp = timestamp
 
                                         generated_text += content
                                         output.response_messages.append(data)

--- a/tests/perf/test_perf_streaming.py
+++ b/tests/perf/test_perf_streaming.py
@@ -6,10 +6,12 @@ endpoint and the local model backend.
 """
 import json
 import unittest
+from unittest.mock import MagicMock, patch
 
 from evalscope.perf.arguments import Arguments
 from evalscope.perf.main import run_perf_benchmark
 from evalscope.perf.plugin.api.default_api import StreamedResponseHandler
+from evalscope.perf.plugin.api.openai_api import OpenaiPlugin
 from evalscope.perf.plugin.api.openai_responses_api import _extract_sse_data
 from tests.perf.perf_test_base import LOCAL_CHAT_URL, PerfTestBase
 
@@ -85,6 +87,46 @@ class TestStreamedResponseHandler(unittest.TestCase):
                     self.assertEqual(messages, [f'data: {payload}'])
                     self.assertEqual(json.loads(messages[0].removeprefix('data:').strip()), expected)
                     self.assertEqual(_extract_sse_data(messages[0]), payload)
+
+
+class TestDefaultApiPluginMetrics(unittest.IsolatedAsyncioTestCase):
+
+    async def test_metadata_only_chunks_do_not_affect_output_timings(self) -> None:
+        events = [
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'role': 'assistant', 'content': ''}}]},
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'content': 'H'}}]},
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'content': 'i'}}]},
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {}, 'finish_reason': 'stop'}],
+                'usage': {'prompt_tokens': 3, 'completion_tokens': 2},
+            },
+        ]
+        stream = ''.join(f'data: {json.dumps(event)}\n\n' for event in events) + 'data: [DONE]\n\n'
+
+        async def iter_chunks():
+            yield stream.encode()
+
+        response = MagicMock()
+        response.status = 200
+        response.headers = {'Content-Type': 'text/event-stream'}
+        response.content.iter_any.return_value = iter_chunks()
+        response.__aenter__.return_value = response
+        client_session = MagicMock()
+        client_session.post.return_value = response
+
+        plugin = OpenaiPlugin(Arguments(model='test-model'))
+        timestamps = [0.0, 0.1, 0.45, 0.65, 0.9]
+        with patch('evalscope.perf.plugin.api.default_api.time.perf_counter', side_effect=timestamps):
+            output = await plugin.process_request(client_session, 'http://localhost/v1/chat/completions', {}, {})
+
+        self.assertAlmostEqual(output.first_chunk_latency, 0.45)
+        self.assertEqual(len(output.inter_chunk_latency), 1)
+        self.assertAlmostEqual(output.inter_chunk_latency[0], 0.2)
+        self.assertEqual(output.generated_text, 'Hi')
+        self.assertAlmostEqual(output.query_latency, 0.9)
+        self.assertEqual(output.response_messages, events)
+        self.assertEqual((output.prompt_tokens, output.completion_tokens), (3, 2))
 
 
 class TestPerfStreaming(PerfTestBase):


### PR DESCRIPTION
## Problem

OpenAI-compatible chat streams can emit `choices` events without generated output. For example,
vLLM sends an initial role-only delta with `content: ""`, and services may send a separate empty
delta carrying `finish_reason`.

`DefaultApiPlugin.process_request()` currently records TTFT for the first event with a non-empty
`choices` array and records every later `choices` event as an ITL sample, even when the extracted
text and reasoning content are empty. This can report TTFT before the first visible output and add
metadata gaps to ITL.

For a deterministic stream with events at 0.10s (role), 0.45s (`H`), 0.65s (`i`), and 0.90s
(finish), the current code reports:

- TTFT: 0.10s
- ITL: [0.35s, 0.20s, 0.25s]

The output-based result should be:

- TTFT: 0.45s
- ITL: [0.20s]

## Fix

Track the last non-empty output timestamp separately from the last response-event timestamp.

- Update TTFT and ITL only when text or reasoning content is non-empty.
- Keep the existing response timestamp for completion time and end-to-end query latency.
- Continue retaining metadata events and parsing usage from them.

## Verification

The new asynchronous regression reproduces role-only, content, finish-only, usage, and `[DONE]`
events with deterministic timestamps. Before the fix, it fails with `0.10 != 0.45` at the TTFT
assertion. After the fix:

- 31 related offline tests pass on current `main`.
- All configured pre-commit hooks pass for the two changed files.
- `compileall` and `git diff --check` pass.

The regression also verifies that generated text, response retention, usage parsing, and
end-to-end query latency remain unchanged.
