### PR TITLE
feat: add VisFactor benchmark

### DIFF
--- a/docs/en/benchmarks/visfactor.md
+++ b/docs/en/benchmarks/visfactor.md
@@ -1,0 +1,135 @@
+# VisFactor
+
+
+## Overview
+
+VisFactor evaluates foundational visual cognition in multimodal large language models using 20 vision-centric subtests adapted from the Factor-Referenced Cognitive Test (FRCT). It isolates abilities that support higher-level visual reasoning instead of measuring performance on a single downstream task.
+
+## Task Description
+
+- **Task Type**: Visual cognition assessment with binary and short free-form questions
+- **Input**: One to four images interleaved with a task-specific instruction
+- **Output**: A JSON object containing a boolean, word, number, coordinate pair, or letter answer
+- **Domain**: Visualization and spatial processing, perceptual closure, visual memory, and reasoning
+
+## Key Features
+
+- Contains 3,046 rows representing 808 test items across 20 FRCT subtests
+- Uses rule-based variants and grouped consistency checks to reduce average chance performance to approximately 2.9%
+- Preserves the official zero-shot prompts and their image ordering from the VLMEvalKit implementation
+- Covers hidden figures, gestalt completion, visual memory, mental rotation, path finding, paper folding, and related abilities
+
+## Evaluation Notes
+
+- Uses the **test** split from the ModelScope mirror of the official `VisFactor.tsv`
+- Extracts the last `{"answer": ...}` object and applies the official category-specific normalization rules
+- A logical test item may contain multiple rows and receives credit only when every row is correct
+- Reports each subtest's item-level accuracy; the primary score is the unweighted macro-average over represented subtests
+- Scoring is deterministic and does not require an LLM judge
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `visfactor` |
+| **Dataset ID** | [lmms-lab-encoder/visfactor](https://modelscope.cn/datasets/lmms-lab-encoder/visfactor/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2502.16435) |
+| **Tags** | `MultiModal`, `QA`, `Reasoning` |
+| **Metrics** | `accuracy` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 3,046 |
+| Prompt Length (Mean) | 463.45 chars |
+| Prompt Length (Min/Max) | 188 / 932 chars |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 6,048 |
+| Images per Sample | min: 1, max: 4, mean: 1.99 |
+| Resolution Range | 100x100 - 668x911 |
+| Formats | jpeg |
+
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "1a4f53fe",
+      "content": [
+        {
+          "text": "Look at the two images:\n\nBelow is the first image, one simple shape:"
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~2.6KB]"
+        },
+        {
+          "text": "Below is the second image, a larger, complex pattern:"
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~8.5KB]"
+        },
+        {
+          "text": "Task: Decide whether the shape in the first image is hidden anywhere inside the second image. The shape will never be rotated, flipped, or resized. The shape will always be right-side-up and exactly the same size as in the first image.\n\nOutput: Respond with only one word: “TRUE” if it is present, “FALSE” if it is not, in JSON format as follows: {\"answer\": YOUR_ANSWER_HERE}."
+        }
+      ]
+    }
+  ],
+  "target": "T",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": 0,
+    "category_id": "CF1",
+    "category_name": "Hidden Figures Test",
+    "eval_index": 0,
+    "additional": ""
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets visfactor \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['visfactor'],
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -68,6 +68,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `torgo` | [TORGO](../../benchmarks/torgo.md) | `Audio`, `SpeechRecognition` |
 | `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal`, `Video` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal`, `Video` |
+| `visfactor` | [VisFactor](../../benchmarks/visfactor.md) | `MultiModal`, `QA`, `Reasoning` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
 | `vstar_bench` | [V*Bench](../../benchmarks/vstar_bench.md) | `Grounding`, `MCQ`, `MultiModal` |
@@ -144,6 +145,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/torgo.md
 ../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
+../../benchmarks/visfactor.md
 ../../benchmarks/visulogic.md
 ../../benchmarks/vqav2.md
 ../../benchmarks/vstar_bench.md

--- a/docs/zh/benchmarks/visfactor.md
+++ b/docs/zh/benchmarks/visfactor.md
@@ -1,0 +1,134 @@
+# VisFactor
+
+
+## 概述
+
+VisFactor 使用从 Factor-Referenced Cognitive Test (FRCT) 改编而来的 20 个以视觉为中心的子测试，评估多模态大语言模型的基础视觉认知能力。它聚焦于支撑高层视觉推理的基本能力，而非衡量单一下游任务的表现。
+
+## 任务描述
+
+- **任务类型**：包含二元判断和简短自由回答的视觉认知评估
+- **输入**：1 至 4 张图像，与任务特定指令交错排列
+- **输出**：一个 JSON 对象，包含布尔值、单词、数字、坐标对或字母形式的答案
+- **领域**：可视化与空间处理、知觉闭合、视觉记忆及推理
+
+## 主要特性
+
+- 包含 3,046 行数据，对应 20 个 FRCT 子测试中的 808 个测试项
+- 采用基于规则的变体和分组一致性检查，将平均随机猜测准确率降至约 2.9%
+- 保留 VLMEvalKit 实现中的官方零样本提示及其图像顺序
+- 覆盖隐藏图形识别、格式塔完形、视觉记忆、心理旋转、路径查找、折纸推理等相关能力
+
+## 评估说明
+
+- 使用官方 `VisFactor.tsv` 在 ModelScope 镜像中的 **test** 划分
+- 提取最后一个 `{"answer": ...}` 对象，并应用官方针对不同类别的标准化规则
+- 单个逻辑测试项可能包含多行数据，仅当所有行均正确时才计为正确
+- 报告每个子测试在测试项级别的准确率；主得分是所涵盖子测试的未加权宏平均值
+- 评分过程完全确定，无需依赖 LLM 评判器
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `visfactor` |
+| **数据集ID** | [lmms-lab-encoder/visfactor](https://modelscope.cn/datasets/lmms-lab-encoder/visfactor/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2502.16435) |
+| **标签** | `MultiModal`, `QA`, `Reasoning` |
+| **指标** | `accuracy` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 3,046 |
+| 提示词长度（平均） | 463.45 字符 |
+| 提示词长度（最小/最大） | 188 / 932 字符 |
+
+**图像统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 6,048 |
+| 每样本图像数 | 最小: 1, 最大: 4, 平均: 1.99 |
+| 分辨率范围 | 100x100 - 668x911 |
+| 格式 | jpeg |
+
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "1a4f53fe",
+      "content": [
+        {
+          "text": "Look at the two images:\n\nBelow is the first image, one simple shape:"
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~2.6KB]"
+        },
+        {
+          "text": "Below is the second image, a larger, complex pattern:"
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~8.5KB]"
+        },
+        {
+          "text": "Task: Decide whether the shape in the first image is hidden anywhere inside the second image. The shape will never be rotated, flipped, or resized. The shape will always be right-side-up and exactly the same size as in the first image.\n\nOutput: Respond with only one word: “TRUE” if it is present, “FALSE” if it is not, in JSON format as follows: {\"answer\": YOUR_ANSWER_HERE}."
+        }
+      ]
+    }
+  ],
+  "target": "T",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "index": 0,
+    "category_id": "CF1",
+    "category_name": "Hidden Figures Test",
+    "eval_index": 0,
+    "additional": ""
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets visfactor \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['visfactor'],
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -68,6 +68,7 @@
 | `torgo` | [TORGO](../../benchmarks/torgo.md) | `Audio`, `SpeechRecognition` |
 | `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal`, `Video` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal`, `Video` |
+| `visfactor` | [VisFactor](../../benchmarks/visfactor.md) | `MultiModal`, `QA`, `Reasoning` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
 | `vstar_bench` | [V*Bench](../../benchmarks/vstar_bench.md) | `Grounding`, `MCQ`, `MultiModal` |
@@ -144,6 +145,7 @@
 ../../benchmarks/torgo.md
 ../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
+../../benchmarks/visfactor.md
 ../../benchmarks/visulogic.md
 ../../benchmarks/vqav2.md
 ../../benchmarks/vstar_bench.md

--- a/evalscope/benchmarks/_meta/visfactor.json
+++ b/evalscope/benchmarks/_meta/visfactor.json
@@ -1,0 +1,168 @@
+{
+  "meta": {
+    "pretty_name": "VisFactor",
+    "dataset_id": "lmms-lab-encoder/visfactor",
+    "paper_url": "https://arxiv.org/abs/2502.16435",
+    "tags": [
+      "MultiModal",
+      "Reasoning",
+      "QA"
+    ],
+    "metrics": [
+      "accuracy"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nVisFactor evaluates foundational visual cognition in multimodal large language models using 20 vision-centric subtests adapted from the Factor-Referenced Cognitive Test (FRCT). It isolates abilities that support higher-level visual reasoning instead of measuring performance on a single downstream task.\n\n## Task Description\n\n- **Task Type**: Visual cognition assessment with binary and short free-form questions\n- **Input**: One to four images interleaved with a task-specific instruction\n- **Output**: A JSON object containing a boolean, word, number, coordinate pair, or letter answer\n- **Domain**: Visualization and spatial processing, perceptual closure, visual memory, and reasoning\n\n## Key Features\n\n- Contains 3,046 rows representing 808 test items across 20 FRCT subtests\n- Uses rule-based variants and grouped consistency checks to reduce average chance performance to approximately 2.9%\n- Preserves the official zero-shot prompts and their image ordering from the VLMEvalKit implementation\n- Covers hidden figures, gestalt completion, visual memory, mental rotation, path finding, paper folding, and related abilities\n\n## Evaluation Notes\n\n- Uses the **test** split from the ModelScope mirror of the official `VisFactor.tsv`\n- Extracts the last `{\"answer\": ...}` object and applies the official category-specific normalization rules\n- A logical test item may contain multiple rows and receives credit only when every row is correct\n- Reports each subtest's item-level accuracy; the primary score is the unweighted macro-average over represented subtests\n- Scoring is deterministic and does not require an LLM judge\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm",
+    "primary_metric": {
+      "name": "accuracy",
+      "aggregation": "macro_mean",
+      "dimensions": {
+        "scope": "categories"
+      }
+    }
+  },
+  "statistics": {
+    "total_samples": 3046,
+    "subset_stats": [
+      {
+        "name": "default",
+        "sample_count": 3046,
+        "prompt_length_mean": 463.45,
+        "prompt_length_min": 188,
+        "prompt_length_max": 932,
+        "prompt_length_std": 135.38,
+        "target_length_mean": 1.36,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 6048,
+            "count_per_sample": {
+              "min": 1,
+              "max": 4,
+              "mean": 1.99
+            },
+            "resolutions": [
+              "100x100",
+              "100x101",
+              "100x102",
+              "100x103",
+              "100x104",
+              "100x105",
+              "100x106",
+              "100x107",
+              "100x108",
+              "100x109"
+            ],
+            "resolution_range": {
+              "min": "100x100",
+              "max": "668x911"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 463.45,
+      "min": 188,
+      "max": 932,
+      "std": 135.38
+    },
+    "target_length_mean": 1.36,
+    "computed_at": "2026-08-28T10:49:49.933894+08:00",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 6048,
+        "count_per_sample": {
+          "min": 1,
+          "max": 4,
+          "mean": 1.99
+        },
+        "resolutions": [
+          "100x100",
+          "100x101",
+          "100x102",
+          "100x103",
+          "100x104",
+          "100x105",
+          "100x106",
+          "100x107",
+          "100x108",
+          "100x109"
+        ],
+        "resolution_range": {
+          "min": "100x100",
+          "max": "668x911"
+        },
+        "formats": [
+          "jpeg"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "1a4f53fe",
+          "content": [
+            {
+              "text": "Look at the two images:\n\nBelow is the first image, one simple shape:"
+            },
+            {
+              "image": "[BASE64_IMAGE: jpeg, ~2.6KB]"
+            },
+            {
+              "text": "Below is the second image, a larger, complex pattern:"
+            },
+            {
+              "image": "[BASE64_IMAGE: jpeg, ~8.5KB]"
+            },
+            {
+              "text": "Task: Decide whether the shape in the first image is hidden anywhere inside the second image. The shape will never be rotated, flipped, or resized. The shape will always be right-side-up and exactly the same size as in the first image.\n\nOutput: Respond with only one word: “TRUE” if it is present, “FALSE” if it is not, in JSON format as follows: {\"answer\": YOUR_ANSWER_HERE}."
+            }
+          ]
+        }
+      ],
+      "target": "T",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "index": 0,
+        "category_id": "CF1",
+        "category_name": "Hidden Figures Test",
+        "eval_index": 0,
+        "additional": ""
+      }
+    },
+    "subset": "default",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# VisFactor\n\n\n## Overview\n\nVisFactor evaluates foundational visual cognition in multimodal large language models using 20 vision-centric subtests adapted from the Factor-Referenced Cognitive Test (FRCT). It isolates abilities that support higher-level visual reasoning instead of measuring performance on a single downstream task.\n\n## Task Description\n\n- **Task Type**: Visual cognition assessment with binary and short free-form questions\n- **Input**: One to four images interleaved with a task-specific instruction\n- **Output**: A JSON object containing a boolean, word, number, coordinate pair, or letter answer\n- **Domain**: Visualization and spatial processing, perceptual closure, visual memory, and reasoning\n\n## Key Features\n\n- Contains 3,046 rows representing 808 test items across 20 FRCT subtests\n- Uses rule-based variants and grouped consistency checks to reduce average chance performance to approximately 2.9%\n- Preserves the official zero-shot prompts and their image ordering from the VLMEvalKit implementation\n- Covers hidden figures, gestalt completion, visual memory, mental rotation, path finding, paper folding, and related abilities\n\n## Evaluation Notes\n\n- Uses the **test** split from the ModelScope mirror of the official `VisFactor.tsv`\n- Extracts the last `{\"answer\": ...}` object and applies the official category-specific normalization rules\n- A logical test item may contain multiple rows and receives credit only when every row is correct\n- Reports each subtest's item-level accuracy; the primary score is the unweighted macro-average over represented subtests\n- Scoring is deterministic and does not require an LLM judge\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `visfactor` |\n| **Dataset ID** | [lmms-lab-encoder/visfactor](https://modelscope.cn/datasets/lmms-lab-encoder/visfactor/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2502.16435) |\n| **Tags** | `MultiModal`, `QA`, `Reasoning` |\n| **Metrics** | `accuracy` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 3,046 |\n| Prompt Length (Mean) | 463.45 chars |\n| Prompt Length (Min/Max) | 188 / 932 chars |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 6,048 |\n| Images per Sample | min: 1, max: 4, mean: 1.99 |\n| Resolution Range | 100x100 - 668x911 |\n| Formats | jpeg |\n\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"1a4f53fe\",\n      \"content\": [\n        {\n          \"text\": \"Look at the two images:\\n\\nBelow is the first image, one simple shape:\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~2.6KB]\"\n        },\n        {\n          \"text\": \"Below is the second image, a larger, complex pattern:\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~8.5KB]\"\n        },\n        {\n          \"text\": \"Task: Decide whether the shape in the first image is hidden anywhere inside the second image. The shape will never be rotated, flipped, or resized. The shape will always be right-side-up and exactly the same size as in the first image.\\n\\nOutput: Respond with only one word: “TRUE” if it is present, “FALSE” if it is not, in JSON format as follows: {\\\"answer\\\": YOUR_ANSWER_HERE}.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"T\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": 0,\n    \"category_id\": \"CF1\",\n    \"category_name\": \"Hidden Figures Test\",\n    \"eval_index\": 0,\n    \"additional\": \"\"\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets visfactor \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['visfactor'],\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# VisFactor\n\n\n## 概述\n\nVisFactor 使用从 Factor-Referenced Cognitive Test (FRCT) 改编而来的 20 个以视觉为中心的子测试，评估多模态大语言模型的基础视觉认知能力。它聚焦于支撑高层视觉推理的基本能力，而非衡量单一下游任务的表现。\n\n## 任务描述\n\n- **任务类型**：包含二元判断和简短自由回答的视觉认知评估\n- **输入**：1 至 4 张图像，与任务特定指令交错排列\n- **输出**：一个 JSON 对象，包含布尔值、单词、数字、坐标对或字母形式的答案\n- **领域**：可视化与空间处理、知觉闭合、视觉记忆及推理\n\n## 主要特性\n\n- 包含 3,046 行数据，对应 20 个 FRCT 子测试中的 808 个测试项\n- 采用基于规则的变体和分组一致性检查，将平均随机猜测准确率降至约 2.9%\n- 保留 VLMEvalKit 实现中的官方零样本提示及其图像顺序\n- 覆盖隐藏图形识别、格式塔完形、视觉记忆、心理旋转、路径查找、折纸推理等相关能力\n\n## 评估说明\n\n- 使用官方 `VisFactor.tsv` 在 ModelScope 镜像中的 **test** 划分\n- 提取最后一个 `{\"answer\": ...}` 对象，并应用官方针对不同类别的标准化规则\n- 单个逻辑测试项可能包含多行数据，仅当所有行均正确时才计为正确\n- 报告每个子测试在测试项级别的准确率；主得分是所涵盖子测试的未加权宏平均值\n- 评分过程完全确定，无需依赖 LLM 评判器\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `visfactor` |\n| **数据集ID** | [lmms-lab-encoder/visfactor](https://modelscope.cn/datasets/lmms-lab-encoder/visfactor/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2502.16435) |\n| **标签** | `MultiModal`, `QA`, `Reasoning` |\n| **指标** | `accuracy` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 3,046 |\n| 提示词长度（平均） | 463.45 字符 |\n| 提示词长度（最小/最大） | 188 / 932 字符 |\n\n**图像统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 6,048 |\n| 每样本图像数 | 最小: 1, 最大: 4, 平均: 1.99 |\n| 分辨率范围 | 100x100 - 668x911 |\n| 格式 | jpeg |\n\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"1a4f53fe\",\n      \"content\": [\n        {\n          \"text\": \"Look at the two images:\\n\\nBelow is the first image, one simple shape:\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~2.6KB]\"\n        },\n        {\n          \"text\": \"Below is the second image, a larger, complex pattern:\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~8.5KB]\"\n        },\n        {\n          \"text\": \"Task: Decide whether the shape in the first image is hidden anywhere inside the second image. The shape will never be rotated, flipped, or resized. The shape will always be right-side-up and exactly the same size as in the first image.\\n\\nOutput: Respond with only one word: “TRUE” if it is present, “FALSE” if it is not, in JSON format as follows: {\\\"answer\\\": YOUR_ANSWER_HERE}.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"T\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"index\": 0,\n    \"category_id\": \"CF1\",\n    \"category_name\": \"Hidden Figures Test\",\n    \"eval_index\": 0,\n    \"additional\": \"\"\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets visfactor \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['visfactor'],\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "2f171efc95f7ced1caeb6d6fd8cc3576",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-28T10:49:50.615738+08:00",
+  "translation_updated_at": "2026-08-28T10:49:58+08:00"
+}

--- a/evalscope/benchmarks/visfactor/utils.py
+++ b/evalscope/benchmarks/visfactor/utils.py
@@ -1,0 +1,94 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import re
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+BOOL_CATEGORY_IDS = frozenset({'CF1', 'CF2', 'MV1', 'MV2', 'MV3', 'P3', 'RL2', 'S1', 'S2', 'SS2', 'VZ1', 'VZ2'})
+STRING_LIST_CATEGORY_IDS = frozenset({'CS1', 'CS2', 'CS3'})
+NUMERIC_CATEGORY_IDS = frozenset({'CF3', 'I3', 'MA1', 'SS3', 'VZ3'})
+
+_JSON_ANSWER_PATTERN = re.compile(r'\{\s*"answer"\s*:\s*(.+?)\s*\}')
+_ADDITIONAL_PATTERN = re.compile(r'<ADDITIONAL_(\d+)>')
+_NUMBER_PATTERN = re.compile(r'\d+')
+
+
+def render_question(question: str, additional: str) -> str:
+    """Render the official prompt by resolving line breaks and additional fields."""
+    text = question.replace('<br>', '\n')
+    if not additional:
+        return text
+
+    values = additional.replace('<br>', '\n').split(';')
+
+    def replace(match: re.Match) -> str:
+        index = int(match.group(1))
+        return values[index] if index < len(values) else match.group(0)
+
+    return _ADDITIONAL_PATTERN.sub(replace, text)
+
+
+def extract_json_answer(prediction: str) -> str:
+    """Extract the last JSON-shaped answer using the official VisFactor rule."""
+    matches = list(_JSON_ANSWER_PATTERN.finditer(prediction))
+    if not matches:
+        return ''
+
+    answer = matches[-1].group(1).strip()
+    if len(answer) >= 2 and answer[0] == answer[-1] and answer[0] in {'"', "'"}:
+        answer = answer[1:-1]
+    return answer
+
+
+def normalize_prediction(category_id: str, prediction: str, additional: str = '') -> str:
+    """Normalize one model response according to its VisFactor subtest."""
+    answer = extract_json_answer(prediction)
+
+    if category_id in BOOL_CATEGORY_IDS or (category_id == 'VZ3' and not additional.isdigit()):
+        if answer.lower() in {'t', 'y', '1', 'true', 'yes'}:
+            return 'T'
+        if answer.lower() in {'f', 'n', '0', 'false', 'no'}:
+            return 'F'
+        return ''
+
+    if category_id in STRING_LIST_CATEGORY_IDS:
+        return answer
+
+    if category_id not in NUMERIC_CATEGORY_IDS:
+        return ''
+
+    candidate = answer or prediction
+    if category_id == 'VZ3':
+        return next((character for character in reversed(candidate) if character.isupper()), '')
+
+    numbers = _NUMBER_PATTERN.findall(candidate)
+    if category_id == 'CF3':
+        return '' if len(numbers) < 2 else f'({numbers[-2]}, {numbers[-1]})'
+    return numbers[-1] if numbers else ''
+
+
+def score_prediction(category_id: str, prediction: str, reference: str, additional: str = '') -> Tuple[str, float]:
+    """Return the normalized prediction and official row-level correctness."""
+    normalized = normalize_prediction(category_id, prediction, additional)
+    if category_id in STRING_LIST_CATEGORY_IDS:
+        accepted_answers = [answer.strip().lower() for answer in reference.split(',')]
+        correct = normalized.strip().lower() in accepted_answers
+    else:
+        correct = normalized == reference
+    return normalized, float(correct)
+
+
+def aggregate_item_accuracy(rows: Iterable[Tuple[str, int, float]]) -> Dict[str, Tuple[float, int]]:
+    """Apply logical AND within each item and return per-category accuracy and item count."""
+    grouped_rows: Dict[Tuple[str, int], List[float]] = defaultdict(list)
+    for category_id, eval_index, score in rows:
+        grouped_rows[(category_id, eval_index)].append(score)
+
+    category_items: Dict[str, List[float]] = defaultdict(list)
+    for (category_id, _), scores in grouped_rows.items():
+        category_items[category_id].append(float(all(scores)))
+
+    return {
+        category_id: (sum(scores) / len(scores), len(scores))
+        for category_id, scores in category_items.items()
+        if scores
+    }

--- a/evalscope/benchmarks/visfactor/visfactor_adapter.py
+++ b/evalscope/benchmarks/visfactor/visfactor_adapter.py
@@ -1,0 +1,155 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import re
+from typing import Any, Dict, List
+
+from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageUser, Content
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.metric.semantics import MetricSelector
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+
+from .utils import aggregate_item_accuracy, render_question, score_prediction
+
+DESCRIPTION = """
+## Overview
+
+VisFactor evaluates foundational visual cognition in multimodal large language models using 20 vision-centric subtests adapted from the Factor-Referenced Cognitive Test (FRCT). It isolates abilities that support higher-level visual reasoning instead of measuring performance on a single downstream task.
+
+## Task Description
+
+- **Task Type**: Visual cognition assessment with binary and short free-form questions
+- **Input**: One to four images interleaved with a task-specific instruction
+- **Output**: A JSON object containing a boolean, word, number, coordinate pair, or letter answer
+- **Domain**: Visualization and spatial processing, perceptual closure, visual memory, and reasoning
+
+## Key Features
+
+- Contains 3,046 rows representing 808 test items across 20 FRCT subtests
+- Uses rule-based variants and grouped consistency checks to reduce average chance performance to approximately 2.9%
+- Preserves the official zero-shot prompts and their image ordering from the VLMEvalKit implementation
+- Covers hidden figures, gestalt completion, visual memory, mental rotation, path finding, paper folding, and related abilities
+
+## Evaluation Notes
+
+- Uses the **test** split from the ModelScope mirror of the official `VisFactor.tsv`
+- Extracts the last `{"answer": ...}` object and applies the official category-specific normalization rules
+- A logical test item may contain multiple rows and receives credit only when every row is correct
+- Reports each subtest's item-level accuracy; the primary score is the unweighted macro-average over represented subtests
+- Scoring is deterministic and does not require an LLM judge
+"""  # noqa: E501
+
+_IMAGE_PATTERN = re.compile(r'<IMAGE_(\d+)>')
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='visfactor',
+        pretty_name='VisFactor',
+        dataset_id='lmms-lab-encoder/visfactor',
+        tags=[Tags.MULTI_MODAL, Tags.REASONING, Tags.QA],
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2502.16435',
+        metric_list=['accuracy'],
+        primary_metric=MetricSelector(
+            name='accuracy',
+            aggregation='macro_mean',
+            dimensions={'scope': 'categories'},
+        ),
+        eval_split='test',
+        evaluation_version='v1.0',
+    )
+)
+class VisFactorAdapter(VisionLanguageAdapter):
+    """Adapter for the official VisFactor prompts and deterministic scorer."""
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        additional = str(record.get('additional') or '')
+        question = render_question(str(record['question']), additional)
+        images = record.get('image') or []
+
+        image_indices = [int(index) for index in _IMAGE_PATTERN.findall(question)]
+        expected_indices = list(range(len(images)))
+        if image_indices != expected_indices:
+            raise ValueError(
+                f'VisFactor record {record.get("index")} references images {image_indices}, '
+                f'but provides indices {expected_indices}.'
+            )
+
+        image_map = {
+            index: self._normalize_media_value(image, media_type='image') for index, image in enumerate(images)
+        }
+        question = _IMAGE_PATTERN.sub(lambda match: f'<image_{match.group(1)}>', question)
+        content: List[Content] = self._parse_text_with_images(text=question, image_map=image_map)
+
+        return Sample(
+            input=[ChatMessageUser(content=content)],
+            target=str(record['answer']),
+            metadata={
+                'index': record['index'],
+                'category_id': str(record['category_id']),
+                'category_name': str(record['category_name']),
+                'eval_index': int(record['eval_index']),
+                'additional': additional,
+            },
+        )
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        metadata = task_state.metadata or {}
+        normalized, correct = score_prediction(
+            category_id=str(metadata['category_id']),
+            prediction=original_prediction,
+            reference=reference,
+            additional=str(metadata.get('additional', '')),
+        )
+        return Score(
+            value={'accuracy': correct},
+            main_score_name='accuracy',
+            extracted_prediction=normalized,
+            prediction=original_prediction,
+        )
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        rows = []
+        category_names = {}
+        for sample_score in sample_scores:
+            metadata = sample_score.sample_metadata or {}
+            category_id = str(metadata['category_id'])
+            category_names[category_id] = str(metadata['category_name'])
+            rows.append((category_id, int(metadata['eval_index']), float(sample_score.score.main_value)))
+
+        category_scores = aggregate_item_accuracy(rows)
+        if not category_scores:
+            return []
+
+        total_items = sum(item_count for _, item_count in category_scores.values())
+        overall = sum(accuracy for accuracy, _ in category_scores.values()) / len(category_scores)
+        results = [
+            AggScore(
+                metric_name='accuracy',
+                aggregation='macro_mean',
+                dimensions={'scope': 'categories'},
+                score=overall,
+                num=total_items,
+                metadata={'category_count': len(category_scores)},
+            )
+        ]
+        results.extend(
+            AggScore(
+                metric_name='accuracy',
+                aggregation='mean',
+                dimensions={'category_id': category_id, 'category_name': category_names[category_id]},
+                score=accuracy,
+                num=item_count,
+            )
+            for category_id, (accuracy, item_count) in sorted(category_scores.items())
+        )
+        return results

--- a/tests/benchmark/test_visfactor.py
+++ b/tests/benchmark/test_visfactor.py
@@ -1,0 +1,120 @@
+import base64
+
+import pytest
+
+from evalscope.api.messages import ContentImage, ContentText
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.visfactor.utils import (
+    aggregate_item_accuracy,
+    extract_json_answer,
+    normalize_prediction,
+    render_question,
+    score_prediction,
+)
+from evalscope.config import TaskConfig
+
+_PNG_BYTES = base64.b64decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+)
+
+
+def test_render_question_resolves_additional_image_placeholder() -> None:
+    question = 'First:<IMAGE_0><br><ADDITIONAL_0> target:<ADDITIONAL_2>'
+    assert render_question(question, 'three;unused;<IMAGE_1>') == 'First:<IMAGE_0>\nthree target:<IMAGE_1>'
+
+
+def test_extract_json_answer_uses_last_object() -> None:
+    prediction = 'Try {"answer": "FALSE"}. Final: {"answer": "TRUE"}.'
+    assert extract_json_answer(prediction) == 'TRUE'
+
+
+@pytest.mark.parametrize(
+    ('category_id', 'prediction', 'reference', 'additional', 'normalized', 'score'),
+    [
+        ('CF1', '{"answer": "yes"}', 'T', '', 'T', 1.0),
+        ('S2', '{"answer": "0"}', 'F', 'same cube', 'F', 1.0),
+        ('CS1', '{"answer": "Boat"}', 'ship,boat,sailboat', '', 'Boat', 1.0),
+        ('CS1', '{"answer": " Boat "}', 'ship, boat, sailboat', '', ' Boat ', 1.0),
+        ('CF3', '{"answer": "(3, 5)"}', '(3, 5)', '5 times 5', '(3, 5)', 1.0),
+        ('I3', 'The groups are 1 and 2, so the result is 2.', '2', 'three', '2', 1.0),
+        ('VZ3', '{"answer": "H"}', 'H', '1', 'H', 1.0),
+        ('VZ3', '{"answer": "false"}', 'F', 'edge pair', 'F', 1.0),
+        ('unknown', '{"answer": "yes"}', 'T', '', '', 0.0),
+    ],
+)
+def test_official_category_scoring(
+    category_id: str,
+    prediction: str,
+    reference: str,
+    additional: str,
+    normalized: str,
+    score: float,
+) -> None:
+    assert score_prediction(category_id, prediction, reference, additional) == (normalized, score)
+
+
+def test_normalize_prediction_matches_official_fallback_rules() -> None:
+    assert normalize_prediction('CF3', 'reasoning 1, 2; final row 4 column 5') == '(4, 5)'
+    assert normalize_prediction('MA1', 'The lookup contains 21 entries. Final answer: 49') == '49'
+    assert normalize_prediction('VZ3', 'I considered A and B; the matching edge is H', '1') == 'H'
+
+
+def test_aggregate_item_accuracy_requires_every_row() -> None:
+    category_scores = aggregate_item_accuracy(
+        [
+            ('CF1', 0, 1.0),
+            ('CF1', 0, 1.0),
+            ('CF1', 1, 1.0),
+            ('CF1', 1, 0.0),
+            ('CS1', 0, 1.0),
+        ]
+    )
+    assert category_scores == {'CF1': (0.5, 2), 'CS1': (1.0, 1)}
+
+
+def test_adapter_interleaves_images_and_selects_official_primary_metric() -> None:
+    adapter = get_benchmark('visfactor', TaskConfig(datasets=['visfactor']))
+    record = {
+        'index': 7,
+        'category_id': 'I3',
+        'category_name': 'Figure Classification',
+        'eval_index': 2,
+        'image': [{'bytes': _PNG_BYTES, 'path': None}] * 3,
+        'question': 'Group 1:<IMAGE_0>Group 2:<IMAGE_1><ADDITIONAL_0>',
+        'answer': '2',
+        'additional': '<IMAGE_2>',
+    }
+
+    sample = adapter.record_to_sample(record)
+    content = sample.input[0].content
+    assert [type(item) for item in content] == [
+        ContentText,
+        ContentImage,
+        ContentText,
+        ContentImage,
+        ContentImage,
+    ]
+
+    scores = [
+        SampleScore(
+            score=Score(value={'accuracy': value}, main_score_name='accuracy'),
+            sample_metadata={
+                'category_id': category_id,
+                'category_name': category_id,
+                'eval_index': eval_index,
+            },
+        )
+        for category_id, eval_index, value in [
+            ('CF1', 0, 1.0),
+            ('CF1', 0, 1.0),
+            ('CF1', 1, 0.0),
+            ('CS1', 0, 1.0),
+        ]
+    ]
+    aggregates = adapter.aggregate_scores(scores)
+    assert aggregates[0].score == pytest.approx(0.75)
+    assert aggregates[0].num == 3
+
+    report = adapter.generate_report({'default': aggregates}, model_name='mock', output_dir='')
+    assert report.score == pytest.approx(0.75)

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -631,6 +631,14 @@ class TestVLMBenchmark(TestBenchmark):
         """Test olmOCR-Bench with mock LLM."""
         self._run_dataset_test('olmocr_bench', limit=5, use_mock=True)
 
+    def test_visfactor(self):
+        """Test VisFactor visual cognition benchmark."""
+        self._run_dataset_test('visfactor', limit=5)
+
+    def test_visfactor_mock(self):
+        """Test VisFactor with mock LLM."""
+        self._run_dataset_test('visfactor', limit=5, use_mock=True)
+
     def test_vtcbench(self):
         """Test VTCBench long context vision-text compression benchmark."""
         self._run_dataset_test('vtcbench', limit=1)


### PR DESCRIPTION
## Summary

- add the VisFactor multimodal benchmark using the ModelScope `lmms-lab-encoder/visfactor` dataset
- preserve the official interleaved multi-image prompts and category-specific deterministic answer normalization
- reproduce the official two-level metric: logical AND across rows in each `(category_id, eval_index)` item, then macro-average accuracy across subtests
- add focused scorer/aggregation tests, VLM smoke tests, generated metadata, and bilingual documentation

## Research and alignment

- Official repository: `CUHK-ARISE/VisFactor` (`vlmeval/dataset/visfactor.py`)
- Paper: arXiv:2502.16435
- Cross-checked against the merged `lmms-eval` VisFactor task implementation
- Verified ModelScope schema and standard loader support: 3,046 rows, 808 logical items, 20 subtests, and 6,048 images

## Validation

- `make lint`
- `pytest tests/benchmark/test_visfactor.py tests/benchmark/test_vlm.py::TestVLMBenchmark::test_visfactor_mock -q`
- `pytest tests/api/test_benchmark_meta.py -q`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`
- real API smoke run with `qwen-vl-plus`, 20 shuffled rows, `eval_batch_size=5`
- independently re-scored the 20 real predictions with the `lmms-eval` reference scorer: 0 mismatches; 20/20 outputs followed the JSON answer contract
- compared 9,138 generated prediction cases over all 3,046 rows with the `lmms-eval` scorer: 0 mismatches
