### PR TITLE
fix(dataset): isolate cache keys, undecode video, and validate limits consistently

### DIFF
--- a/evalscope/api/dataset/dataset.py
+++ b/evalscope/api/dataset/dataset.py
@@ -1,6 +1,7 @@
 import abc
 import copy
 import hashlib
+import math
 import random
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -10,6 +11,31 @@ from pydantic import BaseModel, Field
 
 from evalscope.api.messages import ChatMessage, messages_to_markdown
 from evalscope.api.tool import ToolInfo
+
+_LIMIT_ERROR = 'Limit must be a non-negative integer or a finite float between 0 and 1.'
+
+
+def validate_dataset_limit(limit: Optional[Union[int, float]]) -> Optional[Union[int, float]]:
+    """Validate a dataset sample count or fraction without changing its value."""
+    if limit is None:
+        return None
+    if isinstance(limit, int):
+        if limit < 0:
+            raise ValueError(_LIMIT_ERROR)
+        return limit
+    if isinstance(limit, float):
+        if not math.isfinite(limit) or not 0.0 <= limit <= 1.0:
+            raise ValueError(_LIMIT_ERROR)
+        return limit
+    raise ValueError(_LIMIT_ERROR)
+
+
+def resolve_dataset_limit(limit: Optional[Union[int, float]], dataset_size: int) -> Optional[int]:
+    """Resolve a validated fraction against a dataset size, or return an integer count."""
+    validated_limit = validate_dataset_limit(limit)
+    if isinstance(validated_limit, float):
+        return int(dataset_size * validated_limit)
+    return validated_limit
 
 
 class Sample(BaseModel):
@@ -328,6 +354,7 @@ class DatasetDict:
         Returns:
             DatasetDict: A new DatasetDict containing the provided dataset.
         """
+        limit = validate_dataset_limit(limit)
         data_dict = defaultdict(list)
         dataset_dict = defaultdict(list)
         # init subset keys to prevent order issues
@@ -346,7 +373,7 @@ class DatasetDict:
             # Apply limit if specified; resolve float limits per subset without
             # mutating `limit`, so each subset takes its own fraction
             if limit is not None:
-                subset_limit = int(len(samples) * limit) if isinstance(limit, float) else limit
+                subset_limit = resolve_dataset_limit(limit, len(samples))
                 samples = samples[:subset_limit]
             # Repeat k times; always deepcopy to avoid mutating the original dataset
             # (repeats=0 yields empty list; repeats=1 yields one isolated copy per sample)

--- a/evalscope/api/dataset/loader.py
+++ b/evalscope/api/dataset/loader.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import os
 import random
 import shutil
@@ -19,7 +20,7 @@ from evalscope.utils.io_utils import (
     undecode_media,
 )
 
-from .dataset import Dataset, FieldSpec, MemoryDataset, Sample
+from .dataset import Dataset, FieldSpec, MemoryDataset, Sample, resolve_dataset_limit, validate_dataset_limit
 from .hub import DatasetHub
 from .utils import data_to_samples, shuffle_choices_if_requested
 
@@ -36,6 +37,35 @@ def _shuffle_in_place(data: list, seed: Optional[int]) -> None:
         random.Random(seed).shuffle(data)
     else:
         random.shuffle(data)
+
+
+def _dataset_cache_hash(
+    data_id_or_path: str,
+    split: str,
+    subset: str,
+    version: Optional[str],
+    data_source: Optional[str],
+    kwargs: Dict,
+) -> str:
+    """Build a stable hash from every input that determines a remote dataset."""
+    effective_data_source = _resolve_effective_data_source(data_id_or_path, data_source)
+    payload = {
+        'data_id_or_path': data_id_or_path,
+        'split': split,
+        'subset': subset,
+        'version': version,
+        'data_source': effective_data_source,
+        'kwargs': kwargs,
+    }
+    serialized = json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str)
+    return gen_hash(serialized)
+
+
+def _resolve_effective_data_source(data_id_or_path: str, data_source: Optional[str]) -> str:
+    """Resolve the source using the same local-path precedence as DatasetHub."""
+    if data_source == HubType.LOCAL or os.path.exists(data_id_or_path):
+        return HubType.LOCAL
+    return data_source or HubType.MODELSCOPE
 
 
 class DataLoader(ABC):
@@ -69,7 +99,7 @@ class DataLoader(ABC):
         self.filter_func = filter_func
         self.subset = subset
         self.version = version
-        self.limit = limit
+        self.limit = validate_dataset_limit(limit)
         self.data_source = data_source
         self.shuffle = shuffle
         self.shuffle_choices = shuffle_choices
@@ -99,10 +129,18 @@ class RemoteDataLoader(DataLoader):
         from datasets.features import Audio, Image
 
         path = self.data_id_or_path
+        effective_data_source = _resolve_effective_data_source(path, self.data_source)
         # resolve data_to_sample function
         data_to_sample = record_to_sample_fn(self.sample_fields)
         # generate a unique cache dir for this dataset
-        dataset_hash = gen_hash(f'{path}{self.split}{self.subset}{self.version}{self.kwargs}')
+        dataset_hash = _dataset_cache_hash(
+            path,
+            self.split,
+            self.subset,
+            self.version,
+            self.data_source,
+            self.kwargs,
+        )
         if self.dataset_dir:
             datasets_cache_dir = os.path.join(self.dataset_dir, 'datasets')
         else:
@@ -117,22 +155,22 @@ class RemoteDataLoader(DataLoader):
             dataset = datasets.load_from_disk(dataset_cache_dir)
         else:
             logger.info(
-                f'Loading dataset {path} from {self.data_source} > subset: {self.subset} > split: {self.split} ...'
+                f'Loading dataset {path} from {effective_data_source} > subset: {self.subset} > split: {self.split} ...'
             )
             dataset = DatasetHub(
                 data_id_or_path=path,
-                data_source=self.data_source,
+                data_source=effective_data_source,
                 revision=self.version,
                 trust_remote=self.trust_remote,
                 force_redownload=self.force_redownload,
             ).load(split=self.split, subset=self.subset, **self.kwargs)
 
             # Only save to disk if not loading from local path
-            if self.data_source != HubType.LOCAL:
+            if effective_data_source != HubType.LOCAL:
                 dataset.save_to_disk(dataset_cache_dir)
 
-        # Disable auto-decoding for Image/Audio to keep raw bytes format (compat with datasets >= 3.0)
-        dataset = undecode_media(dataset, media_type=['image', 'audio'])
+        # Disable auto-decoding for media columns to keep their raw bytes representation.
+        dataset = undecode_media(dataset, media_type=['image', 'audio', 'video'])
 
         # shuffle if requested
         if self.shuffle:
@@ -140,12 +178,9 @@ class RemoteDataLoader(DataLoader):
 
         # limit if requested
         if self.limit:
-            if isinstance(self.limit, float):
-                self.limit = int(len(dataset) * self.limit)
-            elif isinstance(self.limit, int) and self.limit < 0:
-                raise ValueError('Limit must be a non-negative integer or a float between 0 and 1.')
-            if len(dataset) > self.limit:
-                dataset = dataset.select(range(self.limit))
+            resolved_limit = resolve_dataset_limit(self.limit, len(dataset))
+            if resolved_limit is not None and len(dataset) > resolved_limit:
+                dataset = dataset.select(range(resolved_limit))
 
         # convert to list
         dataset_list = list(dataset)
@@ -247,11 +282,8 @@ class LocalDataLoader(DataLoader):
 
         # limit if requested
         if self.limit:
-            if isinstance(self.limit, float):
-                self.limit = int(len(dataset) * self.limit)
-            elif isinstance(self.limit, int) and self.limit < 0:
-                raise ValueError('Limit must be a non-negative integer or a float between 0 and 1.')
-            dataset = dataset[: self.limit]
+            resolved_limit = resolve_dataset_limit(self.limit, len(dataset))
+            dataset = dataset[:resolved_limit]
 
         # repeat k times
         if self.repeats > 1:
@@ -294,11 +326,8 @@ class DictDataLoader(DataLoader):
 
         # limit if requested
         if self.limit:
-            if isinstance(self.limit, float):
-                self.limit = int(len(dataset) * self.limit)
-            elif isinstance(self.limit, int) and self.limit < 0:
-                raise ValueError('Limit must be a non-negative integer or a float between 0 and 1.')
-            dataset = dataset[: self.limit]
+            resolved_limit = resolve_dataset_limit(self.limit, len(dataset))
+            dataset = dataset[:resolved_limit]
 
         # repeat k times
         if self.repeats > 1:

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -10,6 +10,7 @@ from pydantic import ConfigDict, Field, SecretStr, field_validator, model_valida
 
 from evalscope.agent.external.config import ExternalAgentConfig
 from evalscope.api.agent import NativeAgentConfig
+from evalscope.api.dataset.dataset import validate_dataset_limit
 from evalscope.api.model import GenerateConfig, Model, ModelAPI
 from evalscope.constants import (
     DEFAULT_DATASET_CACHE_DIR,
@@ -385,8 +386,7 @@ class TaskConfig(BaseArgument):
     def _validate_limit(cls, v: Any) -> Any:
         if v is not None:
             v = parse_int_or_float(v)
-            if v < 0:
-                raise ValueError(f'`limit` must be >= 0 or None, got {v}.')
+            v = validate_dataset_limit(v)
             if v == 0:
                 return None
         return v

--- a/tests/api/test_dataset_dict_limit.py
+++ b/tests/api/test_dataset_dict_limit.py
@@ -1,4 +1,7 @@
+import math
 from typing import List
+
+import pytest
 
 from evalscope.api.dataset import MemoryDataset, Sample
 from evalscope.api.dataset.dataset import DatasetDict
@@ -39,3 +42,29 @@ def test_from_dataset_no_limit_keeps_all_samples() -> None:
 
     assert len(dataset_dict['small']) == 4
     assert len(dataset_dict['large']) == 10
+
+
+@pytest.mark.parametrize('limit', [2.5, -1, -0.1, math.nan, math.inf])
+def test_from_dataset_rejects_invalid_limits(limit: float | int) -> None:
+    dataset = _build_dataset({'small': 4})
+
+    with pytest.raises(ValueError, match='Limit must'):
+        DatasetDict.from_dataset(dataset, subset_list=['small'], limit=limit)
+
+
+@pytest.mark.parametrize(
+    'limit, expected',
+    [
+        (None, 4),
+        (0, 0),
+        (0.5, 2),
+        (1.0, 4),
+        (2, 2),
+    ],
+)
+def test_from_dataset_preserves_valid_limit_semantics(limit: float | int | None, expected: int) -> None:
+    dataset = _build_dataset({'small': 4})
+
+    dataset_dict = DatasetDict.from_dataset(dataset, subset_list=['small'], limit=limit)
+
+    assert len(dataset_dict['small']) == expected

--- a/tests/api/test_dataset_loader.py
+++ b/tests/api/test_dataset_loader.py
@@ -1,0 +1,204 @@
+"""Tests for dataset loader cache isolation, media handling, and limits."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pyarrow as pa
+import pytest
+from datasets import Dataset as HFDataset
+from datasets import DatasetInfo, Features, Value, Video
+from datasets.table import InMemoryTable
+
+from evalscope.api.dataset import Sample
+from evalscope.api.dataset.hub import DatasetHub
+from evalscope.api.dataset.loader import DictDataLoader, LocalDataLoader, RemoteDataLoader
+from evalscope.constants import HubType
+
+
+def _sample_from_record(record: Dict[str, Any]) -> Sample:
+    return Sample(input=record['text'], metadata={'video': record.get('video')})
+
+
+def _install_fake_remote_dataset(monkeypatch: Any) -> None:
+    def fake_load(self: DatasetHub, split: str, subset: str = 'default', **kwargs: Any) -> HFDataset:
+        return HFDataset.from_dict({'text': [f'{subset}-{split}']})
+
+    monkeypatch.setattr(DatasetHub, 'load', fake_load)
+
+
+def _cache_directories(dataset_dir: Path) -> List[Path]:
+    cache_root = dataset_dir / 'datasets'
+    return sorted(path for path in cache_root.iterdir() if path.is_dir())
+
+
+def _load_remote_cache(
+    dataset_dir: Path,
+    *,
+    data_source: str,
+    split: str,
+    subset: str,
+    loader_kwargs: Optional[Dict[str, Any]] = None,
+) -> None:
+    RemoteDataLoader(
+        data_id_or_path='dummy/cache-dataset',
+        split=split,
+        subset=subset,
+        sample_fields=_sample_from_record,
+        data_source=data_source,
+        dataset_dir=str(dataset_dir),
+        **(loader_kwargs or {}),
+    ).load()
+
+
+def test_remote_cache_directory_separates_data_sources(monkeypatch: Any, tmp_path: Path) -> None:
+    _install_fake_remote_dataset(monkeypatch)
+
+    _load_remote_cache(tmp_path, data_source=HubType.MODELSCOPE, split='train', subset='default')
+    _load_remote_cache(tmp_path, data_source=HubType.HUGGINGFACE, split='train', subset='default')
+
+    assert len(_cache_directories(tmp_path)) == 2
+
+
+def test_remote_cache_directory_preserves_split_subset_boundaries(monkeypatch: Any, tmp_path: Path) -> None:
+    _install_fake_remote_dataset(monkeypatch)
+
+    _load_remote_cache(tmp_path, data_source=HubType.MODELSCOPE, split='a', subset='bc')
+    _load_remote_cache(tmp_path, data_source=HubType.MODELSCOPE, split='ab', subset='c')
+
+    assert len(_cache_directories(tmp_path)) == 2
+
+
+def test_remote_cache_directory_is_stable_across_kwargs_order(monkeypatch: Any, tmp_path: Path) -> None:
+    _install_fake_remote_dataset(monkeypatch)
+
+    _load_remote_cache(
+        tmp_path,
+        data_source=HubType.MODELSCOPE,
+        split='train',
+        subset='default',
+        loader_kwargs={'b': 2, 'a': 1},
+    )
+    _load_remote_cache(
+        tmp_path,
+        data_source=HubType.MODELSCOPE,
+        split='train',
+        subset='default',
+        loader_kwargs={'a': 1, 'b': 2},
+    )
+
+    assert len(_cache_directories(tmp_path)) == 1
+
+
+def test_remote_loader_treats_existing_path_as_effective_local_source(monkeypatch: Any, tmp_path: Path) -> None:
+    local_path = tmp_path / 'local-dataset'
+    local_path.mkdir()
+    dataset_dir = tmp_path / 'cache'
+    captured: Dict[str, Any] = {}
+
+    def fake_load(self: DatasetHub, split: str, subset: str = 'default', **kwargs: Any) -> HFDataset:
+        captured['data_source'] = self.data_source
+        return HFDataset.from_dict({'text': ['local']})
+
+    monkeypatch.setattr(DatasetHub, 'load', fake_load)
+
+    dataset = RemoteDataLoader(
+        data_id_or_path=str(local_path),
+        split='train',
+        sample_fields=_sample_from_record,
+        data_source=HubType.MODELSCOPE,
+        dataset_dir=str(dataset_dir),
+    ).load()
+
+    assert len(dataset) == 1
+    assert captured['data_source'] == HubType.LOCAL
+    assert not (dataset_dir / 'datasets').exists()
+
+
+def test_remote_loader_does_not_decode_video(monkeypatch: Any, tmp_path: Path) -> None:
+    features = Features({'video': Video(decode=True), 'text': Value('string')})
+    row = {'video': {'bytes': b'dummy', 'path': None}, 'text': 'clip'}
+    table = pa.Table.from_pylist([row], schema=features.arrow_schema)
+    remote_dataset = HFDataset(InMemoryTable(table), info=DatasetInfo(features=features))
+
+    def fake_load(self: DatasetHub, split: str, subset: str = 'default', **kwargs: Any) -> HFDataset:
+        return remote_dataset
+
+    monkeypatch.setattr(DatasetHub, 'load', fake_load)
+
+    dataset = RemoteDataLoader(
+        data_id_or_path='dummy/video-dataset',
+        split='train',
+        sample_fields=_sample_from_record,
+        data_source=HubType.LOCAL,
+        dataset_dir=str(tmp_path),
+    ).load()
+
+    assert dataset[0].metadata['video'] == {'bytes': b'dummy', 'path': None}
+
+
+def _make_direct_loader(
+    loader_kind: str,
+    tmp_path: Path,
+    monkeypatch: Any,
+    limit: Optional[float | int],
+) -> RemoteDataLoader | LocalDataLoader | DictDataLoader:
+    records = [{'text': f'row-{index}'} for index in range(4)]
+    if loader_kind == 'remote':
+        monkeypatch.setattr(DatasetHub, 'load', lambda self, split, subset='default', **kwargs: HFDataset.from_list(records))
+        return RemoteDataLoader(
+            data_id_or_path='dummy/limit-dataset',
+            split='train',
+            sample_fields=_sample_from_record,
+            data_source=HubType.LOCAL,
+            dataset_dir=str(tmp_path),
+            limit=limit,
+        )
+    if loader_kind == 'local':
+        local_path = tmp_path / 'records.jsonl'
+        local_path.write_text('\n'.join(json.dumps(record) for record in records), encoding='utf-8')
+        return LocalDataLoader(
+            data_id_or_path=str(local_path),
+            split='train',
+            sample_fields=_sample_from_record,
+            limit=limit,
+        )
+    return DictDataLoader(dict_list=records, sample_fields=_sample_from_record, limit=limit)
+
+
+@pytest.mark.parametrize('loader_kind', ['remote', 'local', 'dict'])
+@pytest.mark.parametrize('limit', [2.5, -1, -0.1, math.nan, math.inf])
+def test_direct_loaders_reject_invalid_limits(
+    loader_kind: str,
+    limit: float | int,
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match='Limit must'):
+        _make_direct_loader(loader_kind, tmp_path, monkeypatch, limit).load()
+
+
+@pytest.mark.parametrize('loader_kind', ['remote', 'local', 'dict'])
+@pytest.mark.parametrize(
+    'limit, expected',
+    [
+        (None, 4),
+        (0, 4),
+        (0.5, 2),
+        (1.0, 4),
+        (2, 2),
+    ],
+)
+def test_direct_loaders_preserve_valid_limit_semantics(
+    loader_kind: str,
+    limit: Optional[float | int],
+    expected: int,
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    loader = _make_direct_loader(loader_kind, tmp_path, monkeypatch, limit)
+
+    assert len(loader.load()) == expected
+    assert len(loader.load()) == expected
+    assert loader.limit == limit

--- a/tests/api/test_task_config_validation.py
+++ b/tests/api/test_task_config_validation.py
@@ -1,6 +1,7 @@
 """Tests for unknown-key rejection and the eval_batch_size default resolution."""
 
 import argparse
+import math
 from typing import Optional
 
 import pytest
@@ -218,3 +219,25 @@ def test_update_merges_generation_config_and_recoerces() -> None:
     assert merged['top_p'] == 0.9
     assert isinstance(config.sandbox, SandboxTaskConfig)
     assert config.sandbox.engine == 'volcengine'
+
+
+@pytest.mark.parametrize('limit', [2.5, -1, -0.1, math.nan, math.inf])
+def test_invalid_limits_are_rejected(limit: float | int) -> None:
+    with pytest.raises(ValueError, match='limit'):
+        TaskConfig.from_dict({'model': 'x', 'limit': limit})
+
+
+@pytest.mark.parametrize(
+    'limit, expected',
+    [
+        (None, None),
+        (0, None),
+        (0.5, 0.5),
+        (1.0, 1),
+        (2, 2),
+    ],
+)
+def test_valid_limit_semantics_are_preserved(limit: float | int | None, expected: float | int | None) -> None:
+    config = TaskConfig.from_dict({'model': 'x', 'limit': limit})
+
+    assert config.limit == expected


### PR DESCRIPTION
Fixes three native dataset-loading issues:

- Include the dataset hub, split, subset, version, and loader arguments in the remote cache identity to avoid collisions.
- Keep remote video columns undecoded when materializing datasets.
- Validate limit consistently in TaskConfig, DatasetDict, and direct data loaders without mutating loader state across repeated loads.

Also keeps local-path precedence consistent and adds regression coverage for cache isolation, video loading, invalid limits, and repeated loads.