### PR TITLE
fix(judge): serialize lazy judge initialization

### DIFF
--- a/evalscope/api/mixin/llm_judge_mixin.py
+++ b/evalscope/api/mixin/llm_judge_mixin.py
@@ -66,6 +66,7 @@ class LLMJudgeMixin:
         self._task_config = task_config
 
         self._llm_judges: Optional[List[LLMJudge]] = None
+        self._llm_judges_lock = threading.Lock()
         self._judge_executor: Optional['JudgeExecutor'] = None
         self._judge_executor_lock = threading.Lock()
 
@@ -73,9 +74,11 @@ class LLMJudgeMixin:
 
     @property
     def llm_judges(self) -> List[LLMJudge]:
-        """Every configured judge model, lazily built."""
+        """Every configured judge model, lazily built exactly once."""
         if self._llm_judges is None and self.use_llm_judge:
-            self._llm_judges = self.init_llm_judges()
+            with self._llm_judges_lock:
+                if self._llm_judges is None:
+                    self._llm_judges = self.init_llm_judges()
         return self._llm_judges or []
 
     @property

--- a/tests/api/judge/test_llm_judge_mixin.py
+++ b/tests/api/judge/test_llm_judge_mixin.py
@@ -1,0 +1,95 @@
+"""Lazy ``llm_judges`` initialization must be thread-safe."""
+
+import threading
+import time
+from typing import List, cast
+
+import pytest
+
+from evalscope.api.benchmark import BenchmarkMeta
+from evalscope.api.mixin import LLMJudgeMixin
+from evalscope.metrics import LLMJudge
+
+
+class _CountingJudgeMixin(LLMJudgeMixin):
+    """Minimal judge mixin with deliberately slow initialization."""
+
+    use_llm_judge = True
+
+    def __init__(self) -> None:
+        super().__init__(benchmark_meta=BenchmarkMeta(name='stub', dataset_id='stub'), task_config=None)
+        self.init_calls = 0
+        self._calls_lock = threading.Lock()
+        self._judge = cast(LLMJudge, object())
+
+    def init_llm_judges(self) -> List[LLMJudge]:
+        with self._calls_lock:
+            self.init_calls += 1
+        time.sleep(0.05)
+        return [self._judge]
+
+
+class _FailOnceJudgeMixin(_CountingJudgeMixin):
+    """Fails initialization once so callers can verify retry behavior."""
+
+    def init_llm_judges(self) -> List[LLMJudge]:
+        with self._calls_lock:
+            self.init_calls += 1
+            should_fail = self.init_calls == 1
+        if should_fail:
+            raise RuntimeError('judge initialization failed')
+        return [self._judge]
+
+
+class _DisabledJudgeMixin(_CountingJudgeMixin):
+    """Disables judge construction without requiring task-config plumbing."""
+
+    use_llm_judge = False
+
+
+def test_llm_judges_initializes_exactly_once_under_concurrency() -> None:
+    """All concurrent first accesses must receive one initialized judge list."""
+    mixin = _CountingJudgeMixin()
+    num_threads = 8
+    barrier = threading.Barrier(num_threads)
+    results: List[List[LLMJudge]] = []
+    errors: List[BaseException] = []
+
+    def access() -> None:
+        try:
+            barrier.wait()
+            results.append(mixin.llm_judges)
+        except BaseException as error:  # noqa: BLE001 - surfaced after every worker exits
+            errors.append(error)
+
+    threads = [threading.Thread(target=access) for _ in range(num_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert mixin.init_calls == 1
+    assert len(results) == num_threads
+    assert all(result is results[0] for result in results)
+    assert all(result[0] is results[0][0] for result in results)
+
+
+def test_llm_judges_retries_after_initialization_failure() -> None:
+    """A failed initialization must not publish a partial result."""
+    mixin = _FailOnceJudgeMixin()
+
+    with pytest.raises(RuntimeError, match='judge initialization failed'):
+        _ = mixin.llm_judges
+
+    assert mixin._llm_judges is None
+    assert mixin.llm_judges == [mixin._judge]
+    assert mixin.init_calls == 2
+
+
+def test_llm_judges_returns_empty_when_judge_is_disabled() -> None:
+    """Rule-only scoring must not initialize any judge."""
+    mixin = _DisabledJudgeMixin()
+
+    assert mixin.llm_judges == []
+    assert mixin.init_calls == 0


### PR DESCRIPTION
## Summary

This PR makes lazy LLM Judge construction safe when an evaluation starts reviewing samples concurrently.

- A benchmark now initializes its configured judge list exactly once, even when multiple review workers reach the first score simultaneously.
- All concurrent callers receive the same initialized list and judge instances.
- A failed initialization leaves no partial result published, so a later access can retry.
- Rule-only scoring continues to return an empty list without constructing a judge.

## Root Cause

`LLMJudgeMixin.llm_judges` used an unlocked check-then-initialize sequence. With LLM Judge scoring and `eval_batch_size > 1`, every worker could observe `_llm_judges is None` before any assignment completed, then each construct its own judge list. The evaluator executes per-sample review in a thread pool, so this occurs on the first concurrent review.

## Changes

- Add a dedicated `_llm_judges_lock` to `LLMJudgeMixin`.
- Use double-checked locking around lazy judge construction.
- Keep the executor lock separate: executor construction reads `llm_judges`, so sharing the lock could introduce nested-lock deadlock risk.
- Add deterministic barrier-based regression coverage for concurrent construction, object identity, failure-and-retry behavior, and disabled judge scoring.

## Reproduction

On the unmodified base, eight worker threads synchronized at their first `llm_judges` access each enter `init_llm_judges()`:

```text
init_calls = 8
unique judge-list instances = 8
```

After this change:

```text
init_calls = 1
all workers receive the same judge list and judge instance
```

## Validation

```bash
python -m pytest \
  tests/api/judge/test_llm_judge_mixin.py \
  tests/api/judge/test_migrated_adapters.py \
  tests/api/judge/test_executor.py \
  tests/api/judge/test_contracts.py -q
```

Result: `75 passed`.

```bash
python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings
```

Result: `1 passed`.

All configured repository pre-commit hooks passed via the project virtual environment. `make lint` could not find the shell `pre-commit` executable in this environment, but the equivalent `python -m pre_commit run --all-files` completed successfully.

## Scope

Changes are limited to `LLMJudgeMixin` lazy initialization and regression tests. Judge configuration, scoring semantics, the dynamic judge setter contract, benchmark metadata, and published `evaluation_version` values are unchanged. The branch is rebased onto current `main` and contains one commit.
