### PR TITLE
fix(resources): verify NLTK mirror archives with pinned digests

### DIFF
--- a/evalscope/utils/resource_utils.py
+++ b/evalscope/utils/resource_utils.py
@@ -16,6 +16,45 @@ logger = get_logger()
 # Path to the benchmark metadata directory (individual JSON files per benchmark)
 BENCHMARK_META_DIR = Path(__file__).parent.parent / 'benchmarks' / '_meta'
 
+# Mirror archives are pinned per URL because mirrors can serve different
+# nltk_data snapshots. Only archives with a verified digest may be extracted.
+MIRROR_MAP: Dict[str, Dict[str, Any]] = {
+    'punkt_tab': {
+        'resource_path': 'tokenizers/punkt_tab',
+        'zip_name': 'punkt_tab.zip',
+        'extract_dir': 'tokenizers',
+        'mirrors': [
+            {
+                'url': 'https://modelscope-open.oss-cn-hangzhou.aliyuncs.com/open_data/nltk_data/punkt_tab.zip',
+                'sha256': 'c2b16c23d738effbdc5789d7aa601397c13ba2819bf922fb904687f3f16657ed',
+            },
+        ],
+    },
+    'stopwords': {
+        'resource_path': 'corpora/stopwords',
+        'zip_name': 'stopwords.zip',
+        'extract_dir': 'corpora',
+        'mirrors': [
+            {
+                'url': 'https://gitee.com/yzy0612/nltk_data/raw/gh-pages/packages/corpora/stopwords.zip',
+                'sha256': '15c94179887425ca1bedc265608cab9f27d650211f709bb929e320990a4b01d1',
+            },
+        ],
+    },
+    'averaged_perceptron_tagger_eng': {
+        'resource_path': 'taggers/averaged_perceptron_tagger_eng/',
+        'zip_name': 'averaged_perceptron_tagger_eng.zip',
+        'extract_dir': 'taggers',
+        'mirrors': [
+            {
+                'url': 'https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/taggers/'
+                'averaged_perceptron_tagger_eng.zip',
+                'sha256': '6025f530624335c67d6547d44757b357b4e79bae030a0383e9887a92c1718f0b',
+            },
+        ],
+    },
+}
+
 
 @lru_cache
 def check_nltk_data(name: str) -> None:
@@ -26,37 +65,6 @@ def check_nltk_data(name: str) -> None:
     """  # noqa: E501
     import nltk
 
-    GITEE_MIRROR = 'https://gitee.com/yzy0612/nltk_data/raw/gh-pages/packages'
-    NLTK_DATA_RAW = 'https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages'
-
-    MIRROR_MAP = {
-        'punkt_tab': {
-            'resource_path': 'tokenizers/punkt_tab',
-            'zip_name': 'punkt_tab.zip',
-            'extract_dir': 'tokenizers',
-            'urls': [
-                'https://modelscope-open.oss-cn-hangzhou.aliyuncs.com/open_data/nltk_data/punkt_tab.zip',
-                f'{GITEE_MIRROR}/tokenizers/punkt_tab.zip',
-            ],
-        },
-        'stopwords': {
-            'resource_path': 'corpora/stopwords',
-            'zip_name': 'stopwords.zip',
-            'extract_dir': 'corpora',
-            'urls': [
-                f'{GITEE_MIRROR}/corpora/stopwords.zip',
-            ],
-        },
-        'averaged_perceptron_tagger_eng': {
-            'resource_path': 'taggers/averaged_perceptron_tagger_eng/',
-            'zip_name': 'averaged_perceptron_tagger_eng.zip',
-            'extract_dir': 'taggers',
-            'urls': [
-                f'{NLTK_DATA_RAW}/taggers/averaged_perceptron_tagger_eng.zip',
-            ],
-        },
-    }
-
     def has_resource(resource_path: str) -> bool:
         try:
             nltk.data.find(resource_path)
@@ -64,15 +72,16 @@ def check_nltk_data(name: str) -> None:
         except LookupError:
             return False
 
-    def download_from_mirrors(meta: dict) -> None:
+    def download_from_mirrors(meta: Dict[str, Any]) -> None:
         nltk_base = os.path.expanduser('~/nltk_data')
         extract_dir = os.path.join(nltk_base, meta['extract_dir'])
         os.makedirs(extract_dir, exist_ok=True)
         zip_path = os.path.join(extract_dir, meta['zip_name'])
         last_error = None
-        for url in meta['urls']:
+        for mirror in meta['mirrors']:
+            url = mirror['url']
             try:
-                download_url(url, zip_path)
+                download_url(url, zip_path, sha256=mirror['sha256'])
                 with zipfile.ZipFile(zip_path, 'r') as zip_ref:
                     zip_ref.extractall(extract_dir)
                 return

--- a/tests/test_resource_utils.py
+++ b/tests/test_resource_utils.py
@@ -1,12 +1,14 @@
+import re
 import sys
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterator
+from typing import Iterator, Optional
 
 import pytest
 
 from evalscope.utils import resource_utils
+from evalscope.utils.resource_utils import MIRROR_MAP
 
 
 class _FakeNltkData:
@@ -49,10 +51,10 @@ def test_check_nltk_data_downloads_english_tagger(monkeypatch: pytest.MonkeyPatc
     data = _FakeNltkData()
     _install_fake_nltk(monkeypatch, data)
     monkeypatch.setenv('HOME', str(tmp_path))
-    download_urls = []
+    download_calls = []
 
-    def fake_download(url: str, save_path: str) -> None:
-        download_urls.append(url)
+    def fake_download(url: str, save_path: str, sha256: Optional[str] = None) -> None:
+        download_calls.append({'url': url, 'sha256': sha256})
         with zipfile.ZipFile(save_path, 'w') as archive:
             archive.writestr('averaged_perceptron_tagger_eng/weights.json', '{}')
         data.available = True
@@ -61,10 +63,8 @@ def test_check_nltk_data_downloads_english_tagger(monkeypatch: pytest.MonkeyPatc
 
     resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
 
-    assert download_urls == [
-        'https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/taggers/'
-        'averaged_perceptron_tagger_eng.zip'
-    ]
+    pinned = MIRROR_MAP['averaged_perceptron_tagger_eng']['mirrors'][0]
+    assert download_calls == [pinned]
     assert data.lookups == [
         'taggers/averaged_perceptron_tagger_eng/',
         'taggers/averaged_perceptron_tagger_eng/',
@@ -80,7 +80,7 @@ def test_check_nltk_data_raises_when_resource_is_still_missing(
     _install_fake_nltk(monkeypatch, data)
     monkeypatch.setenv('HOME', str(tmp_path))
 
-    def fake_download(url: str, save_path: str) -> None:
+    def fake_download(url: str, save_path: str, sha256: Optional[str] = None) -> None:
         with zipfile.ZipFile(save_path, 'w') as archive:
             archive.writestr('wrong_resource/weights.json', '{}')
 
@@ -97,7 +97,7 @@ def test_check_nltk_data_propagates_download_failure(monkeypatch: pytest.MonkeyP
     _install_fake_nltk(monkeypatch, data)
     monkeypatch.setenv('HOME', str(tmp_path))
 
-    def fail_download(url: str, save_path: str) -> None:
+    def fail_download(url: str, save_path: str, sha256: Optional[str] = None) -> None:
         raise OSError('offline')
 
     monkeypatch.setattr(resource_utils, 'download_url', fail_download)
@@ -105,4 +105,38 @@ def test_check_nltk_data_propagates_download_failure(monkeypatch: pytest.MonkeyP
     with pytest.raises(RuntimeError, match='All mirrors failed'):
         resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
 
+    assert not (tmp_path / 'nltk_data/taggers/averaged_perceptron_tagger_eng.zip').exists()
+
+
+def test_mirror_map_pins_valid_sha256_digests() -> None:
+    """Every enabled mirror archive must use a valid pinned SHA-256 digest."""
+    for meta in MIRROR_MAP.values():
+        for mirror in meta['mirrors']:
+            assert re.fullmatch(r'[0-9a-f]{64}', mirror['sha256']), mirror['url']
+
+
+def test_check_nltk_data_does_not_extract_checksum_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data = _FakeNltkData()
+    _install_fake_nltk(monkeypatch, data)
+    monkeypatch.setenv('HOME', str(tmp_path))
+    download_calls = []
+
+    def fail_checksum(url: str, save_path: str, sha256: Optional[str] = None) -> None:
+        download_calls.append({'url': url, 'sha256': sha256})
+        raise ValueError(f'Checksum mismatch for {url}')
+
+    def unexpected_extract(*args: object, **kwargs: object) -> None:
+        raise AssertionError('Checksum-mismatched archive must not be extracted')
+
+    monkeypatch.setattr(resource_utils, 'download_url', fail_checksum)
+    monkeypatch.setattr(resource_utils.zipfile, 'ZipFile', unexpected_extract)
+
+    with pytest.raises(RuntimeError, match='All mirrors failed'):
+        resource_utils.check_nltk_data('averaged_perceptron_tagger_eng')
+
+    pinned = MIRROR_MAP['averaged_perceptron_tagger_eng']['mirrors'][0]
+    assert download_calls == [pinned]
     assert not (tmp_path / 'nltk_data/taggers/averaged_perceptron_tagger_eng.zip').exists()


### PR DESCRIPTION
## Summary

This PR makes fallback NLTK resource downloads fail closed unless the downloaded archive matches a pinned SHA-256 digest.

- Pin a digest for every enabled punkt_tab, stopwords, and averaged_perceptron_tagger_eng mirror URL.
- Pass the URL-specific digest to the existing download helper before extraction.
- Remove the Gitee punkt_tab fallback because it has no trusted digest.
- Add offline regression coverage for digest configuration, digest forwarding, checksum failure, and cleanup.

## Root Cause

When a required NLTK resource was absent, check_nltk_data downloaded a ZIP from a mutable third-party mirror and extracted it directly. Although download_url already supports checksum verification, the call did not provide sha256. A valid but replaced or corrupted archive could therefore be installed into the NLTK data directory.

## Changes

- Move the NLTK mirror configuration to a module-level MIRROR_MAP with per-URL SHA-256 values.
- Use download_url(url, zip_path, sha256=...) for every enabled mirror.
- Keep extraction after the verified download only; a checksum failure raises and does not invoke ZipFile.
- Verify the three pinned archives again through the configured proxy before this commit:
  - ModelScope punkt_tab: c2b16c23d738effbdc5789d7aa601397c13ba2819bf922fb904687f3f16657ed
  - Gitee stopwords: 15c94179887425ca1bedc265608cab9f27d650211f709bb929e320990a4b01d1
  - NLTK GitHub averaged_perceptron_tagger_eng: 6025f530624335c67d6547d44757b357b4e79bae030a0383e9887a92c1718f0b

## Reproduction

On the unmodified base, monkeypatching download_url to record its keyword arguments during check_nltk_data(averaged_perceptron_tagger_eng) records sha256 as not passed. The downloader then skips the checksum comparison and resource_utils extracts the returned archive.

## Validation

Targeted resource tests:

```text
python -m pytest tests/test_resource_utils.py -q
6 passed
```

Adjacent NLTK consumer tests:

```text
python -m pytest tests/benchmark/test_ifeval_language_checkers.py -q
2 passed
```

CI smoke test:

```text
python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -s -p no:warnings
1 passed
```

Lint:

```text
PATH=/root/code/evalscope/.venv/bin:$PATH make lint
Passed
```

All added tests use mocked NLTK and download behavior; no test accesses the network.

## Scope

The change is limited to NLTK mirror integrity and its tests. It intentionally reuses the existing checksum-capable download helper and does not include HTTP resume or other download behavior changes.