### PR TITLE
fix(benchmark): preserve metric identities on General QA/VQA scoring errors

### DIFF
--- a/evalscope/benchmarks/general_qa/general_qa_adapter.py
+++ b/evalscope/benchmarks/general_qa/general_qa_adapter.py
@@ -8,6 +8,7 @@ from evalscope.api.messages import ChatMessageSystem, ChatMessageUser, dict_to_c
 from evalscope.api.metric import Score
 from evalscope.api.metric.semantics import MetricSelector
 from evalscope.api.registry import register_benchmark
+from evalscope.benchmarks.general_qa_vqa_metrics import METRIC_SCORE_KEYS, MetricScoringError, calculate_metric_score
 from evalscope.constants import Tags
 from evalscope.utils.logger import get_logger
 
@@ -57,6 +58,7 @@ General-QA is a customizable question answering benchmark for evaluating languag
         train_split=None,
         eval_split='test',
         prompt_template=PROMPT_TEMPLATE,
+        evaluation_version='v1.1',
     )
 )
 class GeneralQAAdapter(DefaultDataAdapter):
@@ -105,18 +107,16 @@ class GeneralQAAdapter(DefaultDataAdapter):
 
         # Calculate scores for each configured metric
         for metric in self.metric_list:
+            if metric not in METRIC_SCORE_KEYS:
+                continue
             try:
-                if metric == 'Rouge':
-                    from evalscope.metrics.utils.rouge import compute_rouge_score_one_sample_zh
-
-                    score.value.update(compute_rouge_score_one_sample_zh([filtered_prediction], [reference]))
-                elif metric == 'BLEU':
-                    from evalscope.metrics import bleu_ngram_one_sample
-
-                    score.value.update(bleu_ngram_one_sample(filtered_prediction, reference))
-            except Exception as e:
+                metric_score = calculate_metric_score(metric, filtered_prediction, reference)
+            except (ImportError, LookupError, MetricScoringError) as e:
                 logger.error(f'Error calculating metric {metric}: {e}')
-                return None
+                score.value.update(dict.fromkeys(METRIC_SCORE_KEYS[metric], 0.0))
+                score.metadata.setdefault('metric_errors', {})[metric] = f'{type(e).__name__}: {e}'
+                continue
+            score.value.update(metric_score)
 
         score.main_score_name = 'Rouge-L-R'
         return score

--- a/evalscope/benchmarks/general_qa_vqa_metrics.py
+++ b/evalscope/benchmarks/general_qa_vqa_metrics.py
@@ -1,0 +1,41 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from typing import Dict, Tuple
+
+METRIC_SCORE_KEYS: Dict[str, Tuple[str, ...]] = {
+    'Rouge': (
+        'Rouge-1-R',
+        'Rouge-1-P',
+        'Rouge-1-F',
+        'Rouge-2-R',
+        'Rouge-2-P',
+        'Rouge-2-F',
+        'Rouge-L-R',
+        'Rouge-L-P',
+        'Rouge-L-F',
+    ),
+    'BLEU': ('bleu-1', 'bleu-2', 'bleu-3', 'bleu-4'),
+}
+
+
+class MetricScoringError(Exception):
+    """Raised when a metric returns an incomplete General QA/VQA score schema."""
+
+
+def calculate_metric_score(metric: str, prediction: str, reference: str) -> Dict[str, float]:
+    """Calculate one General QA/VQA metric and validate its score schema."""
+    if metric == 'Rouge':
+        from evalscope.metrics.utils.rouge import compute_rouge_score_one_sample_zh
+
+        score = compute_rouge_score_one_sample_zh([prediction], [reference])
+    elif metric == 'BLEU':
+        from evalscope.metrics import bleu_ngram_one_sample
+
+        score = bleu_ngram_one_sample(prediction, reference)
+    else:
+        raise ValueError(f'Unsupported General QA/VQA metric: {metric}')
+
+    missing_keys = set(METRIC_SCORE_KEYS[metric]) - score.keys()
+    if missing_keys:
+        raise MetricScoringError(f'{metric} returned incomplete score schema: missing {sorted(missing_keys)}')
+    return score

--- a/evalscope/benchmarks/general_vqa/general_vqa_adapter.py
+++ b/evalscope/benchmarks/general_vqa/general_vqa_adapter.py
@@ -8,6 +8,7 @@ from evalscope.api.evaluator import TaskState
 from evalscope.api.metric import Score
 from evalscope.api.metric.semantics import MetricSelector
 from evalscope.api.registry import register_benchmark
+from evalscope.benchmarks.general_qa_vqa_metrics import METRIC_SCORE_KEYS, MetricScoringError, calculate_metric_score
 from evalscope.constants import Tags
 from evalscope.models.utils.openai import chat_messages_from_openai
 from evalscope.utils.logger import get_logger
@@ -58,6 +59,7 @@ It supports OpenAI-compatible message format with flexible image/video/audio inp
         train_split=None,
         eval_split='test',
         prompt_template=None,
+        evaluation_version='v1.1',
     )
 )
 class GeneralVQAAdapter(VisionLanguageAdapter):
@@ -135,18 +137,16 @@ class GeneralVQAAdapter(VisionLanguageAdapter):
 
         # Calculate scores for each configured metric
         for metric in self.metric_list:
+            if metric not in METRIC_SCORE_KEYS:
+                continue
             try:
-                if metric == 'Rouge':
-                    from evalscope.metrics.utils.rouge import compute_rouge_score_one_sample_zh
-
-                    score.value.update(compute_rouge_score_one_sample_zh([filtered_prediction], [reference]))
-                elif metric == 'BLEU':
-                    from evalscope.metrics import bleu_ngram_one_sample
-
-                    score.value.update(bleu_ngram_one_sample(filtered_prediction, reference))
-            except Exception as e:
+                metric_score = calculate_metric_score(metric, filtered_prediction, reference)
+            except (ImportError, LookupError, MetricScoringError) as e:
                 logger.error(f'Error calculating metric {metric}: {e}')
-                return None
+                score.value.update(dict.fromkeys(METRIC_SCORE_KEYS[metric], 0.0))
+                score.metadata.setdefault('metric_errors', {})[metric] = f'{type(e).__name__}: {e}'
+                continue
+            score.value.update(metric_score)
 
         score.main_score_name = 'Rouge-L-R'
         return score

--- a/tests/benchmark/test_general_qa_adapter.py
+++ b/tests/benchmark/test_general_qa_adapter.py
@@ -1,0 +1,140 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from typing import Any, Dict
+
+import pytest
+
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.metric import SampleScore
+from evalscope.api.metric.semantics import MetricIdentity, MetricSelector
+from evalscope.api.registry import BENCHMARK_REGISTRY
+from evalscope.benchmarks.general_qa.general_qa_adapter import GeneralQAAdapter
+from evalscope.benchmarks.general_qa_vqa_metrics import METRIC_SCORE_KEYS
+from evalscope.config import TaskConfig
+
+ROUGE_KEYS = METRIC_SCORE_KEYS['Rouge']
+BLEU_KEYS = METRIC_SCORE_KEYS['BLEU']
+
+
+def _adapter(metric_list: list[str]) -> GeneralQAAdapter:
+    return GeneralQAAdapter(
+        benchmark_meta=BenchmarkMeta(
+            name='general_qa',
+            dataset_id='dummy',
+            eval_split='test',
+            pretty_name='General-QA',
+            description='General QA test adapter.',
+            metric_list=metric_list,
+            primary_metric=MetricSelector(
+                name='rouge', aggregation='mean', dimensions={'variant': 'l', 'statistic': 'recall'}
+            ),
+        ),
+        task_config=TaskConfig(datasets=['general_qa']),
+    )
+
+
+def _task_state() -> TaskState:
+    return TaskState(model='mock-model', sample=Sample(input='question', target='answer'))
+
+
+def _rouge_values(value: float) -> Dict[str, float]:
+    return dict.fromkeys(ROUGE_KEYS, value)
+
+
+def _raise_metric_error(*args: Any, **kwargs: Any) -> Dict[str, float]:
+    raise LookupError('metric exploded')
+
+
+class TestGeneralQAAdapterMatchScore:
+
+    def test_rouge_error_returns_real_zero_score_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _adapter(['Rouge'])
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh', _raise_metric_error
+        )
+
+        score = adapter.match_score('pred', 'pred', 'answer', _task_state())
+
+        assert score is not None
+        assert score.value == dict.fromkeys(ROUGE_KEYS, 0.0)
+        assert score.main_score_name == 'Rouge-L-R'
+        assert score.metadata['metric_errors']['Rouge'] == 'LookupError: metric exploded'
+
+    def test_rouge_error_is_counted_in_aggregation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _adapter(['Rouge'])
+        call_count = 0
+
+        def succeed_then_fail(*args: Any, **kwargs: Any) -> Dict[str, float]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _rouge_values(1.0)
+            raise LookupError('metric exploded')
+
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh', succeed_then_fail
+        )
+        scores = [
+            SampleScore(score=adapter.match_score('answer', 'answer', 'answer', _task_state()), sample_id=0),
+            SampleScore(score=adapter.match_score('pred', 'pred', 'answer', _task_state()), sample_id=1),
+        ]
+
+        rouge_l_recall = next(
+            item
+            for item in adapter.aggregate_scores(scores)
+            if item.identity
+            == MetricIdentity(
+                name='rouge', aggregation='mean', dimensions={'variant': 'l', 'statistic': 'recall'}
+            )
+        )
+
+        assert rouge_l_recall.score == 0.5
+        assert rouge_l_recall.num == 2
+
+    def test_all_metric_errors_keep_zero_primary_in_report(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _adapter(['Rouge', 'BLEU'])
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh', _raise_metric_error
+        )
+        monkeypatch.setattr('evalscope.metrics.bleu_ngram_one_sample', _raise_metric_error)
+        sample_score = SampleScore(score=adapter.match_score('pred', 'pred', 'answer', _task_state()), sample_id=0)
+
+        report = adapter.generate_report(
+            {'test': adapter.aggregate_scores([sample_score])}, model_name='mock-model', output_dir=''
+        )
+
+        assert report.primary_metric is not None
+        assert report.primary_metric.identity.name == 'rouge'
+        assert report.primary_metric.score == 0.0
+        assert report.primary_metric.num == 1
+
+    def test_bleu_error_keeps_successful_rouge_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = _adapter(['Rouge', 'BLEU'])
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh',
+            lambda *args, **kwargs: _rouge_values(1.0),
+        )
+        monkeypatch.setattr('evalscope.metrics.bleu_ngram_one_sample', _raise_metric_error)
+
+        score = adapter.match_score('answer', 'answer', 'answer', _task_state())
+
+        assert score.value['Rouge-L-R'] == 1.0
+        assert {key: score.value[key] for key in BLEU_KEYS} == dict.fromkeys(BLEU_KEYS, 0.0)
+        assert score.metadata['metric_errors']['BLEU'] == 'LookupError: metric exploded'
+
+
+class TestGeneralQAAdapterMetadata:
+
+    def test_evaluation_version(self) -> None:
+        assert BENCHMARK_REGISTRY['general_qa'].evaluation_version == 'v1.1'
+
+
+class TestGeneralQAAdapterRecordToSample:
+
+    def test_query_answer_record(self) -> None:
+        sample = _adapter(['Rouge']).record_to_sample({'question': 'Q?', 'answer': 'A.'})
+
+        assert sample.input[-1].text == 'Q?'
+        assert sample.target == 'A.'

--- a/tests/benchmark/test_general_vqa_adapter.py
+++ b/tests/benchmark/test_general_vqa_adapter.py
@@ -3,14 +3,23 @@
 import json
 from io import BytesIO
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 from PIL import Image as PILImage
 
 from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
 from evalscope.api.messages import ChatMessageUser, ContentImage, ContentText
+from evalscope.api.metric.semantics import MetricSelector
+from evalscope.api.registry import BENCHMARK_REGISTRY
+from evalscope.benchmarks.general_qa_vqa_metrics import METRIC_SCORE_KEYS
 from evalscope.benchmarks.general_vqa.general_vqa_adapter import GeneralVQAAdapter
 from evalscope.config import TaskConfig
+
+ROUGE_KEYS = METRIC_SCORE_KEYS['Rouge']
+BLEU_KEYS = METRIC_SCORE_KEYS['BLEU']
 
 
 @pytest.fixture
@@ -20,6 +29,10 @@ def adapter() -> GeneralVQAAdapter:
             name='general_vqa',
             dataset_id='dummy',
             eval_split='test',
+            metric_list=['Rouge', 'BLEU'],
+            primary_metric=MetricSelector(
+                name='rouge', aggregation='mean', dimensions={'variant': 'l', 'statistic': 'recall'}
+            ),
         ),
         task_config=TaskConfig(datasets=['general_vqa']),
     )
@@ -31,6 +44,53 @@ def png_bytes() -> bytes:
     buffer = BytesIO()
     image.save(buffer, format='PNG')
     return buffer.getvalue()
+
+
+def _task_state() -> TaskState:
+    return TaskState(model='mock-model', sample=Sample(input='question', target='answer'))
+
+
+def _rouge_values(value: float) -> Dict[str, float]:
+    return dict.fromkeys(ROUGE_KEYS, value)
+
+
+def _raise_metric_error(*args: Any, **kwargs: Any) -> Dict[str, float]:
+    raise LookupError('metric exploded')
+
+
+class TestGeneralVQAAdapterMatchScore:
+
+    def test_rouge_error_returns_real_zero_score_schema(
+        self, adapter: GeneralVQAAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh', _raise_metric_error
+        )
+
+        score = adapter.match_score('pred', 'pred', 'answer', _task_state())
+
+        assert score is not None
+        assert score.value['Rouge-L-R'] == 0.0
+        assert {key: score.value[key] for key in ROUGE_KEYS} == dict.fromkeys(ROUGE_KEYS, 0.0)
+        assert score.metadata['metric_errors']['Rouge'] == 'LookupError: metric exploded'
+
+    def test_bleu_error_keeps_successful_rouge_values(
+        self, adapter: GeneralVQAAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            'evalscope.metrics.utils.rouge.compute_rouge_score_one_sample_zh',
+            lambda *args, **kwargs: _rouge_values(1.0),
+        )
+        monkeypatch.setattr('evalscope.metrics.bleu_ngram_one_sample', _raise_metric_error)
+
+        score = adapter.match_score('answer', 'answer', 'answer', _task_state())
+
+        assert score.value['Rouge-L-R'] == 1.0
+        assert {key: score.value[key] for key in BLEU_KEYS} == dict.fromkeys(BLEU_KEYS, 0.0)
+        assert score.metadata['metric_errors']['BLEU'] == 'LookupError: metric exploded'
+
+    def test_evaluation_version(self) -> None:
+        assert BENCHMARK_REGISTRY['general_vqa'].evaluation_version == 'v1.1'
 
 
 class TestGeneralVQAAdapterRecordToSample:


### PR DESCRIPTION
General QA and General VQA could abort when Rouge or BLEU failed because the adapters returned no Score object.

This change falls back to zero under the metrics actual output names, preserves other successful metrics from the same sample, and shares the expected Rouge and BLEU score schema between both adapters. Unexpected programming errors still propagate.

Failed-score aggregation semantics change, so both benchmark evaluation versions move to v1.1.