### PR TITLE
fix(cache): deduplicate review state and tolerate torn resume rows

### DIFF
--- a/evalscope/api/evaluator/cache.py
+++ b/evalscope/api/evaluator/cache.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from evalscope.api.agent import AgentTrace
 from evalscope.api.dataset import Dataset
@@ -94,14 +94,22 @@ class CacheManager:
 
         cached_task_states = []
         cached_sample_ids = set()
-        cache_items = jsonl_to_list(cache_file)
+        cache_items = jsonl_to_list(cache_file, skip_invalid=True)
 
         # Process each cached item
         for cache_item in cache_items:
             # Deserialize the cached model result
-            cached_model_result = ModelResult.model_validate(cache_item)
+            try:
+                cached_model_result = ModelResult.model_validate(cache_item)
+            except ValidationError as e:
+                logger.warning(f'Skipping invalid prediction cache row in {cache_file}: {e}')
+                continue
             # Convert to task state for further processing
-            cached_state = cached_model_result.to_task_state(dataset=dataset)
+            try:
+                cached_state = cached_model_result.to_task_state(dataset=dataset)
+            except ValidationError as e:
+                logger.warning(f'Skipping invalid prediction cache row in {cache_file}: {e}')
+                continue
 
             if cached_state is None:
                 continue
@@ -173,14 +181,33 @@ class CacheManager:
             # No review cache exists, return empty scores and all task states
             return [], task_states
 
-        cached_sample_scores: List[SampleScore] = []
-        cache_items = jsonl_to_list(cache_file)
+        cached_by_sample_id = {}
+        valid_sample_ids = {state.sample_id for state in task_states}
+        orphan_rows = 0
+        duplicate_rows = 0
+        cache_items = jsonl_to_list(cache_file, skip_invalid=True)
 
         # Process each cached review result
         for cache_item in cache_items:
             # Deserialize the cached review result
-            cached_review_result = ReviewResult.from_cache_item(cache_item)
-            cached_sample_scores.append(cached_review_result.to_sample_score())
+            try:
+                cached_review_result = ReviewResult.from_cache_item(cache_item)
+            except ValidationError as e:
+                logger.warning(f'Skipping invalid review cache row in {cache_file}: {e}')
+                continue
+            sample_score = cached_review_result.to_sample_score()
+            if sample_score.sample_id not in valid_sample_ids:
+                orphan_rows += 1
+                continue
+            if sample_score.sample_id in cached_by_sample_id:
+                duplicate_rows += 1
+            cached_by_sample_id[sample_score.sample_id] = sample_score
+
+        cached_sample_scores: List[SampleScore] = list(cached_by_sample_id.values())
+        if orphan_rows or duplicate_rows:
+            logger.warning(
+                f'Dropped {orphan_rows} orphan and {duplicate_rows} duplicate rows from review cache: {cache_file}'
+            )
 
         # Filter out task states that already have review scores
         cached_sample_ids = {review.sample_id for review in cached_sample_scores}

--- a/evalscope/utils/io_utils.py
+++ b/evalscope/utils/io_utils.py
@@ -198,32 +198,35 @@ def parquet_to_list(parquet_file: str) -> List[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def jsonl_to_list(jsonl_file: str) -> List[Dict[str, Any]]:
+def jsonl_to_list(jsonl_file: str, skip_invalid: bool = False) -> List[Dict[str, Any]]:
     """Read a JSONL file into a list of dicts.
-
-    Attempts to use the ``jsonlines`` library first; falls back to
-    line-by-line ``json.loads`` parsing on any error.
 
     Args:
         jsonl_file (str): Path to the ``.jsonl`` file.
+        skip_invalid (bool): Whether malformed or non-object rows should be
+            logged and skipped. Defaults to ``False`` so dataset inputs do
+            not silently lose records.
 
     Returns:
         List[Dict[str, Any]]: Parsed records.  Returns an empty list and
         logs a warning when the file contains no valid records.
     """
     res_list: List[Dict[str, Any]] = []
-    try:
-        with jsonl.open(jsonl_file, mode='r') as reader:
-            for line in reader.iter(type=dict, allow_none=True, skip_invalid=False):
-                res_list.append(line)
-    except Exception:
-        # Fallback: parse line-by-line with the stdlib json module.
-        res_list = []
-        with open(jsonl_file, 'r', encoding='utf-8') as f:
-            for line in f:
-                stripped = line.strip()
-                if stripped:
-                    res_list.append(json.loads(stripped))
+    with open(jsonl_file, 'r', encoding='utf-8') as f:
+        for line_number, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+                if not isinstance(parsed, dict):
+                    raise TypeError(f'Expected a JSON object, got {type(parsed).__name__}')
+            except (json.JSONDecodeError, TypeError) as e:
+                if not skip_invalid:
+                    raise
+                logger.warning(f'Skipping invalid JSONL row {line_number} in {jsonl_file}: {e}')
+                continue
+            res_list.append(parsed)
 
     if not res_list:
         logger.warning(f'No data found in {jsonl_file}.')

--- a/tests/api/test_io_utils.py
+++ b/tests/api/test_io_utils.py
@@ -1,4 +1,6 @@
 import io
+import json
+from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
@@ -7,7 +9,7 @@ from datasets import Audio, Dataset, DatasetInfo, Features, Image, Sequence, Vid
 from datasets.table import InMemoryTable
 from PIL import Image as PILImage
 
-from evalscope.utils.io_utils import undecode_media
+from evalscope.utils.io_utils import jsonl_to_list, undecode_media
 
 
 def _generate_jpeg_bytes(dim: int, quality: int = 80) -> bytes:
@@ -181,3 +183,33 @@ class TestUndecodeMediaIntegration:
         result_row = result.to_list()[0]
         for other_col in non_media_data:
             assert result_row[other_col] == original_row[other_col]
+
+
+class TestJsonlToList:
+    @staticmethod
+    def _write(path: Path, content: str) -> str:
+        path.write_text(content, encoding='utf-8')
+        return str(path)
+
+    def test_tolerant_read_skips_torn_tail(self, tmp_path: Path) -> None:
+        file_path = self._write(tmp_path / 'torn.jsonl', '{"a": 1}\n{"a": 2}\n{"a": 3')
+
+        records = jsonl_to_list(file_path, skip_invalid=True)
+
+        assert records == [{'a': 1}, {'a': 2}]
+
+    def test_tolerant_read_skips_null_empty_and_non_dict_json(self, tmp_path: Path) -> None:
+        file_path = self._write(
+            tmp_path / 'invalid-types.jsonl',
+            '{"a": 1}\n\nnull\n[]\n"text"\n42\n{"a": 2}\n',
+        )
+
+        records = jsonl_to_list(file_path, skip_invalid=True)
+
+        assert records == [{'a': 1}, {'a': 2}]
+
+    def test_default_read_remains_strict_for_malformed_json(self, tmp_path: Path) -> None:
+        file_path = self._write(tmp_path / 'strict.jsonl', '{"a": 1}\n{"a": 2')
+
+        with pytest.raises(json.JSONDecodeError):
+            jsonl_to_list(file_path)

--- a/tests/evaluator/test_cache_manager.py
+++ b/tests/evaluator/test_cache_manager.py
@@ -1,6 +1,7 @@
 """Unit tests for cache resume behavior."""
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -46,7 +47,21 @@ def _write_review_cache(manager: CacheManager, subset: str, rows: list[Dict[str,
     return review_file
 
 
-def test_filter_review_cache_intersects_and_dedupes(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+@pytest.fixture
+def caplog_evalscope(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> pytest.LogCaptureFixture:
+    """Capture records from EvalScope's non-propagating logger."""
+    monkeypatch.setattr(logging.getLogger('evalscope'), 'propagate', True)
+    caplog.set_level(logging.WARNING, logger='evalscope')
+    return caplog
+
+
+def test_filter_review_cache_intersects_and_dedupes(
+    tmp_path: Path,
+    caplog_evalscope: pytest.LogCaptureFixture,
+) -> None:
     manager = _make_manager(tmp_path)
     task_states = [_make_task_state(0), _make_task_state(1)]
     _write_review_cache(
@@ -65,7 +80,7 @@ def test_filter_review_cache_intersects_and_dedupes(tmp_path: Path, caplog: pyte
     assert [score.sample_id for score in cached_scores] == [0, 1]
     assert cached_scores[1].score.main_value == 1.0
     assert remaining_states == []
-    assert 'Dropped 1 orphan and 1 duplicate rows' in caplog.text
+    assert 'Dropped 1 orphan and 1 duplicate rows' in caplog_evalscope.text
 
 
 def test_filter_review_cache_does_not_merge_distinct_repeat_samples(tmp_path: Path) -> None:
@@ -102,7 +117,7 @@ def test_filter_review_cache_keeps_uncovered_states(tmp_path: Path) -> None:
 
 def test_filter_review_cache_skips_malformed_and_schema_invalid_rows(
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
+    caplog_evalscope: pytest.LogCaptureFixture,
 ) -> None:
     manager = _make_manager(tmp_path)
     task_states = [_make_task_state(0), _make_task_state(1)]
@@ -122,13 +137,13 @@ def test_filter_review_cache_skips_malformed_and_schema_invalid_rows(
 
     assert [score.sample_id for score in cached_scores] == [0, 1]
     assert remaining_states == []
-    assert 'Skipping invalid JSONL row' in caplog.text
-    assert 'Skipping invalid review cache row' in caplog.text
+    assert 'Skipping invalid JSONL row' in caplog_evalscope.text
+    assert 'Skipping invalid review cache row' in caplog_evalscope.text
 
 
 def test_filter_prediction_cache_skips_malformed_and_schema_invalid_rows(
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
+    caplog_evalscope: pytest.LogCaptureFixture,
 ) -> None:
     manager = _make_manager(tmp_path)
     dataset = MemoryDataset(
@@ -152,5 +167,5 @@ def test_filter_prediction_cache_skips_malformed_and_schema_invalid_rows(
 
     assert [state.sample_id for state in cached_task_states] == [0]
     assert [sample.id for sample in filtered_dataset.samples] == [1]
-    assert 'Skipping invalid JSONL row' in caplog.text
-    assert 'Skipping invalid prediction cache row' in caplog.text
+    assert 'Skipping invalid JSONL row' in caplog_evalscope.text
+    assert 'Skipping invalid prediction cache row' in caplog_evalscope.text

--- a/tests/evaluator/test_cache_manager.py
+++ b/tests/evaluator/test_cache_manager.py
@@ -1,0 +1,156 @@
+"""Unit tests for cache resume behavior."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from evalscope.api.dataset import MemoryDataset, Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.evaluator.cache import CacheManager, ModelResult
+from evalscope.utils.io_utils import OutputsStructure
+
+
+def _make_task_state(sample_id: int, group_id: Optional[int] = None) -> TaskState:
+    sample = Sample(id=sample_id, group_id=group_id, input=f'question-{sample_id}', target='answer')
+    return TaskState(model='mock-model', sample=sample, completed=True)
+
+
+def _review_row(sample_id: int, value: float) -> Dict[str, Any]:
+    return {
+        'index': sample_id,
+        'target': 'answer',
+        'messages': [],
+        'sample_score': {
+            'sample_id': sample_id,
+            'score': {
+                'value': {
+                    'acc': value
+                },
+            },
+        },
+    }
+
+
+def _make_manager(tmp_path: Path) -> CacheManager:
+    outputs = OutputsStructure(outputs_dir=str(tmp_path), is_make=True)
+    return CacheManager(outputs=outputs, model_name='mock-model', benchmark_name='mock-bench')
+
+
+def _write_review_cache(manager: CacheManager, subset: str, rows: list[Dict[str, Any]]) -> str:
+    review_file = manager.get_review_cache_path(subset)
+    with open(review_file, 'w', encoding='utf-8') as f:
+        for row in rows:
+            f.write(json.dumps(row) + '\n')
+    return review_file
+
+
+def test_filter_review_cache_intersects_and_dedupes(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    manager = _make_manager(tmp_path)
+    task_states = [_make_task_state(0), _make_task_state(1)]
+    _write_review_cache(
+        manager,
+        'default',
+        [
+            _review_row(0, 1.0),
+            _review_row(1, 0.0),
+            _review_row(1, 1.0),
+            _review_row(99, 0.5),
+        ],
+    )
+
+    cached_scores, remaining_states = manager.filter_review_cache('default', task_states)
+
+    assert [score.sample_id for score in cached_scores] == [0, 1]
+    assert cached_scores[1].score.main_value == 1.0
+    assert remaining_states == []
+    assert 'Dropped 1 orphan and 1 duplicate rows' in caplog.text
+
+
+def test_filter_review_cache_does_not_merge_distinct_repeat_samples(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_states = [_make_task_state(10, group_id=5), _make_task_state(11, group_id=5)]
+    _write_review_cache(manager, 'default', [_review_row(10, 1.0), _review_row(11, 0.0)])
+
+    cached_scores, remaining_states = manager.filter_review_cache('default', task_states)
+
+    assert [score.sample_id for score in cached_scores] == [10, 11]
+    assert remaining_states == []
+
+
+def test_filter_review_cache_returns_all_states_when_no_cache(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_states = [_make_task_state(0), _make_task_state(1)]
+
+    cached_scores, remaining_states = manager.filter_review_cache('default', task_states)
+
+    assert cached_scores == []
+    assert remaining_states == task_states
+
+
+def test_filter_review_cache_keeps_uncovered_states(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_states = [_make_task_state(0), _make_task_state(1), _make_task_state(2)]
+    _write_review_cache(manager, 'default', [_review_row(2, 0.0)])
+
+    cached_scores, remaining_states = manager.filter_review_cache('default', task_states)
+
+    assert [score.sample_id for score in cached_scores] == [2]
+    assert [state.sample_id for state in remaining_states] == [0, 1]
+
+
+def test_filter_review_cache_skips_malformed_and_schema_invalid_rows(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = _make_manager(tmp_path)
+    task_states = [_make_task_state(0), _make_task_state(1)]
+    review_file = _write_review_cache(
+        manager,
+        'default',
+        [
+            _review_row(0, 1.0),
+            {'legacy_field': 'not a valid ReviewResult'},
+            _review_row(1, 0.0),
+        ],
+    )
+    with open(review_file, 'a', encoding='utf-8') as f:
+        f.write('{"sample_score":')
+
+    cached_scores, remaining_states = manager.filter_review_cache('default', task_states)
+
+    assert [score.sample_id for score in cached_scores] == [0, 1]
+    assert remaining_states == []
+    assert 'Skipping invalid JSONL row' in caplog.text
+    assert 'Skipping invalid review cache row' in caplog.text
+
+
+def test_filter_prediction_cache_skips_malformed_and_schema_invalid_rows(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = _make_manager(tmp_path)
+    dataset = MemoryDataset(
+        samples=[
+            Sample(id=0, input='question-0', target='answer'),
+            Sample(id=1, input='question-1', target='answer'),
+        ],
+        name='dummy',
+    )
+    valid_row = ModelResult.from_task_state(_make_task_state(0)).model_dump(mode='json')
+    incomplete_row = ModelResult.from_task_state(_make_task_state(1)).model_dump(mode='json')
+    incomplete_row['model_output'] = None
+    prediction_file = manager.get_prediction_cache_path('default')
+    with open(prediction_file, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(valid_row) + '\n')
+        f.write(json.dumps(incomplete_row) + '\n')
+        f.write(json.dumps({'legacy_field': 'not a valid ModelResult'}) + '\n')
+        f.write('{"index":')
+
+    cached_task_states, filtered_dataset = manager.filter_prediction_cache('default', dataset)
+
+    assert [state.sample_id for state in cached_task_states] == [0]
+    assert [sample.id for sample in filtered_dataset.samples] == [1]
+    assert 'Skipping invalid JSONL row' in caplog.text
+    assert 'Skipping invalid prediction cache row' in caplog.text


### PR DESCRIPTION
## Summary

This PR makes `use_cache` recovery resilient to stale, duplicated, and partially written JSONL cache rows.

- Review-cache rows now intersect with the sample IDs in the current task and deduplicate by sample ID, keeping the last appended row.
- Corrupt JSONL, `null`, and other non-object rows are skipped only when callers explicitly opt into cache-tolerant loading.
- Prediction and review cache rows that fail their Pydantic schema are skipped with warnings instead of aborting the entire resume.

## Root Cause

`CacheManager.filter_review_cache()` deserialized every row in the review JSONL and returned each resulting `SampleScore`. It used the IDs only to remove pending task states, so stale rows from a changed dataset and duplicate rows for a sample were still included in aggregation.

`jsonl_to_list()` retried parsing line by line after the `jsonlines` reader failed, but the fallback called `json.loads()` on every non-empty row without handling malformed records. A crash-truncated tail therefore failed the fallback as well. A literal `null` row could also reach cache model validation as `None`.

## Changes

- Keep cached review scores in a map keyed by `sample_id`, accept only IDs in the current task, and retain the last row for duplicates.
- Log dropped orphan and duplicate review rows so cache recovery is observable.
- Add an explicit `skip_invalid` mode to `jsonl_to_list`; its default remains strict for benchmark and other normal JSONL inputs.
- In tolerant mode, parse JSONL line by line and skip malformed and non-object records with a warning.
- Make prediction and review cache restoration skip individual `ModelResult` or `ReviewResult` schema failures.
- Add regression coverage for orphan rows, last-row-wins deduplication, repeat samples, missing and partial caches, malformed tails, `null`/non-object JSON, and invalid cache schemas.

## Reproduction

On the unmodified base, review states `0, 1` and the following cache rows:

```text
0/1.0, 1/0.0, 1/1.0, 99/0.5
```

return four scores (`[0, 1, 1, 99]`) and include the stale row in metrics. The correct result is two scores (`[0, 1]`) with the final value for sample `1`.

Likewise, reading a cache ending with a truncated JSON object raises `JSONDecodeError`, and a valid `null` line subsequently raises `ValidationError` during review restoration. Either failure prevents `use_cache` from resuming an interrupted evaluation.

## Validation

```bash
python -m pytest \
  tests/evaluator/test_cache_manager.py \
  tests/api/test_io_utils.py -q
```

Result:

```text
21 passed
```

```bash
python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings
```

Result:

```text
1 passed
```

All configured pre-commit hooks passed when run through the project virtual environment. `make lint` could not locate the shell `pre-commit` executable in this environment, but the equivalent `python -m pre_commit run --all-files` completed successfully.

## Scope

The change is limited to cache restoration and its JSONL reader contract. Normal JSONL reads remain strict, live samples are not deduplicated across distinct IDs, and no benchmark prompts, scoring definitions, aggregation rules, or published `evaluation_version` values change.
