### PR TITLE
feat: add OneMillion-Bench benchmark

### DIFF
--- a/docs/en/benchmarks/one_million_bench.md
+++ b/docs/en/benchmarks/one_million_bench.md
@@ -1,0 +1,162 @@
+# $OneMillion-Bench
+
+
+## Overview
+
+$OneMillion-Bench ($1M-Bench) evaluates how well language models and agents complete economically valuable,
+expert-level professional work. The public release contains 400 bilingual tasks written and reviewed by domain
+experts across finance, healthcare, industry, law, and natural science.
+
+## Task Description
+
+- **Task Type**: Open-ended professional question answering with rubric-based LLM judging
+- **Input**: A realistic, context-heavy professional request in Chinese or English
+- **Output**: A complete free-form professional analysis or deliverable
+- **Domain**: Economics and finance, healthcare and medicine, industry, law, and natural sciences
+
+## Key Features
+
+- 400 zero-shot tasks, balanced across Chinese and global tracks and five professional domains (40 tasks per
+  language-domain subset)
+- Each task has 11-37 expert-authored criteria covering factual information, analytical reasoning, instruction
+  following, and structure and formatting
+- Every task includes both positive criteria and negative penalties, with rubric weights ranging from -20 to 12 in
+  the hosted release
+- Samples are exposed as ten language-domain subsets so both the paper's language tracks and domain breakdowns are
+  visible in EvalScope reports
+
+## Evaluation Notes
+
+- An LLM judge is required. Configure `judge.strategy='llm'` (or `'auto'`) and `judge.models`; the official harness
+  currently recommends Gemini 3.1 Pro Preview, but judge identity affects absolute scores and is not hard-coded here
+- All rubrics for one response are judged together in one request using the official binary hit/miss instructions
+- `expert_score` is the weighted sum of hit rubrics divided by the sum of positive weights, clipped to `[0, 1]`;
+  `pass_rate` is 1 when `expert_score >= 0.7`, otherwise 0
+- Judge replies must contain every rubric exactly once. Malformed replies and transport failures are excluded instead
+  of being silently converted to zero scores
+- The official study compares vanilla models, search-enabled models, and deep-research agents separately. This native
+  adapter performs the benchmark's one-turn generation path; results from external tool-using agents are comparable
+  only when their final responses are evaluated under the same judge configuration
+- Tasks often require long, cited reports. Configure sufficiently large generation and judge `max_tokens` values;
+  with one judge and one repeat, a full run performs 400 generation calls and 400 judge calls
+
+Resources: [Paper](https://arxiv.org/abs/2603.07980) |
+[GitHub](https://github.com/humanlaya/OneMillion-Bench) |
+[Dataset](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `one_million_bench` |
+| **Dataset ID** | [evalscope/OneMillion-Bench](https://modelscope.cn/datasets/evalscope/OneMillion-Bench/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2603.07980) |
+| **Tags** | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |
+| **Metrics** | `expert_score`, `pass_rate` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `test` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 400 |
+| Prompt Length (Mean) | 1470.49 chars |
+| Prompt Length (Min/Max) | 105 / 15951 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `global_economics_and_finance` | 40 | 1810.97 | 868 | 3723 |
+| `global_healthcare_and_medicine` | 40 | 2029.97 | 479 | 8870 |
+| `global_industry` | 40 | 2581.15 | 453 | 9538 |
+| `global_law` | 40 | 3277.78 | 404 | 15951 |
+| `global_natural_sciences` | 40 | 1634.65 | 284 | 5775 |
+| `cn_economics_and_finance` | 40 | 555.05 | 111 | 1169 |
+| `cn_healthcare_and_medicine` | 40 | 584.38 | 135 | 2628 |
+| `cn_industry` | 40 | 965.6 | 144 | 7755 |
+| `cn_law` | 40 | 709.55 | 208 | 2041 |
+| `cn_natural_sciences` | 40 | 555.83 | 105 | 1590 |
+
+## Sample Example
+
+**Subset**: `global_economics_and_finance`
+
+```json
+{
+  "input": [
+    {
+      "id": "24273bb5",
+      "content": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+    }
+  ],
+  "target": "[{\"rubric_number\": 1, \"rubric_detail\": \"Mention the high weighting of top US companies (e.g., Top 5 or AI-related stocks) in the index (approximately 30% or more) and identify this as a source of systemic risk.\", \"rubric_weight\": 10, \"rubric_ ... [TRUNCATED 3986 chars] ... c_number\": 16, \"rubric_detail\": \"The report contains hollow concluding remarks (e.g., \\\"In summary,\\\" \\\"We look forward to\\\") or transitional sentences lacking substantive content.\", \"rubric_weight\": -2, \"rubric_tag\": \"Analytical Reasoning\"}]",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "global_economics_and_finance",
+  "metadata": {
+    "id": "e1b94c86-b6c9-43f6-8251-2e513e5efc52",
+    "case_id": 1663,
+    "language": "global",
+    "domain": "Economics and Finance",
+    "topics": [
+      "Economics and Finance",
+      "Financing & M&A",
+      "Mergers & Acquisitions"
+    ],
+    "time_sensitivity": {
+      "time_sensitivity": "Weakly time-sensitive",
+      "year_month": "2025-10",
+      "day": "NA"
+    },
+    "question": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+  }
+}
+```
+
+*Note: Some content was truncated for display.*
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+{question}
+```
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets one_million_bench \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['one_million_bench'],
+    dataset_args={
+        'one_million_bench': {
+            # subset_list: ['global_economics_and_finance', 'global_healthcare_and_medicine', 'global_industry']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/llm.md
+++ b/docs/en/get_started/supported_dataset/llm.md
@@ -113,6 +113,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 | `musr` | [MuSR](../../benchmarks/musr.md) | `MCQ`, `Reasoning` |
 | `ncbi` | [NCBI](../../benchmarks/ncbi.md) | `Knowledge`, `NER` |
 | `needle_haystack` | [Needle-in-a-Haystack](../../benchmarks/needle_haystack.md) | `LongContext`, `Retrieval` |
+| `one_million_bench` | [$OneMillion-Bench](../../benchmarks/one_million_bench.md) | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |
 | `ontonotes5` | [OntoNotes5](../../benchmarks/ontonotes5.md) | `Knowledge`, `NER` |
 | `openai_mrcr` | [OpenAI MRCR](../../benchmarks/openai_mrcr.md) | `LongContext`, `Retrieval` |
 | `perspective_gap_prompt_writing` | [PerspectiveGap Prompt Writing](../../benchmarks/perspective_gap_prompt_writing.md) | `Agent`, `InstructionFollowing` |
@@ -259,6 +260,7 @@ Below is the list of supported LLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/musr.md
 ../../benchmarks/ncbi.md
 ../../benchmarks/needle_haystack.md
+../../benchmarks/one_million_bench.md
 ../../benchmarks/ontonotes5.md
 ../../benchmarks/openai_mrcr.md
 ../../benchmarks/perspective_gap_prompt_writing.md

--- a/docs/zh/benchmarks/one_million_bench.md
+++ b/docs/zh/benchmarks/one_million_bench.md
@@ -1,0 +1,150 @@
+# $OneMillion-Bench
+
+
+## 概述
+
+$OneMillion-Bench（简称 $1M-Bench）用于评估语言模型和智能体在完成具有经济价值的专家级专业工作方面的表现。公开版本包含由金融、医疗、工业、法律和自然科学等领域的专家编写并审核的400个双语任务。
+
+## 任务描述
+
+- **任务类型**：基于评分标准的开放式专业问答，由大语言模型（LLM）进行评判
+- **输入**：一段现实且上下文丰富的中文或英文专业请求
+- **输出**：一份完整的自由格式专业分析报告或交付成果
+- **领域**：经济学与金融、医疗与医学、工业、法律、自然科学
+
+## 核心特性
+
+- 包含400个零样本任务，在中文和全球两条语言赛道及五个专业领域之间均衡分布（每个语言-领域子集包含40个任务）
+- 每个任务包含11至37条由专家编写的评分标准，涵盖事实信息、分析推理、指令遵循以及结构与格式等方面
+- 每个任务同时包含正向评分项和负向扣分项，在公开版本中评分权重范围为 -20 到 12
+- 样本以十个语言-领域子集的形式提供，以便在 EvalScope 报告中清晰展示论文中的语言赛道和领域划分
+
+## 评估说明
+
+- 需要使用 LLM 作为评判器。请配置 `judge.strategy='llm'`（或 `'auto'`）及 `judge.models`；官方评测框架当前推荐使用 Gemini 3.1 Pro Preview，但评判器的选择会影响绝对得分，此处未硬编码指定
+- 对单个回答的所有评分标准将在一次请求中统一评判，并采用官方提供的二元命中/未命中（hit/miss）判断指令
+- `expert_score` 是命中评分项的加权总和除以所有正向权重之和，结果裁剪至 `[0, 1]` 区间；当 `expert_score >= 0.7` 时，`pass_rate` 为 1，否则为 0
+- 评判器回复必须包含每条评分标准恰好一次。格式错误的回复和传输失败将被排除，而非静默转换为零分
+- 官方研究分别比较了基础模型、支持搜索的模型和深度研究型智能体。本原生适配器执行的是基准测试中的单轮生成路径；只有当外部工具调用型智能体的最终回答在相同评判器配置下进行评估时，其结果才具有可比性
+- 任务通常要求生成长篇、带引用的报告。请配置足够大的生成和评判 `max_tokens` 值；使用一个评判器和一次重复运行时，完整评测将执行400次生成调用和400次评判调用
+
+资源链接：[论文](https://arxiv.org/abs/2603.07980) |
+[GitHub](https://github.com/humanlaya/OneMillion-Bench) |
+[数据集](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `one_million_bench` |
+| **数据集ID** | [evalscope/OneMillion-Bench](https://modelscope.cn/datasets/evalscope/OneMillion-Bench/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2603.07980) |
+| **标签** | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |
+| **指标** | `expert_score`, `pass_rate` |
+| **默认示例数** | 0-shot |
+| **评估分割** | `test` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 400 |
+| 提示词长度（平均） | 1470.49 字符 |
+| 提示词长度（最小/最大） | 105 / 15951 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `global_economics_and_finance` | 40 | 1810.97 | 868 | 3723 |
+| `global_healthcare_and_medicine` | 40 | 2029.97 | 479 | 8870 |
+| `global_industry` | 40 | 2581.15 | 453 | 9538 |
+| `global_law` | 40 | 3277.78 | 404 | 15951 |
+| `global_natural_sciences` | 40 | 1634.65 | 284 | 5775 |
+| `cn_economics_and_finance` | 40 | 555.05 | 111 | 1169 |
+| `cn_healthcare_and_medicine` | 40 | 584.38 | 135 | 2628 |
+| `cn_industry` | 40 | 965.6 | 144 | 7755 |
+| `cn_law` | 40 | 709.55 | 208 | 2041 |
+| `cn_natural_sciences` | 40 | 555.83 | 105 | 1590 |
+
+## 样例示例
+
+**子集**: `global_economics_and_finance`
+
+```json
+{
+  "input": [
+    {
+      "id": "24273bb5",
+      "content": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+    }
+  ],
+  "target": "[{\"rubric_number\": 1, \"rubric_detail\": \"Mention the high weighting of top US companies (e.g., Top 5 or AI-related stocks) in the index (approximately 30% or more) and identify this as a source of systemic risk.\", \"rubric_weight\": 10, \"rubric_ ... [TRUNCATED 3986 chars] ... c_number\": 16, \"rubric_detail\": \"The report contains hollow concluding remarks (e.g., \\\"In summary,\\\" \\\"We look forward to\\\") or transitional sentences lacking substantive content.\", \"rubric_weight\": -2, \"rubric_tag\": \"Analytical Reasoning\"}]",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "global_economics_and_finance",
+  "metadata": {
+    "id": "e1b94c86-b6c9-43f6-8251-2e513e5efc52",
+    "case_id": 1663,
+    "language": "global",
+    "domain": "Economics and Finance",
+    "topics": [
+      "Economics and Finance",
+      "Financing & M&A",
+      "Mergers & Acquisitions"
+    ],
+    "time_sensitivity": {
+      "time_sensitivity": "Weakly time-sensitive",
+      "year_month": "2025-10",
+      "day": "NA"
+    },
+    "question": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+  }
+}
+```
+
+*注：部分内容因显示需要已被截断。*
+
+## 提示模板
+
+**提示模板：**
+```text
+{question}
+```
+
+## 使用方法
+
+### 使用命令行（CLI）
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets one_million_bench \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['one_million_bench'],
+    dataset_args={
+        'one_million_bench': {
+            # subset_list: ['global_economics_and_finance', 'global_healthcare_and_medicine', 'global_industry']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/llm.md
+++ b/docs/zh/get_started/supported_dataset/llm.md
@@ -113,6 +113,7 @@
 | `musr` | [MuSR](../../benchmarks/musr.md) | `MCQ`, `Reasoning` |
 | `ncbi` | [NCBI](../../benchmarks/ncbi.md) | `Knowledge`, `NER` |
 | `needle_haystack` | [Needle-in-a-Haystack](../../benchmarks/needle_haystack.md) | `LongContext`, `Retrieval` |
+| `one_million_bench` | [$OneMillion-Bench](../../benchmarks/one_million_bench.md) | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |
 | `ontonotes5` | [OntoNotes5](../../benchmarks/ontonotes5.md) | `Knowledge`, `NER` |
 | `openai_mrcr` | [OpenAI MRCR](../../benchmarks/openai_mrcr.md) | `LongContext`, `Retrieval` |
 | `perspective_gap_prompt_writing` | [PerspectiveGap Prompt Writing](../../benchmarks/perspective_gap_prompt_writing.md) | `Agent`, `InstructionFollowing` |
@@ -259,6 +260,7 @@
 ../../benchmarks/musr.md
 ../../benchmarks/ncbi.md
 ../../benchmarks/needle_haystack.md
+../../benchmarks/one_million_bench.md
 ../../benchmarks/ontonotes5.md
 ../../benchmarks/openai_mrcr.md
 ../../benchmarks/perspective_gap_prompt_writing.md

--- a/evalscope/benchmarks/_meta/one_million_bench.json
+++ b/evalscope/benchmarks/_meta/one_million_bench.json
@@ -1,0 +1,190 @@
+{
+  "meta": {
+    "pretty_name": "$OneMillion-Bench",
+    "dataset_id": "evalscope/OneMillion-Bench",
+    "paper_url": "https://arxiv.org/abs/2603.07980",
+    "tags": [
+      "Agent",
+      "Knowledge",
+      "QA",
+      "Reasoning",
+      "MultiLingual"
+    ],
+    "metrics": [
+      "expert_score",
+      "pass_rate"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "test",
+    "train_split": "",
+    "subset_list": [
+      "global_economics_and_finance",
+      "global_healthcare_and_medicine",
+      "global_industry",
+      "global_law",
+      "global_natural_sciences",
+      "cn_economics_and_finance",
+      "cn_healthcare_and_medicine",
+      "cn_industry",
+      "cn_law",
+      "cn_natural_sciences"
+    ],
+    "description": "\n## Overview\n\n$OneMillion-Bench ($1M-Bench) evaluates how well language models and agents complete economically valuable,\nexpert-level professional work. The public release contains 400 bilingual tasks written and reviewed by domain\nexperts across finance, healthcare, industry, law, and natural science.\n\n## Task Description\n\n- **Task Type**: Open-ended professional question answering with rubric-based LLM judging\n- **Input**: A realistic, context-heavy professional request in Chinese or English\n- **Output**: A complete free-form professional analysis or deliverable\n- **Domain**: Economics and finance, healthcare and medicine, industry, law, and natural sciences\n\n## Key Features\n\n- 400 zero-shot tasks, balanced across Chinese and global tracks and five professional domains (40 tasks per\n  language-domain subset)\n- Each task has 11-37 expert-authored criteria covering factual information, analytical reasoning, instruction\n  following, and structure and formatting\n- Every task includes both positive criteria and negative penalties, with rubric weights ranging from -20 to 12 in\n  the hosted release\n- Samples are exposed as ten language-domain subsets so both the paper's language tracks and domain breakdowns are\n  visible in EvalScope reports\n\n## Evaluation Notes\n\n- An LLM judge is required. Configure `judge.strategy='llm'` (or `'auto'`) and `judge.models`; the official harness\n  currently recommends Gemini 3.1 Pro Preview, but judge identity affects absolute scores and is not hard-coded here\n- All rubrics for one response are judged together in one request using the official binary hit/miss instructions\n- `expert_score` is the weighted sum of hit rubrics divided by the sum of positive weights, clipped to `[0, 1]`;\n  `pass_rate` is 1 when `expert_score >= 0.7`, otherwise 0\n- Judge replies must contain every rubric exactly once. Malformed replies and transport failures are excluded instead\n  of being silently converted to zero scores\n- The official study compares vanilla models, search-enabled models, and deep-research agents separately. This native\n  adapter performs the benchmark's one-turn generation path; results from external tool-using agents are comparable\n  only when their final responses are evaluated under the same judge configuration\n- Tasks often require long, cited reports. Configure sufficiently large generation and judge `max_tokens` values;\n  with one judge and one repeat, a full run performs 400 generation calls and 400 judge calls\n\nResources: [Paper](https://arxiv.org/abs/2603.07980) |\n[GitHub](https://github.com/humanlaya/OneMillion-Bench) |\n[Dataset](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)\n",
+    "prompt_template": "{question}",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "llm",
+    "primary_metric": {
+      "name": "expert_score",
+      "aggregation": null,
+      "dimensions": {}
+    }
+  },
+  "statistics": {
+    "total_samples": 400,
+    "subset_stats": [
+      {
+        "name": "global_economics_and_finance",
+        "sample_count": 40,
+        "prompt_length_mean": 1810.97,
+        "prompt_length_min": 868,
+        "prompt_length_max": 3723,
+        "prompt_length_std": 634.18,
+        "target_length_mean": 5313.43
+      },
+      {
+        "name": "global_healthcare_and_medicine",
+        "sample_count": 40,
+        "prompt_length_mean": 2029.97,
+        "prompt_length_min": 479,
+        "prompt_length_max": 8870,
+        "prompt_length_std": 1575.31,
+        "target_length_mean": 4261.62
+      },
+      {
+        "name": "global_industry",
+        "sample_count": 40,
+        "prompt_length_mean": 2581.15,
+        "prompt_length_min": 453,
+        "prompt_length_max": 9538,
+        "prompt_length_std": 2099.52,
+        "target_length_mean": 4612.4
+      },
+      {
+        "name": "global_law",
+        "sample_count": 40,
+        "prompt_length_mean": 3277.78,
+        "prompt_length_min": 404,
+        "prompt_length_max": 15951,
+        "prompt_length_std": 3584.08,
+        "target_length_mean": 4756.1
+      },
+      {
+        "name": "global_natural_sciences",
+        "sample_count": 40,
+        "prompt_length_mean": 1634.65,
+        "prompt_length_min": 284,
+        "prompt_length_max": 5775,
+        "prompt_length_std": 1138.76,
+        "target_length_mean": 4451.6
+      },
+      {
+        "name": "cn_economics_and_finance",
+        "sample_count": 40,
+        "prompt_length_mean": 555.05,
+        "prompt_length_min": 111,
+        "prompt_length_max": 1169,
+        "prompt_length_std": 227.91,
+        "target_length_mean": 2870.15
+      },
+      {
+        "name": "cn_healthcare_and_medicine",
+        "sample_count": 40,
+        "prompt_length_mean": 584.38,
+        "prompt_length_min": 135,
+        "prompt_length_max": 2628,
+        "prompt_length_std": 500.36,
+        "target_length_mean": 2109.47
+      },
+      {
+        "name": "cn_industry",
+        "sample_count": 40,
+        "prompt_length_mean": 965.6,
+        "prompt_length_min": 144,
+        "prompt_length_max": 7755,
+        "prompt_length_std": 1237.56,
+        "target_length_mean": 2230
+      },
+      {
+        "name": "cn_law",
+        "sample_count": 40,
+        "prompt_length_mean": 709.55,
+        "prompt_length_min": 208,
+        "prompt_length_max": 2041,
+        "prompt_length_std": 450.85,
+        "target_length_mean": 2250.3
+      },
+      {
+        "name": "cn_natural_sciences",
+        "sample_count": 40,
+        "prompt_length_mean": 555.83,
+        "prompt_length_min": 105,
+        "prompt_length_max": 1590,
+        "prompt_length_std": 393.56,
+        "target_length_mean": 2303.55
+      }
+    ],
+    "prompt_length": {
+      "mean": 1470.49,
+      "min": 105,
+      "max": 15951,
+      "std": 1770.97
+    },
+    "target_length_mean": 3515.86,
+    "computed_at": "2026-08-28T10:59:21.667165+08:00"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "24273bb5",
+          "content": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+        }
+      ],
+      "target": "[{\"rubric_number\": 1, \"rubric_detail\": \"Mention the high weighting of top US companies (e.g., Top 5 or AI-related stocks) in the index (approximately 30% or more) and identify this as a source of systemic risk.\", \"rubric_weight\": 10, \"rubric_ ... [TRUNCATED 3986 chars] ... c_number\": 16, \"rubric_detail\": \"The report contains hollow concluding remarks (e.g., \\\"In summary,\\\" \\\"We look forward to\\\") or transitional sentences lacking substantive content.\", \"rubric_weight\": -2, \"rubric_tag\": \"Analytical Reasoning\"}]",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "global_economics_and_finance",
+      "metadata": {
+        "id": "e1b94c86-b6c9-43f6-8251-2e513e5efc52",
+        "case_id": 1663,
+        "language": "global",
+        "domain": "Economics and Finance",
+        "topics": [
+          "Economics and Finance",
+          "Financing & M&A",
+          "Mergers & Acquisitions"
+        ],
+        "time_sensitivity": {
+          "time_sensitivity": "Weakly time-sensitive",
+          "year_month": "2025-10",
+          "day": "NA"
+        },
+        "question": "You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \"risk of sharp market correction\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response."
+      }
+    },
+    "subset": "global_economics_and_finance",
+    "truncated": true
+  },
+  "readme": {
+    "en": "# $OneMillion-Bench\n\n\n## Overview\n\n$OneMillion-Bench ($1M-Bench) evaluates how well language models and agents complete economically valuable,\nexpert-level professional work. The public release contains 400 bilingual tasks written and reviewed by domain\nexperts across finance, healthcare, industry, law, and natural science.\n\n## Task Description\n\n- **Task Type**: Open-ended professional question answering with rubric-based LLM judging\n- **Input**: A realistic, context-heavy professional request in Chinese or English\n- **Output**: A complete free-form professional analysis or deliverable\n- **Domain**: Economics and finance, healthcare and medicine, industry, law, and natural sciences\n\n## Key Features\n\n- 400 zero-shot tasks, balanced across Chinese and global tracks and five professional domains (40 tasks per\n  language-domain subset)\n- Each task has 11-37 expert-authored criteria covering factual information, analytical reasoning, instruction\n  following, and structure and formatting\n- Every task includes both positive criteria and negative penalties, with rubric weights ranging from -20 to 12 in\n  the hosted release\n- Samples are exposed as ten language-domain subsets so both the paper's language tracks and domain breakdowns are\n  visible in EvalScope reports\n\n## Evaluation Notes\n\n- An LLM judge is required. Configure `judge.strategy='llm'` (or `'auto'`) and `judge.models`; the official harness\n  currently recommends Gemini 3.1 Pro Preview, but judge identity affects absolute scores and is not hard-coded here\n- All rubrics for one response are judged together in one request using the official binary hit/miss instructions\n- `expert_score` is the weighted sum of hit rubrics divided by the sum of positive weights, clipped to `[0, 1]`;\n  `pass_rate` is 1 when `expert_score >= 0.7`, otherwise 0\n- Judge replies must contain every rubric exactly once. Malformed replies and transport failures are excluded instead\n  of being silently converted to zero scores\n- The official study compares vanilla models, search-enabled models, and deep-research agents separately. This native\n  adapter performs the benchmark's one-turn generation path; results from external tool-using agents are comparable\n  only when their final responses are evaluated under the same judge configuration\n- Tasks often require long, cited reports. Configure sufficiently large generation and judge `max_tokens` values;\n  with one judge and one repeat, a full run performs 400 generation calls and 400 judge calls\n\nResources: [Paper](https://arxiv.org/abs/2603.07980) |\n[GitHub](https://github.com/humanlaya/OneMillion-Bench) |\n[Dataset](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `one_million_bench` |\n| **Dataset ID** | [evalscope/OneMillion-Bench](https://modelscope.cn/datasets/evalscope/OneMillion-Bench/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2603.07980) |\n| **Tags** | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |\n| **Metrics** | `expert_score`, `pass_rate` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 400 |\n| Prompt Length (Mean) | 1470.49 chars |\n| Prompt Length (Min/Max) | 105 / 15951 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `global_economics_and_finance` | 40 | 1810.97 | 868 | 3723 |\n| `global_healthcare_and_medicine` | 40 | 2029.97 | 479 | 8870 |\n| `global_industry` | 40 | 2581.15 | 453 | 9538 |\n| `global_law` | 40 | 3277.78 | 404 | 15951 |\n| `global_natural_sciences` | 40 | 1634.65 | 284 | 5775 |\n| `cn_economics_and_finance` | 40 | 555.05 | 111 | 1169 |\n| `cn_healthcare_and_medicine` | 40 | 584.38 | 135 | 2628 |\n| `cn_industry` | 40 | 965.6 | 144 | 7755 |\n| `cn_law` | 40 | 709.55 | 208 | 2041 |\n| `cn_natural_sciences` | 40 | 555.83 | 105 | 1590 |\n\n## Sample Example\n\n**Subset**: `global_economics_and_finance`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"24273bb5\",\n      \"content\": \"You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \\\"risk of sharp market correction\\\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response.\"\n    }\n  ],\n  \"target\": \"[{\\\"rubric_number\\\": 1, \\\"rubric_detail\\\": \\\"Mention the high weighting of top US companies (e.g., Top 5 or AI-related stocks) in the index (approximately 30% or more) and identify this as a source of systemic risk.\\\", \\\"rubric_weight\\\": 10, \\\"rubric_ ... [TRUNCATED 3986 chars] ... c_number\\\": 16, \\\"rubric_detail\\\": \\\"The report contains hollow concluding remarks (e.g., \\\\\\\"In summary,\\\\\\\" \\\\\\\"We look forward to\\\\\\\") or transitional sentences lacking substantive content.\\\", \\\"rubric_weight\\\": -2, \\\"rubric_tag\\\": \\\"Analytical Reasoning\\\"}]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"global_economics_and_finance\",\n  \"metadata\": {\n    \"id\": \"e1b94c86-b6c9-43f6-8251-2e513e5efc52\",\n    \"case_id\": 1663,\n    \"language\": \"global\",\n    \"domain\": \"Economics and Finance\",\n    \"topics\": [\n      \"Economics and Finance\",\n      \"Financing & M&A\",\n      \"Mergers & Acquisitions\"\n    ],\n    \"time_sensitivity\": {\n      \"time_sensitivity\": \"Weakly time-sensitive\",\n      \"year_month\": \"2025-10\",\n      \"day\": \"NA\"\n    },\n    \"question\": \"You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \\\"risk of sharp market correction\\\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response.\"\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n{question}\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets one_million_bench \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['one_million_bench'],\n    dataset_args={\n        'one_million_bench': {\n            # subset_list: ['global_economics_and_finance', 'global_healthcare_and_medicine', 'global_industry']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# $OneMillion-Bench\n\n\n## 概述\n\n$OneMillion-Bench（简称 $1M-Bench）用于评估语言模型和智能体在完成具有经济价值的专家级专业工作方面的表现。公开版本包含由金融、医疗、工业、法律和自然科学等领域的专家编写并审核的400个双语任务。\n\n## 任务描述\n\n- **任务类型**：基于评分标准的开放式专业问答，由大语言模型（LLM）进行评判\n- **输入**：一段现实且上下文丰富的中文或英文专业请求\n- **输出**：一份完整的自由格式专业分析报告或交付成果\n- **领域**：经济学与金融、医疗与医学、工业、法律、自然科学\n\n## 核心特性\n\n- 包含400个零样本任务，在中文和全球两条语言赛道及五个专业领域之间均衡分布（每个语言-领域子集包含40个任务）\n- 每个任务包含11至37条由专家编写的评分标准，涵盖事实信息、分析推理、指令遵循以及结构与格式等方面\n- 每个任务同时包含正向评分项和负向扣分项，在公开版本中评分权重范围为 -20 到 12\n- 样本以十个语言-领域子集的形式提供，以便在 EvalScope 报告中清晰展示论文中的语言赛道和领域划分\n\n## 评估说明\n\n- 需要使用 LLM 作为评判器。请配置 `judge.strategy='llm'`（或 `'auto'`）及 `judge.models`；官方评测框架当前推荐使用 Gemini 3.1 Pro Preview，但评判器的选择会影响绝对得分，此处未硬编码指定\n- 对单个回答的所有评分标准将在一次请求中统一评判，并采用官方提供的二元命中/未命中（hit/miss）判断指令\n- `expert_score` 是命中评分项的加权总和除以所有正向权重之和，结果裁剪至 `[0, 1]` 区间；当 `expert_score >= 0.7` 时，`pass_rate` 为 1，否则为 0\n- 评判器回复必须包含每条评分标准恰好一次。格式错误的回复和传输失败将被排除，而非静默转换为零分\n- 官方研究分别比较了基础模型、支持搜索的模型和深度研究型智能体。本原生适配器执行的是基准测试中的单轮生成路径；只有当外部工具调用型智能体的最终回答在相同评判器配置下进行评估时，其结果才具有可比性\n- 任务通常要求生成长篇、带引用的报告。请配置足够大的生成和评判 `max_tokens` 值；使用一个评判器和一次重复运行时，完整评测将执行400次生成调用和400次评判调用\n\n资源链接：[论文](https://arxiv.org/abs/2603.07980) |\n[GitHub](https://github.com/humanlaya/OneMillion-Bench) |\n[数据集](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `one_million_bench` |\n| **数据集ID** | [evalscope/OneMillion-Bench](https://modelscope.cn/datasets/evalscope/OneMillion-Bench/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2603.07980) |\n| **标签** | `Agent`, `Knowledge`, `MultiLingual`, `QA`, `Reasoning` |\n| **指标** | `expert_score`, `pass_rate` |\n| **默认示例数** | 0-shot |\n| **评估分割** | `test` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 400 |\n| 提示词长度（平均） | 1470.49 字符 |\n| 提示词长度（最小/最大） | 105 / 15951 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `global_economics_and_finance` | 40 | 1810.97 | 868 | 3723 |\n| `global_healthcare_and_medicine` | 40 | 2029.97 | 479 | 8870 |\n| `global_industry` | 40 | 2581.15 | 453 | 9538 |\n| `global_law` | 40 | 3277.78 | 404 | 15951 |\n| `global_natural_sciences` | 40 | 1634.65 | 284 | 5775 |\n| `cn_economics_and_finance` | 40 | 555.05 | 111 | 1169 |\n| `cn_healthcare_and_medicine` | 40 | 584.38 | 135 | 2628 |\n| `cn_industry` | 40 | 965.6 | 144 | 7755 |\n| `cn_law` | 40 | 709.55 | 208 | 2041 |\n| `cn_natural_sciences` | 40 | 555.83 | 105 | 1590 |\n\n## 样例示例\n\n**子集**: `global_economics_and_finance`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"24273bb5\",\n      \"content\": \"You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \\\"risk of sharp market correction\\\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response.\"\n    }\n  ],\n  \"target\": \"[{\\\"rubric_number\\\": 1, \\\"rubric_detail\\\": \\\"Mention the high weighting of top US companies (e.g., Top 5 or AI-related stocks) in the index (approximately 30% or more) and identify this as a source of systemic risk.\\\", \\\"rubric_weight\\\": 10, \\\"rubric_ ... [TRUNCATED 3986 chars] ... c_number\\\": 16, \\\"rubric_detail\\\": \\\"The report contains hollow concluding remarks (e.g., \\\\\\\"In summary,\\\\\\\" \\\\\\\"We look forward to\\\\\\\") or transitional sentences lacking substantive content.\\\", \\\"rubric_weight\\\": -2, \\\"rubric_tag\\\": \\\"Analytical Reasoning\\\"}]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"global_economics_and_finance\",\n  \"metadata\": {\n    \"id\": \"e1b94c86-b6c9-43f6-8251-2e513e5efc52\",\n    \"case_id\": 1663,\n    \"language\": \"global\",\n    \"domain\": \"Economics and Finance\",\n    \"topics\": [\n      \"Economics and Finance\",\n      \"Financing & M&A\",\n      \"Mergers & Acquisitions\"\n    ],\n    \"time_sensitivity\": {\n      \"time_sensitivity\": \"Weakly time-sensitive\",\n      \"year_month\": \"2025-10\",\n      \"day\": \"NA\"\n    },\n    \"question\": \"You are an international financial risk analyst. Based on the Financial Stability Report released by the Bank of England's Financial Policy Committee in October 2025, global financial markets may face a \\\"risk of sharp market correction\\\" if in ... [TRUNCATED 924 chars] ... ields, and global capital flows.\\nSpecial Conditions: Use only information published before December 31, 2025; do not fabricate information; generated content must cite real URLs. The answer must be complete and useful; do not fake a response.\"\n  }\n}\n```\n\n*注：部分内容因显示需要已被截断。*\n\n## 提示模板\n\n**提示模板：**\n```text\n{question}\n```\n\n## 使用方法\n\n### 使用命令行（CLI）\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets one_million_bench \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['one_million_bench'],\n    dataset_args={\n        'one_million_bench': {\n            # subset_list: ['global_economics_and_finance', 'global_healthcare_and_medicine', 'global_industry']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "b8447100ff45f3c90d20cbaf107ee68f",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-28T10:59:21.773792+08:00",
+  "translation_updated_at": "2026-08-28T10:59:26+08:00"
+}

--- a/evalscope/benchmarks/one_million_bench/one_million_bench_adapter.py
+++ b/evalscope/benchmarks/one_million_bench/one_million_bench_adapter.py
@@ -1,0 +1,320 @@
+import json
+from typing import Any, Dict, List, Literal, Sequence, Type
+
+from pydantic import BaseModel, Field, model_validator
+
+from evalscope.api.benchmark import BenchmarkMeta, DefaultDataAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.judge import (
+    CaseVerdict,
+    JudgeCase,
+    JudgeContext,
+    JudgeDefinition,
+    JudgeRequest,
+    OutputContract,
+    ReducedVerdict,
+)
+from evalscope.api.messages import ChatMessageSystem, ChatMessageUser
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import ScoringPolicy, Tags
+
+SUBSET_LIST = [
+    'global_economics_and_finance',
+    'global_healthcare_and_medicine',
+    'global_industry',
+    'global_law',
+    'global_natural_sciences',
+    'cn_economics_and_finance',
+    'cn_healthcare_and_medicine',
+    'cn_industry',
+    'cn_law',
+    'cn_natural_sciences',
+]
+
+_DOMAIN_SUBSETS = {
+    ('global', 'Economics and Finance'): 'global_economics_and_finance',
+    ('global', 'Economics & Finance'): 'global_economics_and_finance',
+    ('global', 'Healthcare and Medicine'): 'global_healthcare_and_medicine',
+    ('global', 'Industry'): 'global_industry',
+    ('global', 'Law'): 'global_law',
+    ('global', 'Natural Sciences'): 'global_natural_sciences',
+    ('cn', '经济金融'): 'cn_economics_and_finance',
+    ('cn', '医疗健康'): 'cn_healthcare_and_medicine',
+    ('cn', '工业'): 'cn_industry',
+    ('cn', '法律'): 'cn_law',
+    ('cn', '自然科学'): 'cn_natural_sciences',
+}
+
+_JUDGE_PROMPT = """## 角色与核心任务
+
+**角色：** 你是一名公正、精确且严格的AI响应评估裁判。
+
+**核心任务：** 根据详细的评分标准（Rubric），对大型语言模型的回复（modelResponse）进行逐项评估。你需要判断模型回复是否符合评分标准中的具体描述。
+
+**评估原则：**
+
+1. **寻找直接证据：** 评估必须严格依据模型回复中**实际存在**的文本证据。不能进行主观猜测或过度解读。只有明确指出的内容才算数。
+
+2. **二元判断（是/否）：** 每一个 Rubric 项的评估结果只有两种：
+   - **命中 (是)**：模型回复中确实包含或命中了rubric描述的内容或特征。
+   - **未命中 (否)**：模型回复中没有包含或没有命中rubric描述的内容或特征。
+
+   *注意：这一逻辑通用于正分项（得分点）和负分项（扣分点）。只要rubric里的描述发生了，就是“命中/是”。*
+
+3. **评分规则：**
+   - **正向得分项（rubricWeight > 0）**：输出“是”代表得到该项分数，输出“否”代表不得分（0分）。
+   - **负向扣分项（rubricWeight < 0）**：输出“是”代表需要扣分（扣除对应分值），输出“否”代表不扣分（0分）。
+
+---
+
+## 评分步骤
+
+请保持冷静和专注，严格遵循以下步骤：
+
+**步骤一：理解上下文**
+仔细阅读用户问题（prompt）、模型回复（modelResponse）、评分标准（rubric）。
+
+**步骤二：判断是否命中**
+对照评分标准（rubric）的描述，检查模型回复：
+- 如果回复中**出现**了rubric描述的情况（无论是好的行为还是坏的错误），状态为 **“命中”**，结论输出 **“是”**。
+- 如果回复中**未出现**rubric描述的情况，状态为 **“未命中”**，结论输出 **“否”**。
+
+**步骤三：自我反思与格式化**
+- 检查证据是否充分支持你的“是/否”判断。
+- 对每条 Rubric 输出 `rubric_id`、`status` 和 `justification`，其中 `status` 必须是“是”或“否”。
+- 将所有逐项结果放入单个 JSON 对象的 `results` 列表中。
+
+---
+
+## 输入信息
+
+### 用户问题（prompt）
+{prompt}
+
+---
+
+### AI回复（modelResponse）
+{model_response}
+
+---
+
+### 评分项（Rubrics）
+{rubrics}
+
+---
+
+请逐条评估所有Rubric。"""
+
+_DESCRIPTION = """
+## Overview
+
+$OneMillion-Bench ($1M-Bench) evaluates how well language models and agents complete economically valuable,
+expert-level professional work. The public release contains 400 bilingual tasks written and reviewed by domain
+experts across finance, healthcare, industry, law, and natural science.
+
+## Task Description
+
+- **Task Type**: Open-ended professional question answering with rubric-based LLM judging
+- **Input**: A realistic, context-heavy professional request in Chinese or English
+- **Output**: A complete free-form professional analysis or deliverable
+- **Domain**: Economics and finance, healthcare and medicine, industry, law, and natural sciences
+
+## Key Features
+
+- 400 zero-shot tasks, balanced across Chinese and global tracks and five professional domains (40 tasks per
+  language-domain subset)
+- Each task has 11-37 expert-authored criteria covering factual information, analytical reasoning, instruction
+  following, and structure and formatting
+- Every task includes both positive criteria and negative penalties, with rubric weights ranging from -20 to 12 in
+  the hosted release
+- Samples are exposed as ten language-domain subsets so both the paper's language tracks and domain breakdowns are
+  visible in EvalScope reports
+
+## Evaluation Notes
+
+- An LLM judge is required. Configure `judge.strategy='llm'` (or `'auto'`) and `judge.models`; the official harness
+  currently recommends Gemini 3.1 Pro Preview, but judge identity affects absolute scores and is not hard-coded here
+- All rubrics for one response are judged together in one request using the official binary hit/miss instructions
+- `expert_score` is the weighted sum of hit rubrics divided by the sum of positive weights, clipped to `[0, 1]`;
+  `pass_rate` is 1 when `expert_score >= 0.7`, otherwise 0
+- Judge replies must contain every rubric exactly once. Malformed replies and transport failures are excluded instead
+  of being silently converted to zero scores
+- The official study compares vanilla models, search-enabled models, and deep-research agents separately. This native
+  adapter performs the benchmark's one-turn generation path; results from external tool-using agents are comparable
+  only when their final responses are evaluated under the same judge configuration
+- Tasks often require long, cited reports. Configure sufficiently large generation and judge `max_tokens` values;
+  with one judge and one repeat, a full run performs 400 generation calls and 400 judge calls
+
+Resources: [Paper](https://arxiv.org/abs/2603.07980) |
+[GitHub](https://github.com/humanlaya/OneMillion-Bench) |
+[Dataset](https://modelscope.cn/datasets/evalscope/OneMillion-Bench)
+"""
+
+
+class RubricJudgment(BaseModel):
+    rubric_id: int
+    status: Literal[
+        '是', '否', 'Yes', 'No', 'yes', 'no', 'Y', 'N', 'YES', 'NO', 'true', 'false', 'True', 'False', '命中', '未命中'
+    ]
+    justification: str
+
+
+def _grading_result_model(expected_ids: Sequence[int]) -> Type[BaseModel]:
+    expected = set(expected_ids)
+
+    class GradingResult(BaseModel):
+        results: List[RubricJudgment] = Field(description='One judgment for every rubric in the prompt.')
+
+        @model_validator(mode='after')
+        def validate_rubric_ids(self) -> 'GradingResult':
+            actual = [result.rubric_id for result in self.results]
+            if len(actual) != len(set(actual)):
+                raise ValueError('rubric_id values must be unique')
+            if set(actual) != expected:
+                raise ValueError(f'rubric_id values must exactly match {sorted(expected)}')
+            return self
+
+    return GradingResult
+
+
+def _format_rubrics(rubrics: Sequence[Dict[str, Any]]) -> str:
+    return '\n\n'.join(
+        f'**Rubric {rubric["rubric_number"]}**\n'
+        f'rubricDetail: {rubric["rubric_detail"]}\n'
+        f'rubricWeight: {int(rubric["rubric_weight"]):+d}分'
+        for rubric in rubrics
+    )
+
+
+def _is_hit(status: str) -> bool:
+    return status in {'是', 'Yes', 'yes', 'Y', 'YES', 'true', 'True', '命中'}
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='one_million_bench',
+        pretty_name='$OneMillion-Bench',
+        dataset_id='evalscope/OneMillion-Bench',
+        tags=[Tags.AGENT, Tags.KNOWLEDGE, Tags.QA, Tags.REASONING, Tags.MULTI_LINGUAL],
+        description=_DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2603.07980',
+        subset_list=SUBSET_LIST,
+        default_subset='default',
+        eval_split='test',
+        metric_list=['expert_score', 'pass_rate'],
+        primary_metric='expert_score',
+        prompt_template='{question}',
+        evaluation_version='v1.0',
+    )
+)
+class OneMillionBenchAdapter(DefaultDataAdapter):
+    """Adapter for the official weighted-rubric $OneMillion-Bench evaluation."""
+
+    scoring_policy = ScoringPolicy.JUDGE_ONLY
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.reformat_subset = True
+        self.category_map = {subset: 'CN' if subset.startswith('cn_') else 'Global' for subset in SUBSET_LIST}
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        rubrics = record.get('rubrics')
+        if not isinstance(rubrics, list) or not rubrics:
+            raise ValueError('$OneMillion-Bench record must contain a non-empty rubrics list.')
+
+        tags = record.get('tags') or {}
+        topics = tags.get('topics') or []
+        if not topics:
+            raise ValueError(f'$OneMillion-Bench record {record.get("id")!r} has no domain topic.')
+
+        language = str(record.get('language', '')).strip()
+        domain = str(topics[0]).strip()
+        subset = _DOMAIN_SUBSETS.get((language, domain))
+        if subset is None:
+            raise ValueError(f'Unsupported $OneMillion-Bench language-domain pair: {(language, domain)!r}.')
+
+        question = str(record['question'])
+        messages = []
+        system_prompt = str(record.get('system_prompt') or '').strip()
+        if system_prompt:
+            messages.append(ChatMessageSystem(content=system_prompt))
+        messages.append(ChatMessageUser(content=question))
+
+        return Sample(
+            input=messages,
+            target=json.dumps(rubrics, ensure_ascii=False),
+            subset_key=subset,
+            metadata={
+                'id': record.get('id'),
+                'case_id': record.get('case_id'),
+                'language': language,
+                'domain': domain,
+                'topics': topics,
+                'time_sensitivity': tags.get('time_sensitivity'),
+                'question': question,
+            },
+        )
+
+    def judge_definition(self, context: JudgeContext) -> JudgeDefinition:
+        rubrics = json.loads(context.reference)
+        rubric_ids = [int(rubric['rubric_number']) for rubric in rubrics]
+        contract = OutputContract(schema_model=_grading_result_model(rubric_ids))
+
+        def request(
+            case: JudgeCase,
+            placement: Any,
+            completed_cases: Sequence[CaseVerdict],
+            judge_context: JudgeContext,
+        ) -> JudgeRequest:
+            metadata = judge_context.task_state.metadata or {}
+            prompt = _JUDGE_PROMPT.format(
+                prompt=metadata['question'],
+                model_response=judge_context.original_prediction,
+                rubrics=_format_rubrics(case.metadata['rubrics']),
+            )
+            return JudgeRequest(messages=[ChatMessageUser(content=prompt + case.output_contract.instruction())])
+
+        def reduce(case_verdicts: Sequence[CaseVerdict], judge_context: JudgeContext) -> ReducedVerdict:
+            judgments = case_verdicts[0].value.results
+            verdict_by_id = {judgment.rubric_id: judgment for judgment in judgments}
+            positive_weight = sum(int(rubric['rubric_weight']) for rubric in rubrics if rubric['rubric_weight'] > 0)
+            if positive_weight <= 0:
+                raise ValueError('$OneMillion-Bench requires at least one positive-weight rubric.')
+
+            rubric_scores = []
+            raw_score = 0
+            for rubric in rubrics:
+                rubric_id = int(rubric['rubric_number'])
+                weight = int(rubric['rubric_weight'])
+                judgment = verdict_by_id[rubric_id]
+                awarded = weight if _is_hit(judgment.status) else 0
+                raw_score += awarded
+                rubric_scores.append(
+                    {
+                        'rubric_id': rubric_id,
+                        'status': judgment.status,
+                        'weight': weight,
+                        'score': awarded,
+                        'justification': judgment.justification,
+                    }
+                )
+
+            expert_score = min(max(raw_score / positive_weight, 0.0), 1.0)
+            return ReducedVerdict(
+                value={
+                    'expert_score': expert_score,
+                    'pass_rate': float(expert_score >= 0.7),
+                },
+                metadata={
+                    'raw_score': raw_score,
+                    'max_score': positive_weight,
+                    'rubric_scores': rubric_scores,
+                },
+            )
+
+        return JudgeDefinition.workflow(
+            cases=[JudgeCase(case_id='rubrics', output_contract=contract, metadata={'rubrics': rubrics})],
+            request=request,
+            reduce=reduce,
+            main_score_name='expert_score',
+        )

--- a/evalscope/benchmarks/one_million_bench/one_million_bench_adapter.py
+++ b/evalscope/benchmarks/one_million_bench/one_million_bench_adapter.py
@@ -199,11 +199,9 @@ def _is_hit(status: str) -> bool:
         description=_DESCRIPTION,
         paper_url='https://arxiv.org/abs/2603.07980',
         subset_list=SUBSET_LIST,
-        default_subset='default',
         eval_split='test',
         metric_list=['expert_score', 'pass_rate'],
         primary_metric='expert_score',
-        prompt_template='{question}',
         evaluation_version='v1.0',
     )
 )

--- a/evalscope/metrics/semantics/catalog.py
+++ b/evalscope/metrics/semantics/catalog.py
@@ -422,6 +422,8 @@ METRIC_DEFINITIONS.update(
         # non-primary and directionless, but deserve report labels rather than internal identities.
         'is_incorrect': MetricEntry(baseline='diagnostic.parse_status.ratio', display_name='Incorrect rate'),
         'is_not_attempted': MetricEntry(baseline='diagnostic.parse_status.ratio', display_name='Not attempted rate'),
+        # $OneMillion-Bench reports this normalized rubric-weighted score as its primary metric.
+        'expert_score': MetricEntry(baseline='quality.score.ratio', metric_name='Expert Score'),
         'total_model_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),
         'total_other_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),
         'total_tool_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),
@@ -462,6 +464,9 @@ BENCHMARK_METRIC_OVERRIDES: Dict[Tuple[str, str], MetricEntry] = {
     # `total_score` is a judge score in mia_bench but the raw sum of passed rubric weights in
     # job_bench, i.e. an intermediate judge value: reassign the collision to a diagnostic.
     ('job_bench', 'judge_score'): MetricEntry(baseline='diagnostic.unspecified'),
+    # $OneMillion-Bench defines pass rate as the share of tasks whose expert score reaches 0.7,
+    # not as pass@k over repeated generations.
+    ('one_million_bench', 'pass_rate'): MetricEntry(baseline='quality.accuracy.ratio', metric_name='Pass Rate'),
 }
 """``(benchmark_name, final_metric_name)`` -> entry, only for same-name / different-meaning
 collisions. Each entry carries the collision reason in a comment."""

--- a/evalscope/report/report.py
+++ b/evalscope/report/report.py
@@ -412,11 +412,13 @@ class Report(BaseModel):
         table = defaultdict(list)
         for metric in self.metrics:
             metric_count = 0
+            has_overall_subset = False
             for category in metric.categories:
                 for subset in category.subsets:
                     if subset.is_aggregate and not include_aggregate:
                         continue
                     metric_count += 1
+                    has_overall_subset = has_overall_subset or subset.name == ReportKey.overall_score
                     table[ReportKey.model_name].append(self.model_name)
                     table[ReportKey.dataset_name].append(self.dataset_name)
                     table[ReportKey.metric_name].append(metric.name)
@@ -425,11 +427,7 @@ class Report(BaseModel):
                     table[ReportKey.num].append(subset.num)
                     table[ReportKey.score].append(subset.score)
             # add overall metric when there are multiple subsets
-            if (
-                metric_count > 1
-                and add_overall_metric
-                and (ReportKey.overall_score not in table[ReportKey.subset_name])
-            ):
+            if metric_count > 1 and add_overall_metric and not has_overall_subset:
                 table[ReportKey.model_name].append(self.model_name)
                 table[ReportKey.dataset_name].append(self.dataset_name)
                 table[ReportKey.metric_name].append(metric.name)

--- a/tests/api/judge/test_migrated_adapters.py
+++ b/tests/api/judge/test_migrated_adapters.py
@@ -1,4 +1,6 @@
 """Smoke tests for migrated Native judge adapters."""
+
+import json
 from typing import Any, List
 
 import pytest
@@ -30,7 +32,6 @@ class ScriptedJudge:
 
 
 class TransportFailingJudge(ScriptedJudge):
-
     def __init__(self) -> None:
         super().__init__([])
 
@@ -42,6 +43,69 @@ class TransportFailingJudge(ScriptedJudge):
 def make_state(prediction: str, target: str) -> TaskState:
     sample = Sample(id=0, input='Who wrote Hamlet?', target=target, metadata={})
     return TaskState(model='m', sample=sample, output=ModelOutput.from_content('m', prediction), completed=True)
+
+
+def make_one_million_state(adapter) -> TaskState:
+    sample = adapter.record_to_sample(
+        {
+            'id': 'sample-id',
+            'case_id': 1,
+            'language': 'global',
+            'system_prompt': '',
+            'question': 'Write a professional answer.',
+            'tags': {
+                'topics': ['Law'],
+                'time_sensitivity': {'time_sensitivity': 'Time-agnostic', 'year_month': 'NA', 'day': 'NA'},
+            },
+            'rubrics': [
+                {
+                    'rubric_number': 1,
+                    'rubric_detail': 'Includes the requested analysis.',
+                    'rubric_weight': 10,
+                    'rubric_tag': 'Analytical Reasoning',
+                }
+            ],
+        }
+    )
+    sample.id = 0
+    sample.group_id = 0
+    return TaskState(
+        model='m', sample=sample, output=ModelOutput.from_content('m', 'Professional answer.'), completed=True
+    )
+
+
+def test_one_million_bench_valid_verdict_scores_the_sample() -> None:
+    config = TaskConfig(
+        model='m', datasets=['one_million_bench'], judge={'strategy': 'llm', 'models': [{'model_id': 'j'}]}
+    )
+    adapter = get_benchmark('one_million_bench', config)
+    adapter.llm_judge = ScriptedJudge(
+        [
+            json.dumps(
+                {'results': [{'rubric_id': 1, 'status': '是', 'justification': 'The requested analysis is present.'}]},
+                ensure_ascii=False,
+            )
+        ]
+    )
+
+    score = adapter.calculate_metrics(make_one_million_state(adapter)).score
+
+    assert score.status is ScoreStatus.SUCCESS
+    assert score.value == {'expert_score': 1.0, 'pass_rate': 1.0}
+
+
+@pytest.mark.parametrize('judge', [ScriptedJudge(['not JSON']), TransportFailingJudge()])
+def test_one_million_bench_judge_failure_excludes_the_sample(judge) -> None:
+    config = TaskConfig(
+        model='m', datasets=['one_million_bench'], judge={'strategy': 'llm', 'models': [{'model_id': 'j'}]}
+    )
+    adapter = get_benchmark('one_million_bench', config)
+    adapter.llm_judge = judge
+
+    score = adapter.calculate_metrics(make_one_million_state(adapter)).score
+
+    assert score.status is ScoreStatus.EXCLUDED
+    assert score.value == {}
 
 
 @pytest.mark.parametrize('benchmark_name', ['simple_qa', 'chinese_simpleqa', 'simple_vqa'])

--- a/tests/benchmark/test_eval.py
+++ b/tests/benchmark/test_eval.py
@@ -5,12 +5,15 @@ load_dotenv('.env')
 
 env = dotenv_values('.env')
 
+import json
 import os
 import unittest
+from unittest.mock import patch
 
 import pytest
 
 from evalscope.constants import EvalType, JudgeStrategy, OutputType
+from evalscope.models.mockllm import MockLLM
 from evalscope.utils.logger import get_logger
 from tests.common import TestBenchmark
 
@@ -980,6 +983,49 @@ class TestNativeBenchmark(TestBenchmark):
             }
         }}
         self._run_dataset_test('plawbench', limit=2, judge=judge)
+
+    def test_one_million_bench_mock(self):
+        """Test $OneMillion-Bench with a mock model and judge."""
+        judge_response = json.dumps(
+            {
+                'results': [
+                    {'rubric_id': rubric_id, 'status': '否', 'justification': 'Mock verdict.'}
+                    for rubric_id in range(1, 12)
+                ]
+            },
+            ensure_ascii=False,
+        )
+        with patch.object(MockLLM, 'default_output', judge_response):
+            self._run_dataset_test(
+                'one_million_bench',
+                dataset_args={'subset_list': ['global_law']},
+                limit=1,
+                use_mock=True,
+                judge={'models': {'model_id': 'mock-judge', 'eval_type': EvalType.MOCK_LLM}},
+            )
+
+    def test_one_million_bench(self):
+        """Test $OneMillion-Bench with a real model and judge API."""
+        judge = {'models': {
+            'model_id': 'qwen3-max',
+            'api_url': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+            'api_key': env.get('DASHSCOPE_API_KEY'),
+            'generation_config': {
+                'temperature': 0.0,
+                'max_tokens': 8192,
+                'extra_body': {
+                    'enable_thinking': False
+                }
+            }
+        }}
+        self._run_dataset_test(
+            'one_million_bench',
+            dataset_args={'subset_list': ['global_law']},
+            limit=1,
+            eval_batch_size=5,
+            generation_config={'temperature': 0.0, 'max_tokens': 8192},
+            judge=judge,
+        )
 
     # Indic-language benchmarks
     def test_milu_mock(self):

--- a/tests/benchmark/test_one_million_bench.py
+++ b/tests/benchmark/test_one_million_bench.py
@@ -1,0 +1,214 @@
+import json
+from typing import Any, List
+
+import pytest
+
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageSystem
+from evalscope.api.metric import AggScore
+from evalscope.api.model import ModelOutput
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.one_million_bench.one_million_bench_adapter import OneMillionBenchAdapter
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeScoreType, ScoreStatus
+from evalscope.metrics.judge.llm_judge import DEFAULT_PROMPT_TEMPLATE, LLMJudge
+from evalscope.report import gen_table
+from evalscope.report.generator import ReportGenerator
+
+
+class ScriptedJudge:
+    score_type = JudgeScoreType.PATTERN
+    score_mapping = {'A': 1.0, 'B': 0.0}
+    prompt_template = DEFAULT_PROMPT_TEMPLATE
+    system_prompt = None
+    build_prompt = LLMJudge.build_prompt
+
+    def __init__(self, replies: List[str]) -> None:
+        self.replies = replies
+        self.judge_id = self.model_id = 'scripted'
+        self.calls: List[Any] = []
+
+    def generate(self, messages: Any) -> ModelOutput:
+        self.calls.append(messages)
+        return ModelOutput.from_content('scripted', self.replies[min(len(self.calls) - 1, len(self.replies) - 1)])
+
+
+def make_adapter() -> OneMillionBenchAdapter:
+    config = TaskConfig(
+        model='mock-model',
+        datasets=['one_million_bench'],
+        judge={'strategy': 'llm', 'models': [{'model_id': 'judge-model'}]},
+    )
+    adapter = get_benchmark('one_million_bench', config)
+    assert isinstance(adapter, OneMillionBenchAdapter)
+    return adapter
+
+
+def make_record() -> dict:
+    return {
+        'id': 'sample-id',
+        'case_id': 7,
+        'language': 'global',
+        'system_prompt': '',
+        'question': 'Prepare a professional report.',
+        'tags': {
+            'topics': ['Economics and Finance', 'Investment'],
+            'time_sensitivity': {'time_sensitivity': 'Time-agnostic', 'year_month': 'NA', 'day': 'NA'},
+        },
+        'rubrics': [
+            {
+                'rubric_number': 1,
+                'rubric_detail': 'Includes the required evidence.',
+                'rubric_weight': 5,
+                'rubric_tag': 'Factual Information',
+            },
+            {
+                'rubric_number': 2,
+                'rubric_detail': 'Provides a complete analysis.',
+                'rubric_weight': 3,
+                'rubric_tag': 'Analytical Reasoning',
+            },
+            {
+                'rubric_number': 3,
+                'rubric_detail': 'Contains unsupported claims.',
+                'rubric_weight': -2,
+                'rubric_tag': 'Factual Information',
+            },
+        ],
+    }
+
+
+def make_state(adapter: OneMillionBenchAdapter, prediction: str = 'A detailed report.') -> TaskState:
+    sample = adapter.record_to_sample(make_record())
+    sample.id = 0
+    sample.group_id = 0
+    return TaskState(
+        model='mock-model', sample=sample, output=ModelOutput.from_content('mock-model', prediction), completed=True
+    )
+
+
+def test_registration_and_sample_conversion() -> None:
+    adapter = make_adapter()
+    record = make_record()
+    record['system_prompt'] = 'Act as a financial analyst.'
+
+    sample = adapter.record_to_sample(record)
+
+    assert adapter.dataset_id == 'evalscope/OneMillion-Bench'
+    assert adapter.scoring_policy.value == 'judge_only'
+    assert sample.subset_key == 'global_economics_and_finance'
+    assert isinstance(sample.input[0], ChatMessageSystem)
+    assert sample.input[0].text == 'Act as a financial analyst.'
+    assert sample.input[1].text == record['question']
+    assert json.loads(sample.target) == record['rubrics']
+    assert sample.metadata['case_id'] == 7
+
+
+def test_official_weighted_score_and_negative_penalty() -> None:
+    adapter = make_adapter()
+    judge = ScriptedJudge(
+        [
+            json.dumps(
+                {
+                    'results': [
+                        {'rubric_id': 1, 'status': '是', 'justification': 'Evidence is present.'},
+                        {'rubric_id': 2, 'status': '否', 'justification': 'Analysis is incomplete.'},
+                        {'rubric_id': 3, 'status': '是', 'justification': 'An unsupported claim appears.'},
+                    ]
+                },
+                ensure_ascii=False,
+            )
+        ]
+    )
+    adapter.llm_judge = judge
+
+    score = adapter.calculate_metrics(make_state(adapter)).score
+
+    assert score.status is ScoreStatus.SUCCESS
+    assert score.value['expert_score'] == pytest.approx(3 / 8)
+    assert score.value['pass_rate'] == 0.0
+    assert score.main_score_name == 'expert_score'
+    assert score.metadata['raw_score'] == 3
+    assert score.metadata['max_score'] == 8
+    assert 'rubricWeight: -2分' in judge.calls[0][0].text
+
+
+def test_expert_score_is_clipped_and_pass_threshold_is_inclusive() -> None:
+    adapter = make_adapter()
+    positive = [
+        {'rubric_id': 1, 'status': '是', 'justification': 'hit'},
+        {'rubric_id': 2, 'status': '是', 'justification': 'hit'},
+        {'rubric_id': 3, 'status': '否', 'justification': 'not hit'},
+    ]
+    adapter.llm_judge = ScriptedJudge([json.dumps({'results': positive}, ensure_ascii=False)])
+
+    passing_score = adapter.calculate_metrics(make_state(adapter)).score
+
+    assert passing_score.value == {'expert_score': 1.0, 'pass_rate': 1.0}
+
+
+def test_missing_rubric_verdict_excludes_sample() -> None:
+    adapter = make_adapter()
+    adapter.llm_judge = ScriptedJudge(
+        [
+            json.dumps(
+                {
+                    'results': [
+                        {'rubric_id': 1, 'status': '是', 'justification': 'hit'},
+                        {'rubric_id': 2, 'status': '否', 'justification': 'miss'},
+                    ]
+                },
+                ensure_ascii=False,
+            )
+        ]
+    )
+
+    score = adapter.calculate_metrics(make_state(adapter)).score
+
+    assert score.status is ScoreStatus.EXCLUDED
+    assert score.value == {}
+    assert score.metadata['judge_attempts'][0]['status'] == 'parse_error'
+
+
+@pytest.mark.parametrize(
+    ('language', 'domain', 'expected_subset'),
+    [
+        ('global', 'Economics & Finance', 'global_economics_and_finance'),
+        ('cn', '医疗健康', 'cn_healthcare_and_medicine'),
+        ('cn', '自然科学', 'cn_natural_sciences'),
+    ],
+)
+def test_observed_domain_aliases_are_normalized(language: str, domain: str, expected_subset: str) -> None:
+    adapter = make_adapter()
+    record = make_record()
+    record['language'] = language
+    record['tags']['topics'][0] = domain
+
+    assert adapter.record_to_sample(record).subset_key == expected_subset
+
+
+def test_report_uses_official_metric_labels_and_sample_weighted_means() -> None:
+    adapter = make_adapter()
+    score_dict = {
+        'global_law': [
+            AggScore(score=0.5, metric_name='expert_score', aggregation='mean', num=2),
+            AggScore(score=0.5, metric_name='pass_rate', aggregation='mean', num=2),
+        ],
+        'cn_law': [
+            AggScore(score=1.0, metric_name='expert_score', aggregation='mean', num=1),
+            AggScore(score=1.0, metric_name='pass_rate', aggregation='mean', num=1),
+        ],
+    }
+
+    report = ReportGenerator.generate_report(score_dict, 'mock-model', adapter)
+    metrics = {metric.identity.name: metric for metric in report.metrics}
+    table = gen_table(report_list=[report], add_overall_metric=True)
+
+    assert adapter.aggregation == 'mean'
+    assert report.primary_metric_identity == metrics['expert_score'].identity
+    assert metrics['expert_score'].score == pytest.approx(2 / 3, abs=1e-4)
+    assert metrics['pass_rate'].score == pytest.approx(2 / 3, abs=1e-4)
+    assert 'Expert Score ↑' in table
+    assert 'Pass Rate ↑' in table
+    assert table.count('66.7%') == 2
+    assert table.count('OVERALL') == 2

--- a/tests/report/test_combinator.py
+++ b/tests/report/test_combinator.py
@@ -131,6 +131,30 @@ def test_gen_table_disambiguates_repeated_metric_display_names() -> None:
     assert 'Accuracy ↑ (fact_acc:mean)' in table
 
 
+def test_gen_table_adds_overall_row_for_each_metric() -> None:
+    adapter = _StubAdapter('multi_metric', primary_metric='accuracy')
+    report = ReportGenerator.generate_report(
+        score_dict={
+            'first': [
+                AggScore(score=0.5, metric_name='accuracy', aggregation='mean', num=2),
+                AggScore(score=0.25, metric_name='f1', aggregation='mean', num=2),
+            ],
+            'second': [
+                AggScore(score=1.0, metric_name='accuracy', aggregation='mean', num=1),
+                AggScore(score=1.0, metric_name='f1', aggregation='mean', num=1),
+            ],
+        },
+        model_name='test-model',
+        data_adapter=adapter,
+    )
+
+    table = report.to_dataframe(add_overall_metric=True)
+    overall_rows = table[table['Subset'] == 'OVERALL']
+
+    assert overall_rows['Metric'].tolist() == ['accuracy:mean', 'f1:mean']
+    assert overall_rows['Score'].tolist() == [0.6667, 0.5]
+
+
 def test_gen_table_hides_placeholder_category_columns_without_changing_dataframe() -> None:
     report = _categorized_report(('default', ))
     raw_dataframe = report.to_dataframe()


### PR DESCRIPTION
## Summary

- add the native `$OneMillion-Bench` adapter with the official weighted binary-rubric scoring flow
- expose ten language/domain subsets, `expert_score`, and threshold-based `pass_rate` with correct report semantics
- enforce fail-closed judge JSON contracts and add unit, judge, smoke, report, and generated documentation coverage
- fix multi-metric report tables so every metric receives its own `OVERALL` row

## Validation

- `make lint`
- `pytest tests/api/judge/test_migrated_adapters.py tests/benchmark/test_one_million_bench.py tests/report/test_combinator.py tests/report/semantics/test_catalog.py -q` (`43 passed`)
- `pytest tests/benchmark/test_eval.py::TestNativeBenchmark::test_one_million_bench_mock tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings` (`2 passed`)
- real DashScope API smoke test on one `global_law` sample; independently verified `29 / 49 = 0.5918367347`
- `make docs-pipeline BENCHMARK=one_million_bench FORCE=1` and `make docs-generate`

## References

- Paper: https://arxiv.org/abs/2603.07980
- Official implementation: https://github.com/humanlaya/OneMillion-Bench
- Dataset: https://modelscope.cn/datasets/evalscope/OneMillion-Bench
