### PR TITLE
fix(benchmark): handle empty OmniDocBench page metrics

### DIFF
--- a/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
+++ b/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
@@ -164,7 +164,12 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
         """Average official page metrics and compute Overall from the aggregated components."""
         metric_values = defaultdict(list)
         metric_ids = defaultdict(list)
-        for sample_score in sample_scores:
+        scored_sample_scores = [
+            sample_score
+            for sample_score in sample_scores
+            if sample_score.score.status.is_usable and sample_score.score.value
+        ]
+        for sample_score in scored_sample_scores:
             for metric_name, value in sample_score.score.value.items():
                 metric_values[metric_name].append(float(value))
                 metric_ids[metric_name].append(sample_score.sample_id)
@@ -195,8 +200,8 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
                     score=overall,
                     metric_name='normalized_score',
                     aggregation='official',
-                    num=len(sample_scores),
-                    ids=[sample_score.sample_id for sample_score in sample_scores],
+                    num=len(scored_sample_scores),
+                    ids=[sample_score.sample_id for sample_score in scored_sample_scores],
                     metadata={
                         'component_page_denominators': {
                             component: len(metric_values[component]) for component in overall_components

--- a/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
+++ b/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
@@ -75,6 +75,7 @@ OmniDocBench v1.6 evaluates end-to-end document parsing for text, formulas, tabl
         metric_list=[*PAGE_METRICS, 'normalized_score'],
         primary_metric='normalized_score',
         eval_split='test',
+        evaluation_version='v1.1',
         prompt_template=PROMPT_TEMPLATE,
         review_timeout=REVIEW_TIMEOUT,
         sandbox_config=DEFAULT_SANDBOX_CONFIG,
@@ -194,14 +195,19 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
 
         overall_components = ('text_block_Edit_dist', 'display_formula_CDM', 'table_TEDS')
         if all(component in means for component in overall_components):
+            overall_sample_scores = [
+                sample_score
+                for sample_score in scored_sample_scores
+                if any(component in sample_score.score.value for component in overall_components)
+            ]
             overall = ((1.0 - means['text_block_Edit_dist']) + means['display_formula_CDM'] + means['table_TEDS']) / 3.0
             aggregated.append(
                 AggScore(
                     score=overall,
                     metric_name='normalized_score',
                     aggregation='official',
-                    num=len(scored_sample_scores),
-                    ids=[sample_score.sample_id for sample_score in scored_sample_scores],
+                    num=len(overall_sample_scores),
+                    ids=[sample_score.sample_id for sample_score in overall_sample_scores],
                     metadata={
                         'component_page_denominators': {
                             component: len(metric_values[component]) for component in overall_components

--- a/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
+++ b/evalscope/benchmarks/omnidoc_bench/v1_6/omnidoc_bench_v1_6_adapter.py
@@ -12,7 +12,7 @@ from evalscope.api.messages import ChatMessageUser, Content, ContentImage, Conte
 from evalscope.api.metric import AggScore, SampleScore, Score
 from evalscope.api.mixin import CodeExecutionSandboxMixin
 from evalscope.api.registry import register_benchmark
-from evalscope.constants import Tags
+from evalscope.constants import ScoreStatus, Tags
 
 from ..legacy.omnidoc_bench_adapter import PROMPT_TEMPLATE
 from .sandbox_scorer import PAGE_METRICS, build_scoring_program, parse_scoring_result
@@ -148,12 +148,17 @@ class OmniDocBenchV16Adapter(CodeExecutionSandboxMixin, VisionLanguageAdapter):
         program = build_scoring_program(annotation, image_name, original_prediction)
         result = self.execute_code_in_sandbox(program, timeout=int(self.review_timeout), language='python')
         metrics = parse_scoring_result(result)
-        return Score(
+        score = Score(
             value=metrics,
             prediction=original_prediction,
             extracted_prediction=filtered_prediction,
-            main_score_name=next(name for name in PAGE_METRICS if name in metrics),
         )
+        if not metrics:
+            score.status = ScoreStatus.EXCLUDED
+            score.metadata = {'scoring_excluded_reason': 'no_page_metrics'}
+            return score
+        score.main_score_name = next(name for name in PAGE_METRICS if name in metrics)
+        return score
 
     def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
         """Average official page metrics and compute Overall from the aggregated components."""

--- a/evalscope/benchmarks/omnidoc_bench/v1_6/sandbox_scorer.py
+++ b/evalscope/benchmarks/omnidoc_bench/v1_6/sandbox_scorer.py
@@ -136,8 +136,8 @@ def parse_scoring_result(result: Dict[str, Any]) -> Dict[str, float]:
         values = json.loads(payload)
     except json.JSONDecodeError as error:
         raise RuntimeError('Official OmniDocBench v1.6 scoring returned invalid JSON.') from error
-    if not isinstance(values, dict) or not values:
-        raise RuntimeError('Official OmniDocBench v1.6 scoring returned no page metrics.')
+    if not isinstance(values, dict):
+        raise RuntimeError('Official OmniDocBench v1.6 scoring returned a non-object metric result.')
 
     unexpected = sorted(set(values) - set(PAGE_METRICS))
     if unexpected:

--- a/tests/benchmark/test_omnidoc_bench.py
+++ b/tests/benchmark/test_omnidoc_bench.py
@@ -56,6 +56,29 @@ def test_v16_match_score_handles_pages_without_supported_metrics(
         assert score.metadata == {'scoring_excluded_reason': 'no_page_metrics'}
 
 
+def test_v16_aggregation_excludes_unscored_pages_from_normalized_score_count() -> None:
+    adapter = OmniDocBenchV16Adapter.__new__(OmniDocBenchV16Adapter)
+    sample_scores = [
+        SampleScore(
+            sample_id=1,
+            score=Score(
+                value={
+                    'text_block_Edit_dist': 0.2,
+                    'display_formula_CDM': 0.8,
+                    'table_TEDS': 0.7,
+                }
+            ),
+        ),
+        SampleScore(sample_id=2, score=Score(status=ScoreStatus.EXCLUDED)),
+    ]
+
+    aggregated = adapter.aggregate_scores(sample_scores)
+
+    normalized_score = next(score for score in aggregated if score.metric_name == 'normalized_score')
+    assert normalized_score.num == 1
+    assert normalized_score.ids == [1]
+
+
 def test_v16_loads_snapshot_once_and_reads_images_locally(tmp_path: Path) -> None:
     image_names = ['page.png', 'long_' + '页面' * 36 + '.png']
     records = [{'page_info': {'image_path': image_name}} for image_name in image_names]

--- a/tests/benchmark/test_omnidoc_bench.py
+++ b/tests/benchmark/test_omnidoc_bench.py
@@ -9,7 +9,51 @@ from evalscope.api.dataset import DictDataLoader
 from evalscope.api.metric import MetricSelector, SampleScore, Score
 from evalscope.api.registry import get_benchmark
 from evalscope.benchmarks.omnidoc_bench.legacy.omnidoc_bench_adapter import OmniDocBenchAdapter
+from evalscope.benchmarks.omnidoc_bench.v1_6.omnidoc_bench_v1_6_adapter import OmniDocBenchV16Adapter
+from evalscope.benchmarks.omnidoc_bench.v1_6.sandbox_scorer import RESULT_SENTINEL, parse_scoring_result
 from evalscope.config import TaskConfig
+from evalscope.constants import ScoreStatus
+
+
+def _sandbox_result(metrics: dict[str, float]) -> dict[str, str]:
+    return {'status': 'success', 'output': RESULT_SENTINEL + json.dumps(metrics)}
+
+
+def _v16_adapter_with_result(result: dict[str, str]) -> OmniDocBenchV16Adapter:
+    adapter = OmniDocBenchV16Adapter.__new__(OmniDocBenchV16Adapter)
+    adapter._task_config = SimpleNamespace(sandbox=SimpleNamespace(enabled=True))
+    adapter._benchmark_meta = SimpleNamespace(review_timeout=1)
+    adapter.execute_code_in_sandbox = mock.Mock(return_value=result)
+    return adapter
+
+
+@pytest.mark.parametrize(
+    ('metrics', 'expected'),
+    [({}, {}), ({'text_block_Edit_dist': 0.25}, {'text_block_Edit_dist': 0.25})],
+)
+def test_v16_parse_scoring_result_accepts_empty_and_normal_results(
+    metrics: dict[str, float], expected: dict[str, float]
+) -> None:
+    assert parse_scoring_result(_sandbox_result(metrics)) == expected
+
+
+@pytest.mark.parametrize(
+    ('metrics', 'status', 'main_score_name'),
+    [({}, ScoreStatus.EXCLUDED, None), ({'text_block_Edit_dist': 0.25}, ScoreStatus.SUCCESS, 'text_block_Edit_dist')],
+)
+def test_v16_match_score_handles_pages_without_supported_metrics(
+    metrics: dict[str, float], status: ScoreStatus, main_score_name: str | None
+) -> None:
+    adapter = _v16_adapter_with_result(_sandbox_result(metrics))
+    task_state = SimpleNamespace(metadata={'image_name': 'page.png'})
+
+    score = adapter.match_score('prediction', 'prediction', '{}', task_state)
+
+    assert score.value == metrics
+    assert score.status is status
+    assert score.main_score_name == main_score_name
+    if not metrics:
+        assert score.metadata == {'scoring_excluded_reason': 'no_page_metrics'}
 
 
 def test_v16_loads_snapshot_once_and_reads_images_locally(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes https://github.com/modelscope/evalscope/issues/1650

The OmniDocBench v1.6 scorer can return an empty metric object for a page with no supported metric-bearing content. Such pages are now marked excluded instead of aborting the whole run, while malformed and invalid scorer results still fail closed.

The normalized score count and IDs only include pages that contribute to the official Overall components. The benchmark evaluation version moves to v1.1.