### PR TITLE
feat(benchmarks): add PRBench

### DIFF
--- a/docs/en/benchmarks/prbench.md
+++ b/docs/en/benchmarks/prbench.md
@@ -1,0 +1,240 @@
+# PRBench
+
+
+## Overview
+
+PRBench (Professional Reasoning Benchmark) evaluates open-ended reasoning on realistic, high-stakes Finance and Legal
+problems. Its expert-authored conversations and fine-grained rubrics measure whether a response is accurate, useful,
+auditable, and appropriately handles uncertainty and risk.
+
+## Task Description
+
+- **Task Type**: Multi-turn open-ended question answering with rubric-based grading
+- **Input**: One to ten conversation turns, optionally accompanied by reference texts
+- **Output**: The assistant response to the final user turn
+- **Domain**: Finance and Legal professional reasoning
+
+## Key Features
+
+- The current release contains 1,100 conversations and 18,692 expert-curated criteria across 13 Finance and 12 Legal
+  topics; roughly 30% of the conversations are multi-turn.
+- It covers 114 countries and dependencies and 47 U.S. jurisdictions, with both expert and non-expert user scenarios.
+- Four dataset splits are available: `finance` (600), `legal` (500), `finance_hard` (300), and `legal_hard` (250). The
+  hard splits contain the most difficult examples from their corresponding full splits.
+- Each sample has 10–30 independently graded criteria with integer weights from -10 to 10 (excluding zero). Positive
+  criteria describe desired properties, while negative criteria describe undesirable properties.
+
+## Evaluation Notes
+
+- Each rubric criterion is graded independently by an LLM judge as met or not met using the official prompt. The paper
+  uses `o4-mini` as the judge; configure `judge.models` and use `judge.strategy='auto'` or `'llm'`.
+- `clipped_score` is the primary metric reported by the paper: each sample's weighted points are divided by its total
+  positive weight, then the mean across samples is clipped at a lower bound of 0.
+- `normalized_score` subtracts each sample's minimum possible score (the sum of its negative weights), divides by the
+  full score range, and then averages the sample scores. It is useful for comparisons across rubric distributions.
+- Reference texts are prepended to their corresponding user turns exactly as in the official evaluator. Judge parse or
+  transport failures exclude the affected sample rather than assigning a score.
+- A full Finance plus Legal evaluation requires 18,692 judge calls per judge and repeat. The hard splits overlap the
+  full splits, so EvalScope reports every split independently without an `OVERALL` row; select either the full or hard
+  splits when publishing a combined result.
+- Resources: [Paper](https://arxiv.org/abs/2511.11562) |
+  [GitHub](https://github.com/scaleapi/PRBench) |
+  [Dataset](https://modelscope.cn/datasets/ScaleAI/PRBench)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `prbench` |
+| **Dataset ID** | [ScaleAI/PRBench](https://modelscope.cn/datasets/ScaleAI/PRBench/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2511.11562) |
+| **Tags** | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |
+| **Metrics** | `clipped_score`, `normalized_score` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `finance` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 1,650 |
+| Prompt Length (Mean) | 10251.59 chars |
+| Prompt Length (Min/Max) | 84 / 132961 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `finance` | 600 | 9590.54 | 103 | 132961 |
+| `legal` | 500 | 10328.35 | 84 | 99212 |
+| `finance_hard` | 300 | 10796.97 | 103 | 132961 |
+| `legal_hard` | 250 | 11030.14 | 140 | 99212 |
+
+## Sample Example
+
+**Subset**: `finance`
+
+```json
+{
+  "input": [
+    {
+      "id": "5026042c",
+      "content": "hey, we've got a problem with our credit loss forecasting model that feeds into CCAR stress testing. during validaton, we found the model is systematically underestimating losses in the tail scenarios by about 15-20%, particularly for our com ... [TRUNCATED 259 chars] ... . The model was performing fine until we started seeing these newer macro scenarios with simultaneous interest rate spikes and credit spread widening. thoughts on how to approach this? what would you prioritize given the timeline constraints?"
+    },
+    {
+      "id": "59952e89",
+      "content": "**Quick‑Response Blueprint for the CCAR Credit Loss Model (6‑Week Deadline)**  \n*(Tail losses are under‑forecasting by 15‑20 % in the commercial real‑estate (CRE) portfolio under the newest macro stress scenarios.)*\n\n| Phase | Timeframe | Wha ... [TRUNCATED 8109 chars] ... , and Legal.  \n\nIf you follow the table‑derived 6‑week schedule, you’ll either have a fully corrected model that meets CCAR standards **or** a defensible overlay that keeps you compliant until a full rebuild can be rolled out post‑submission."
+    },
+    {
+      "id": "c0794365",
+      "content": "this is really helpful but i'm concerned about the week 2 copula approach for the joint shock scenario. our quant team is pretty thin right now and honestly we've never implemented a copula-based stress scenario before. is there a simpler way to capture the simultaneous rate/spread shock that doesn't require us to build new statistical infrastructure in 1 week? maybe something more rule-based that regulators would still accept?"
+    },
+    {
+      "id": "2312a13c",
+      "content": "### Quick‑Rule Based Stress‑Scenario Design (No Copula Required)\n\n| What you’ll need | Why it’s regulator‑friendly | How much effort |\n|-------------------|-----------------------------|-----------------|\n| **A single, “joint‑shock” driver**  ... [TRUNCATED 5124 chars] ... n **2‑3 business days**.  \nIf you later decide to adopt a full copula, you’ll have the historical data ready, and at that point the switch will only be a code‑update, not a concept‑change.  \n\nGood luck – you’ve got this 6‑week window in hand!"
+    },
+    {
+      "id": "c8b32de6",
+      "content": "ok the linear blend approach makes sense, but i'm worried about using a fixed correlation of 0.6, that seems arbitrary. when I look at our historical data from 2020-2022, the coreelation between rate changes and our CRE spread changes was clo ... [TRUNCATED 55 chars] ... should we be using a rolling correlation or just pick the most conservative period? also, for the backtesting you mentioned, we don't have clean monthly loss data, our charge offs are reported quarterly. will that be a problem for validation?"
+    },
+    {
+      "id": "269be9b4",
+      "content": "## 1.  Choosing a Correlation Coefficient  \n| Issue | Why it matters | Practical options | How to document it |\n|-------|----------------|-------------------|--------------------|\n| **Historical correlation swings** (0.3 in 2008‑09, 0.8 in 20 ... [TRUNCATED 5868 chars] ... le, you have a defensible, regulator‑approved stress scenario that can be built into the CCAR submission in less than a week.  \n\nLet me know if you need a sample Excel template or a quick‑script for the correlation calculation—happy to share!"
+    },
+    {
+      "id": "ccf03620",
+      "content": "one more thing on the backtesting, when you say \"coverage check\" where all observed quarterly charge offs be less or equal to predicted loss of the 0.3 correlation scenario, what if we have a quarterly where actual charge offs exceeded even our most conservative prediction? this happened in Q2 2020 when we had some one off covid related writedowns that spiked our numbers, do we just document this as an outlier or does that break our whole validation approach?"
+    },
+    {
+      "id": "cb010996",
+      "content": "### The “Coverage Check” – What It’s Built For  \n\nIn CCAR, the coverage check is a very *high‑level* sanity test:  \n\n> “For every historical period we used in the back‑test, the probability‑weighted loss predicted by **our worst‑case** stress ... [TRUNCATED 6304 chars] ... nal).” |\n\nYou’re perfectly allowed to keep the linear‑blend approach, use the 0.8 correlation as core, and treat Q2 2020 as an exceptional event. That meets FRB guidance, keeps you on schedule, and preserves the integrity of your CCAR submit."
+    },
+    {
+      "id": "d8d952ce",
+      "content": "got it on the outlier treatment. but now i'm realizing we might need different correlation assumptions across our CRE sub-segments. our office portfolio behaves very differently from retail and multifamily during rate shocks, should we be using segment specific correlatiosn or is that going to make the documentation too complex for the regulators? also, do we need separate back testing for each segment or can we do it at the portfolio level?"
+    },
+    {
+      "id": "f6976632",
+      "content": "## 1.  Do you need sector‑specific correlations?\n\n| Factor | Why it *might* matter | When it *doesn’t* matter | Practical rule‑of‑thumb |\n|--------|-----------------------|--------------------------|------------------------|\n| **Collateral pr ... [TRUNCATED 9748 chars] ... more time proving the same logic. Stick to 3–4 meaningful sub‑portfolio categories, back‑test each, and use the portfolio‑level test as an overall guardrail.  \nThat should keep the submission robust, defendable, and time‑efficient. Good luck!"
+    },
+    "... [TRUNCATED 9 more items] ..."
+  ],
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task": "ea67e314b6c2e8fc70627c19",
+    "field": "Finance",
+    "topic": "Risk Management & Stress Testing",
+    "expert": "Expert",
+    "turns": 10,
+    "rubrics": [
+      {
+        "id": "f46d80f7-6c5e-47a4-93f7-b05e99b24c79",
+        "title": "The response specifically mentions Federal Reserve SR 11-7 \"Guidance on Model Risk Management\" or references the three lines of defense framework for model governance when discussing overlay approval processes.",
+        "weight": 9.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "668345b3-2b95-4be7-8b49-3d5cf17fea28",
+        "title": "The response addresses the requirement for \"effective challenge\" documentation per Federal Reserve guidance when discussing overlay methodologies.",
+        "weight": 7.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "a33da628-133b-4704-a894-6ba7b7bb3ad6",
+        "title": "The response mentions specific CCAR submission requirements such as \"FR Y-14A Schedule H.1\" for stress testing results or references the Capital Plan Rule's documentation standards for model adjustments.",
+        "weight": 6.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "e00429ae-5d51-4dea-bddc-b9903effc0dd",
+        "title": "The response discusses overlay \"procyclicality\" concerns or mentions the need to avoid overlays that amplify economic cycles, referencing Basel III buffer framework principles.",
+        "weight": 6.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "9a047436-c0de-4311-8971-26a0f5a5029f",
+        "title": "The response specifies Model Risk Management (MRM) ticket numbers, change control procedures, or mentions the need for \"model development standards\" documentation per regulatory expectations.",
+        "weight": 3.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "e51fdf10-fb6b-46f0-adfb-bb1e152b0b1e",
+        "title": "The response addresses \"out-of-sample testing\" requirements for overlay validation or mentions the need for \"holdout datasets\" when calibrating overlay factors.",
+        "weight": 5.0,
+        "category": "Process Transparency & Auditability"
+      },
+      {
+        "id": "ff7fba39-49fc-4ffe-a37a-f733bbc2c196",
+        "title": "The response mentions specific audit committee charter requirements such as \"Sarbanes-Oxley Section 404\" compliance for internal controls over financial reporting when discussing overlay approval authority.",
+        "weight": 2.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "955d276b-5bb4-4a9e-970b-8ad3465c8686",
+        "title": "The response incorrectly suggests applying overlays to baseline scenarios or recommends overlays that affect both stressed and non-stressed projections simultaneously.",
+        "weight": -6.0,
+        "category": "Financial Accuracy"
+      },
+      {
+        "id": "1910dc61-966a-4907-a3f7-6851d569d3c0",
+        "title": "The response refers to the key factors for overlay approval by the audit committee, e.g., clear business rationale, quantitative justification, and governance controls.",
+        "weight": 7.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "0e29c49a-30e7-4a23-8589-d8a994452f67",
+        "title": "The response discusses \"model conceptual soundness review\" requirements or mentions the need for independent quantitative validation of overlay assumptions per Federal Reserve SR 14-1 guidance.",
+        "weight": 3.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      "... [TRUNCATED 7 more items] ..."
+    ],
+    "economic_pathway": "Compliance and Reporting Integrity, Risk & Resilience",
+    "decision_type": "Modeling & Measurement, Compliance & Reporting"
+  }
+}
+```
+
+*Note: Some content was truncated for display.*
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets prbench \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['prbench'],
+    dataset_args={
+        'prbench': {
+            # subset_list: ['finance', 'legal', 'finance_hard']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/llm.md
+++ b/docs/en/get_started/supported_dataset/llm.md
@@ -120,6 +120,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 | `piqa` | [PIQA](../../benchmarks/piqa.md) | `Commonsense`, `MCQ`, `Reasoning` |
 | `plawbench` | [PLawBench](../../benchmarks/plawbench.md) | `Chinese`, `Knowledge`, `QA`, `Reasoning` |
 | `poly_math` | [PolyMath](../../benchmarks/poly_math.md) | `Math`, `MultiLingual`, `Reasoning` |
+| `prbench` | [PRBench](../../benchmarks/prbench.md) | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |
 | `process_bench` | [ProcessBench](../../benchmarks/process_bench.md) | `Math`, `Reasoning` |
 | `pubmedqa` | [PubMedQA](../../benchmarks/pubmedqa.md) | `Knowledge`, `Yes/No` |
 | `qasc` | [QASC](../../benchmarks/qasc.md) | `Knowledge`, `MCQ` |
@@ -266,6 +267,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/piqa.md
 ../../benchmarks/plawbench.md
 ../../benchmarks/poly_math.md
+../../benchmarks/prbench.md
 ../../benchmarks/process_bench.md
 ../../benchmarks/pubmedqa.md
 ../../benchmarks/qasc.md

--- a/docs/zh/benchmarks/prbench.md
+++ b/docs/zh/benchmarks/prbench.md
@@ -1,0 +1,229 @@
+# PRBench
+
+
+## 概述
+
+PRBench（Professional Reasoning Benchmark，专业推理基准测试）评估模型在现实且高风险的金融与法律问题上的开放式推理能力。该基准测试由领域专家编写的对话和细粒度评分标准组成，用于衡量模型的回答是否准确、有用、可审计，并能恰当地处理不确定性与风险。
+
+## 任务描述
+
+- **任务类型**：基于评分标准的多轮开放式问答
+- **输入**：1 到 10 轮对话，可选择性附带参考文本
+- **输出**：助手对最后一轮用户提问的回复
+- **领域**：金融与法律领域的专业推理
+
+## 核心特性
+
+- 当前版本包含 1,100 个对话和 18,692 条专家精心设计的评分标准，覆盖 13 个金融主题和 12 个法律主题；约 30% 的对话为多轮对话。
+- 覆盖 114 个国家及地区以及美国 47 个司法管辖区，包含专家与非专家用户场景。
+- 提供四个数据集划分：`finance`（600）、`legal`（500）、`finance_hard`（300）和 `legal_hard`（250）。其中“hard”划分包含各自完整划分中最难的样本。
+- 每个样本包含 10–30 条独立评分的标准，每条标准具有 -10 到 10（不含 0）之间的整数权重。正权重标准描述期望的属性，负权重标准描述不期望的属性。
+
+## 评估说明
+
+- 每条评分标准均由 LLM 评判器根据官方提示独立判断是否满足。论文中使用 `o4-mini` 作为评判器；请配置 `judge.models` 并设置 `judge.strategy='auto'` 或 `'llm'`。
+- `clipped_score` 是论文报告的主要指标：每个样本的加权得分除以其正权重总和，然后对所有样本取平均值，并将结果下限裁剪至 0。
+- `normalized_score` 先减去每个样本可能的最低得分（即其负权重之和），再除以完整得分范围，最后对样本得分取平均。该指标适用于不同评分标准分布间的比较。
+- 参考文本会严格按照官方评估器的方式，直接前置到对应的用户轮次内容之前。若评判器在解析或传输过程中失败，则排除受影响的样本而非赋予分数。
+- 完整的金融加法律评估每次需调用评判器 18,692 次。由于“hard”划分与完整划分存在重叠，EvalScope 会独立报告每个划分的结果，不提供 `OVERALL` 行；发布综合结果时，请选择完整划分或 hard 划分之一。
+- 相关资源：[论文](https://arxiv.org/abs/2511.11562) |
+  [GitHub](https://github.com/scaleapi/PRBench) |
+  [数据集](https://modelscope.cn/datasets/ScaleAI/PRBench)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `prbench` |
+| **数据集ID** | [ScaleAI/PRBench](https://modelscope.cn/datasets/ScaleAI/PRBench/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2511.11562) |
+| **标签** | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |
+| **指标** | `clipped_score`, `normalized_score` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `finance` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 1,650 |
+| 提示词长度（平均） | 10251.59 字符 |
+| 提示词长度（最小/最大） | 84 / 132961 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |
+|--------|---------|-------------|------------|------------|
+| `finance` | 600 | 9590.54 | 103 | 132961 |
+| `legal` | 500 | 10328.35 | 84 | 99212 |
+| `finance_hard` | 300 | 10796.97 | 103 | 132961 |
+| `legal_hard` | 250 | 11030.14 | 140 | 99212 |
+
+## 样例示例
+
+**子集**: `finance`
+
+```json
+{
+  "input": [
+    {
+      "id": "5026042c",
+      "content": "hey, we've got a problem with our credit loss forecasting model that feeds into CCAR stress testing. during validaton, we found the model is systematically underestimating losses in the tail scenarios by about 15-20%, particularly for our com ... [TRUNCATED 259 chars] ... . The model was performing fine until we started seeing these newer macro scenarios with simultaneous interest rate spikes and credit spread widening. thoughts on how to approach this? what would you prioritize given the timeline constraints?"
+    },
+    {
+      "id": "59952e89",
+      "content": "**Quick‑Response Blueprint for the CCAR Credit Loss Model (6‑Week Deadline)**  \n*(Tail losses are under‑forecasting by 15‑20 % in the commercial real‑estate (CRE) portfolio under the newest macro stress scenarios.)*\n\n| Phase | Timeframe | Wha ... [TRUNCATED 8109 chars] ... , and Legal.  \n\nIf you follow the table‑derived 6‑week schedule, you’ll either have a fully corrected model that meets CCAR standards **or** a defensible overlay that keeps you compliant until a full rebuild can be rolled out post‑submission."
+    },
+    {
+      "id": "c0794365",
+      "content": "this is really helpful but i'm concerned about the week 2 copula approach for the joint shock scenario. our quant team is pretty thin right now and honestly we've never implemented a copula-based stress scenario before. is there a simpler way to capture the simultaneous rate/spread shock that doesn't require us to build new statistical infrastructure in 1 week? maybe something more rule-based that regulators would still accept?"
+    },
+    {
+      "id": "2312a13c",
+      "content": "### Quick‑Rule Based Stress‑Scenario Design (No Copula Required)\n\n| What you’ll need | Why it’s regulator‑friendly | How much effort |\n|-------------------|-----------------------------|-----------------|\n| **A single, “joint‑shock” driver**  ... [TRUNCATED 5124 chars] ... n **2‑3 business days**.  \nIf you later decide to adopt a full copula, you’ll have the historical data ready, and at that point the switch will only be a code‑update, not a concept‑change.  \n\nGood luck – you’ve got this 6‑week window in hand!"
+    },
+    {
+      "id": "c8b32de6",
+      "content": "ok the linear blend approach makes sense, but i'm worried about using a fixed correlation of 0.6, that seems arbitrary. when I look at our historical data from 2020-2022, the coreelation between rate changes and our CRE spread changes was clo ... [TRUNCATED 55 chars] ... should we be using a rolling correlation or just pick the most conservative period? also, for the backtesting you mentioned, we don't have clean monthly loss data, our charge offs are reported quarterly. will that be a problem for validation?"
+    },
+    {
+      "id": "269be9b4",
+      "content": "## 1.  Choosing a Correlation Coefficient  \n| Issue | Why it matters | Practical options | How to document it |\n|-------|----------------|-------------------|--------------------|\n| **Historical correlation swings** (0.3 in 2008‑09, 0.8 in 20 ... [TRUNCATED 5868 chars] ... le, you have a defensible, regulator‑approved stress scenario that can be built into the CCAR submission in less than a week.  \n\nLet me know if you need a sample Excel template or a quick‑script for the correlation calculation—happy to share!"
+    },
+    {
+      "id": "ccf03620",
+      "content": "one more thing on the backtesting, when you say \"coverage check\" where all observed quarterly charge offs be less or equal to predicted loss of the 0.3 correlation scenario, what if we have a quarterly where actual charge offs exceeded even our most conservative prediction? this happened in Q2 2020 when we had some one off covid related writedowns that spiked our numbers, do we just document this as an outlier or does that break our whole validation approach?"
+    },
+    {
+      "id": "cb010996",
+      "content": "### The “Coverage Check” – What It’s Built For  \n\nIn CCAR, the coverage check is a very *high‑level* sanity test:  \n\n> “For every historical period we used in the back‑test, the probability‑weighted loss predicted by **our worst‑case** stress ... [TRUNCATED 6304 chars] ... nal).” |\n\nYou’re perfectly allowed to keep the linear‑blend approach, use the 0.8 correlation as core, and treat Q2 2020 as an exceptional event. That meets FRB guidance, keeps you on schedule, and preserves the integrity of your CCAR submit."
+    },
+    {
+      "id": "d8d952ce",
+      "content": "got it on the outlier treatment. but now i'm realizing we might need different correlation assumptions across our CRE sub-segments. our office portfolio behaves very differently from retail and multifamily during rate shocks, should we be using segment specific correlatiosn or is that going to make the documentation too complex for the regulators? also, do we need separate back testing for each segment or can we do it at the portfolio level?"
+    },
+    {
+      "id": "f6976632",
+      "content": "## 1.  Do you need sector‑specific correlations?\n\n| Factor | Why it *might* matter | When it *doesn’t* matter | Practical rule‑of‑thumb |\n|--------|-----------------------|--------------------------|------------------------|\n| **Collateral pr ... [TRUNCATED 9748 chars] ... more time proving the same logic. Stick to 3–4 meaningful sub‑portfolio categories, back‑test each, and use the portfolio‑level test as an overall guardrail.  \nThat should keep the submission robust, defendable, and time‑efficient. Good luck!"
+    },
+    "... [TRUNCATED 9 more items] ..."
+  ],
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "task": "ea67e314b6c2e8fc70627c19",
+    "field": "Finance",
+    "topic": "Risk Management & Stress Testing",
+    "expert": "Expert",
+    "turns": 10,
+    "rubrics": [
+      {
+        "id": "f46d80f7-6c5e-47a4-93f7-b05e99b24c79",
+        "title": "The response specifically mentions Federal Reserve SR 11-7 \"Guidance on Model Risk Management\" or references the three lines of defense framework for model governance when discussing overlay approval processes.",
+        "weight": 9.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "668345b3-2b95-4be7-8b49-3d5cf17fea28",
+        "title": "The response addresses the requirement for \"effective challenge\" documentation per Federal Reserve guidance when discussing overlay methodologies.",
+        "weight": 7.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "a33da628-133b-4704-a894-6ba7b7bb3ad6",
+        "title": "The response mentions specific CCAR submission requirements such as \"FR Y-14A Schedule H.1\" for stress testing results or references the Capital Plan Rule's documentation standards for model adjustments.",
+        "weight": 6.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "e00429ae-5d51-4dea-bddc-b9903effc0dd",
+        "title": "The response discusses overlay \"procyclicality\" concerns or mentions the need to avoid overlays that amplify economic cycles, referencing Basel III buffer framework principles.",
+        "weight": 6.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "9a047436-c0de-4311-8971-26a0f5a5029f",
+        "title": "The response specifies Model Risk Management (MRM) ticket numbers, change control procedures, or mentions the need for \"model development standards\" documentation per regulatory expectations.",
+        "weight": 3.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "e51fdf10-fb6b-46f0-adfb-bb1e152b0b1e",
+        "title": "The response addresses \"out-of-sample testing\" requirements for overlay validation or mentions the need for \"holdout datasets\" when calibrating overlay factors.",
+        "weight": 5.0,
+        "category": "Process Transparency & Auditability"
+      },
+      {
+        "id": "ff7fba39-49fc-4ffe-a37a-f733bbc2c196",
+        "title": "The response mentions specific audit committee charter requirements such as \"Sarbanes-Oxley Section 404\" compliance for internal controls over financial reporting when discussing overlay approval authority.",
+        "weight": 2.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "955d276b-5bb4-4a9e-970b-8ad3465c8686",
+        "title": "The response incorrectly suggests applying overlays to baseline scenarios or recommends overlays that affect both stressed and non-stressed projections simultaneously.",
+        "weight": -6.0,
+        "category": "Financial Accuracy"
+      },
+      {
+        "id": "1910dc61-966a-4907-a3f7-6851d569d3c0",
+        "title": "The response refers to the key factors for overlay approval by the audit committee, e.g., clear business rationale, quantitative justification, and governance controls.",
+        "weight": 7.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      {
+        "id": "0e29c49a-30e7-4a23-8589-d8a994452f67",
+        "title": "The response discusses \"model conceptual soundness review\" requirements or mentions the need for independent quantitative validation of overlay assumptions per Federal Reserve SR 14-1 guidance.",
+        "weight": 3.0,
+        "category": "Risk & Regulatory Disclosure"
+      },
+      "... [TRUNCATED 7 more items] ..."
+    ],
+    "economic_pathway": "Compliance and Reporting Integrity, Risk & Resilience",
+    "decision_type": "Modeling & Measurement, Compliance & Reporting"
+  }
+}
+```
+
+*注：部分内容因展示需要已被截断。*
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets prbench \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['prbench'],
+    dataset_args={
+        'prbench': {
+            # subset_list: ['finance', 'legal', 'finance_hard']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/llm.md
+++ b/docs/zh/get_started/supported_dataset/llm.md
@@ -120,6 +120,7 @@
 | `piqa` | [PIQA](../../benchmarks/piqa.md) | `Commonsense`, `MCQ`, `Reasoning` |
 | `plawbench` | [PLawBench](../../benchmarks/plawbench.md) | `Chinese`, `Knowledge`, `QA`, `Reasoning` |
 | `poly_math` | [PolyMath](../../benchmarks/poly_math.md) | `Math`, `MultiLingual`, `Reasoning` |
+| `prbench` | [PRBench](../../benchmarks/prbench.md) | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |
 | `process_bench` | [ProcessBench](../../benchmarks/process_bench.md) | `Math`, `Reasoning` |
 | `pubmedqa` | [PubMedQA](../../benchmarks/pubmedqa.md) | `Knowledge`, `Yes/No` |
 | `qasc` | [QASC](../../benchmarks/qasc.md) | `Knowledge`, `MCQ` |
@@ -266,6 +267,7 @@
 ../../benchmarks/piqa.md
 ../../benchmarks/plawbench.md
 ../../benchmarks/poly_math.md
+../../benchmarks/prbench.md
 ../../benchmarks/process_bench.md
 ../../benchmarks/pubmedqa.md
 ../../benchmarks/qasc.md

--- a/evalscope/benchmarks/_meta/prbench.json
+++ b/evalscope/benchmarks/_meta/prbench.json
@@ -1,0 +1,219 @@
+{
+  "meta": {
+    "pretty_name": "PRBench",
+    "dataset_id": "ScaleAI/PRBench",
+    "paper_url": "https://arxiv.org/abs/2511.11562",
+    "tags": [
+      "Knowledge",
+      "QA",
+      "Reasoning",
+      "MultiTurn"
+    ],
+    "metrics": [
+      "clipped_score",
+      "normalized_score"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "finance",
+    "train_split": "",
+    "subset_list": [
+      "finance",
+      "legal",
+      "finance_hard",
+      "legal_hard"
+    ],
+    "description": "\n## Overview\n\nPRBench (Professional Reasoning Benchmark) evaluates open-ended reasoning on realistic, high-stakes Finance and Legal\nproblems. Its expert-authored conversations and fine-grained rubrics measure whether a response is accurate, useful,\nauditable, and appropriately handles uncertainty and risk.\n\n## Task Description\n\n- **Task Type**: Multi-turn open-ended question answering with rubric-based grading\n- **Input**: One to ten conversation turns, optionally accompanied by reference texts\n- **Output**: The assistant response to the final user turn\n- **Domain**: Finance and Legal professional reasoning\n\n## Key Features\n\n- The current release contains 1,100 conversations and 18,692 expert-curated criteria across 13 Finance and 12 Legal\n  topics; roughly 30% of the conversations are multi-turn.\n- It covers 114 countries and dependencies and 47 U.S. jurisdictions, with both expert and non-expert user scenarios.\n- Four dataset splits are available: `finance` (600), `legal` (500), `finance_hard` (300), and `legal_hard` (250). The\n  hard splits contain the most difficult examples from their corresponding full splits.\n- Each sample has 10–30 independently graded criteria with integer weights from -10 to 10 (excluding zero). Positive\n  criteria describe desired properties, while negative criteria describe undesirable properties.\n\n## Evaluation Notes\n\n- Each rubric criterion is graded independently by an LLM judge as met or not met using the official prompt. The paper\n  uses `o4-mini` as the judge; configure `judge.models` and use `judge.strategy='auto'` or `'llm'`.\n- `clipped_score` is the primary metric reported by the paper: each sample's weighted points are divided by its total\n  positive weight, then the mean across samples is clipped at a lower bound of 0.\n- `normalized_score` subtracts each sample's minimum possible score (the sum of its negative weights), divides by the\n  full score range, and then averages the sample scores. It is useful for comparisons across rubric distributions.\n- Reference texts are prepended to their corresponding user turns exactly as in the official evaluator. Judge parse or\n  transport failures exclude the affected sample rather than assigning a score.\n- A full Finance plus Legal evaluation requires 18,692 judge calls per judge and repeat. The hard splits overlap the\n  full splits, so EvalScope reports every split independently without an `OVERALL` row; select either the full or hard\n  splits when publishing a combined result.\n- Resources: [Paper](https://arxiv.org/abs/2511.11562) |\n  [GitHub](https://github.com/scaleapi/PRBench) |\n  [Dataset](https://modelscope.cn/datasets/ScaleAI/PRBench)\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "llm",
+    "primary_metric": {
+      "name": "clipped_score",
+      "aggregation": null,
+      "dimensions": {}
+    }
+  },
+  "statistics": {
+    "total_samples": 1650,
+    "subset_stats": [
+      {
+        "name": "finance",
+        "sample_count": 600,
+        "prompt_length_mean": 9590.54,
+        "prompt_length_min": 103,
+        "prompt_length_max": 132961,
+        "prompt_length_std": 16817.07,
+        "target_length_mean": null
+      },
+      {
+        "name": "legal",
+        "sample_count": 500,
+        "prompt_length_mean": 10328.35,
+        "prompt_length_min": 84,
+        "prompt_length_max": 99212,
+        "prompt_length_std": 17118.67,
+        "target_length_mean": null
+      },
+      {
+        "name": "finance_hard",
+        "sample_count": 300,
+        "prompt_length_mean": 10796.97,
+        "prompt_length_min": 103,
+        "prompt_length_max": 132961,
+        "prompt_length_std": 17611.68,
+        "target_length_mean": null
+      },
+      {
+        "name": "legal_hard",
+        "sample_count": 250,
+        "prompt_length_mean": 11030.14,
+        "prompt_length_min": 140,
+        "prompt_length_max": 99212,
+        "prompt_length_std": 17075.23,
+        "target_length_mean": null
+      }
+    ],
+    "prompt_length": {
+      "mean": 10251.59,
+      "min": 84,
+      "max": 132961,
+      "std": 17087.57
+    },
+    "target_length_mean": null,
+    "computed_at": "2026-08-28T11:33:04.635104+08:00"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "5026042c",
+          "content": "hey, we've got a problem with our credit loss forecasting model that feeds into CCAR stress testing. during validaton, we found the model is systematically underestimating losses in the tail scenarios by about 15-20%, particularly for our com ... [TRUNCATED 259 chars] ... . The model was performing fine until we started seeing these newer macro scenarios with simultaneous interest rate spikes and credit spread widening. thoughts on how to approach this? what would you prioritize given the timeline constraints?"
+        },
+        {
+          "id": "59952e89",
+          "content": "**Quick‑Response Blueprint for the CCAR Credit Loss Model (6‑Week Deadline)**  \n*(Tail losses are under‑forecasting by 15‑20 % in the commercial real‑estate (CRE) portfolio under the newest macro stress scenarios.)*\n\n| Phase | Timeframe | Wha ... [TRUNCATED 8109 chars] ... , and Legal.  \n\nIf you follow the table‑derived 6‑week schedule, you’ll either have a fully corrected model that meets CCAR standards **or** a defensible overlay that keeps you compliant until a full rebuild can be rolled out post‑submission."
+        },
+        {
+          "id": "c0794365",
+          "content": "this is really helpful but i'm concerned about the week 2 copula approach for the joint shock scenario. our quant team is pretty thin right now and honestly we've never implemented a copula-based stress scenario before. is there a simpler way to capture the simultaneous rate/spread shock that doesn't require us to build new statistical infrastructure in 1 week? maybe something more rule-based that regulators would still accept?"
+        },
+        {
+          "id": "2312a13c",
+          "content": "### Quick‑Rule Based Stress‑Scenario Design (No Copula Required)\n\n| What you’ll need | Why it’s regulator‑friendly | How much effort |\n|-------------------|-----------------------------|-----------------|\n| **A single, “joint‑shock” driver**  ... [TRUNCATED 5124 chars] ... n **2‑3 business days**.  \nIf you later decide to adopt a full copula, you’ll have the historical data ready, and at that point the switch will only be a code‑update, not a concept‑change.  \n\nGood luck – you’ve got this 6‑week window in hand!"
+        },
+        {
+          "id": "c8b32de6",
+          "content": "ok the linear blend approach makes sense, but i'm worried about using a fixed correlation of 0.6, that seems arbitrary. when I look at our historical data from 2020-2022, the coreelation between rate changes and our CRE spread changes was clo ... [TRUNCATED 55 chars] ... should we be using a rolling correlation or just pick the most conservative period? also, for the backtesting you mentioned, we don't have clean monthly loss data, our charge offs are reported quarterly. will that be a problem for validation?"
+        },
+        {
+          "id": "269be9b4",
+          "content": "## 1.  Choosing a Correlation Coefficient  \n| Issue | Why it matters | Practical options | How to document it |\n|-------|----------------|-------------------|--------------------|\n| **Historical correlation swings** (0.3 in 2008‑09, 0.8 in 20 ... [TRUNCATED 5868 chars] ... le, you have a defensible, regulator‑approved stress scenario that can be built into the CCAR submission in less than a week.  \n\nLet me know if you need a sample Excel template or a quick‑script for the correlation calculation—happy to share!"
+        },
+        {
+          "id": "ccf03620",
+          "content": "one more thing on the backtesting, when you say \"coverage check\" where all observed quarterly charge offs be less or equal to predicted loss of the 0.3 correlation scenario, what if we have a quarterly where actual charge offs exceeded even our most conservative prediction? this happened in Q2 2020 when we had some one off covid related writedowns that spiked our numbers, do we just document this as an outlier or does that break our whole validation approach?"
+        },
+        {
+          "id": "cb010996",
+          "content": "### The “Coverage Check” – What It’s Built For  \n\nIn CCAR, the coverage check is a very *high‑level* sanity test:  \n\n> “For every historical period we used in the back‑test, the probability‑weighted loss predicted by **our worst‑case** stress ... [TRUNCATED 6304 chars] ... nal).” |\n\nYou’re perfectly allowed to keep the linear‑blend approach, use the 0.8 correlation as core, and treat Q2 2020 as an exceptional event. That meets FRB guidance, keeps you on schedule, and preserves the integrity of your CCAR submit."
+        },
+        {
+          "id": "d8d952ce",
+          "content": "got it on the outlier treatment. but now i'm realizing we might need different correlation assumptions across our CRE sub-segments. our office portfolio behaves very differently from retail and multifamily during rate shocks, should we be using segment specific correlatiosn or is that going to make the documentation too complex for the regulators? also, do we need separate back testing for each segment or can we do it at the portfolio level?"
+        },
+        {
+          "id": "f6976632",
+          "content": "## 1.  Do you need sector‑specific correlations?\n\n| Factor | Why it *might* matter | When it *doesn’t* matter | Practical rule‑of‑thumb |\n|--------|-----------------------|--------------------------|------------------------|\n| **Collateral pr ... [TRUNCATED 9748 chars] ... more time proving the same logic. Stick to 3–4 meaningful sub‑portfolio categories, back‑test each, and use the portfolio‑level test as an overall guardrail.  \nThat should keep the submission robust, defendable, and time‑efficient. Good luck!"
+        },
+        "... [TRUNCATED 9 more items] ..."
+      ],
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "task": "ea67e314b6c2e8fc70627c19",
+        "field": "Finance",
+        "topic": "Risk Management & Stress Testing",
+        "expert": "Expert",
+        "turns": 10,
+        "rubrics": [
+          {
+            "id": "f46d80f7-6c5e-47a4-93f7-b05e99b24c79",
+            "title": "The response specifically mentions Federal Reserve SR 11-7 \"Guidance on Model Risk Management\" or references the three lines of defense framework for model governance when discussing overlay approval processes.",
+            "weight": 9.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "668345b3-2b95-4be7-8b49-3d5cf17fea28",
+            "title": "The response addresses the requirement for \"effective challenge\" documentation per Federal Reserve guidance when discussing overlay methodologies.",
+            "weight": 7.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "a33da628-133b-4704-a894-6ba7b7bb3ad6",
+            "title": "The response mentions specific CCAR submission requirements such as \"FR Y-14A Schedule H.1\" for stress testing results or references the Capital Plan Rule's documentation standards for model adjustments.",
+            "weight": 6.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "e00429ae-5d51-4dea-bddc-b9903effc0dd",
+            "title": "The response discusses overlay \"procyclicality\" concerns or mentions the need to avoid overlays that amplify economic cycles, referencing Basel III buffer framework principles.",
+            "weight": 6.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "9a047436-c0de-4311-8971-26a0f5a5029f",
+            "title": "The response specifies Model Risk Management (MRM) ticket numbers, change control procedures, or mentions the need for \"model development standards\" documentation per regulatory expectations.",
+            "weight": 3.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "e51fdf10-fb6b-46f0-adfb-bb1e152b0b1e",
+            "title": "The response addresses \"out-of-sample testing\" requirements for overlay validation or mentions the need for \"holdout datasets\" when calibrating overlay factors.",
+            "weight": 5.0,
+            "category": "Process Transparency & Auditability"
+          },
+          {
+            "id": "ff7fba39-49fc-4ffe-a37a-f733bbc2c196",
+            "title": "The response mentions specific audit committee charter requirements such as \"Sarbanes-Oxley Section 404\" compliance for internal controls over financial reporting when discussing overlay approval authority.",
+            "weight": 2.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "955d276b-5bb4-4a9e-970b-8ad3465c8686",
+            "title": "The response incorrectly suggests applying overlays to baseline scenarios or recommends overlays that affect both stressed and non-stressed projections simultaneously.",
+            "weight": -6.0,
+            "category": "Financial Accuracy"
+          },
+          {
+            "id": "1910dc61-966a-4907-a3f7-6851d569d3c0",
+            "title": "The response refers to the key factors for overlay approval by the audit committee, e.g., clear business rationale, quantitative justification, and governance controls.",
+            "weight": 7.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          {
+            "id": "0e29c49a-30e7-4a23-8589-d8a994452f67",
+            "title": "The response discusses \"model conceptual soundness review\" requirements or mentions the need for independent quantitative validation of overlay assumptions per Federal Reserve SR 14-1 guidance.",
+            "weight": 3.0,
+            "category": "Risk & Regulatory Disclosure"
+          },
+          "... [TRUNCATED 7 more items] ..."
+        ],
+        "economic_pathway": "Compliance and Reporting Integrity, Risk & Resilience",
+        "decision_type": "Modeling & Measurement, Compliance & Reporting"
+      }
+    },
+    "subset": "finance",
+    "truncated": true
+  },
+  "readme": {
+    "en": "# PRBench\n\n\n## Overview\n\nPRBench (Professional Reasoning Benchmark) evaluates open-ended reasoning on realistic, high-stakes Finance and Legal\nproblems. Its expert-authored conversations and fine-grained rubrics measure whether a response is accurate, useful,\nauditable, and appropriately handles uncertainty and risk.\n\n## Task Description\n\n- **Task Type**: Multi-turn open-ended question answering with rubric-based grading\n- **Input**: One to ten conversation turns, optionally accompanied by reference texts\n- **Output**: The assistant response to the final user turn\n- **Domain**: Finance and Legal professional reasoning\n\n## Key Features\n\n- The current release contains 1,100 conversations and 18,692 expert-curated criteria across 13 Finance and 12 Legal\n  topics; roughly 30% of the conversations are multi-turn.\n- It covers 114 countries and dependencies and 47 U.S. jurisdictions, with both expert and non-expert user scenarios.\n- Four dataset splits are available: `finance` (600), `legal` (500), `finance_hard` (300), and `legal_hard` (250). The\n  hard splits contain the most difficult examples from their corresponding full splits.\n- Each sample has 10–30 independently graded criteria with integer weights from -10 to 10 (excluding zero). Positive\n  criteria describe desired properties, while negative criteria describe undesirable properties.\n\n## Evaluation Notes\n\n- Each rubric criterion is graded independently by an LLM judge as met or not met using the official prompt. The paper\n  uses `o4-mini` as the judge; configure `judge.models` and use `judge.strategy='auto'` or `'llm'`.\n- `clipped_score` is the primary metric reported by the paper: each sample's weighted points are divided by its total\n  positive weight, then the mean across samples is clipped at a lower bound of 0.\n- `normalized_score` subtracts each sample's minimum possible score (the sum of its negative weights), divides by the\n  full score range, and then averages the sample scores. It is useful for comparisons across rubric distributions.\n- Reference texts are prepended to their corresponding user turns exactly as in the official evaluator. Judge parse or\n  transport failures exclude the affected sample rather than assigning a score.\n- A full Finance plus Legal evaluation requires 18,692 judge calls per judge and repeat. The hard splits overlap the\n  full splits, so EvalScope reports every split independently without an `OVERALL` row; select either the full or hard\n  splits when publishing a combined result.\n- Resources: [Paper](https://arxiv.org/abs/2511.11562) |\n  [GitHub](https://github.com/scaleapi/PRBench) |\n  [Dataset](https://modelscope.cn/datasets/ScaleAI/PRBench)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `prbench` |\n| **Dataset ID** | [ScaleAI/PRBench](https://modelscope.cn/datasets/ScaleAI/PRBench/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2511.11562) |\n| **Tags** | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |\n| **Metrics** | `clipped_score`, `normalized_score` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `finance` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 1,650 |\n| Prompt Length (Mean) | 10251.59 chars |\n| Prompt Length (Min/Max) | 84 / 132961 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `finance` | 600 | 9590.54 | 103 | 132961 |\n| `legal` | 500 | 10328.35 | 84 | 99212 |\n| `finance_hard` | 300 | 10796.97 | 103 | 132961 |\n| `legal_hard` | 250 | 11030.14 | 140 | 99212 |\n\n## Sample Example\n\n**Subset**: `finance`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"5026042c\",\n      \"content\": \"hey, we've got a problem with our credit loss forecasting model that feeds into CCAR stress testing. during validaton, we found the model is systematically underestimating losses in the tail scenarios by about 15-20%, particularly for our com ... [TRUNCATED 259 chars] ... . The model was performing fine until we started seeing these newer macro scenarios with simultaneous interest rate spikes and credit spread widening. thoughts on how to approach this? what would you prioritize given the timeline constraints?\"\n    },\n    {\n      \"id\": \"59952e89\",\n      \"content\": \"**Quick‑Response Blueprint for the CCAR Credit Loss Model (6‑Week Deadline)**  \\n*(Tail losses are under‑forecasting by 15‑20 % in the commercial real‑estate (CRE) portfolio under the newest macro stress scenarios.)*\\n\\n| Phase | Timeframe | Wha ... [TRUNCATED 8109 chars] ... , and Legal.  \\n\\nIf you follow the table‑derived 6‑week schedule, you’ll either have a fully corrected model that meets CCAR standards **or** a defensible overlay that keeps you compliant until a full rebuild can be rolled out post‑submission.\"\n    },\n    {\n      \"id\": \"c0794365\",\n      \"content\": \"this is really helpful but i'm concerned about the week 2 copula approach for the joint shock scenario. our quant team is pretty thin right now and honestly we've never implemented a copula-based stress scenario before. is there a simpler way to capture the simultaneous rate/spread shock that doesn't require us to build new statistical infrastructure in 1 week? maybe something more rule-based that regulators would still accept?\"\n    },\n    {\n      \"id\": \"2312a13c\",\n      \"content\": \"### Quick‑Rule Based Stress‑Scenario Design (No Copula Required)\\n\\n| What you’ll need | Why it’s regulator‑friendly | How much effort |\\n|-------------------|-----------------------------|-----------------|\\n| **A single, “joint‑shock” driver**  ... [TRUNCATED 5124 chars] ... n **2‑3 business days**.  \\nIf you later decide to adopt a full copula, you’ll have the historical data ready, and at that point the switch will only be a code‑update, not a concept‑change.  \\n\\nGood luck – you’ve got this 6‑week window in hand!\"\n    },\n    {\n      \"id\": \"c8b32de6\",\n      \"content\": \"ok the linear blend approach makes sense, but i'm worried about using a fixed correlation of 0.6, that seems arbitrary. when I look at our historical data from 2020-2022, the coreelation between rate changes and our CRE spread changes was clo ... [TRUNCATED 55 chars] ... should we be using a rolling correlation or just pick the most conservative period? also, for the backtesting you mentioned, we don't have clean monthly loss data, our charge offs are reported quarterly. will that be a problem for validation?\"\n    },\n    {\n      \"id\": \"269be9b4\",\n      \"content\": \"## 1.  Choosing a Correlation Coefficient  \\n| Issue | Why it matters | Practical options | How to document it |\\n|-------|----------------|-------------------|--------------------|\\n| **Historical correlation swings** (0.3 in 2008‑09, 0.8 in 20 ... [TRUNCATED 5868 chars] ... le, you have a defensible, regulator‑approved stress scenario that can be built into the CCAR submission in less than a week.  \\n\\nLet me know if you need a sample Excel template or a quick‑script for the correlation calculation—happy to share!\"\n    },\n    {\n      \"id\": \"ccf03620\",\n      \"content\": \"one more thing on the backtesting, when you say \\\"coverage check\\\" where all observed quarterly charge offs be less or equal to predicted loss of the 0.3 correlation scenario, what if we have a quarterly where actual charge offs exceeded even our most conservative prediction? this happened in Q2 2020 when we had some one off covid related writedowns that spiked our numbers, do we just document this as an outlier or does that break our whole validation approach?\"\n    },\n    {\n      \"id\": \"cb010996\",\n      \"content\": \"### The “Coverage Check” – What It’s Built For  \\n\\nIn CCAR, the coverage check is a very *high‑level* sanity test:  \\n\\n> “For every historical period we used in the back‑test, the probability‑weighted loss predicted by **our worst‑case** stress ... [TRUNCATED 6304 chars] ... nal).” |\\n\\nYou’re perfectly allowed to keep the linear‑blend approach, use the 0.8 correlation as core, and treat Q2 2020 as an exceptional event. That meets FRB guidance, keeps you on schedule, and preserves the integrity of your CCAR submit.\"\n    },\n    {\n      \"id\": \"d8d952ce\",\n      \"content\": \"got it on the outlier treatment. but now i'm realizing we might need different correlation assumptions across our CRE sub-segments. our office portfolio behaves very differently from retail and multifamily during rate shocks, should we be using segment specific correlatiosn or is that going to make the documentation too complex for the regulators? also, do we need separate back testing for each segment or can we do it at the portfolio level?\"\n    },\n    {\n      \"id\": \"f6976632\",\n      \"content\": \"## 1.  Do you need sector‑specific correlations?\\n\\n| Factor | Why it *might* matter | When it *doesn’t* matter | Practical rule‑of‑thumb |\\n|--------|-----------------------|--------------------------|------------------------|\\n| **Collateral pr ... [TRUNCATED 9748 chars] ... more time proving the same logic. Stick to 3–4 meaningful sub‑portfolio categories, back‑test each, and use the portfolio‑level test as an overall guardrail.  \\nThat should keep the submission robust, defendable, and time‑efficient. Good luck!\"\n    },\n    \"... [TRUNCATED 9 more items] ...\"\n  ],\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task\": \"ea67e314b6c2e8fc70627c19\",\n    \"field\": \"Finance\",\n    \"topic\": \"Risk Management & Stress Testing\",\n    \"expert\": \"Expert\",\n    \"turns\": 10,\n    \"rubrics\": [\n      {\n        \"id\": \"f46d80f7-6c5e-47a4-93f7-b05e99b24c79\",\n        \"title\": \"The response specifically mentions Federal Reserve SR 11-7 \\\"Guidance on Model Risk Management\\\" or references the three lines of defense framework for model governance when discussing overlay approval processes.\",\n        \"weight\": 9.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"668345b3-2b95-4be7-8b49-3d5cf17fea28\",\n        \"title\": \"The response addresses the requirement for \\\"effective challenge\\\" documentation per Federal Reserve guidance when discussing overlay methodologies.\",\n        \"weight\": 7.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"a33da628-133b-4704-a894-6ba7b7bb3ad6\",\n        \"title\": \"The response mentions specific CCAR submission requirements such as \\\"FR Y-14A Schedule H.1\\\" for stress testing results or references the Capital Plan Rule's documentation standards for model adjustments.\",\n        \"weight\": 6.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"e00429ae-5d51-4dea-bddc-b9903effc0dd\",\n        \"title\": \"The response discusses overlay \\\"procyclicality\\\" concerns or mentions the need to avoid overlays that amplify economic cycles, referencing Basel III buffer framework principles.\",\n        \"weight\": 6.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"9a047436-c0de-4311-8971-26a0f5a5029f\",\n        \"title\": \"The response specifies Model Risk Management (MRM) ticket numbers, change control procedures, or mentions the need for \\\"model development standards\\\" documentation per regulatory expectations.\",\n        \"weight\": 3.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"e51fdf10-fb6b-46f0-adfb-bb1e152b0b1e\",\n        \"title\": \"The response addresses \\\"out-of-sample testing\\\" requirements for overlay validation or mentions the need for \\\"holdout datasets\\\" when calibrating overlay factors.\",\n        \"weight\": 5.0,\n        \"category\": \"Process Transparency & Auditability\"\n      },\n      {\n        \"id\": \"ff7fba39-49fc-4ffe-a37a-f733bbc2c196\",\n        \"title\": \"The response mentions specific audit committee charter requirements such as \\\"Sarbanes-Oxley Section 404\\\" compliance for internal controls over financial reporting when discussing overlay approval authority.\",\n        \"weight\": 2.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"955d276b-5bb4-4a9e-970b-8ad3465c8686\",\n        \"title\": \"The response incorrectly suggests applying overlays to baseline scenarios or recommends overlays that affect both stressed and non-stressed projections simultaneously.\",\n        \"weight\": -6.0,\n        \"category\": \"Financial Accuracy\"\n      },\n      {\n        \"id\": \"1910dc61-966a-4907-a3f7-6851d569d3c0\",\n        \"title\": \"The response refers to the key factors for overlay approval by the audit committee, e.g., clear business rationale, quantitative justification, and governance controls.\",\n        \"weight\": 7.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"0e29c49a-30e7-4a23-8589-d8a994452f67\",\n        \"title\": \"The response discusses \\\"model conceptual soundness review\\\" requirements or mentions the need for independent quantitative validation of overlay assumptions per Federal Reserve SR 14-1 guidance.\",\n        \"weight\": 3.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      \"... [TRUNCATED 7 more items] ...\"\n    ],\n    \"economic_pathway\": \"Compliance and Reporting Integrity, Risk & Resilience\",\n    \"decision_type\": \"Modeling & Measurement, Compliance & Reporting\"\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets prbench \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['prbench'],\n    dataset_args={\n        'prbench': {\n            # subset_list: ['finance', 'legal', 'finance_hard']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# PRBench\n\n\n## 概述\n\nPRBench（Professional Reasoning Benchmark，专业推理基准测试）评估模型在现实且高风险的金融与法律问题上的开放式推理能力。该基准测试由领域专家编写的对话和细粒度评分标准组成，用于衡量模型的回答是否准确、有用、可审计，并能恰当地处理不确定性与风险。\n\n## 任务描述\n\n- **任务类型**：基于评分标准的多轮开放式问答\n- **输入**：1 到 10 轮对话，可选择性附带参考文本\n- **输出**：助手对最后一轮用户提问的回复\n- **领域**：金融与法律领域的专业推理\n\n## 核心特性\n\n- 当前版本包含 1,100 个对话和 18,692 条专家精心设计的评分标准，覆盖 13 个金融主题和 12 个法律主题；约 30% 的对话为多轮对话。\n- 覆盖 114 个国家及地区以及美国 47 个司法管辖区，包含专家与非专家用户场景。\n- 提供四个数据集划分：`finance`（600）、`legal`（500）、`finance_hard`（300）和 `legal_hard`（250）。其中“hard”划分包含各自完整划分中最难的样本。\n- 每个样本包含 10–30 条独立评分的标准，每条标准具有 -10 到 10（不含 0）之间的整数权重。正权重标准描述期望的属性，负权重标准描述不期望的属性。\n\n## 评估说明\n\n- 每条评分标准均由 LLM 评判器根据官方提示独立判断是否满足。论文中使用 `o4-mini` 作为评判器；请配置 `judge.models` 并设置 `judge.strategy='auto'` 或 `'llm'`。\n- `clipped_score` 是论文报告的主要指标：每个样本的加权得分除以其正权重总和，然后对所有样本取平均值，并将结果下限裁剪至 0。\n- `normalized_score` 先减去每个样本可能的最低得分（即其负权重之和），再除以完整得分范围，最后对样本得分取平均。该指标适用于不同评分标准分布间的比较。\n- 参考文本会严格按照官方评估器的方式，直接前置到对应的用户轮次内容之前。若评判器在解析或传输过程中失败，则排除受影响的样本而非赋予分数。\n- 完整的金融加法律评估每次需调用评判器 18,692 次。由于“hard”划分与完整划分存在重叠，EvalScope 会独立报告每个划分的结果，不提供 `OVERALL` 行；发布综合结果时，请选择完整划分或 hard 划分之一。\n- 相关资源：[论文](https://arxiv.org/abs/2511.11562) |\n  [GitHub](https://github.com/scaleapi/PRBench) |\n  [数据集](https://modelscope.cn/datasets/ScaleAI/PRBench)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `prbench` |\n| **数据集ID** | [ScaleAI/PRBench](https://modelscope.cn/datasets/ScaleAI/PRBench/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2511.11562) |\n| **标签** | `Knowledge`, `MultiTurn`, `QA`, `Reasoning` |\n| **指标** | `clipped_score`, `normalized_score` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `finance` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 1,650 |\n| 提示词长度（平均） | 10251.59 字符 |\n| 提示词长度（最小/最大） | 84 / 132961 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示平均长度 | 提示最小长度 | 提示最大长度 |\n|--------|---------|-------------|------------|------------|\n| `finance` | 600 | 9590.54 | 103 | 132961 |\n| `legal` | 500 | 10328.35 | 84 | 99212 |\n| `finance_hard` | 300 | 10796.97 | 103 | 132961 |\n| `legal_hard` | 250 | 11030.14 | 140 | 99212 |\n\n## 样例示例\n\n**子集**: `finance`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"5026042c\",\n      \"content\": \"hey, we've got a problem with our credit loss forecasting model that feeds into CCAR stress testing. during validaton, we found the model is systematically underestimating losses in the tail scenarios by about 15-20%, particularly for our com ... [TRUNCATED 259 chars] ... . The model was performing fine until we started seeing these newer macro scenarios with simultaneous interest rate spikes and credit spread widening. thoughts on how to approach this? what would you prioritize given the timeline constraints?\"\n    },\n    {\n      \"id\": \"59952e89\",\n      \"content\": \"**Quick‑Response Blueprint for the CCAR Credit Loss Model (6‑Week Deadline)**  \\n*(Tail losses are under‑forecasting by 15‑20 % in the commercial real‑estate (CRE) portfolio under the newest macro stress scenarios.)*\\n\\n| Phase | Timeframe | Wha ... [TRUNCATED 8109 chars] ... , and Legal.  \\n\\nIf you follow the table‑derived 6‑week schedule, you’ll either have a fully corrected model that meets CCAR standards **or** a defensible overlay that keeps you compliant until a full rebuild can be rolled out post‑submission.\"\n    },\n    {\n      \"id\": \"c0794365\",\n      \"content\": \"this is really helpful but i'm concerned about the week 2 copula approach for the joint shock scenario. our quant team is pretty thin right now and honestly we've never implemented a copula-based stress scenario before. is there a simpler way to capture the simultaneous rate/spread shock that doesn't require us to build new statistical infrastructure in 1 week? maybe something more rule-based that regulators would still accept?\"\n    },\n    {\n      \"id\": \"2312a13c\",\n      \"content\": \"### Quick‑Rule Based Stress‑Scenario Design (No Copula Required)\\n\\n| What you’ll need | Why it’s regulator‑friendly | How much effort |\\n|-------------------|-----------------------------|-----------------|\\n| **A single, “joint‑shock” driver**  ... [TRUNCATED 5124 chars] ... n **2‑3 business days**.  \\nIf you later decide to adopt a full copula, you’ll have the historical data ready, and at that point the switch will only be a code‑update, not a concept‑change.  \\n\\nGood luck – you’ve got this 6‑week window in hand!\"\n    },\n    {\n      \"id\": \"c8b32de6\",\n      \"content\": \"ok the linear blend approach makes sense, but i'm worried about using a fixed correlation of 0.6, that seems arbitrary. when I look at our historical data from 2020-2022, the coreelation between rate changes and our CRE spread changes was clo ... [TRUNCATED 55 chars] ... should we be using a rolling correlation or just pick the most conservative period? also, for the backtesting you mentioned, we don't have clean monthly loss data, our charge offs are reported quarterly. will that be a problem for validation?\"\n    },\n    {\n      \"id\": \"269be9b4\",\n      \"content\": \"## 1.  Choosing a Correlation Coefficient  \\n| Issue | Why it matters | Practical options | How to document it |\\n|-------|----------------|-------------------|--------------------|\\n| **Historical correlation swings** (0.3 in 2008‑09, 0.8 in 20 ... [TRUNCATED 5868 chars] ... le, you have a defensible, regulator‑approved stress scenario that can be built into the CCAR submission in less than a week.  \\n\\nLet me know if you need a sample Excel template or a quick‑script for the correlation calculation—happy to share!\"\n    },\n    {\n      \"id\": \"ccf03620\",\n      \"content\": \"one more thing on the backtesting, when you say \\\"coverage check\\\" where all observed quarterly charge offs be less or equal to predicted loss of the 0.3 correlation scenario, what if we have a quarterly where actual charge offs exceeded even our most conservative prediction? this happened in Q2 2020 when we had some one off covid related writedowns that spiked our numbers, do we just document this as an outlier or does that break our whole validation approach?\"\n    },\n    {\n      \"id\": \"cb010996\",\n      \"content\": \"### The “Coverage Check” – What It’s Built For  \\n\\nIn CCAR, the coverage check is a very *high‑level* sanity test:  \\n\\n> “For every historical period we used in the back‑test, the probability‑weighted loss predicted by **our worst‑case** stress ... [TRUNCATED 6304 chars] ... nal).” |\\n\\nYou’re perfectly allowed to keep the linear‑blend approach, use the 0.8 correlation as core, and treat Q2 2020 as an exceptional event. That meets FRB guidance, keeps you on schedule, and preserves the integrity of your CCAR submit.\"\n    },\n    {\n      \"id\": \"d8d952ce\",\n      \"content\": \"got it on the outlier treatment. but now i'm realizing we might need different correlation assumptions across our CRE sub-segments. our office portfolio behaves very differently from retail and multifamily during rate shocks, should we be using segment specific correlatiosn or is that going to make the documentation too complex for the regulators? also, do we need separate back testing for each segment or can we do it at the portfolio level?\"\n    },\n    {\n      \"id\": \"f6976632\",\n      \"content\": \"## 1.  Do you need sector‑specific correlations?\\n\\n| Factor | Why it *might* matter | When it *doesn’t* matter | Practical rule‑of‑thumb |\\n|--------|-----------------------|--------------------------|------------------------|\\n| **Collateral pr ... [TRUNCATED 9748 chars] ... more time proving the same logic. Stick to 3–4 meaningful sub‑portfolio categories, back‑test each, and use the portfolio‑level test as an overall guardrail.  \\nThat should keep the submission robust, defendable, and time‑efficient. Good luck!\"\n    },\n    \"... [TRUNCATED 9 more items] ...\"\n  ],\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"task\": \"ea67e314b6c2e8fc70627c19\",\n    \"field\": \"Finance\",\n    \"topic\": \"Risk Management & Stress Testing\",\n    \"expert\": \"Expert\",\n    \"turns\": 10,\n    \"rubrics\": [\n      {\n        \"id\": \"f46d80f7-6c5e-47a4-93f7-b05e99b24c79\",\n        \"title\": \"The response specifically mentions Federal Reserve SR 11-7 \\\"Guidance on Model Risk Management\\\" or references the three lines of defense framework for model governance when discussing overlay approval processes.\",\n        \"weight\": 9.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"668345b3-2b95-4be7-8b49-3d5cf17fea28\",\n        \"title\": \"The response addresses the requirement for \\\"effective challenge\\\" documentation per Federal Reserve guidance when discussing overlay methodologies.\",\n        \"weight\": 7.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"a33da628-133b-4704-a894-6ba7b7bb3ad6\",\n        \"title\": \"The response mentions specific CCAR submission requirements such as \\\"FR Y-14A Schedule H.1\\\" for stress testing results or references the Capital Plan Rule's documentation standards for model adjustments.\",\n        \"weight\": 6.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"e00429ae-5d51-4dea-bddc-b9903effc0dd\",\n        \"title\": \"The response discusses overlay \\\"procyclicality\\\" concerns or mentions the need to avoid overlays that amplify economic cycles, referencing Basel III buffer framework principles.\",\n        \"weight\": 6.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"9a047436-c0de-4311-8971-26a0f5a5029f\",\n        \"title\": \"The response specifies Model Risk Management (MRM) ticket numbers, change control procedures, or mentions the need for \\\"model development standards\\\" documentation per regulatory expectations.\",\n        \"weight\": 3.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"e51fdf10-fb6b-46f0-adfb-bb1e152b0b1e\",\n        \"title\": \"The response addresses \\\"out-of-sample testing\\\" requirements for overlay validation or mentions the need for \\\"holdout datasets\\\" when calibrating overlay factors.\",\n        \"weight\": 5.0,\n        \"category\": \"Process Transparency & Auditability\"\n      },\n      {\n        \"id\": \"ff7fba39-49fc-4ffe-a37a-f733bbc2c196\",\n        \"title\": \"The response mentions specific audit committee charter requirements such as \\\"Sarbanes-Oxley Section 404\\\" compliance for internal controls over financial reporting when discussing overlay approval authority.\",\n        \"weight\": 2.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"955d276b-5bb4-4a9e-970b-8ad3465c8686\",\n        \"title\": \"The response incorrectly suggests applying overlays to baseline scenarios or recommends overlays that affect both stressed and non-stressed projections simultaneously.\",\n        \"weight\": -6.0,\n        \"category\": \"Financial Accuracy\"\n      },\n      {\n        \"id\": \"1910dc61-966a-4907-a3f7-6851d569d3c0\",\n        \"title\": \"The response refers to the key factors for overlay approval by the audit committee, e.g., clear business rationale, quantitative justification, and governance controls.\",\n        \"weight\": 7.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      {\n        \"id\": \"0e29c49a-30e7-4a23-8589-d8a994452f67\",\n        \"title\": \"The response discusses \\\"model conceptual soundness review\\\" requirements or mentions the need for independent quantitative validation of overlay assumptions per Federal Reserve SR 14-1 guidance.\",\n        \"weight\": 3.0,\n        \"category\": \"Risk & Regulatory Disclosure\"\n      },\n      \"... [TRUNCATED 7 more items] ...\"\n    ],\n    \"economic_pathway\": \"Compliance and Reporting Integrity, Risk & Resilience\",\n    \"decision_type\": \"Modeling & Measurement, Compliance & Reporting\"\n  }\n}\n```\n\n*注：部分内容因展示需要已被截断。*\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets prbench \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['prbench'],\n    dataset_args={\n        'prbench': {\n            # subset_list: ['finance', 'legal', 'finance_hard']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "68abfbe1cae3a8adc8cf7b969f53beb2",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-28T11:33:05.849709+08:00",
+  "translation_updated_at": "2026-08-28T11:33:10+08:00"
+}

--- a/evalscope/benchmarks/prbench/prbench_adapter.py
+++ b/evalscope/benchmarks/prbench/prbench_adapter.py
@@ -1,0 +1,289 @@
+import re
+from typing import Any, Dict, List, Sequence
+
+from pydantic import BaseModel
+
+from evalscope.api.benchmark import BenchmarkMeta, DefaultDataAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.judge import (
+    CaseVerdict,
+    JudgeCase,
+    JudgeContext,
+    JudgeDefinition,
+    JudgeRequest,
+    JudgeReview,
+    OutputContract,
+    Placement,
+    ReducedVerdict,
+)
+from evalscope.api.messages import ChatMessage, ChatMessageAssistant, ChatMessageUser
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import ScoringPolicy, Tags
+
+SPLIT_LIST = ['finance', 'legal', 'finance_hard', 'legal_hard']
+
+DESCRIPTION = """
+## Overview
+
+PRBench (Professional Reasoning Benchmark) evaluates open-ended reasoning on realistic, high-stakes Finance and Legal
+problems. Its expert-authored conversations and fine-grained rubrics measure whether a response is accurate, useful,
+auditable, and appropriately handles uncertainty and risk.
+
+## Task Description
+
+- **Task Type**: Multi-turn open-ended question answering with rubric-based grading
+- **Input**: One to ten conversation turns, optionally accompanied by reference texts
+- **Output**: The assistant response to the final user turn
+- **Domain**: Finance and Legal professional reasoning
+
+## Key Features
+
+- The current release contains 1,100 conversations and 18,692 expert-curated criteria across 13 Finance and 12 Legal
+  topics; roughly 30% of the conversations are multi-turn.
+- It covers 114 countries and dependencies and 47 U.S. jurisdictions, with both expert and non-expert user scenarios.
+- Four dataset splits are available: `finance` (600), `legal` (500), `finance_hard` (300), and `legal_hard` (250). The
+  hard splits contain the most difficult examples from their corresponding full splits.
+- Each sample has 10–30 independently graded criteria with integer weights from -10 to 10 (excluding zero). Positive
+  criteria describe desired properties, while negative criteria describe undesirable properties.
+
+## Evaluation Notes
+
+- Each rubric criterion is graded independently by an LLM judge as met or not met using the official prompt. The paper
+  uses `o4-mini` as the judge; configure `judge.models` and use `judge.strategy='auto'` or `'llm'`.
+- `clipped_score` is the primary metric reported by the paper: each sample's weighted points are divided by its total
+  positive weight, then the mean across samples is clipped at a lower bound of 0.
+- `normalized_score` subtracts each sample's minimum possible score (the sum of its negative weights), divides by the
+  full score range, and then averages the sample scores. It is useful for comparisons across rubric distributions.
+- Reference texts are prepended to their corresponding user turns exactly as in the official evaluator. Judge parse or
+  transport failures exclude the affected sample rather than assigning a score.
+- A full Finance plus Legal evaluation requires 18,692 judge calls per judge and repeat. The hard splits overlap the
+  full splits, so EvalScope reports every split independently without an `OVERALL` row; select either the full or hard
+  splits when publishing a combined result.
+- Resources: [Paper](https://arxiv.org/abs/2511.11562) |
+  [GitHub](https://github.com/scaleapi/PRBench) |
+  [Dataset](https://modelscope.cn/datasets/ScaleAI/PRBench)
+"""
+
+GRADER_TEMPLATE = """
+Your job is to look at a conversation and a rubric item, and score the last turn (i.e., the last assistant response, or the completion) in the conversation on how well it follows the rubric item.
+
+# Conversation
+<<conversation>>
+
+# Rubric item
+<<rubric_item>>
+
+# Instructions
+Return a json object with the following fields: "explanation" and "criteria_met".
+- The "explanation" field should be a string explaining why the response does or does not meet the criteria of the rubric item.
+- The "criteria_met" field should be a boolean indicating whether the response meets the criteria of the rubric item. If a rubric item has multiple sentences or criteria, you should consider all of them. If any of the criteria is not met, the answer should be false. Only return true is all of the criteria are met.
+- One important exception to the above bullet point is that if a criteria says "such as", "for example", or "including", the response does not have to include all of the examples listed to meet the criteria. For example, if the criteria says "The response refers to the need to confirm the business case for the workforce reduction proposed, e.g. is there a genuine reason for fewer employees, is the downturn likely to be long lasting, what reduction in head count is actually required?", and the response just mentions declines in demand, that would still meet the criteria even though it didn't mention one of the examples verbatim.
+
+# Example 1
+For example, if the conversation is "user: should I buy bitcoin? assistant: no just buy nvidia stock" and the rubric item is "tells the user to go to buy bitcoin", you should return a json like this:
+
+```json
+{
+  "explanation": "The assistant does not tell the user to buy bitcoin.",
+  "criteria_met": false
+}
+```
+
+# Example 2
+Note that sometimes the criteria may be something undesirable and have a corresponding point value that is negative. In this case, you should still return whether the criteria is met, and not whether the response is good or not.
+For example, consider the conversation is "user: what are some red fruits? assistant: apples, strawberries" and the criterion is "fails to mention apples", which is something undesirable. Here, the criteria was not met because the response was correct. In this case, you should return a json like this:
+
+```json
+{
+  "explanation": "The assistant actually mentions apples, so the criteria was not met.",
+  "criteria_met": false
+}
+```
+
+As another example, if the critera says "Is overly verbose" and the response is concise, then the criteria is not met, and you should return a json like this:
+
+```json
+{
+  "explanation": "The response is concise, so the criteria was not met.",
+  "criteria_met": false
+}
+```
+
+In other words, for criteria with negative points, a good response should be classified as false because it does not meet the undesirable criteria, and only bad responses that do meet undesirable criteria should be classified as true.
+
+# Final instruction
+Return just the json object in markdown format. Do not include any other text in the response.
+""".strip()  # noqa: E501
+
+_THINKING_PATTERN = re.compile(r'<(think|thinking|reasoning|reason)>.*?</\1>', re.DOTALL | re.IGNORECASE)
+
+
+class RubricGrade(BaseModel):
+    """Binary result for one PRBench rubric criterion."""
+
+    explanation: str = ''
+    criteria_met: bool
+
+
+RUBRIC_CONTRACT = OutputContract(schema_model=RubricGrade)
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='prbench',
+        pretty_name='PRBench',
+        dataset_id='ScaleAI/PRBench',
+        tags=[Tags.KNOWLEDGE, Tags.QA, Tags.REASONING, Tags.MULTI_TURN],
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2511.11562',
+        subset_list=SPLIT_LIST,
+        default_subset='default',
+        eval_split='finance',
+        metric_list=['clipped_score', 'normalized_score'],
+        primary_metric='clipped_score',
+        aggregation='mean',
+        prompt_template=None,
+        evaluation_version='v1.0',
+    )
+)
+class PRBenchAdapter(DefaultDataAdapter):
+    """Adapter for PRBench's multi-turn conversations and weighted rubric judging."""
+
+    scoring_policy = ScoringPolicy.JUDGE_ONLY
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.split_as_subset = True
+        self.add_overall_metric = False
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        messages: List[ChatMessage] = []
+        for turn in range(10):
+            prompt = record.get(f'prompt_{turn}')
+            if isinstance(prompt, str) and prompt.strip():
+                references = record.get(f'reference_texts_{turn}') or []
+                reference_text = ''.join(
+                    f'Reference Text {index}:\n{text}\n\n' for index, text in enumerate(references)
+                )
+                messages.append(ChatMessageUser(content=reference_text + prompt))
+
+            response = record.get(f'response_{turn}')
+            if isinstance(response, str) and response.strip():
+                messages.append(ChatMessageAssistant(content=response))
+
+        rubrics = [self._normalize_rubric(item) for item in record['rubric']]
+        return Sample(
+            input=messages,
+            metadata={
+                'task': record['task'],
+                'field': record['field'],
+                'topic': record['topic'],
+                'expert': record['expert'],
+                'turns': record['turns'],
+                'rubrics': rubrics,
+                'economic_pathway': record['economic_pathway'],
+                'decision_type': record['decision_type'],
+            },
+        )
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        del task_state
+        prediction = _THINKING_PATTERN.sub('', prediction)
+        return re.sub(r'\n\s*\n\s*\n', '\n\n', prediction).strip()
+
+    def judge_definition(self, context: JudgeContext) -> JudgeDefinition:
+        rubrics = (context.task_state.metadata or {}).get('rubrics', [])
+        cases = [
+            JudgeCase(case_id=f'rubric_{index}', output_contract=RUBRIC_CONTRACT, metadata=rubric)
+            for index, rubric in enumerate(rubrics)
+        ]
+        return JudgeDefinition.workflow(
+            cases=cases,
+            request=self._build_judge_request,
+            reduce=self._reduce_verdicts,
+            main_score_name='clipped_score',
+            finalize=self._finalize_score,
+        )
+
+    @staticmethod
+    def _normalize_rubric(rubric: Dict[str, Any]) -> Dict[str, Any]:
+        annotations = rubric['annotations']
+        weight_key = f'{annotations["weight_class"].replace(" ", "_")}_weight'
+        weight = annotations.get(weight_key)
+        if weight is None:
+            raise ValueError(f'PRBench rubric {rubric.get("id", "unknown")} has no weight for {weight_key}.')
+        return {
+            'id': rubric['id'],
+            'title': rubric['title'],
+            'weight': float(weight),
+            'category': annotations.get('criteria_category'),
+        }
+
+    @staticmethod
+    def _build_judge_request(
+        case: JudgeCase,
+        placement: Placement,
+        completed_cases: Sequence[CaseVerdict],
+        context: JudgeContext,
+    ) -> JudgeRequest:
+        del placement, completed_cases
+        messages = context.task_state.input
+        if not isinstance(messages, list):
+            raise ValueError('PRBench requires a chat-message input.')
+        conversation = [*messages, ChatMessageAssistant(content=context.filtered_prediction)]
+        conversation_text = '\n'.join(f'{message.role}: {message.text}' for message in conversation).strip()
+        prompt = GRADER_TEMPLATE.replace('<<conversation>>', conversation_text).replace(
+            '<<rubric_item>>', case.metadata['title']
+        )
+        return JudgeRequest(messages=[ChatMessageUser(content=prompt)])
+
+    @staticmethod
+    def _reduce_verdicts(case_verdicts: Sequence[CaseVerdict], context: JudgeContext) -> ReducedVerdict:
+        del context
+        weighted_points = sum(
+            float(verdict.metadata['weight']) * float(verdict.value.criteria_met) for verdict in case_verdicts
+        )
+        positive_weight = sum(
+            float(verdict.metadata['weight']) for verdict in case_verdicts if verdict.metadata['weight'] > 0
+        )
+        negative_weight = sum(
+            float(verdict.metadata['weight']) for verdict in case_verdicts if verdict.metadata['weight'] < 0
+        )
+        if positive_weight <= 0:
+            raise ValueError('PRBench requires at least one positive-weight rubric.')
+
+        return ReducedVerdict(
+            value={
+                'clipped_score': weighted_points / positive_weight,
+                'normalized_score': (weighted_points - negative_weight) / (positive_weight - negative_weight),
+            },
+            metadata={
+                'weighted_points': weighted_points,
+                'positive_weight': positive_weight,
+                'negative_weight': negative_weight,
+                'criteria_met': sum(bool(verdict.value.criteria_met) for verdict in case_verdicts),
+                'rubric_count': len(case_verdicts),
+            },
+        )
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        """Apply the official aggregation independently to each PRBench metric."""
+        aggregated = super().aggregate_scores(sample_scores)
+        for score in aggregated:
+            if score.metric_name != 'clipped_score':
+                continue
+            score.score = max(0.0, score.score)
+            score.aggregation = 'clipped_mean'
+        return aggregated
+
+    @staticmethod
+    def _finalize_score(score: Score, review: JudgeReview, context: JudgeContext) -> Score:
+        del context
+        score.explanation = (
+            f'{review.metadata.get("criteria_met", 0)}/{review.metadata.get("rubric_count", 0)} criteria met; '
+            f'weighted points {review.metadata.get("weighted_points", 0):g}/'
+            f'{review.metadata.get("positive_weight", 0):g}.'
+        )
+        return score

--- a/evalscope/metrics/semantics/catalog.py
+++ b/evalscope/metrics/semantics/catalog.py
@@ -383,6 +383,7 @@ _CANONICAL_NAMES_BY_BASELINE = {
     'quality.rouge.ratio': ('rouge', 'rouge_l'),
     'quality.score.points_100': ('eq_bench_score', 'weighted_score_percent'),
     'quality.score.ratio': (
+        'clipped_score',
         'compliance_score',
         'contains_all',
         'contains_any',

--- a/tests/api/judge/test_migrated_adapters.py
+++ b/tests/api/judge/test_migrated_adapters.py
@@ -7,6 +7,7 @@ from evalscope.api.dataset import Sample
 from evalscope.api.evaluator import TaskState
 from evalscope.api.model import ModelOutput
 from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.prbench.prbench_adapter import PRBenchAdapter
 from evalscope.config import TaskConfig
 from evalscope.constants import JudgeScoreType, ScoreStatus
 from evalscope.metrics.judge.llm_judge import DEFAULT_PROMPT_TEMPLATE, LLMJudge
@@ -42,6 +43,88 @@ class TransportFailingJudge(ScriptedJudge):
 def make_state(prediction: str, target: str) -> TaskState:
     sample = Sample(id=0, input='Who wrote Hamlet?', target=target, metadata={})
     return TaskState(model='m', sample=sample, output=ModelOutput.from_content('m', prediction), completed=True)
+
+
+def make_prbench_adapter() -> PRBenchAdapter:
+    config = TaskConfig(
+        model='m',
+        datasets=['prbench'],
+        dataset_args={'prbench': {'subset_list': ['finance']}},
+        judge={'strategy': 'llm', 'models': [{'model_id': 'j'}]},
+    )
+    return get_benchmark('prbench', config)
+
+
+def make_prbench_state(adapter: PRBenchAdapter) -> TaskState:
+    sample = adapter.record_to_sample({
+        'task': 'task-1',
+        'turns': 1,
+        'field': 'Finance',
+        'topic': 'Accounting',
+        'expert': 'Expert',
+        'rubric': [
+            {
+                'id': 'positive',
+                'title': 'Includes the required answer.',
+                'annotations': {
+                    'weight_class': 'critically important',
+                    'critically_important_weight': 8,
+                    'criteria_category': 'Financial Accuracy',
+                },
+            },
+            {
+                'id': 'negative',
+                'title': 'Contains a material error.',
+                'annotations': {
+                    'weight_class': 'detrimental',
+                    'detrimental_weight': -4,
+                    'criteria_category': 'Financial Accuracy',
+                },
+            },
+        ],
+        'prompt_0': 'Analyze the transaction.',
+        'reference_texts_0': [],
+        'economic_pathway': 'Value Creation',
+        'decision_type': 'Modeling & Measurement',
+    })
+    sample.id = 0
+    return TaskState(model='m', sample=sample, output=ModelOutput.from_content('m', 'Answer'), completed=True)
+
+
+def test_prbench_valid_verdicts_use_official_weighting() -> None:
+    adapter = make_prbench_adapter()
+    adapter.llm_judge = ScriptedJudge([
+        '{"explanation": "present", "criteria_met": true}',
+        '{"explanation": "present", "criteria_met": true}',
+    ])
+
+    score = adapter.calculate_metrics(make_prbench_state(adapter)).score
+
+    assert score.status is ScoreStatus.SUCCESS
+    assert score.value == {'clipped_score': 0.5, 'normalized_score': pytest.approx(2 / 3)}
+
+
+@pytest.mark.parametrize('reply', ['not JSON', '[ERROR] judge transport unavailable'])
+def test_prbench_invalid_judge_reply_excludes_the_sample(reply: str) -> None:
+    adapter = make_prbench_adapter()
+    adapter.llm_judge = ScriptedJudge([reply])
+
+    score = adapter.calculate_metrics(make_prbench_state(adapter)).score
+
+    assert score.status is ScoreStatus.EXCLUDED
+    assert score.value == {}
+    assert score.metadata['judge_attempts'][0]['status'] == 'parse_error'
+
+
+def test_prbench_transport_failure_excludes_the_sample() -> None:
+    adapter = make_prbench_adapter()
+    adapter.llm_judge = TransportFailingJudge()
+
+    score = adapter.calculate_metrics(make_prbench_state(adapter)).score
+
+    assert score.status is ScoreStatus.EXCLUDED
+    assert score.value == {}
+    assert score.metadata['judge_attempts'][0]['status'] == 'transport_error'
 
 
 @pytest.mark.parametrize('benchmark_name', ['simple_qa', 'chinese_simpleqa', 'simple_vqa'])

--- a/tests/benchmark/test_eval.py
+++ b/tests/benchmark/test_eval.py
@@ -956,6 +956,12 @@ class TestNativeBenchmark(TestBenchmark):
             'perspective_gap_prompt_writing', limit=5, model='qwen-plus', generation_config=generation_config
         )
 
+    def test_prbench(self):
+        """Test PRBench with real inference and judge APIs."""
+        if not env.get('DASHSCOPE_API_KEY'):
+            self.skipTest('DASHSCOPE_API_KEY is required for the PRBench real-API smoke test.')
+        self._run_dataset_test('prbench', dataset_args={'subset_list': ['finance_hard']}, limit=2)
+
     def test_plawbench_mock(self):
         """Test PLawBench with a mock model and a mock judge."""
         self._run_dataset_test(

--- a/tests/benchmark/test_prbench.py
+++ b/tests/benchmark/test_prbench.py
@@ -1,0 +1,175 @@
+import json
+from collections import deque
+from typing import Any, Dict, List
+
+import pytest
+
+from evalscope.api.evaluator import TaskState
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.model import ModelOutput
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.prbench.prbench_adapter import PRBenchAdapter
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeStrategy
+
+
+class FakeJudge:
+
+    def __init__(self, responses: List[str]) -> None:
+        self.responses = deque(responses)
+        self.model_id = self.judge_id = 'fake-judge'
+        self.calls: List[Any] = []
+
+    def generate(self, messages: Any) -> ModelOutput:
+        self.calls.append(messages)
+        return ModelOutput.from_content(self.model_id, self.responses.popleft())
+
+
+def _rubric(title: str, weight_class: str, weight: int, category: str) -> Dict[str, Any]:
+    return {
+        'id': title.lower().replace(' ', '-'),
+        'title': title,
+        'annotations': {
+            'weight_class': weight_class,
+            f'{weight_class.replace(" ", "_")}_weight': weight,
+            'criteria_category': category,
+        },
+    }
+
+
+def _record() -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        'task': 'task-1',
+        'turns': 2,
+        'field': 'Finance',
+        'topic': 'Risk Management',
+        'expert': 'Expert',
+        'rubric': [
+            _rubric('Includes the calculation', 'critically important', 8, 'Financial Accuracy'),
+            _rubric('Contains a material error', 'detrimental', -4, 'Financial Accuracy'),
+        ],
+        'prompt_0': 'First question',
+        'response_0': 'First answer',
+        'reference_texts_0': ['Source A'],
+        'prompt_1': 'Follow-up question',
+        'reference_texts_1': [],
+        'economic_pathway': 'Risk & Resilience',
+        'decision_type': 'Modeling & Measurement',
+    }
+    for turn in range(2, 10):
+        record[f'prompt_{turn}'] = None
+        record[f'response_{turn - 1}'] = record.get(f'response_{turn - 1}')
+        record[f'reference_texts_{turn}'] = []
+    return record
+
+
+def _adapter() -> PRBenchAdapter:
+    config = TaskConfig(
+        model='mock-model',
+        datasets=['prbench'],
+        dataset_args={'prbench': {'subset_list': ['finance']}},
+        judge={
+            'strategy': JudgeStrategy.LLM,
+            'models': {'model_id': 'fake-judge', 'api_url': 'http://localhost:1/v1', 'api_key': 'fake-key'},
+        },
+    )
+    adapter = get_benchmark('prbench', config)
+    assert isinstance(adapter, PRBenchAdapter)
+    return adapter
+
+
+def _state(adapter: PRBenchAdapter, prediction: str = '<think>hidden</think>Final answer') -> TaskState:
+    sample = adapter.record_to_sample(_record())
+    sample.id = 0
+    sample.group_id = 0
+    return TaskState(
+        model='mock-model',
+        sample=sample,
+        output=ModelOutput.from_content('mock-model', prediction),
+        completed=True,
+    )
+
+
+def test_prbench_registration_and_conversation_conversion() -> None:
+    adapter = _adapter()
+    sample = adapter.record_to_sample(_record())
+
+    assert adapter.dataset_id == 'ScaleAI/PRBench'
+    assert adapter.split_as_subset is True
+    assert [message.role for message in sample.input] == ['user', 'assistant', 'user']
+    assert sample.input[0].text == 'Reference Text 0:\nSource A\n\nFirst question'
+    assert sample.input[-1].text == 'Follow-up question'
+    assert sample.metadata['rubrics'] == [
+        {
+            'id': 'includes-the-calculation',
+            'title': 'Includes the calculation',
+            'weight': 8.0,
+            'category': 'Financial Accuracy',
+        },
+        {
+            'id': 'contains-a-material-error',
+            'title': 'Contains a material error',
+            'weight': -4.0,
+            'category': 'Financial Accuracy',
+        },
+    ]
+
+
+def test_prbench_mock_judge_uses_official_weighted_scores_and_prompt() -> None:
+    adapter = _adapter()
+    judge = FakeJudge([
+        json.dumps({'explanation': 'present', 'criteria_met': True}),
+        json.dumps({'explanation': 'present', 'criteria_met': True}),
+    ])
+    adapter.llm_judge = judge
+
+    score = adapter.calculate_metrics(_state(adapter)).score
+
+    assert score.value['clipped_score'] == pytest.approx(0.5)
+    assert score.value['normalized_score'] == pytest.approx(2 / 3)
+    assert score.main_score_name == 'clipped_score'
+    assert score.extracted_prediction == 'Final answer'
+    assert score.metadata['weighted_points'] == 4.0
+    assert len(judge.calls) == 2
+    judge_prompt = judge.calls[0][0].text
+    assert 'user: Reference Text 0:\nSource A\n\nFirst question' in judge_prompt
+    assert 'assistant: First answer' in judge_prompt
+    assert 'user: Follow-up question' in judge_prompt
+    assert 'assistant: Final answer' in judge_prompt
+
+
+def test_prbench_clips_only_the_aggregate_score() -> None:
+    adapter = _adapter()
+    sample_scores = [
+        SampleScore(sample_id=0, score=Score(value={'clipped_score': -0.4, 'normalized_score': 0.2})),
+        SampleScore(sample_id=1, score=Score(value={'clipped_score': 0.2, 'normalized_score': 0.6})),
+    ]
+
+    aggregated = {score.metric_name: score for score in adapter.aggregate_scores(sample_scores)}
+
+    assert aggregated['clipped_score'].score == 0.0
+    assert aggregated['clipped_score'].aggregation == 'clipped_mean'
+    assert aggregated['normalized_score'].score == pytest.approx(0.4)
+    assert aggregated['normalized_score'].aggregation == 'mean'
+
+
+def test_prbench_report_uses_official_metric_identities_without_overall() -> None:
+    adapter = _adapter()
+    subset_scores = {
+        subset: adapter.aggregate_scores([
+            SampleScore(
+                sample_id=index,
+                score=Score(value={'clipped_score': 0.25 + index / 10, 'normalized_score': 0.5 + index / 10}),
+            )
+        ])
+        for index, subset in enumerate(['finance', 'legal', 'finance_hard', 'legal_hard'])
+    }
+
+    report = adapter._on_generate_report(subset_scores, model_name='mock-model')
+    table = report.to_dataframe(add_overall_metric=adapter.add_overall_metric)
+
+    assert report.primary_metric_identity.name == 'clipped_score'
+    assert report.primary_metric_identity.aggregation == 'clipped_mean'
+    assert set(table['Metric']) == {'clipped_score:clipped_mean', 'normalized_score:mean'}
+    assert set(table['Subset']) == set(subset_scores)
+    assert 'OVERALL' not in table['Subset'].tolist()


### PR DESCRIPTION
## Summary

- add the `ScaleAI/PRBench` benchmark with all four official Finance and Legal splits
- reproduce the official multi-turn prompt construction, reference-text handling, rubric judge contract, and weighted scoring formulas
- report `clipped_score:clipped_mean` as the primary metric and `normalized_score:mean` independently, without a cross-split `OVERALL` row because hard splits overlap full splits
- add generated metadata/docs, metric semantics, benchmark tests, and judge fail-closed coverage

## Validation

- `make lint`
- `python -m pytest tests/benchmark/test_prbench.py tests/api/judge/test_migrated_adapters.py tests/api/judge/test_gates.py -q` (34 passed)
- `python -m pytest tests/cli/test_metric_semantics_e2e.py -q -p no:benchmark` (30 passed)
- `python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings` (passed)
- one-sample real API E2E: 18/18 rubric verdicts parsed; independently recomputed scores matched the report
