### PR TITLE
fix(benchmark): restore F821 and fix jobbench mis-ignored linting issue

### DIFF
--- a/evalscope/benchmarks/job_bench/job_bench_adapter.py
+++ b/evalscope/benchmarks/job_bench/job_bench_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
-ignore = ["E501", "E741", "F401", "F403", "F405", "F541", "F821"]
+ignore = ["E501", "E741", "F401", "F403", "F405", "F541"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E", "F", "W"]


### PR DESCRIPTION
## Summary

- [x] restore ruff rule F821.
- [x] fix jobbench `List` not imported.
- [x] no test update needed
- [x] no doc update needed. 