### PR TITLE
feat(benchmarks): add Ref-Adv-s

### DIFF
--- a/docs/en/benchmarks/ref_adv_s.md
+++ b/docs/en/benchmarks/ref_adv_s.md
@@ -1,0 +1,155 @@
+# Ref-Adv-s
+
+
+## Overview
+
+Ref-Adv-s is the public 1,142-case subset of Ref-Adv, a referring expression comprehension benchmark designed to test whether multimodal large language models can distinguish a target from hard same-category visual distractors instead of relying on grounding shortcuts.
+
+## Task Description
+
+- **Task Type**: Referring expression comprehension / visual grounding
+- **Input**: One image and an English referring expression
+- **Output**: One or more bounding boxes in JSON, with the first box used for scoring
+- **Domain**: COCO and OpenImages scenes containing hard same-category distractors
+
+## Key Features
+
+- Contains 1,142 public cases sampled from the 5,000-case Ref-Adv benchmark
+- Includes human-authored and model-assisted expressions, explicit negation, and at least two distractors per case
+- Preserves the official `direct` and chain-of-thought (`cot`) prompt modes
+- Uses the dataset's single `train` split as the evaluation split
+
+## Evaluation Notes
+
+- Reports official `Acc@0.5`, `Acc@0.75`, and `Acc@0.9` metrics from the IoU of the first parsed box
+- Also reports `Acc@0.5` for the official distractor-count bins `2-3`, `4-6`, and `>=7`
+- Parses the last valid fenced JSON object, or an unfenced JSON value that ends the response, using the official key search order
+- A failed first parse triggers the official one-turn format-repair prompt; a second failure receives zero accuracy
+- Set `pred_box_format` to `abs_xyxy` for Qwen2.5-VL and to `norm_1000_xyxy` for Qwen3-VL/Qwen3.5; `norm_1_xyxy` is also supported by the official evaluator
+- [Paper](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `ref_adv_s` |
+| **Dataset ID** | [evalscope/ref-adv-s](https://modelscope.cn/datasets/evalscope/ref-adv-s/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2602.23898) |
+| **Tags** | `Grounding`, `MultiModal`, `Reasoning` |
+| **Metrics** | `ACC@0.5`, `ACC@0.75`, `ACC@0.9`, `2-3/ACC@0.5`, `4-6/ACC@0.5`, `>=7/ACC@0.5` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `train` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 1,142 |
+| Prompt Length (Mean) | 177.67 chars |
+| Prompt Length (Min/Max) | 136 / 282 chars |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 1,142 |
+| Images per Sample | min: 1, max: 1, mean: 1 |
+| Resolution Range | 240x320 - 1024x1024 |
+| Formats | jpeg |
+
+
+## Sample Example
+
+**Subset**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "d3a7e578",
+      "content": [
+        {
+          "text": "<image>\nLocate every object that matches the description \"the computer screen that is in the middle vertically of the three stacks\" in the image. Report bbox coordinates in JSON format."
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~118.1KB]"
+        }
+      ]
+    }
+  ],
+  "target": "[297.0, 345.0, 427.0, 440.0]",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "row_idx": 0,
+    "file_name": "000000547144.jpg",
+    "image_source": "coco_val2017",
+    "human_authored": true,
+    "use_negation": false,
+    "distractor_count": 5,
+    "target_box_normalized": [
+      0.4640625,
+      0.71875,
+      0.6671875,
+      0.9166666666666666
+    ],
+    "sent_size": [
+      640,
+      480
+    ],
+    "retry_followup_used": false
+  }
+}
+```
+
+## Prompt Template
+
+**Prompt Template:**
+```text
+<image>
+Locate every object that matches the description "{ref_sentence}" in the image. Report bbox coordinates in JSON format.
+```
+
+## Extra Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `prompt_mode` | `str` | `direct` | Official prompt mode. Choices: ['direct', 'cot'] |
+| `pred_box_format` | `str` | `norm_1000_xyxy` | Coordinate format emitted by the evaluated model. Choices: ['abs_xyxy', 'norm_1000_xyxy', 'norm_1_xyxy'] |
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets ref_adv_s \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['ref_adv_s'],
+    dataset_args={
+        'ref_adv_s': {
+            # extra_params: {}  # uses default extra parameters
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -59,6 +59,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `pmc_vqa` | [PMC-VQA](../../benchmarks/pmc_vqa.md) | `MCQ`, `Medical`, `MultiModal` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
+| `ref_adv_s` | [Ref-Adv-s](../../benchmarks/ref_adv_s.md) | `Grounding`, `MultiModal`, `Reasoning` |
 | `science_qa` | [ScienceQA](../../benchmarks/science_qa.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `screenspot_pro` | [ScreenSpot-Pro](../../benchmarks/screenspot_pro.md) | `Agent`, `Grounding`, `MultiModal` |
 | `seed_bench_2_plus` | [SEED-Bench-2-Plus](../../benchmarks/seed_bench_2_plus.md) | `Knowledge`, `MCQ`, `MultiModal`, `Reasoning` |
@@ -135,6 +136,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/pmc_vqa.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md
+../../benchmarks/ref_adv_s.md
 ../../benchmarks/science_qa.md
 ../../benchmarks/screenspot_pro.md
 ../../benchmarks/seed_bench_2_plus.md

--- a/docs/zh/benchmarks/ref_adv_s.md
+++ b/docs/zh/benchmarks/ref_adv_s.md
@@ -1,0 +1,155 @@
+# Ref-Adv-s
+
+
+## 概述
+
+Ref-Adv-s 是 Ref-Adv 基准测试中公开的 1,142 个样例子集。该基准测试旨在评估多模态大语言模型是否能够从同类视觉干扰物中准确识别目标对象，而非依赖简单的视觉定位捷径。
+
+## 任务描述
+
+- **任务类型**：指代表达理解 / 视觉定位
+- **输入**：一张图像和一个英文指代表达式
+- **输出**：一个或多个 JSON 格式的边界框，其中第一个边界框用于评分
+- **领域**：包含同类干扰物的 COCO 和 OpenImages 场景
+
+## 主要特点
+
+- 包含从 5,000 个样例的 Ref-Adv 基准测试中采样的 1,142 个公开样例
+- 包含人工撰写和模型辅助生成的表达式、显式否定词，且每个样例至少包含两个干扰物
+- 保留官方的 `direct` 和思维链（`cot`）提示模式
+- 使用数据集唯一的 `train` 划分作为评估划分
+
+## 评估说明
+
+- 报告官方指标 `Acc@0.5`、`Acc@0.75` 和 `Acc@0.9`，基于第一个解析出的边界框与真实框的 IoU 计算
+- 同时报告干扰物数量分组（`2-3`、`4-6` 和 `>=7`）下的 `Acc@0.5` 指标
+- 使用官方指定的键搜索顺序，解析响应中最后一个有效的围栏式 JSON 对象，或以非围栏式 JSON 值结尾的内容
+- 若首次解析失败，将触发官方的一轮格式修复提示；若第二次仍失败，则该样本得分为零
+- 对于 Qwen2.5-VL，请将 `pred_box_format` 设置为 `abs_xyxy`；对于 Qwen3-VL/Qwen3.5，请设置为 `norm_1000_xyxy`；官方评估器也支持 `norm_1_xyxy`
+- [论文](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `ref_adv_s` |
+| **数据集ID** | [evalscope/ref-adv-s](https://modelscope.cn/datasets/evalscope/ref-adv-s/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2602.23898) |
+| **标签** | `Grounding`, `MultiModal`, `Reasoning` |
+| **指标** | `ACC@0.5`, `ACC@0.75`, `ACC@0.9`, `2-3/ACC@0.5`, `4-6/ACC@0.5`, `>=7/ACC@0.5` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `train` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 1,142 |
+| 提示词长度（平均） | 177.67 字符 |
+| 提示词长度（最小/最大） | 136 / 282 字符 |
+
+**图像统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 总图像数 | 1,142 |
+| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |
+| 分辨率范围 | 240x320 - 1024x1024 |
+| 格式 | jpeg |
+
+
+## 样例示例
+
+**子集**: `default`
+
+```json
+{
+  "input": [
+    {
+      "id": "d3a7e578",
+      "content": [
+        {
+          "text": "<image>\nLocate every object that matches the description \"the computer screen that is in the middle vertically of the three stacks\" in the image. Report bbox coordinates in JSON format."
+        },
+        {
+          "image": "[BASE64_IMAGE: jpeg, ~118.1KB]"
+        }
+      ]
+    }
+  ],
+  "target": "[297.0, 345.0, 427.0, 440.0]",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "row_idx": 0,
+    "file_name": "000000547144.jpg",
+    "image_source": "coco_val2017",
+    "human_authored": true,
+    "use_negation": false,
+    "distractor_count": 5,
+    "target_box_normalized": [
+      0.4640625,
+      0.71875,
+      0.6671875,
+      0.9166666666666666
+    ],
+    "sent_size": [
+      640,
+      480
+    ],
+    "retry_followup_used": false
+  }
+}
+```
+
+## 提示模板
+
+**提示模板：**
+```text
+<image>
+Locate every object that matches the description "{ref_sentence}" in the image. Report bbox coordinates in JSON format.
+```
+
+## 额外参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|-----------|------|---------|-------------|
+| `prompt_mode` | `str` | `direct` | 官方提示模式。选项：['direct', 'cot'] |
+| `pred_box_format` | `str` | `norm_1000_xyxy` | 被评估模型输出的坐标格式。选项：['abs_xyxy', 'norm_1000_xyxy', 'norm_1_xyxy'] |
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets ref_adv_s \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['ref_adv_s'],
+    dataset_args={
+        'ref_adv_s': {
+            # extra_params: {}  # 使用默认额外参数
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -59,6 +59,7 @@
 | `pmc_vqa` | [PMC-VQA](../../benchmarks/pmc_vqa.md) | `MCQ`, `Medical`, `MultiModal` |
 | `pope` | [POPE](../../benchmarks/pope.md) | `Hallucination`, `MultiModal`, `Yes/No` |
 | `real_world_qa` | [RealWorldQA](../../benchmarks/real_world_qa.md) | `Knowledge`, `MultiModal`, `QA` |
+| `ref_adv_s` | [Ref-Adv-s](../../benchmarks/ref_adv_s.md) | `Grounding`, `MultiModal`, `Reasoning` |
 | `science_qa` | [ScienceQA](../../benchmarks/science_qa.md) | `Knowledge`, `MCQ`, `MultiModal` |
 | `screenspot_pro` | [ScreenSpot-Pro](../../benchmarks/screenspot_pro.md) | `Agent`, `Grounding`, `MultiModal` |
 | `seed_bench_2_plus` | [SEED-Bench-2-Plus](../../benchmarks/seed_bench_2_plus.md) | `Knowledge`, `MCQ`, `MultiModal`, `Reasoning` |
@@ -135,6 +136,7 @@
 ../../benchmarks/pmc_vqa.md
 ../../benchmarks/pope.md
 ../../benchmarks/real_world_qa.md
+../../benchmarks/ref_adv_s.md
 ../../benchmarks/science_qa.md
 ../../benchmarks/screenspot_pro.md
 ../../benchmarks/seed_bench_2_plus.md

--- a/evalscope/benchmarks/_meta/ref_adv_s.json
+++ b/evalscope/benchmarks/_meta/ref_adv_s.json
@@ -1,0 +1,197 @@
+{
+  "meta": {
+    "pretty_name": "Ref-Adv-s",
+    "dataset_id": "evalscope/ref-adv-s",
+    "paper_url": "https://arxiv.org/abs/2602.23898",
+    "tags": [
+      "MultiModal",
+      "Grounding",
+      "Reasoning"
+    ],
+    "metrics": [
+      "ACC@0.5",
+      "ACC@0.75",
+      "ACC@0.9",
+      "2-3/ACC@0.5",
+      "4-6/ACC@0.5",
+      ">=7/ACC@0.5"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "train",
+    "train_split": "",
+    "subset_list": [
+      "default"
+    ],
+    "description": "\n## Overview\n\nRef-Adv-s is the public 1,142-case subset of Ref-Adv, a referring expression comprehension benchmark designed to test whether multimodal large language models can distinguish a target from hard same-category visual distractors instead of relying on grounding shortcuts.\n\n## Task Description\n\n- **Task Type**: Referring expression comprehension / visual grounding\n- **Input**: One image and an English referring expression\n- **Output**: One or more bounding boxes in JSON, with the first box used for scoring\n- **Domain**: COCO and OpenImages scenes containing hard same-category distractors\n\n## Key Features\n\n- Contains 1,142 public cases sampled from the 5,000-case Ref-Adv benchmark\n- Includes human-authored and model-assisted expressions, explicit negation, and at least two distractors per case\n- Preserves the official `direct` and chain-of-thought (`cot`) prompt modes\n- Uses the dataset's single `train` split as the evaluation split\n\n## Evaluation Notes\n\n- Reports official `Acc@0.5`, `Acc@0.75`, and `Acc@0.9` metrics from the IoU of the first parsed box\n- Also reports `Acc@0.5` for the official distractor-count bins `2-3`, `4-6`, and `>=7`\n- Parses the last valid fenced JSON object, or an unfenced JSON value that ends the response, using the official key search order\n- A failed first parse triggers the official one-turn format-repair prompt; a second failure receives zero accuracy\n- Set `pred_box_format` to `abs_xyxy` for Qwen2.5-VL and to `norm_1000_xyxy` for Qwen3-VL/Qwen3.5; `norm_1_xyxy` is also supported by the official evaluator\n- [Paper](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)\n",
+    "prompt_template": "<image>\nLocate every object that matches the description \"{ref_sentence}\" in the image. Report bbox coordinates in JSON format.",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {
+      "prompt_mode": {
+        "type": "str",
+        "description": "Official prompt mode.",
+        "value": "direct",
+        "choices": [
+          "direct",
+          "cot"
+        ]
+      },
+      "pred_box_format": {
+        "type": "str",
+        "description": "Coordinate format emitted by the evaluated model.",
+        "value": "norm_1000_xyxy",
+        "choices": [
+          "abs_xyxy",
+          "norm_1000_xyxy",
+          "norm_1_xyxy"
+        ]
+      }
+    },
+    "sandbox_config": {},
+    "category": "vlm",
+    "primary_metric": {
+      "name": "accuracy",
+      "aggregation": "mean",
+      "dimensions": {
+        "scope": "overall",
+        "threshold": 0.5
+      }
+    }
+  },
+  "statistics": {
+    "total_samples": 1142,
+    "subset_stats": [
+      {
+        "name": "default",
+        "sample_count": 1142,
+        "prompt_length_mean": 177.67,
+        "prompt_length_min": 136,
+        "prompt_length_max": 282,
+        "prompt_length_std": 19.7,
+        "target_length_mean": 32.15,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 1142,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1011x1024",
+              "1019x1024",
+              "1024x1024",
+              "1024x413",
+              "1024x430",
+              "1024x434",
+              "1024x469",
+              "1024x471",
+              "1024x542",
+              "1024x550"
+            ],
+            "resolution_range": {
+              "min": "240x320",
+              "max": "1024x1024"
+            },
+            "formats": [
+              "jpeg"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 177.67,
+      "min": 136,
+      "max": 282,
+      "std": 19.7
+    },
+    "target_length_mean": 32.15,
+    "computed_at": "2026-08-28T13:10:31.339045",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 1142,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "resolutions": [
+          "1011x1024",
+          "1019x1024",
+          "1024x1024",
+          "1024x413",
+          "1024x430",
+          "1024x434",
+          "1024x469",
+          "1024x471",
+          "1024x542",
+          "1024x550"
+        ],
+        "resolution_range": {
+          "min": "240x320",
+          "max": "1024x1024"
+        },
+        "formats": [
+          "jpeg"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "d3a7e578",
+          "content": [
+            {
+              "text": "<image>\nLocate every object that matches the description \"the computer screen that is in the middle vertically of the three stacks\" in the image. Report bbox coordinates in JSON format."
+            },
+            {
+              "image": "[BASE64_IMAGE: jpeg, ~118.1KB]"
+            }
+          ]
+        }
+      ],
+      "target": "[297.0, 345.0, 427.0, 440.0]",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "row_idx": 0,
+        "file_name": "000000547144.jpg",
+        "image_source": "coco_val2017",
+        "human_authored": true,
+        "use_negation": false,
+        "distractor_count": 5,
+        "target_box_normalized": [
+          0.4640625,
+          0.71875,
+          0.6671875,
+          0.9166666666666666
+        ],
+        "sent_size": [
+          640,
+          480
+        ],
+        "retry_followup_used": false
+      }
+    },
+    "subset": "default",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# Ref-Adv-s\n\n\n## Overview\n\nRef-Adv-s is the public 1,142-case subset of Ref-Adv, a referring expression comprehension benchmark designed to test whether multimodal large language models can distinguish a target from hard same-category visual distractors instead of relying on grounding shortcuts.\n\n## Task Description\n\n- **Task Type**: Referring expression comprehension / visual grounding\n- **Input**: One image and an English referring expression\n- **Output**: One or more bounding boxes in JSON, with the first box used for scoring\n- **Domain**: COCO and OpenImages scenes containing hard same-category distractors\n\n## Key Features\n\n- Contains 1,142 public cases sampled from the 5,000-case Ref-Adv benchmark\n- Includes human-authored and model-assisted expressions, explicit negation, and at least two distractors per case\n- Preserves the official `direct` and chain-of-thought (`cot`) prompt modes\n- Uses the dataset's single `train` split as the evaluation split\n\n## Evaluation Notes\n\n- Reports official `Acc@0.5`, `Acc@0.75`, and `Acc@0.9` metrics from the IoU of the first parsed box\n- Also reports `Acc@0.5` for the official distractor-count bins `2-3`, `4-6`, and `>=7`\n- Parses the last valid fenced JSON object, or an unfenced JSON value that ends the response, using the official key search order\n- A failed first parse triggers the official one-turn format-repair prompt; a second failure receives zero accuracy\n- Set `pred_box_format` to `abs_xyxy` for Qwen2.5-VL and to `norm_1000_xyxy` for Qwen3-VL/Qwen3.5; `norm_1_xyxy` is also supported by the official evaluator\n- [Paper](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `ref_adv_s` |\n| **Dataset ID** | [evalscope/ref-adv-s](https://modelscope.cn/datasets/evalscope/ref-adv-s/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2602.23898) |\n| **Tags** | `Grounding`, `MultiModal`, `Reasoning` |\n| **Metrics** | `ACC@0.5`, `ACC@0.75`, `ACC@0.9`, `2-3/ACC@0.5`, `4-6/ACC@0.5`, `>=7/ACC@0.5` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `train` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 1,142 |\n| Prompt Length (Mean) | 177.67 chars |\n| Prompt Length (Min/Max) | 136 / 282 chars |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 1,142 |\n| Images per Sample | min: 1, max: 1, mean: 1 |\n| Resolution Range | 240x320 - 1024x1024 |\n| Formats | jpeg |\n\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"d3a7e578\",\n      \"content\": [\n        {\n          \"text\": \"<image>\\nLocate every object that matches the description \\\"the computer screen that is in the middle vertically of the three stacks\\\" in the image. Report bbox coordinates in JSON format.\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~118.1KB]\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"[297.0, 345.0, 427.0, 440.0]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"row_idx\": 0,\n    \"file_name\": \"000000547144.jpg\",\n    \"image_source\": \"coco_val2017\",\n    \"human_authored\": true,\n    \"use_negation\": false,\n    \"distractor_count\": 5,\n    \"target_box_normalized\": [\n      0.4640625,\n      0.71875,\n      0.6671875,\n      0.9166666666666666\n    ],\n    \"sent_size\": [\n      640,\n      480\n    ],\n    \"retry_followup_used\": false\n  }\n}\n```\n\n## Prompt Template\n\n**Prompt Template:**\n```text\n<image>\nLocate every object that matches the description \"{ref_sentence}\" in the image. Report bbox coordinates in JSON format.\n```\n\n## Extra Parameters\n\n| Parameter | Type | Default | Description |\n|-----------|------|---------|-------------|\n| `prompt_mode` | `str` | `direct` | Official prompt mode. Choices: ['direct', 'cot'] |\n| `pred_box_format` | `str` | `norm_1000_xyxy` | Coordinate format emitted by the evaluated model. Choices: ['abs_xyxy', 'norm_1000_xyxy', 'norm_1_xyxy'] |\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets ref_adv_s \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['ref_adv_s'],\n    dataset_args={\n        'ref_adv_s': {\n            # extra_params: {}  # uses default extra parameters\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# Ref-Adv-s\n\n\n## 概述\n\nRef-Adv-s 是 Ref-Adv 基准测试中公开的 1,142 个样例子集。该基准测试旨在评估多模态大语言模型是否能够从同类视觉干扰物中准确识别目标对象，而非依赖简单的视觉定位捷径。\n\n## 任务描述\n\n- **任务类型**：指代表达理解 / 视觉定位\n- **输入**：一张图像和一个英文指代表达式\n- **输出**：一个或多个 JSON 格式的边界框，其中第一个边界框用于评分\n- **领域**：包含同类干扰物的 COCO 和 OpenImages 场景\n\n## 主要特点\n\n- 包含从 5,000 个样例的 Ref-Adv 基准测试中采样的 1,142 个公开样例\n- 包含人工撰写和模型辅助生成的表达式、显式否定词，且每个样例至少包含两个干扰物\n- 保留官方的 `direct` 和思维链（`cot`）提示模式\n- 使用数据集唯一的 `train` 划分作为评估划分\n\n## 评估说明\n\n- 报告官方指标 `Acc@0.5`、`Acc@0.75` 和 `Acc@0.9`，基于第一个解析出的边界框与真实框的 IoU 计算\n- 同时报告干扰物数量分组（`2-3`、`4-6` 和 `>=7`）下的 `Acc@0.5` 指标\n- 使用官方指定的键搜索顺序，解析响应中最后一个有效的围栏式 JSON 对象，或以非围栏式 JSON 值结尾的内容\n- 若首次解析失败，将触发官方的一轮格式修复提示；若第二次仍失败，则该样本得分为零\n- 对于 Qwen2.5-VL，请将 `pred_box_format` 设置为 `abs_xyxy`；对于 Qwen3-VL/Qwen3.5，请设置为 `norm_1000_xyxy`；官方评估器也支持 `norm_1_xyxy`\n- [论文](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `ref_adv_s` |\n| **数据集ID** | [evalscope/ref-adv-s](https://modelscope.cn/datasets/evalscope/ref-adv-s/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2602.23898) |\n| **标签** | `Grounding`, `MultiModal`, `Reasoning` |\n| **指标** | `ACC@0.5`, `ACC@0.75`, `ACC@0.9`, `2-3/ACC@0.5`, `4-6/ACC@0.5`, `>=7/ACC@0.5` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `train` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 1,142 |\n| 提示词长度（平均） | 177.67 字符 |\n| 提示词长度（最小/最大） | 136 / 282 字符 |\n\n**图像统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 总图像数 | 1,142 |\n| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |\n| 分辨率范围 | 240x320 - 1024x1024 |\n| 格式 | jpeg |\n\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"d3a7e578\",\n      \"content\": [\n        {\n          \"text\": \"<image>\\nLocate every object that matches the description \\\"the computer screen that is in the middle vertically of the three stacks\\\" in the image. Report bbox coordinates in JSON format.\"\n        },\n        {\n          \"image\": \"[BASE64_IMAGE: jpeg, ~118.1KB]\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"[297.0, 345.0, 427.0, 440.0]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"row_idx\": 0,\n    \"file_name\": \"000000547144.jpg\",\n    \"image_source\": \"coco_val2017\",\n    \"human_authored\": true,\n    \"use_negation\": false,\n    \"distractor_count\": 5,\n    \"target_box_normalized\": [\n      0.4640625,\n      0.71875,\n      0.6671875,\n      0.9166666666666666\n    ],\n    \"sent_size\": [\n      640,\n      480\n    ],\n    \"retry_followup_used\": false\n  }\n}\n```\n\n## 提示模板\n\n**提示模板：**\n```text\n<image>\nLocate every object that matches the description \"{ref_sentence}\" in the image. Report bbox coordinates in JSON format.\n```\n\n## 额外参数\n\n| 参数 | 类型 | 默认值 | 描述 |\n|-----------|------|---------|-------------|\n| `prompt_mode` | `str` | `direct` | 官方提示模式。选项：['direct', 'cot'] |\n| `pred_box_format` | `str` | `norm_1000_xyxy` | 被评估模型输出的坐标格式。选项：['abs_xyxy', 'norm_1000_xyxy', 'norm_1_xyxy'] |\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets ref_adv_s \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['ref_adv_s'],\n    dataset_args={\n        'ref_adv_s': {\n            # extra_params: {}  # 使用默认额外参数\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "5d4c867292184df5ca68fda4a252a09e",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-28T13:10:32.195552",
+  "translation_updated_at": "2026-08-28T13:11:24+08:00"
+}

--- a/evalscope/benchmarks/ref_adv_s/ref_adv_s_adapter.py
+++ b/evalscope/benchmarks/ref_adv_s/ref_adv_s_adapter.py
@@ -1,0 +1,255 @@
+# flake8: noqa: E501
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from evalscope.api.benchmark import BenchmarkMeta, MultiTurnAdapter, VisionLanguageAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessage, ChatMessageUser, Content, ContentImage, ContentText
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.metric.semantics import MetricSelector
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+from evalscope.metrics.utils.functions import mean
+from evalscope.utils.logger import get_logger
+
+logger = get_logger()
+
+DIRECT_PROMPT = (
+    '<image>\n'
+    'Locate every object that matches the description "{ref_sentence}" in the image. '
+    'Report bbox coordinates in JSON format.'
+)
+COT_PROMPT = (
+    '<image>\n'
+    'Locate every object that matches the description "{ref_sentence}" in the image.\n'
+    'Think first, then answer.\n'
+    'Finally report bbox coordinates in JSON format.'
+)
+FOLLOWUP_PROMPT = (
+    'Your previous answer did not end with a valid JSON bbox output.\\n'
+    'Now output ONLY one complete JSON code block.\\n'
+    'Use this exact schema:\\n'
+    '```json\\n'
+    '{"bboxes": [[x1, y1, x2, y2]]}\\n'
+    '```\\n'
+    'Do not output any extra text.'
+)
+PROMPTS = {'direct': DIRECT_PROMPT, 'cot': COT_PROMPT}
+
+DESCRIPTION = """
+## Overview
+
+Ref-Adv-s is the public 1,142-case subset of Ref-Adv, a referring expression comprehension benchmark designed to test whether multimodal large language models can distinguish a target from hard same-category visual distractors instead of relying on grounding shortcuts.
+
+## Task Description
+
+- **Task Type**: Referring expression comprehension / visual grounding
+- **Input**: One image and an English referring expression
+- **Output**: One or more bounding boxes in JSON, with the first box used for scoring
+- **Domain**: COCO and OpenImages scenes containing hard same-category distractors
+
+## Key Features
+
+- Contains 1,142 public cases sampled from the 5,000-case Ref-Adv benchmark
+- Includes human-authored and model-assisted expressions, explicit negation, and at least two distractors per case
+- Preserves the official `direct` and chain-of-thought (`cot`) prompt modes
+- Uses the dataset's single `train` split as the evaluation split
+
+## Evaluation Notes
+
+- Reports official `Acc@0.5`, `Acc@0.75`, and `Acc@0.9` metrics from the IoU of the first parsed box
+- Also reports `Acc@0.5` for the official distractor-count bins `2-3`, `4-6`, and `>=7`
+- Parses the last valid fenced JSON object, or an unfenced JSON value that ends the response, using the official key search order
+- A failed first parse triggers the official one-turn format-repair prompt; a second failure receives zero accuracy
+- Set `pred_box_format` to `abs_xyxy` for Qwen2.5-VL and to `norm_1000_xyxy` for Qwen3-VL/Qwen3.5; `norm_1_xyxy` is also supported by the official evaluator
+- [Paper](https://arxiv.org/abs/2602.23898) | [GitHub](https://github.com/dddraxxx/Ref-Adv)
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='ref_adv_s',
+        pretty_name='Ref-Adv-s',
+        dataset_id='evalscope/ref-adv-s',
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2602.23898',
+        tags=[Tags.MULTI_MODAL, Tags.GROUNDING, Tags.REASONING],
+        subset_list=['default'],
+        eval_split='train',
+        metric_list=[
+            'ACC@0.5',
+            'ACC@0.75',
+            'ACC@0.9',
+            '2-3/ACC@0.5',
+            '4-6/ACC@0.5',
+            '>=7/ACC@0.5',
+        ],
+        primary_metric=MetricSelector(
+            name='accuracy', aggregation='mean', dimensions={'scope': 'overall', 'threshold': 0.5}
+        ),
+        prompt_template=DIRECT_PROMPT,
+        extra_params={
+            'prompt_mode': {
+                'type': 'str',
+                'description': 'Official prompt mode.',
+                'value': 'direct',
+                'choices': ['direct', 'cot'],
+            },
+            'pred_box_format': {
+                'type': 'str',
+                'description': 'Coordinate format emitted by the evaluated model.',
+                'value': 'norm_1000_xyxy',
+                'choices': ['abs_xyxy', 'norm_1000_xyxy', 'norm_1_xyxy'],
+            },
+        },
+        evaluation_version='v1.0',
+    )
+)
+class RefAdvSAdapter(VisionLanguageAdapter, MultiTurnAdapter):
+    """Adapter for the public Ref-Adv-s referring expression benchmark."""
+
+    max_turns = 2
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.prompt_template = PROMPTS[self.extra_params['prompt_mode']]
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Optional[Sample]:
+        """Convert one Ref-Adv-s record into a multimodal grounding sample."""
+        from evalscope.utils.io_utils import PIL_to_base64
+
+        from .utils import base64_image_size, to_normalized_xyxy
+
+        image_field = record.get('image')
+        if isinstance(image_field, dict) and image_field.get('bytes'):
+            image_uri = self._image_bytes_to_base64(image_field['bytes'], default_format='jpeg')
+        elif hasattr(image_field, 'save'):
+            image_uri = PIL_to_base64(image_field.convert('RGB'), format='JPEG', add_header=True)
+        else:
+            logger.warning(f'Ref-Adv-s row {record.get("row_idx")} has no usable image; skipping.')
+            return None
+
+        width, height = int(record['width']), int(record['height'])
+        sent_size = [width, height]
+        if self._max_image_bytes is not None:
+            sent_size = list(base64_image_size(image_uri))
+
+        target_box = record.get('solution')
+        if not isinstance(target_box, list) or len(target_box) != 4:
+            raise ValueError(f'Ref-Adv-s row {record.get("row_idx")} has an invalid solution: {target_box!r}')
+        target_normalized = to_normalized_xyxy(target_box, (width, height), 'abs_xyxy')
+        distractor_count = int(record['distractors'])
+        prompt_text = self.prompt_template.format(ref_sentence=record['normal_caption'])
+        content: List[Content] = [ContentText(text=prompt_text), ContentImage(image=image_uri)]
+
+        return Sample(
+            input=[ChatMessageUser(content=content)],
+            target=json.dumps(target_box),
+            metadata={
+                'row_idx': record['row_idx'],
+                'file_name': record['file_name'],
+                'image_source': record['image_source'],
+                'human_authored': record['human_authored'],
+                'use_negation': record['use_negation'],
+                'distractor_count': distractor_count,
+                'target_box_normalized': target_normalized,
+                'sent_size': sent_size,
+                'retry_followup_used': False,
+            },
+        )
+
+    def initialize_history(self, sample: Sample) -> List[ChatMessage]:
+        """Keep any configured system message outside the turn-building loop."""
+        return list(sample.input[:-1])
+
+    def build_turn_prompt(
+        self,
+        sample: Sample,
+        history: List[ChatMessage],
+        turn_index: int,
+    ) -> Optional[Union[str, ChatMessage]]:
+        """Issue the official prompt, then retry once only when JSON parsing fails."""
+        if turn_index == 0:
+            return sample.input[-1]
+
+        from .utils import parse_bboxes
+
+        boxes, _ = parse_bboxes(
+            history[-1].text,
+            image_size=sample.metadata['sent_size'],
+            box_format=self.extra_params['pred_box_format'],
+        )
+        if boxes:
+            return None
+        sample.metadata['retry_followup_used'] = True
+        return FOLLOWUP_PROMPT
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        """Extract the first official JSON bbox and normalize it to unit coordinates."""
+        from .utils import parse_bboxes
+
+        boxes, parse_error = parse_bboxes(
+            prediction,
+            image_size=task_state.metadata['sent_size'],
+            box_format=self.extra_params['pred_box_format'],
+        )
+        task_state.metadata['parse_error'] = parse_error
+        return json.dumps(boxes[0]) if boxes else ''
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        """Compute the official first-box IoU threshold metrics and distractor breakdown."""
+        from .utils import distractor_bin, iou_xyxy
+
+        prediction_box = json.loads(filtered_prediction) if filtered_prediction else None
+        target_box = task_state.metadata['target_box_normalized']
+        iou = iou_xyxy(prediction_box, target_box) if prediction_box is not None else 0.0
+        score = Score(extracted_prediction=filtered_prediction, prediction=original_prediction)
+        score.value = {
+            'ACC@0.5': float(iou >= 0.5),
+            'ACC@0.75': float(iou >= 0.75),
+            'ACC@0.9': float(iou >= 0.9),
+        }
+        bin_name = distractor_bin(task_state.metadata['distractor_count'])
+        if bin_name is not None:
+            score.value[f'{bin_name}/ACC@0.5'] = float(iou >= 0.5)
+        score.main_score_name = 'ACC@0.5'
+        score.metadata = {
+            'iou': iou,
+            'parse_error': task_state.metadata.get('parse_error', ''),
+            'retry_followup_used': task_state.metadata.get('retry_followup_used', False),
+        }
+        return score
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        """Aggregate official thresholds and distractor bins as structured accuracy metrics."""
+        metric_specs = (
+            ('ACC@0.5', 0.5, 'overall'),
+            ('ACC@0.75', 0.75, 'overall'),
+            ('ACC@0.9', 0.9, 'overall'),
+            ('2-3/ACC@0.5', 0.5, '2-3'),
+            ('4-6/ACC@0.5', 0.5, '4-6'),
+            ('>=7/ACC@0.5', 0.5, '>=7'),
+        )
+        aggregates = []
+        for raw_name, threshold, scope in metric_specs:
+            selected = [sample_score for sample_score in sample_scores if raw_name in sample_score.score.value]
+            if not selected:
+                continue
+            aggregates.append(
+                AggScore(
+                    score=mean([float(item.score.value[raw_name]) for item in selected]),
+                    metric_name='accuracy',
+                    aggregation='mean',
+                    dimensions={'scope': scope, 'threshold': threshold},
+                    num=len(selected),
+                    ids=[item.sample_id for item in selected],
+                )
+            )
+        return aggregates

--- a/evalscope/benchmarks/ref_adv_s/utils.py
+++ b/evalscope/benchmarks/ref_adv_s/utils.py
@@ -1,0 +1,140 @@
+import base64
+import io
+import json
+import re
+from typing import Any, List, Optional, Sequence, Tuple
+
+_FENCE_RE = re.compile(r'```(?:json)?\s*(.*?)```', flags=re.DOTALL | re.IGNORECASE)
+_PRIORITY_KEYS = ('bboxes', 'boxes', 'bbox', 'bbox_2d', 'predictions', 'results', 'objects', 'coordinates')
+
+
+def _load_last_json_candidate(text: str) -> Optional[Any]:
+    """Load the last fenced JSON value, or an unfenced JSON value ending the reply."""
+    fenced_chunks = [match.group(1).strip() for match in _FENCE_RE.finditer(text) if match.group(1).strip()]
+    for chunk in reversed(fenced_chunks):
+        try:
+            return json.loads(chunk)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    stripped = text.rstrip()
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(stripped):
+        if char not in '[{':
+            continue
+        try:
+            value, end = decoder.raw_decode(stripped[index:])
+        except json.JSONDecodeError:
+            continue
+        if index + end == len(stripped):
+            return value
+    return None
+
+
+def _collect_boxes(value: Any, boxes: List[List[float]], max_boxes: int = 100) -> None:
+    if len(boxes) >= max_boxes:
+        return
+    if isinstance(value, list):
+        if len(value) == 4 and all(isinstance(item, (int, float)) for item in value):
+            boxes.append([float(item) for item in value])
+            return
+        for item in value:
+            _collect_boxes(item, boxes, max_boxes)
+        return
+    if not isinstance(value, dict):
+        return
+
+    for key in _PRIORITY_KEYS:
+        if key in value:
+            _collect_boxes(value[key], boxes, max_boxes)
+    for key, item in value.items():
+        if key not in _PRIORITY_KEYS:
+            _collect_boxes(item, boxes, max_boxes)
+
+
+def to_normalized_xyxy(box: Sequence[float], image_size: Sequence[int], box_format: str) -> List[float]:
+    """Convert an official Ref-Adv bbox format to sorted, clipped unit coordinates."""
+    x1, y1, x2, y2 = (float(value) for value in box)
+    width, height = image_size
+    if box_format == 'abs_xyxy':
+        x1, x2 = x1 / width, x2 / width
+        y1, y2 = y1 / height, y2 / height
+    elif box_format == 'norm_1000_xyxy':
+        x1, y1, x2, y2 = (value / 1000.0 for value in (x1, y1, x2, y2))
+    elif box_format != 'norm_1_xyxy':
+        raise ValueError(f'Unsupported pred_box_format: {box_format}')
+
+    left, right = sorted((x1, x2))
+    top, bottom = sorted((y1, y2))
+    return [
+        min(max(left, 0.0), 1.0),
+        min(max(top, 0.0), 1.0),
+        min(max(right, 0.0), 1.0),
+        min(max(bottom, 0.0), 1.0),
+    ]
+
+
+def parse_bboxes(
+    text: str,
+    image_size: Sequence[int],
+    box_format: str,
+) -> Tuple[List[List[float]], str]:
+    """Parse and normalize bounding boxes using the official Ref-Adv JSON rules."""
+    if not text or not text.strip():
+        return [], 'empty_response'
+
+    parsed = _load_last_json_candidate(text)
+    if parsed is None:
+        return [], 'no_bbox_found'
+
+    raw_boxes: List[List[float]] = []
+    _collect_boxes(parsed, raw_boxes)
+    if not raw_boxes:
+        return [], 'no_bbox_found'
+
+    boxes: List[List[float]] = []
+    seen = set()
+    for box in raw_boxes:
+        normalized = to_normalized_xyxy(box, image_size, box_format)
+        key = tuple(round(value, 6) for value in normalized)
+        if key in seen:
+            continue
+        seen.add(key)
+        boxes.append(normalized)
+    return boxes, ''
+
+
+def iou_xyxy(box_a: Sequence[float], box_b: Sequence[float]) -> float:
+    """Calculate intersection over union for two xyxy bounding boxes."""
+    ax1, ay1, ax2, ay2 = (float(value) for value in box_a)
+    bx1, by1, bx2, by2 = (float(value) for value in box_b)
+    intersection_width = max(0.0, min(ax2, bx2) - max(ax1, bx1))
+    intersection_height = max(0.0, min(ay2, by2) - max(ay1, by1))
+    intersection = intersection_width * intersection_height
+    if intersection <= 0.0:
+        return 0.0
+
+    area_a = max(0.0, ax2 - ax1) * max(0.0, ay2 - ay1)
+    area_b = max(0.0, bx2 - bx1) * max(0.0, by2 - by1)
+    union = area_a + area_b - intersection
+    return intersection / union if union > 0.0 else 0.0
+
+
+def distractor_bin(count: int) -> Optional[str]:
+    """Return the official distractor-count reporting bin."""
+    if 2 <= count <= 3:
+        return '2-3'
+    if 4 <= count <= 6:
+        return '4-6'
+    if count >= 7:
+        return '>=7'
+    return None
+
+
+def base64_image_size(data_uri: str) -> Tuple[int, int]:
+    """Return the width and height of a base64 data-URI image."""
+    from PIL import Image
+
+    payload = data_uri.split(',', 1)[-1]
+    with Image.open(io.BytesIO(base64.b64decode(payload))) as image:
+        return image.size

--- a/tests/benchmark/test_ref_adv_s.py
+++ b/tests/benchmark/test_ref_adv_s.py
@@ -1,0 +1,145 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from evalscope.api.dataset import Sample
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageUser
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.ref_adv_s.ref_adv_s_adapter import FOLLOWUP_PROMPT, RefAdvSAdapter
+from evalscope.benchmarks.ref_adv_s.utils import distractor_bin, iou_xyxy, parse_bboxes, to_normalized_xyxy
+from evalscope.config import TaskConfig
+
+
+def make_adapter(box_format: str = 'norm_1000_xyxy') -> RefAdvSAdapter:
+    config = TaskConfig(
+        model='mock',
+        datasets=['ref_adv_s'],
+        dataset_args={'ref_adv_s': {'extra_params': {'pred_box_format': box_format}}},
+    )
+    return get_benchmark('ref_adv_s', config)
+
+
+@pytest.mark.parametrize(
+    ('box_format', 'box'),
+    [
+        ('abs_xyxy', [64, 48, 320, 240]),
+        ('norm_1000_xyxy', [100, 100, 500, 500]),
+        ('norm_1_xyxy', [0.1, 0.1, 0.5, 0.5]),
+    ],
+)
+def test_parse_bboxes_supports_official_coordinate_formats(box_format: str, box: list[float]) -> None:
+    response = f'```json\n{{"bboxes": [{json.dumps(box)}]}}\n```'
+    boxes, error = parse_bboxes(response, image_size=(640, 480), box_format=box_format)
+
+    assert error == ''
+    assert boxes[0] == pytest.approx([0.1, 0.1, 0.5, 0.5])
+
+
+def test_parse_bboxes_uses_last_fenced_json_and_deduplicates() -> None:
+    response = (
+        '```json\n{"bbox": [0, 0, 100, 100]}\n```\n'
+        'Final answer:\n```json\n{"objects": [{"bbox_2d": [200, 300, 800, 900]}, '
+        '{"bbox_2d": [200, 300, 800, 900]}]}\n```'
+    )
+    boxes, error = parse_bboxes(response, image_size=(1000, 1000), box_format='norm_1000_xyxy')
+
+    assert error == ''
+    assert boxes == [[0.2, 0.3, 0.8, 0.9]]
+
+
+def test_parse_bboxes_requires_complete_json_at_end_without_fence() -> None:
+    boxes, error = parse_bboxes('Reasoning {"bboxes": [[1, 2, 3, 4]]} trailing text', (10, 10), 'abs_xyxy')
+    assert boxes == []
+    assert error == 'no_bbox_found'
+
+    boxes, error = parse_bboxes('Reasoning\n{"bboxes": [[1, 2, 3, 4]]}', (10, 10), 'abs_xyxy')
+    assert error == ''
+    assert boxes == [[0.1, 0.2, 0.3, 0.4]]
+
+
+def test_to_normalized_xyxy_sorts_and_clips_coordinates() -> None:
+    assert to_normalized_xyxy([1200, 900, -100, -50], (1, 1), 'norm_1000_xyxy') == [0.0, 0.0, 1.0, 0.9]
+    with pytest.raises(ValueError, match='Unsupported pred_box_format'):
+        to_normalized_xyxy([0, 0, 1, 1], (1, 1), 'xywh')
+
+
+def test_iou_and_distractor_bins_match_official_definitions() -> None:
+    assert iou_xyxy([0, 0, 1, 1], [0.5, 0.5, 1, 1]) == pytest.approx(0.25)
+    assert distractor_bin(2) == '2-3'
+    assert distractor_bin(4) == '4-6'
+    assert distractor_bin(7) == '>=7'
+    assert distractor_bin(1) is None
+
+
+def test_followup_is_only_used_after_parse_failure() -> None:
+    adapter = make_adapter()
+    sample = Sample(
+        input=[ChatMessageUser(content='prompt')],
+        metadata={'sent_size': [640, 480], 'retry_followup_used': False},
+    )
+
+    valid_history = [sample.input[0], ChatMessageAssistant(content='{"bboxes": [[1, 2, 3, 4]]}')]
+    assert adapter.build_turn_prompt(sample, valid_history, 1) is None
+    assert sample.metadata['retry_followup_used'] is False
+
+    invalid_history = [sample.input[0], ChatMessageAssistant(content='not json')]
+    assert adapter.build_turn_prompt(sample, invalid_history, 1) == FOLLOWUP_PROMPT
+    assert sample.metadata['retry_followup_used'] is True
+
+
+def test_match_score_reports_official_thresholds_and_bin() -> None:
+    adapter = object.__new__(RefAdvSAdapter)
+    state = SimpleNamespace(
+        metadata={
+            'target_box_normalized': [0.0, 0.0, 1.0, 1.0],
+            'distractor_count': 5,
+            'parse_error': '',
+            'retry_followup_used': False,
+        }
+    )
+
+    score = adapter.match_score('raw', '[0.0, 0.0, 1.0, 0.8]', 'unused', state)
+
+    assert isinstance(score, Score)
+    assert score.value == {'ACC@0.5': 1.0, 'ACC@0.75': 1.0, 'ACC@0.9': 0.0, '4-6/ACC@0.5': 1.0}
+    assert score.main_score_name == 'ACC@0.5'
+    assert score.metadata['iou'] == pytest.approx(0.8)
+
+
+def test_aggregation_emits_structured_official_metrics() -> None:
+    adapter = make_adapter()
+    scores = []
+    for sample_id, value, bin_name in ((0, 1.0, '2-3'), (1, 0.0, '4-6')):
+        score = Score(value={'ACC@0.5': value, 'ACC@0.75': 0.0, 'ACC@0.9': 0.0})
+        score.value[f'{bin_name}/ACC@0.5'] = value
+        scores.append(SampleScore(score=score, sample_id=sample_id))
+
+    aggregates = adapter.aggregate_scores(scores)
+    identities = {(item.metric_name, item.aggregation, frozenset(item.dimensions.items())) for item in aggregates}
+
+    assert ('accuracy', 'mean', frozenset({('scope', 'overall'), ('threshold', 0.5)})) in identities
+    assert ('accuracy', 'mean', frozenset({('scope', '2-3'), ('threshold', 0.5)})) in identities
+    assert next(
+        item for item in aggregates if item.dimensions == {'scope': 'overall', 'threshold': 0.5}
+    ).score == pytest.approx(0.5)
+
+
+def test_parse_failure_scores_zero() -> None:
+    adapter = make_adapter()
+    state = SimpleNamespace(
+        metadata={
+            'sent_size': [640, 480],
+            'target_box_normalized': [0.1, 0.1, 0.2, 0.2],
+            'distractor_count': 2,
+            'retry_followup_used': True,
+        }
+    )
+
+    extracted = adapter.extract_answer('no valid bbox', state)
+    score = adapter.match_score('no valid bbox', extracted, 'unused', state)
+
+    assert extracted == ''
+    assert score.value['ACC@0.5'] == 0.0
+    assert score.metadata == {'iou': 0.0, 'parse_error': 'no_bbox_found', 'retry_followup_used': True}

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -516,6 +516,14 @@ class TestVLMBenchmark(TestBenchmark):
         dataset_args = {'subset_list': ['CAD']}
         self._run_dataset_test('screenspot_pro', dataset_args=dataset_args, limit=5, use_mock=True)
 
+    def test_ref_adv_s(self):
+        """Test Ref-Adv-s adversarial referring expression benchmark."""
+        self._run_dataset_test('ref_adv_s', limit=5)
+
+    def test_ref_adv_s_mock(self):
+        """Test Ref-Adv-s with mock LLM."""
+        self._run_dataset_test('ref_adv_s', limit=5, use_mock=True)
+
     def test_cc_ocr_v2(self):
         """Test CC-OCR-V2 real-world document OCR benchmark."""
         dataset_args = {'subset_list': ['info_board_parsing', 'text_grounding', 'blueprint_qa']}


### PR DESCRIPTION
## Summary
- integrate the public 1,142-sample Ref-Adv-s visual grounding benchmark
- reproduce official direct/CoT prompts, JSON bbox parsing, one-turn format retry, coordinate formats, and first-box IoU scoring
- report structured Acc@0.5/0.75/0.9 metrics plus official distractor-count breakdowns
- add unit, mock pipeline, metadata, and bilingual documentation

## Validation
- `make lint`
- `pytest tests/benchmark/test_ref_adv_s.py tests/benchmark/test_vlm.py::TestVLMBenchmark::test_ref_adv_s_mock -q`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings`
- real API run: 20 samples with `qwen-vl-plus`, independently re-derived with 0 score mismatches
- compared IoU against all 34,260 bundled official prediction rows with 0 mismatches
