### PR TITLE
feat(benchmarks): add VLMs Are Biased

### DIFF
--- a/docs/en/benchmarks/vlms_are_biased.md
+++ b/docs/en/benchmarks/vlms_are_biased.md
@@ -1,0 +1,147 @@
+# VLMs Are Biased
+
+
+## Overview
+
+VLMs Are Biased (VLMBias) evaluates whether vision-language models answer objective visual questions from the image or fall back to memorized prior knowledge. It uses counterfactual images whose visible properties conflict with familiar concepts, such as an Adidas-style logo with four stripes or an animal with an unusual number of legs.
+
+## Task Description
+
+- **Task Type**: Free-form visual question answering for counting and identification
+- **Input**: A counterfactual or control image paired with a counting, binary identification, or short-answer question
+- **Output**: A number, `Yes`/`No`, or a short identity enclosed in curly brackets
+- **Domain**: Animals, logos, flags, chess pieces, game boards, optical illusions, and patterned grids
+
+## Key Features
+
+- The primary `main` split contains 2,784 objective visual questions over 1,392 counterfactual images at 384, 768, and 1152 pixel resolutions
+- Five official analysis splits cover binary identification, in-image title injection, original unmodified controls, and background-removed variants
+- Each counterfactual record provides both the visually correct `ground_truth` and the prior-knowledge `expected_bias`
+- The benchmark exposes seven topics and nineteen sub-topics for detailed analysis without creating synthetic EvalScope subsets
+
+## Evaluation Notes
+
+- The dataset prompt is used verbatim, including its required curly-bracket answer format
+- Primary metric: **Accuracy** (`acc`), using the official case-insensitive comparison after stripping outer braces; if exact text matching fails, digit sequences are compared
+- Secondary metric: **Bias Ratio** (`bias_ratio`, lower is better), the fraction of predictions matching `expected_bias` under the same normalization
+- Accuracy is also reported by topic, matching the official lmms-eval integration
+- `bias_ratio` is omitted for the `original` split because those control records do not define `expected_bias`
+- The six official dataset splits are exposed as separate EvalScope subsets and evaluated by default; select only `main` to reproduce the paper's headline benchmark
+- Generation should be deterministic and concise; the official lmms-eval setup uses `temperature=0` and at most 32 new tokens
+- [Paper](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [Project page](https://vlmsarebiased.github.io/)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `vlms_are_biased` |
+| **Dataset ID** | [evalscope/vlms-are-biased](https://modelscope.cn/datasets/evalscope/vlms-are-biased/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2505.23941) |
+| **Tags** | `MultiModal`, `QA`, `Reasoning` |
+| **Metrics** | `accuracy`, `bias_ratio` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `main` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 11,594 |
+| Prompt Length (Mean) | 90.01 chars |
+| Prompt Length (Min/Max) | 60 / 138 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `main` | 2,784 | 91.52 | 78 | 129 |
+| `identification` | 1,392 | 83.27 | 68 | 102 |
+| `withtitle` | 2,784 | 91.52 | 78 | 129 |
+| `original` | 458 | 85.03 | 60 | 130 |
+| `remove_background_q1q2` | 2,784 | 94.23 | 78 | 138 |
+| `remove_background_q3` | 1,392 | 83.91 | 70 | 102 |
+
+**Image Statistics:**
+
+| Metric | Value |
+|--------|-------|
+| Total Images | 11,594 |
+| Images per Sample | min: 1, max: 1, mean: 1 |
+| Resolution Range | 384x183 - 1862x1430 |
+| Formats | png |
+
+
+## Sample Example
+
+**Subset**: `main`
+
+```json
+{
+  "input": [
+    {
+      "id": "3872fe66",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~1.9KB]"
+        },
+        {
+          "text": "Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}."
+        }
+      ]
+    }
+  ],
+  "target": "Yes",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "id": "VerticalHorizontal_001_Q1_notitle_px384",
+    "topic": "Optical Illusion",
+    "sub_topic": "Vertical-Horizontal illusion",
+    "type_of_question": "Q1",
+    "expected_bias": "No",
+    "with_title": false,
+    "pixel": 384
+  }
+}
+```
+
+## Prompt Template
+
+*No prompt template defined.*
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets vlms_are_biased \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['vlms_are_biased'],
+    dataset_args={
+        'vlms_are_biased': {
+            # subset_list: ['main', 'identification', 'withtitle']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/vlm.md
+++ b/docs/en/get_started/supported_dataset/vlm.md
@@ -69,6 +69,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 | `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal`, `Video` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal`, `Video` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
+| `vlms_are_biased` | [VLMs Are Biased](../../benchmarks/vlms_are_biased.md) | `MultiModal`, `QA`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
 | `vstar_bench` | [V*Bench](../../benchmarks/vstar_bench.md) | `Grounding`, `MCQ`, `MultiModal` |
 | `vtcbench` | [VTCBench](../../benchmarks/vtcbench.md) | `LongContext`, `MultiModal`, `QA`, `Reasoning`, `Retrieval` |
@@ -145,6 +146,7 @@ Below is the list of supported VLM benchmarks. Click on a benchmark name for det
 ../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
 ../../benchmarks/visulogic.md
+../../benchmarks/vlms_are_biased.md
 ../../benchmarks/vqav2.md
 ../../benchmarks/vstar_bench.md
 ../../benchmarks/vtcbench.md

--- a/docs/zh/benchmarks/vlms_are_biased.md
+++ b/docs/zh/benchmarks/vlms_are_biased.md
@@ -1,0 +1,147 @@
+# VLMs Are Biased
+
+
+## 概述
+
+VLMs Are Biased（VLMBias）用于评估视觉-语言模型（VLM）在回答客观视觉问题时，是依据图像内容作答，还是依赖于记忆中的先验知识。该基准测试使用反事实图像（counterfactual images），这些图像的可见属性与常见概念相冲突，例如带有四条纹的阿迪达斯风格标志，或拥有异常腿数的动物。
+
+## 任务描述
+
+- **任务类型**：自由形式的视觉问答（计数与识别）
+- **输入**：一张反事实图像或对照图像，配以计数、二元识别或简短回答类问题
+- **输出**：一个数字、`Yes`/`No`，或用花括号括起的简短身份标识
+- **领域**：动物、商标、旗帜、国际象棋棋子、游戏棋盘、视错觉和图案网格
+
+## 核心特性
+
+- 主要的 `main` 划分包含 2,784 个客观视觉问题，覆盖 1,392 张反事实图像，分辨率分别为 384、768 和 1152 像素
+- 五个官方分析划分涵盖二元识别、图像内标题注入、原始未修改对照图像，以及去除背景的变体
+- 每条反事实记录同时提供视觉上正确的 `ground_truth` 和基于先验知识的 `expected_bias`
+- 该基准测试涵盖七个主题和十九个子主题，支持细粒度分析，无需创建合成的 EvalScope 子集
+
+## 评估说明
+
+- 数据集提示词按原文使用，包括其要求的花括号答案格式
+- 主要指标：**准确率**（`acc`），采用官方提供的大小写不敏感比较方法（去除外层花括号后）；若精确文本匹配失败，则比较其中的数字序列
+- 次要指标：**偏见比率**（`bias_ratio`，越低越好），即在相同归一化条件下，预测结果与 `expected_bias` 一致的比例
+- 准确率也按主题分别报告，与官方 lmms-eval 集成一致
+- `original` 划分不计算 `bias_ratio`，因为这些对照样本未定义 `expected_bias`
+- 六个官方数据集划分作为独立的 EvalScope 子集公开，并默认全部参与评估；若仅选择 `main` 子集，可复现论文中的主要基准结果
+- 生成应具有确定性且简洁；官方 lmms-eval 设置使用 `temperature=0`，最多生成 32 个新 token
+- [论文](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [项目主页](https://vlmsarebiased.github.io/)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `vlms_are_biased` |
+| **数据集ID** | [evalscope/vlms-are-biased](https://modelscope.cn/datasets/evalscope/vlms-are-biased/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2505.23941) |
+| **标签** | `MultiModal`, `QA`, `Reasoning` |
+| **指标** | `accuracy`, `bias_ratio` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `main` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 11,594 |
+| 提示词长度（平均） | 90.01 字符 |
+| 提示词长度（最小/最大） | 60 / 138 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `main` | 2,784 | 91.52 | 78 | 129 |
+| `identification` | 1,392 | 83.27 | 68 | 102 |
+| `withtitle` | 2,784 | 91.52 | 78 | 129 |
+| `original` | 458 | 85.03 | 60 | 130 |
+| `remove_background_q1q2` | 2,784 | 94.23 | 78 | 138 |
+| `remove_background_q3` | 1,392 | 83.91 | 70 | 102 |
+
+**图像统计信息：**
+
+| 指标 | 值 |
+|--------|-------|
+| 图像总数 | 11,594 |
+| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |
+| 分辨率范围 | 384x183 - 1862x1430 |
+| 格式 | png |
+
+
+## 样例示例
+
+**子集**: `main`
+
+```json
+{
+  "input": [
+    {
+      "id": "3872fe66",
+      "content": [
+        {
+          "image": "[BASE64_IMAGE: png, ~1.9KB]"
+        },
+        {
+          "text": "Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}."
+        }
+      ]
+    }
+  ],
+  "target": "Yes",
+  "id": 0,
+  "group_id": 0,
+  "metadata": {
+    "id": "VerticalHorizontal_001_Q1_notitle_px384",
+    "topic": "Optical Illusion",
+    "sub_topic": "Vertical-Horizontal illusion",
+    "type_of_question": "Q1",
+    "expected_bias": "No",
+    "with_title": false,
+    "pixel": 384
+  }
+}
+```
+
+## 提示模板
+
+*未定义提示模板。*
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets vlms_are_biased \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['vlms_are_biased'],
+    dataset_args={
+        'vlms_are_biased': {
+            # subset_list: ['main', 'identification', 'withtitle']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/vlm.md
+++ b/docs/zh/get_started/supported_dataset/vlm.md
@@ -69,6 +69,7 @@
 | `tvbench` | [TVBench](../../benchmarks/tvbench.md) | `MCQ`, `MultiModal`, `Video` |
 | `videomme_v2` | [Video-MME-v2](../../benchmarks/videomme_v2.md) | `MCQ`, `MultiModal`, `Video` |
 | `visulogic` | [VisuLogic](../../benchmarks/visulogic.md) | `MCQ`, `Math`, `MultiModal`, `Reasoning` |
+| `vlms_are_biased` | [VLMs Are Biased](../../benchmarks/vlms_are_biased.md) | `MultiModal`, `QA`, `Reasoning` |
 | `vqav2` | [VQAv2](../../benchmarks/vqav2.md) | `MultiModal`, `QA` |
 | `vstar_bench` | [V*Bench](../../benchmarks/vstar_bench.md) | `Grounding`, `MCQ`, `MultiModal` |
 | `vtcbench` | [VTCBench](../../benchmarks/vtcbench.md) | `LongContext`, `MultiModal`, `QA`, `Reasoning`, `Retrieval` |
@@ -145,6 +146,7 @@
 ../../benchmarks/tvbench.md
 ../../benchmarks/videomme_v2.md
 ../../benchmarks/visulogic.md
+../../benchmarks/vlms_are_biased.md
 ../../benchmarks/vqav2.md
 ../../benchmarks/vstar_bench.md
 ../../benchmarks/vtcbench.md

--- a/evalscope/benchmarks/_meta/vlms_are_biased.json
+++ b/evalscope/benchmarks/_meta/vlms_are_biased.json
@@ -1,0 +1,372 @@
+{
+  "meta": {
+    "pretty_name": "VLMs Are Biased",
+    "dataset_id": "evalscope/vlms-are-biased",
+    "paper_url": "https://arxiv.org/abs/2505.23941",
+    "tags": [
+      "MultiModal",
+      "QA",
+      "Reasoning"
+    ],
+    "metrics": [
+      "accuracy",
+      "bias_ratio"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "main",
+    "train_split": "",
+    "subset_list": [
+      "main",
+      "identification",
+      "withtitle",
+      "original",
+      "remove_background_q1q2",
+      "remove_background_q3"
+    ],
+    "description": "\n## Overview\n\nVLMs Are Biased (VLMBias) evaluates whether vision-language models answer objective visual questions from the image or fall back to memorized prior knowledge. It uses counterfactual images whose visible properties conflict with familiar concepts, such as an Adidas-style logo with four stripes or an animal with an unusual number of legs.\n\n## Task Description\n\n- **Task Type**: Free-form visual question answering for counting and identification\n- **Input**: A counterfactual or control image paired with a counting, binary identification, or short-answer question\n- **Output**: A number, `Yes`/`No`, or a short identity enclosed in curly brackets\n- **Domain**: Animals, logos, flags, chess pieces, game boards, optical illusions, and patterned grids\n\n## Key Features\n\n- The primary `main` split contains 2,784 objective visual questions over 1,392 counterfactual images at 384, 768, and 1152 pixel resolutions\n- Five official analysis splits cover binary identification, in-image title injection, original unmodified controls, and background-removed variants\n- Each counterfactual record provides both the visually correct `ground_truth` and the prior-knowledge `expected_bias`\n- The benchmark exposes seven topics and nineteen sub-topics for detailed analysis without creating synthetic EvalScope subsets\n\n## Evaluation Notes\n\n- The dataset prompt is used verbatim, including its required curly-bracket answer format\n- Primary metric: **Accuracy** (`acc`), using the official case-insensitive comparison after stripping outer braces; if exact text matching fails, digit sequences are compared\n- Secondary metric: **Bias Ratio** (`bias_ratio`, lower is better), the fraction of predictions matching `expected_bias` under the same normalization\n- Accuracy is also reported by topic, matching the official lmms-eval integration\n- `bias_ratio` is omitted for the `original` split because those control records do not define `expected_bias`\n- The six official dataset splits are exposed as separate EvalScope subsets and evaluated by default; select only `main` to reproduce the paper's headline benchmark\n- Generation should be deterministic and concise; the official lmms-eval setup uses `temperature=0` and at most 32 new tokens\n- [Paper](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [Project page](https://vlmsarebiased.github.io/)\n",
+    "prompt_template": "",
+    "system_prompt": "",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "vlm",
+    "primary_metric": {
+      "name": "accuracy",
+      "aggregation": null,
+      "dimensions": {
+        "scope": "overall"
+      }
+    }
+  },
+  "statistics": {
+    "total_samples": 11594,
+    "subset_stats": [
+      {
+        "name": "main",
+        "sample_count": 2784,
+        "prompt_length_mean": 91.52,
+        "prompt_length_min": 78,
+        "prompt_length_max": 129,
+        "prompt_length_std": 10.44,
+        "target_length_mean": 1.53,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 2784,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1152",
+              "1027x1152",
+              "1152x1055",
+              "1152x1057",
+              "1152x1149",
+              "1152x1152",
+              "1152x1296",
+              "1152x551",
+              "1152x571",
+              "1152x615"
+            ],
+            "resolution_range": {
+              "min": "384x183",
+              "max": "1862x1152"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "identification",
+        "sample_count": 1392,
+        "prompt_length_mean": 83.27,
+        "prompt_length_min": 68,
+        "prompt_length_max": 102,
+        "prompt_length_std": 7.6,
+        "target_length_mean": 2.14,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 1392,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1152",
+              "1027x1152",
+              "1152x1055",
+              "1152x1057",
+              "1152x1149",
+              "1152x1152",
+              "1152x1296",
+              "1152x551",
+              "1152x571",
+              "1152x615"
+            ],
+            "resolution_range": {
+              "min": "384x183",
+              "max": "1152x1296"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "withtitle",
+        "sample_count": 2784,
+        "prompt_length_mean": 91.52,
+        "prompt_length_min": 78,
+        "prompt_length_max": 129,
+        "prompt_length_std": 10.44,
+        "target_length_mean": 1.53,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 2784,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1303",
+              "1027x1304",
+              "1152x1000",
+              "1152x1007",
+              "1152x1014",
+              "1152x1015",
+              "1152x1025",
+              "1152x1027",
+              "1152x1028",
+              "1152x1030"
+            ],
+            "resolution_range": {
+              "min": "384x239",
+              "max": "1862x1430"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "original",
+        "sample_count": 458,
+        "prompt_length_mean": 85.03,
+        "prompt_length_min": 60,
+        "prompt_length_max": 130,
+        "prompt_length_std": 20.87,
+        "target_length_mean": 12.33,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 458,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1024x1024",
+              "1024x491",
+              "1024x510",
+              "1024x567",
+              "1024x572",
+              "1024x608",
+              "1024x616",
+              "1024x617",
+              "1024x618",
+              "1024x630"
+            ],
+            "resolution_range": {
+              "min": "768x512",
+              "max": "1324x1324"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "remove_background_q1q2",
+        "sample_count": 2784,
+        "prompt_length_mean": 94.23,
+        "prompt_length_min": 78,
+        "prompt_length_max": 138,
+        "prompt_length_std": 12.83,
+        "target_length_mean": 1.58,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 2784,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1152",
+              "1027x1152",
+              "1152x1055",
+              "1152x1057",
+              "1152x1149",
+              "1152x1152",
+              "1152x1296",
+              "1152x551",
+              "1152x571",
+              "1152x615"
+            ],
+            "resolution_range": {
+              "min": "384x183",
+              "max": "1152x1296"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      },
+      {
+        "name": "remove_background_q3",
+        "sample_count": 1392,
+        "prompt_length_mean": 83.91,
+        "prompt_length_min": 70,
+        "prompt_length_max": 102,
+        "prompt_length_std": 7.37,
+        "target_length_mean": 2.28,
+        "multimodal": {
+          "has_images": true,
+          "has_audio": false,
+          "has_video": false,
+          "image": {
+            "count_total": 1392,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "resolutions": [
+              "1021x1152",
+              "1027x1152",
+              "1152x1055",
+              "1152x1057",
+              "1152x1149",
+              "1152x1152",
+              "1152x1296",
+              "1152x551",
+              "1152x571",
+              "1152x615"
+            ],
+            "resolution_range": {
+              "min": "384x183",
+              "max": "1152x1296"
+            },
+            "formats": [
+              "png"
+            ]
+          }
+        }
+      }
+    ],
+    "prompt_length": {
+      "mean": 90.01,
+      "min": 60,
+      "max": 138,
+      "std": 11.78
+    },
+    "target_length_mean": 2.14,
+    "computed_at": "2026-08-28T13:46:07.900906+08:00",
+    "multimodal": {
+      "has_images": true,
+      "has_audio": false,
+      "has_video": false,
+      "image": {
+        "count_total": 11594,
+        "count_per_sample": {
+          "min": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "resolutions": [
+          "1021x1152",
+          "1021x1303",
+          "1024x1024",
+          "1024x491",
+          "1024x510",
+          "1024x567",
+          "1024x572",
+          "1024x608",
+          "1024x616",
+          "1024x617"
+        ],
+        "resolution_range": {
+          "min": "384x183",
+          "max": "1862x1430"
+        },
+        "formats": [
+          "png"
+        ]
+      }
+    }
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "3872fe66",
+          "content": [
+            {
+              "image": "[BASE64_IMAGE: png, ~1.9KB]"
+            },
+            {
+              "text": "Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}."
+            }
+          ]
+        }
+      ],
+      "target": "Yes",
+      "id": 0,
+      "group_id": 0,
+      "metadata": {
+        "id": "VerticalHorizontal_001_Q1_notitle_px384",
+        "topic": "Optical Illusion",
+        "sub_topic": "Vertical-Horizontal illusion",
+        "type_of_question": "Q1",
+        "expected_bias": "No",
+        "with_title": false,
+        "pixel": 384
+      }
+    },
+    "subset": "main",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# VLMs Are Biased\n\n\n## Overview\n\nVLMs Are Biased (VLMBias) evaluates whether vision-language models answer objective visual questions from the image or fall back to memorized prior knowledge. It uses counterfactual images whose visible properties conflict with familiar concepts, such as an Adidas-style logo with four stripes or an animal with an unusual number of legs.\n\n## Task Description\n\n- **Task Type**: Free-form visual question answering for counting and identification\n- **Input**: A counterfactual or control image paired with a counting, binary identification, or short-answer question\n- **Output**: A number, `Yes`/`No`, or a short identity enclosed in curly brackets\n- **Domain**: Animals, logos, flags, chess pieces, game boards, optical illusions, and patterned grids\n\n## Key Features\n\n- The primary `main` split contains 2,784 objective visual questions over 1,392 counterfactual images at 384, 768, and 1152 pixel resolutions\n- Five official analysis splits cover binary identification, in-image title injection, original unmodified controls, and background-removed variants\n- Each counterfactual record provides both the visually correct `ground_truth` and the prior-knowledge `expected_bias`\n- The benchmark exposes seven topics and nineteen sub-topics for detailed analysis without creating synthetic EvalScope subsets\n\n## Evaluation Notes\n\n- The dataset prompt is used verbatim, including its required curly-bracket answer format\n- Primary metric: **Accuracy** (`acc`), using the official case-insensitive comparison after stripping outer braces; if exact text matching fails, digit sequences are compared\n- Secondary metric: **Bias Ratio** (`bias_ratio`, lower is better), the fraction of predictions matching `expected_bias` under the same normalization\n- Accuracy is also reported by topic, matching the official lmms-eval integration\n- `bias_ratio` is omitted for the `original` split because those control records do not define `expected_bias`\n- The six official dataset splits are exposed as separate EvalScope subsets and evaluated by default; select only `main` to reproduce the paper's headline benchmark\n- Generation should be deterministic and concise; the official lmms-eval setup uses `temperature=0` and at most 32 new tokens\n- [Paper](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [Project page](https://vlmsarebiased.github.io/)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `vlms_are_biased` |\n| **Dataset ID** | [evalscope/vlms-are-biased](https://modelscope.cn/datasets/evalscope/vlms-are-biased/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2505.23941) |\n| **Tags** | `MultiModal`, `QA`, `Reasoning` |\n| **Metrics** | `accuracy`, `bias_ratio` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `main` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 11,594 |\n| Prompt Length (Mean) | 90.01 chars |\n| Prompt Length (Min/Max) | 60 / 138 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `main` | 2,784 | 91.52 | 78 | 129 |\n| `identification` | 1,392 | 83.27 | 68 | 102 |\n| `withtitle` | 2,784 | 91.52 | 78 | 129 |\n| `original` | 458 | 85.03 | 60 | 130 |\n| `remove_background_q1q2` | 2,784 | 94.23 | 78 | 138 |\n| `remove_background_q3` | 1,392 | 83.91 | 70 | 102 |\n\n**Image Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Images | 11,594 |\n| Images per Sample | min: 1, max: 1, mean: 1 |\n| Resolution Range | 384x183 - 1862x1430 |\n| Formats | png |\n\n\n## Sample Example\n\n**Subset**: `main`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"3872fe66\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~1.9KB]\"\n        },\n        {\n          \"text\": \"Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Yes\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"id\": \"VerticalHorizontal_001_Q1_notitle_px384\",\n    \"topic\": \"Optical Illusion\",\n    \"sub_topic\": \"Vertical-Horizontal illusion\",\n    \"type_of_question\": \"Q1\",\n    \"expected_bias\": \"No\",\n    \"with_title\": false,\n    \"pixel\": 384\n  }\n}\n```\n\n## Prompt Template\n\n*No prompt template defined.*\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets vlms_are_biased \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['vlms_are_biased'],\n    dataset_args={\n        'vlms_are_biased': {\n            # subset_list: ['main', 'identification', 'withtitle']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# VLMs Are Biased\n\n\n## 概述\n\nVLMs Are Biased（VLMBias）用于评估视觉-语言模型（VLM）在回答客观视觉问题时，是依据图像内容作答，还是依赖于记忆中的先验知识。该基准测试使用反事实图像（counterfactual images），这些图像的可见属性与常见概念相冲突，例如带有四条纹的阿迪达斯风格标志，或拥有异常腿数的动物。\n\n## 任务描述\n\n- **任务类型**：自由形式的视觉问答（计数与识别）\n- **输入**：一张反事实图像或对照图像，配以计数、二元识别或简短回答类问题\n- **输出**：一个数字、`Yes`/`No`，或用花括号括起的简短身份标识\n- **领域**：动物、商标、旗帜、国际象棋棋子、游戏棋盘、视错觉和图案网格\n\n## 核心特性\n\n- 主要的 `main` 划分包含 2,784 个客观视觉问题，覆盖 1,392 张反事实图像，分辨率分别为 384、768 和 1152 像素\n- 五个官方分析划分涵盖二元识别、图像内标题注入、原始未修改对照图像，以及去除背景的变体\n- 每条反事实记录同时提供视觉上正确的 `ground_truth` 和基于先验知识的 `expected_bias`\n- 该基准测试涵盖七个主题和十九个子主题，支持细粒度分析，无需创建合成的 EvalScope 子集\n\n## 评估说明\n\n- 数据集提示词按原文使用，包括其要求的花括号答案格式\n- 主要指标：**准确率**（`acc`），采用官方提供的大小写不敏感比较方法（去除外层花括号后）；若精确文本匹配失败，则比较其中的数字序列\n- 次要指标：**偏见比率**（`bias_ratio`，越低越好），即在相同归一化条件下，预测结果与 `expected_bias` 一致的比例\n- 准确率也按主题分别报告，与官方 lmms-eval 集成一致\n- `original` 划分不计算 `bias_ratio`，因为这些对照样本未定义 `expected_bias`\n- 六个官方数据集划分作为独立的 EvalScope 子集公开，并默认全部参与评估；若仅选择 `main` 子集，可复现论文中的主要基准结果\n- 生成应具有确定性且简洁；官方 lmms-eval 设置使用 `temperature=0`，最多生成 32 个新 token\n- [论文](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [项目主页](https://vlmsarebiased.github.io/)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `vlms_are_biased` |\n| **数据集ID** | [evalscope/vlms-are-biased](https://modelscope.cn/datasets/evalscope/vlms-are-biased/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2505.23941) |\n| **标签** | `MultiModal`, `QA`, `Reasoning` |\n| **指标** | `accuracy`, `bias_ratio` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `main` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 11,594 |\n| 提示词长度（平均） | 90.01 字符 |\n| 提示词长度（最小/最大） | 60 / 138 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `main` | 2,784 | 91.52 | 78 | 129 |\n| `identification` | 1,392 | 83.27 | 68 | 102 |\n| `withtitle` | 2,784 | 91.52 | 78 | 129 |\n| `original` | 458 | 85.03 | 60 | 130 |\n| `remove_background_q1q2` | 2,784 | 94.23 | 78 | 138 |\n| `remove_background_q3` | 1,392 | 83.91 | 70 | 102 |\n\n**图像统计信息：**\n\n| 指标 | 值 |\n|--------|-------|\n| 图像总数 | 11,594 |\n| 每样本图像数 | 最小: 1, 最大: 1, 平均: 1 |\n| 分辨率范围 | 384x183 - 1862x1430 |\n| 格式 | png |\n\n\n## 样例示例\n\n**子集**: `main`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"3872fe66\",\n      \"content\": [\n        {\n          \"image\": \"[BASE64_IMAGE: png, ~1.9KB]\"\n        },\n        {\n          \"text\": \"Are the horizontal and vertical lines equal in length? Answer in curly brackets, e.g., {Yes} or {No}.\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Yes\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"id\": \"VerticalHorizontal_001_Q1_notitle_px384\",\n    \"topic\": \"Optical Illusion\",\n    \"sub_topic\": \"Vertical-Horizontal illusion\",\n    \"type_of_question\": \"Q1\",\n    \"expected_bias\": \"No\",\n    \"with_title\": false,\n    \"pixel\": 384\n  }\n}\n```\n\n## 提示模板\n\n*未定义提示模板。*\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets vlms_are_biased \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['vlms_are_biased'],\n    dataset_args={\n        'vlms_are_biased': {\n            # subset_list: ['main', 'identification', 'withtitle']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "6e7abd5b93971e0f76453dccd923ce57",
+    "needs_translation": false
+  },
+  "updated_at": "2026-08-28T13:46:17.233686+08:00",
+  "translation_updated_at": "2026-08-28T13:46:22+08:00"
+}

--- a/evalscope/benchmarks/vlms_are_biased/utils.py
+++ b/evalscope/benchmarks/vlms_are_biased/utils.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict
+
+
+def normalize_answer(answer: str) -> str:
+    """Normalize an answer using the official lmms-eval comparison rule."""
+    return str(answer or '').strip().lower().strip('{}').strip()
+
+
+def score_answer(prediction: str, ground_truth: str, expected_bias: Any = None) -> Dict[str, float]:
+    """Compute the official accuracy and optional bias-ratio indicators."""
+    normalized_prediction = normalize_answer(prediction)
+    normalized_ground_truth = normalize_answer(ground_truth)
+    normalized_bias = normalize_answer(expected_bias) if expected_bias is not None else None
+
+    is_correct = normalized_prediction == normalized_ground_truth
+    matches_bias = normalized_bias is not None and normalized_prediction == normalized_bias
+
+    if not is_correct and not matches_bias:
+        prediction_digits = ''.join(character for character in normalized_prediction if character.isdigit())
+        ground_truth_digits = ''.join(character for character in normalized_ground_truth if character.isdigit())
+        bias_digits = (
+            ''.join(character for character in normalized_bias if character.isdigit())
+            if normalized_bias is not None
+            else ''
+        )
+        if prediction_digits and ground_truth_digits:
+            is_correct = prediction_digits == ground_truth_digits
+        if prediction_digits and bias_digits:
+            matches_bias = prediction_digits == bias_digits
+
+    result = {'acc': float(is_correct)}
+    if normalized_bias is not None:
+        result['bias_ratio'] = float(matches_bias)
+    return result

--- a/evalscope/benchmarks/vlms_are_biased/vlms_are_biased_adapter.py
+++ b/evalscope/benchmarks/vlms_are_biased/vlms_are_biased_adapter.py
@@ -10,6 +10,8 @@ from evalscope.api.metric.scorer import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
 
+from .utils import normalize_answer, score_answer
+
 SUBSET_LIST = [
     'main',
     'identification',
@@ -49,39 +51,6 @@ VLMs Are Biased (VLMBias) evaluates whether vision-language models answer object
 - Generation should be deterministic and concise; the official lmms-eval setup uses `temperature=0` and at most 32 new tokens
 - [Paper](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [Project page](https://vlmsarebiased.github.io/)
 """
-
-
-def normalize_answer(answer: str) -> str:
-    """Normalize an answer using the official lmms-eval comparison rule."""
-    return str(answer or '').strip().lower().strip('{}').strip()
-
-
-def score_answer(prediction: str, ground_truth: str, expected_bias: Any = None) -> Dict[str, float]:
-    """Compute the official accuracy and optional bias-ratio indicators."""
-    normalized_prediction = normalize_answer(prediction)
-    normalized_ground_truth = normalize_answer(ground_truth)
-    normalized_bias = normalize_answer(expected_bias) if expected_bias is not None else None
-
-    is_correct = normalized_prediction == normalized_ground_truth
-    matches_bias = normalized_bias is not None and normalized_prediction == normalized_bias
-
-    if not is_correct and not matches_bias:
-        prediction_digits = ''.join(character for character in normalized_prediction if character.isdigit())
-        ground_truth_digits = ''.join(character for character in normalized_ground_truth if character.isdigit())
-        bias_digits = (
-            ''.join(character for character in normalized_bias if character.isdigit())
-            if normalized_bias is not None
-            else ''
-        )
-        if prediction_digits and ground_truth_digits:
-            is_correct = prediction_digits == ground_truth_digits
-        if prediction_digits and bias_digits:
-            matches_bias = prediction_digits == bias_digits
-
-    result = {'acc': float(is_correct)}
-    if normalized_bias is not None:
-        result['bias_ratio'] = float(matches_bias)
-    return result
 
 
 @register_benchmark(

--- a/evalscope/benchmarks/vlms_are_biased/vlms_are_biased_adapter.py
+++ b/evalscope/benchmarks/vlms_are_biased/vlms_are_biased_adapter.py
@@ -1,0 +1,180 @@
+# flake8: noqa: E501
+from typing import Any, Dict, List
+
+from evalscope.api.benchmark import BenchmarkMeta, VisionLanguageAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessageUser, ContentImage, ContentText
+from evalscope.api.metric import AggScore, MetricSelector, SampleScore
+from evalscope.api.metric.scorer import Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+
+SUBSET_LIST = [
+    'main',
+    'identification',
+    'withtitle',
+    'original',
+    'remove_background_q1q2',
+    'remove_background_q3',
+]
+
+DESCRIPTION = """
+## Overview
+
+VLMs Are Biased (VLMBias) evaluates whether vision-language models answer objective visual questions from the image or fall back to memorized prior knowledge. It uses counterfactual images whose visible properties conflict with familiar concepts, such as an Adidas-style logo with four stripes or an animal with an unusual number of legs.
+
+## Task Description
+
+- **Task Type**: Free-form visual question answering for counting and identification
+- **Input**: A counterfactual or control image paired with a counting, binary identification, or short-answer question
+- **Output**: A number, `Yes`/`No`, or a short identity enclosed in curly brackets
+- **Domain**: Animals, logos, flags, chess pieces, game boards, optical illusions, and patterned grids
+
+## Key Features
+
+- The primary `main` split contains 2,784 objective visual questions over 1,392 counterfactual images at 384, 768, and 1152 pixel resolutions
+- Five official analysis splits cover binary identification, in-image title injection, original unmodified controls, and background-removed variants
+- Each counterfactual record provides both the visually correct `ground_truth` and the prior-knowledge `expected_bias`
+- The benchmark exposes seven topics and nineteen sub-topics for detailed analysis without creating synthetic EvalScope subsets
+
+## Evaluation Notes
+
+- The dataset prompt is used verbatim, including its required curly-bracket answer format
+- Primary metric: **Accuracy** (`acc`), using the official case-insensitive comparison after stripping outer braces; if exact text matching fails, digit sequences are compared
+- Secondary metric: **Bias Ratio** (`bias_ratio`, lower is better), the fraction of predictions matching `expected_bias` under the same normalization
+- Accuracy is also reported by topic, matching the official lmms-eval integration
+- `bias_ratio` is omitted for the `original` split because those control records do not define `expected_bias`
+- The six official dataset splits are exposed as separate EvalScope subsets and evaluated by default; select only `main` to reproduce the paper's headline benchmark
+- Generation should be deterministic and concise; the official lmms-eval setup uses `temperature=0` and at most 32 new tokens
+- [Paper](https://arxiv.org/abs/2505.23941) | [GitHub](https://github.com/anvo25/vlms-are-biased) | [Project page](https://vlmsarebiased.github.io/)
+"""
+
+
+def normalize_answer(answer: str) -> str:
+    """Normalize an answer using the official lmms-eval comparison rule."""
+    return str(answer or '').strip().lower().strip('{}').strip()
+
+
+def score_answer(prediction: str, ground_truth: str, expected_bias: Any = None) -> Dict[str, float]:
+    """Compute the official accuracy and optional bias-ratio indicators."""
+    normalized_prediction = normalize_answer(prediction)
+    normalized_ground_truth = normalize_answer(ground_truth)
+    normalized_bias = normalize_answer(expected_bias) if expected_bias is not None else None
+
+    is_correct = normalized_prediction == normalized_ground_truth
+    matches_bias = normalized_bias is not None and normalized_prediction == normalized_bias
+
+    if not is_correct and not matches_bias:
+        prediction_digits = ''.join(character for character in normalized_prediction if character.isdigit())
+        ground_truth_digits = ''.join(character for character in normalized_ground_truth if character.isdigit())
+        bias_digits = (
+            ''.join(character for character in normalized_bias if character.isdigit())
+            if normalized_bias is not None
+            else ''
+        )
+        if prediction_digits and ground_truth_digits:
+            is_correct = prediction_digits == ground_truth_digits
+        if prediction_digits and bias_digits:
+            matches_bias = prediction_digits == bias_digits
+
+    result = {'acc': float(is_correct)}
+    if normalized_bias is not None:
+        result['bias_ratio'] = float(matches_bias)
+    return result
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='vlms_are_biased',
+        pretty_name='VLMs Are Biased',
+        dataset_id='evalscope/vlms-are-biased',
+        subset_list=SUBSET_LIST,
+        tags=[Tags.MULTI_MODAL, Tags.QA, Tags.REASONING],
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2505.23941',
+        metric_list=['acc', 'bias_ratio'],
+        primary_metric=MetricSelector(name='accuracy', dimensions={'scope': 'overall'}),
+        eval_split='main',
+        evaluation_version='v1.0',
+    )
+)
+class VLMsAreBiasedAdapter(VisionLanguageAdapter):
+    """Data adapter for the six official VLMs Are Biased dataset splits."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.split_as_subset = True
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        """Convert one visual question into an EvalScope sample."""
+        image = self._image_bytes_to_base64(record['image']['bytes'], guess_mimetype=True)
+        expected_bias = record.get('expected_bias')
+        return Sample(
+            input=[
+                ChatMessageUser(
+                    content=[
+                        ContentImage(image=image),
+                        ContentText(text=record['prompt']),
+                    ]
+                )
+            ],
+            target=str(record['ground_truth']).strip(),
+            metadata={
+                'id': record['ID'],
+                'topic': record['topic'],
+                'sub_topic': record['sub_topic'],
+                'type_of_question': record['type_of_question'],
+                'expected_bias': expected_bias,
+                'with_title': record['with_title'],
+                'pixel': record['pixel'],
+            },
+        )
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        """Normalize the model reply according to the official scorer."""
+        return normalize_answer(prediction)
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        """Score visual accuracy and prior-knowledge bias alignment."""
+        score = Score(extracted_prediction=filtered_prediction, prediction=original_prediction)
+        score.value = score_answer(
+            prediction=filtered_prediction,
+            ground_truth=reference,
+            expected_bias=(task_state.metadata or {}).get('expected_bias'),
+        )
+        score.main_score_name = 'acc'
+        return score
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        """Aggregate official overall metrics and per-topic accuracy."""
+        aggregate_scores = super().aggregate_scores(sample_scores)
+        for aggregate_score in aggregate_scores:
+            aggregate_score.dimensions = {'scope': 'overall'}
+        topics = sorted(
+            {topic for sample_score in sample_scores if (topic := (sample_score.sample_metadata or {}).get('topic'))}
+        )
+        for topic in topics:
+            topic_scores = [
+                sample_score
+                for sample_score in sample_scores
+                if (sample_score.sample_metadata or {}).get('topic') == topic
+            ]
+            accuracy = sum(float(sample_score.score.value['acc']) for sample_score in topic_scores) / len(topic_scores)
+            aggregate_scores.append(
+                AggScore(
+                    metric_name='acc',
+                    aggregation='mean',
+                    dimensions={'topic': topic},
+                    score=accuracy,
+                    num=len(topic_scores),
+                    ids=[sample_score.sample_id for sample_score in topic_scores],
+                )
+            )
+        return aggregate_scores

--- a/evalscope/metrics/semantics/catalog.py
+++ b/evalscope/metrics/semantics/catalog.py
@@ -422,6 +422,10 @@ METRIC_DEFINITIONS.update(
         # non-primary and directionless, but deserve report labels rather than internal identities.
         'is_incorrect': MetricEntry(baseline='diagnostic.parse_status.ratio', display_name='Incorrect rate'),
         'is_not_attempted': MetricEntry(baseline='diagnostic.parse_status.ratio', display_name='Not attempted rate'),
+        'bias_ratio': MetricEntry(
+            baseline='quality.error_rate.ratio',
+            metric_name='Bias Ratio',
+        ),
         'total_model_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),
         'total_other_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),
         'total_tool_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),

--- a/tests/benchmark/test_vlm.py
+++ b/tests/benchmark/test_vlm.py
@@ -584,6 +584,16 @@ class TestVLMBenchmark(TestBenchmark):
         """Test CountQA with mock LLM."""
         self._run_dataset_test('count_qa', limit=5, use_mock=True)
 
+    def test_vlms_are_biased(self):
+        """Test VLMs Are Biased counterfactual visual reasoning benchmark."""
+        dataset_args = {'subset_list': ['main']}
+        self._run_dataset_test('vlms_are_biased', dataset_args=dataset_args, limit=5)
+
+    def test_vlms_are_biased_mock(self):
+        """Test VLMs Are Biased with mock LLM."""
+        dataset_args = {'subset_list': ['main']}
+        self._run_dataset_test('vlms_are_biased', dataset_args=dataset_args, limit=5, use_mock=True)
+
     def test_phyx_mc(self):
         """Test PhyX multiple-choice physical reasoning benchmark."""
         dataset_args = {'subset_list': ['optics', 'modern_physics']}

--- a/tests/benchmark/test_vlms_are_biased.py
+++ b/tests/benchmark/test_vlms_are_biased.py
@@ -1,0 +1,119 @@
+"""Unit tests for the VLMs Are Biased adapter and official scoring rules."""
+import io
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from PIL import Image
+
+from evalscope.api.metric import MetricDirection, SampleScore
+from evalscope.api.metric.scorer import Score
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.vlms_are_biased.vlms_are_biased_adapter import normalize_answer, score_answer
+from evalscope.config import TaskConfig
+from evalscope.metrics.semantics.catalog import METRIC_DEFINITIONS
+
+
+def _adapter() -> Any:
+    task_config = TaskConfig(model='mock', datasets=['vlms_are_biased'])
+    return get_benchmark('vlms_are_biased', task_config)
+
+
+def _image_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new('RGB', (2, 2)).save(buffer, format='PNG')
+    return buffer.getvalue()
+
+
+def _record(**overrides: Any) -> Dict[str, Any]:
+    record = {
+        'image': {
+            'bytes': _image_bytes(),
+            'path': 'sample.png'
+        },
+        'ID': 'sample_Q1_px384',
+        'topic': 'Logos',
+        'sub_topic': 'Shoe Logos',
+        'prompt': 'How many stripes are visible? Answer with a number in curly brackets, e.g., {9}.',
+        'ground_truth': '4',
+        'expected_bias': '3',
+        'with_title': False,
+        'type_of_question': 'Q1',
+        'pixel': 384,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_normalize_answer_matches_official_brace_rule() -> None:
+    assert normalize_answer('  {Yes}\n') == 'yes'
+    assert normalize_answer('{{4}}') == '4'
+    assert normalize_answer('The answer is {4}.') == 'the answer is {4}.'
+
+
+def test_score_answer_exact_and_bias_matches() -> None:
+    assert score_answer('{4}', '4', '3') == {'acc': 1.0, 'bias_ratio': 0.0}
+    assert score_answer('{3}', '4', '3') == {'acc': 0.0, 'bias_ratio': 1.0}
+    assert score_answer('{2}', '4', '3') == {'acc': 0.0, 'bias_ratio': 0.0}
+    assert score_answer('{YES}', 'Yes', 'No') == {'acc': 1.0, 'bias_ratio': 0.0}
+
+
+def test_score_answer_uses_official_digit_fallback() -> None:
+    assert score_answer('There are {4} visible stripes.', '4', '3') == {'acc': 1.0, 'bias_ratio': 0.0}
+    assert score_answer('I see 3 stripes.', '4', '3') == {'acc': 0.0, 'bias_ratio': 1.0}
+    assert score_answer('I counted 3, then 4.', '4', '3') == {'acc': 0.0, 'bias_ratio': 0.0}
+
+
+def test_original_control_omits_bias_ratio() -> None:
+    assert score_answer('{Audi}', 'Audi', None) == {'acc': 1.0}
+
+
+def test_bias_ratio_semantics_are_lower_is_better() -> None:
+    semantics = METRIC_DEFINITIONS['bias_ratio'].resolve('bias_ratio')
+
+    assert semantics.metric_name == 'Bias Ratio'
+    assert semantics.direction is MetricDirection.LOWER_IS_BETTER
+
+
+def test_record_to_sample_preserves_official_prompt_and_metadata() -> None:
+    sample = _adapter().record_to_sample(_record())
+
+    assert sample.target == '4'
+    assert sample.input[0].content[0].image.startswith('data:image/png;base64,')
+    assert sample.input[0].content[1].text == _record()['prompt']
+    assert sample.metadata == {
+        'id': 'sample_Q1_px384',
+        'topic': 'Logos',
+        'sub_topic': 'Shoe Logos',
+        'type_of_question': 'Q1',
+        'expected_bias': '3',
+        'with_title': False,
+        'pixel': 384,
+    }
+
+
+def test_match_score_uses_expected_bias_metadata() -> None:
+    score = _adapter().match_score(
+        original_prediction='{3}',
+        filtered_prediction='3',
+        reference='4',
+        task_state=SimpleNamespace(metadata={'expected_bias': '3'}),
+    )
+
+    assert score.value == {'acc': 0.0, 'bias_ratio': 1.0}
+    assert score.main_score_name == 'acc'
+
+
+def test_aggregation_reports_official_per_topic_accuracy() -> None:
+    sample_scores = [
+        SampleScore(sample_id='1', score=Score(value={'acc': 1.0, 'bias_ratio': 0.0}), sample_metadata={'topic': 'Logos'}),
+        SampleScore(sample_id='2', score=Score(value={'acc': 0.0, 'bias_ratio': 1.0}), sample_metadata={'topic': 'Logos'}),
+        SampleScore(sample_id='3', score=Score(value={'acc': 1.0, 'bias_ratio': 0.0}), sample_metadata={'topic': 'Flags'}),
+    ]
+
+    aggregate_scores = _adapter().aggregate_scores(sample_scores)
+    by_identity = {(score.metric_name, score.dimensions.get('topic')): score.score for score in aggregate_scores}
+
+    assert by_identity[('accuracy', None)] == 2 / 3
+    assert by_identity[('bias_ratio', None)] == 1 / 3
+    assert by_identity[('accuracy', 'Logos')] == 0.5
+    assert by_identity[('accuracy', 'Flags')] == 1.0

--- a/tests/benchmark/test_vlms_are_biased.py
+++ b/tests/benchmark/test_vlms_are_biased.py
@@ -8,7 +8,7 @@ from PIL import Image
 from evalscope.api.metric import MetricDirection, SampleScore
 from evalscope.api.metric.scorer import Score
 from evalscope.api.registry import get_benchmark
-from evalscope.benchmarks.vlms_are_biased.vlms_are_biased_adapter import normalize_answer, score_answer
+from evalscope.benchmarks.vlms_are_biased.utils import normalize_answer, score_answer
 from evalscope.config import TaskConfig
 from evalscope.metrics.semantics.catalog import METRIC_DEFINITIONS
 


### PR DESCRIPTION
## Summary

- add the `vlms_are_biased` native VLM benchmark backed by `evalscope/vlms-are-biased`
- expose all six official dataset splits while keeping `main` selectable for the paper's headline evaluation
- reproduce the official prompt, answer normalization, accuracy, bias-ratio, and per-topic accuracy behavior
- declare `bias_ratio` as a lower-is-better quality metric and generate bilingual benchmark documentation

## Design

The adapter reuses `VisionLanguageAdapter` and the standard split-based `RemoteDataLoader` flow. It only implements sample conversion, the official deterministic scorer, and the official per-topic aggregation. No custom loading path or speculative configuration is introduced.

## Validation

- inspected the official repository at `anvo25/vlms-are-biased`, paper arXiv:2505.23941, and the official lmms-eval integration
- verified all six ModelScope splits: 11,594 samples total
- `make lint`
- `pytest tests/benchmark/test_vlms_are_biased.py tests/benchmark/test_vlm.py::TestVLMBenchmark::test_vlms_are_biased_mock -q` — 9 passed
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings` — passed
- real `qwen-vl-plus` API E2E over 30 samples across all six splits; independently recomputed every `acc` and `bias_ratio` value with zero mismatches
- `make docs-pipeline BENCHMARK='vlms_are_biased' FORCE=1`

## Reporting semantics

- `accuracy`: higher is better, primary metric selected at `scope=overall`
- `bias_ratio`: lower is better
- per-topic accuracy is emitted with a `topic` dimension and cannot be mistaken for the primary overall accuracy
- the `original` control split omits `bias_ratio` because the dataset has no `expected_bias` labels
