### PR TITLE
fix(models): retry 200 responses that carry a gateway error payload

### DIFF
--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -52,6 +52,32 @@ NON_RETRYABLE_OPENAI_ERRORS: Tuple[Type[Exception], ...] = (
 )
 
 
+class EmptyCompletionError(RuntimeError):
+    """A 200 response whose body carried no choices (usually a gateway error)."""
+
+
+def raise_if_error_payload(completion: ChatCompletion) -> None:
+    """Reject an error payload that the SDK deserialized as a completion.
+
+    Some gateways (OpenRouter among them) commit ``200 OK`` headers before the
+    upstream has produced anything, holding the connection open with whitespace
+    padding. When the request then fails, the status line is already sent, so
+    the error can only be appended to the body:
+
+        {"error": {"message": "Insufficient balance", "code": 402}}
+
+    The SDK parses that into a ``ChatCompletion`` whose ``choices`` is None and
+    keeps the real error in ``model_extra``. Raising here — inside the retry
+    boundary — turns a silent, run-killing corruption into a retried request
+    that reports what the gateway actually said.
+    """
+    if completion.choices is not None:
+        return
+    error = (completion.model_extra or {}).get('error')
+    detail = f': {error}' if error else ' (no error detail in body)'
+    raise EmptyCompletionError(f'Gateway returned a response with no choices{detail}')
+
+
 class OpenAICompatibleAPI(ModelAPI):
     def __init__(
         self,
@@ -150,6 +176,7 @@ class OpenAICompatibleAPI(ModelAPI):
             def _create_and_collect() -> Tuple[ChatCompletion, Optional[float]]:
                 raw_completion = self.client.chat.completions.create(**request)
                 if isinstance(raw_completion, ChatCompletion):
+                    raise_if_error_payload(raw_completion)
                     return raw_completion, None
                 return collect_stream_response(raw_completion, request_start=t_start)
 
@@ -233,6 +260,7 @@ class OpenAICompatibleAPI(ModelAPI):
             async def _create_and_collect() -> Tuple[ChatCompletion, Optional[float]]:
                 raw_completion = await self.async_client.chat.completions.create(**request)
                 if isinstance(raw_completion, ChatCompletion):
+                    raise_if_error_payload(raw_completion)
                     return raw_completion, None
                 return await async_collect_stream_response(raw_completion, request_start=t_start)
 

--- a/evalscope/models/openai_compatible.py
+++ b/evalscope/models/openai_compatible.py
@@ -52,30 +52,30 @@ NON_RETRYABLE_OPENAI_ERRORS: Tuple[Type[Exception], ...] = (
 )
 
 
-class EmptyCompletionError(RuntimeError):
-    """A 200 response whose body carried no choices (usually a gateway error)."""
+class EmptyCompletionError(ValueError):
+    """A 200 response whose body carried no choices."""
+
+
+class _NonRetryableEmptyCompletionError(EmptyCompletionError):
+    pass
+
+
+_NON_RETRYABLE_COMPLETION_ERRORS = (*NON_RETRYABLE_OPENAI_ERRORS, _NonRetryableEmptyCompletionError)
+_NON_RETRYABLE_GATEWAY_CODES = {'400', '401', '402', '403', '404', '422'}
 
 
 def raise_if_error_payload(completion: ChatCompletion) -> None:
-    """Reject an error payload that the SDK deserialized as a completion.
-
-    Some gateways (OpenRouter among them) commit ``200 OK`` headers before the
-    upstream has produced anything, holding the connection open with whitespace
-    padding. When the request then fails, the status line is already sent, so
-    the error can only be appended to the body:
-
-        {"error": {"message": "Insufficient balance", "code": 402}}
-
-    The SDK parses that into a ``ChatCompletion`` whose ``choices`` is None and
-    keeps the real error in ``model_extra``. Raising here — inside the retry
-    boundary — turns a silent, run-killing corruption into a retried request
-    that reports what the gateway actually said.
-    """
+    """Reject an error payload that the SDK deserialized as a completion."""
     if completion.choices is not None:
         return
     error = (completion.model_extra or {}).get('error')
     detail = f': {error}' if error else ' (no error detail in body)'
-    raise EmptyCompletionError(f'Gateway returned a response with no choices{detail}')
+    error_type = (
+        _NonRetryableEmptyCompletionError
+        if isinstance(error, dict) and str(error.get('code')) in _NON_RETRYABLE_GATEWAY_CODES
+        else EmptyCompletionError
+    )
+    raise error_type(f'Gateway returned a response with no choices{detail}')
 
 
 class OpenAICompatibleAPI(ModelAPI):
@@ -184,7 +184,7 @@ class OpenAICompatibleAPI(ModelAPI):
                 _create_and_collect,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                no_retry_exceptions=NON_RETRYABLE_OPENAI_ERRORS,
+                no_retry_exceptions=_NON_RETRYABLE_COMPLETION_ERRORS,
             )
 
             total_time = time.monotonic() - t_start
@@ -268,7 +268,7 @@ class OpenAICompatibleAPI(ModelAPI):
                 _create_and_collect,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                no_retry_exceptions=NON_RETRYABLE_OPENAI_ERRORS,
+                no_retry_exceptions=_NON_RETRYABLE_COMPLETION_ERRORS,
             )
 
             total_time = time.monotonic() - t_start

--- a/tests/models/test_empty_completion_retry.py
+++ b/tests/models/test_empty_completion_retry.py
@@ -1,0 +1,169 @@
+"""A 200 response carrying an error payload must be retried, not silently fatal.
+
+Some gateways commit ``200 OK`` headers before the upstream has produced
+anything, holding the connection open with whitespace padding. When the request
+later fails, the status line is already on the wire, so the error can only be
+appended to the body. The SDK deserializes that into a ``ChatCompletion`` whose
+``choices`` is None, which reaches the caller looking exactly like success.
+
+These tests exercise the backend call sites with mock SDK clients; no network
+access is performed.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+from openai.types.chat import ChatCompletion
+
+from evalscope.api.model import GenerateConfig
+from evalscope.models.openai_compatible import EmptyCompletionError, OpenAICompatibleAPI
+
+# Captured verbatim from an OpenRouter free-tier request that failed 13s after
+# the keepalive had already committed 200 OK: whitespace padding, then the error.
+GATEWAY_ERROR_BODY = ('\n         \n' * 31) + '{"error":{"message":"Insufficient balance","code":402}}'
+
+
+def _error_payload_completion() -> ChatCompletion:
+    """Deserialize an error body the way the OpenAI SDK does for a 200 response."""
+    return ChatCompletion.construct(**json.loads(GATEWAY_ERROR_BODY))
+
+
+def _valid_completion(content: str = 'complete response') -> ChatCompletion:
+    return ChatCompletion.model_validate({
+        'id': 'completion-id',
+        'created': 1,
+        'model': 'test-model',
+        'object': 'chat.completion',
+        'choices': [{
+            'index': 0,
+            'finish_reason': 'stop',
+            'message': {'role': 'assistant', 'content': content},
+        }],
+    })
+
+
+def _prepare_api(monkeypatch: pytest.MonkeyPatch) -> OpenAICompatibleAPI:
+    api = object.__new__(OpenAICompatibleAPI)
+    api.base_url = 'https://example.test/v1'
+    api.model_name = 'test-model'
+    api.resolve_tools = lambda tools, tool_choice, config: (tools, tool_choice, config)
+    api.completion_params = lambda config, tools: {'model': 'test-model'}
+    api.validate_request_params = lambda request: None
+    api.on_response = lambda response: None
+    api.chat_choices_from_completion = lambda completion, tools: []
+
+    monkeypatch.setattr('evalscope.models.openai_compatible.openai_chat_messages', lambda *args, **kwargs: [])
+
+    def model_output(completion, choices):
+        return SimpleNamespace(
+            content=completion.choices[0].message.content,
+            usage=None,
+            message=SimpleNamespace(),
+            time=None,
+        )
+
+    monkeypatch.setattr('evalscope.models.openai_compatible.model_output_from_openai', model_output)
+    return api
+
+
+def test_sdk_deserializes_error_payload_as_a_choiceless_completion() -> None:
+    """The premise: an error body becomes a ChatCompletion that looks like success."""
+    completion = _error_payload_completion()
+
+    assert completion.choices is None
+    assert getattr(completion, 'id', None) is None
+    # The gateway's real error survives here, which is what the retry reports.
+    assert completion.model_extra == {'error': {'message': 'Insufficient balance', 'code': 402}}
+
+
+def test_generate_retries_when_gateway_returns_error_payload(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            return _error_payload_completion()
+        return _valid_completion()
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    result = api.generate([], [], None, GenerateConfig(retries=5, retry_interval=0))
+
+    assert attempts == 3
+    assert result.content == 'complete response'
+
+
+def test_generate_async_retries_when_gateway_returns_error_payload(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    async def create(**request):
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            return _error_payload_completion()
+        return _valid_completion()
+
+    async_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    monkeypatch.setattr(OpenAICompatibleAPI, 'async_client', property(lambda self: async_client))
+
+    result = asyncio.run(api.generate_async([], [], None, GenerateConfig(retries=5, retry_interval=0)))
+
+    assert attempts == 3
+    assert result.content == 'complete response'
+
+
+def test_exhausted_retries_report_the_gateway_error(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        return _error_payload_completion()
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with pytest.raises(EmptyCompletionError, match='Insufficient balance'):
+        api.generate([], [], None, GenerateConfig(retries=3, retry_interval=0))
+
+    assert attempts == 3
+
+
+def test_choiceless_completion_without_error_detail_still_retries(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        return ChatCompletion.construct()
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with pytest.raises(EmptyCompletionError, match='no error detail'):
+        api.generate([], [], None, GenerateConfig(retries=2, retry_interval=0))
+
+    assert attempts == 2
+
+
+def test_valid_completion_is_not_retried(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        return _valid_completion('first response')
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    result = api.generate([], [], None, GenerateConfig(retries=5, retry_interval=0))
+
+    assert attempts == 1
+    assert result.content == 'first response'

--- a/tests/models/test_empty_completion_retry.py
+++ b/tests/models/test_empty_completion_retry.py
@@ -1,14 +1,4 @@
-"""A 200 response carrying an error payload must be retried, not silently fatal.
-
-Some gateways commit ``200 OK`` headers before the upstream has produced
-anything, holding the connection open with whitespace padding. When the request
-later fails, the status line is already on the wire, so the error can only be
-appended to the body. The SDK deserializes that into a ``ChatCompletion`` whose
-``choices`` is None, which reaches the caller looking exactly like success.
-
-These tests exercise the backend call sites with mock SDK clients; no network
-access is performed.
-"""
+"""Tests for gateway errors deserialized as empty chat completions."""
 
 import asyncio
 import json
@@ -26,9 +16,13 @@ from evalscope.models.openai_compatible import EmptyCompletionError, OpenAICompa
 GATEWAY_ERROR_BODY = ('\n         \n' * 31) + '{"error":{"message":"Insufficient balance","code":402}}'
 
 
-def _error_payload_completion() -> ChatCompletion:
+def _error_payload_completion(
+    code: int = 402, message: str = 'Insufficient balance'
+) -> ChatCompletion:
     """Deserialize an error body the way the OpenAI SDK does for a 200 response."""
-    return ChatCompletion.construct(**json.loads(GATEWAY_ERROR_BODY))
+    payload = json.loads(GATEWAY_ERROR_BODY)
+    payload['error'] = {'message': message, 'code': code}
+    return ChatCompletion.construct(**payload)
 
 
 def _valid_completion(content: str = 'complete response') -> ChatCompletion:
@@ -79,6 +73,42 @@ def test_sdk_deserializes_error_payload_as_a_choiceless_completion() -> None:
     assert completion.model_extra == {'error': {'message': 'Insufficient balance', 'code': 402}}
 
 
+@pytest.mark.parametrize('code', [400, 401, 402, 403, 404, 422])
+def test_generate_does_not_retry_non_retryable_gateway_errors(monkeypatch, code) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    def create(**request):
+        nonlocal attempts
+        attempts += 1
+        return _error_payload_completion(code=code, message='client error')
+
+    api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with pytest.raises(ValueError, match='client error'):
+        api.generate([], [], None, GenerateConfig(retries=5, retry_interval=0))
+
+    assert attempts == 1
+
+
+def test_generate_async_does_not_retry_non_retryable_gateway_error(monkeypatch) -> None:
+    api = _prepare_api(monkeypatch)
+    attempts = 0
+
+    async def create(**request):
+        nonlocal attempts
+        attempts += 1
+        return _error_payload_completion()
+
+    async_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    monkeypatch.setattr(OpenAICompatibleAPI, 'async_client', property(lambda self: async_client))
+
+    with pytest.raises(ValueError, match='Insufficient balance'):
+        asyncio.run(api.generate_async([], [], None, GenerateConfig(retries=5, retry_interval=0)))
+
+    assert attempts == 1
+
+
 def test_generate_retries_when_gateway_returns_error_payload(monkeypatch) -> None:
     api = _prepare_api(monkeypatch)
     attempts = 0
@@ -87,7 +117,7 @@ def test_generate_retries_when_gateway_returns_error_payload(monkeypatch) -> Non
         nonlocal attempts
         attempts += 1
         if attempts <= 2:
-            return _error_payload_completion()
+            return _error_payload_completion(code=503, message='Provider unavailable')
         return _valid_completion()
 
     api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
@@ -106,7 +136,7 @@ def test_generate_async_retries_when_gateway_returns_error_payload(monkeypatch) 
         nonlocal attempts
         attempts += 1
         if attempts <= 2:
-            return _error_payload_completion()
+            return _error_payload_completion(code=503, message='Provider unavailable')
         return _valid_completion()
 
     async_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
@@ -125,13 +155,14 @@ def test_exhausted_retries_report_the_gateway_error(monkeypatch) -> None:
     def create(**request):
         nonlocal attempts
         attempts += 1
-        return _error_payload_completion()
+        return _error_payload_completion(code=503, message='Provider unavailable')
 
     api.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
 
-    with pytest.raises(EmptyCompletionError, match='Insufficient balance'):
+    with pytest.raises(EmptyCompletionError, match='Provider unavailable') as exc_info:
         api.generate([], [], None, GenerateConfig(retries=3, retry_interval=0))
 
+    assert isinstance(exc_info.value, ValueError)
     assert attempts == 3
 
 


### PR DESCRIPTION
Closes #1674

## Summary

Some OpenAI-compatible gateways return an error payload with `200 OK`. The OpenAI SDK deserializes it as a `ChatCompletion` with `choices=None`, so the error previously surfaced outside EvalScope's retry boundary with limited diagnostics.

This PR:

- validates non-streaming completions inside the existing sync and async retry boundary;
- reports the gateway error preserved in `model_extra`;
- retries transient or unclassified gateway failures;
- fails fast for deterministic `400`, `401`, `402`, `403`, `404`, and `422` errors;
- preserves the existing `ValueError` compatibility and streaming behavior.

## Tests

Added deterministic, network-free coverage for:

- OpenAI SDK deserialization of gateway error payloads;
- sync and async transient-error retries;
- retry exhaustion and missing error details;
- non-retryable gateway client errors;
- valid completions without unnecessary retries.
