### PR TITLE
fix(ifbench): enforce unique words in sentence checker

### DIFF
--- a/evalscope/benchmarks/ifbench/ifbench_adapter.py
+++ b/evalscope/benchmarks/ifbench/ifbench_adapter.py
@@ -57,6 +57,7 @@ IFBench is a benchmark designed to evaluate how reliably AI models follow novel,
         few_shot_num=0,
         train_split=None,
         eval_split='train',
+        evaluation_version='v1.1',
     )
 )
 class IFBenchAdapter(DefaultDataAdapter):

--- a/evalscope/benchmarks/ifbench/instructions.py
+++ b/evalscope/benchmarks/ifbench/instructions.py
@@ -932,7 +932,8 @@ class CharacterCountUniqueWordsChecker(Instruction):
         for sentence in sentences:
             if len(sentence.strip()) != char_count:
                 return False
-        return True
+        words = [word.casefold() for word in _word_tokens_without_punctuation(value)]
+        return bool(words) and len(words) == len(set(words))
 
 
 class NthWordJapaneseChecker(Instruction):

--- a/tests/benchmark/test_ifbench_instructions.py
+++ b/tests/benchmark/test_ifbench_instructions.py
@@ -1,0 +1,59 @@
+import pytest
+
+from evalscope.api.registry import BENCHMARK_REGISTRY
+from evalscope.benchmarks.ifbench.ifbench_adapter import IFBenchAdapter
+from evalscope.benchmarks.ifbench.instructions import CharacterCountUniqueWordsChecker
+
+
+def test_ifbench_evaluation_version_reflects_scoring_change() -> None:
+    metadata = BENCHMARK_REGISTRY['ifbench']
+
+    assert metadata.data_adapter is IFBenchAdapter
+    assert metadata.evaluation_version == 'v1.1'
+
+
+@pytest.mark.parametrize(
+    'response',
+    [
+        'Cat. Cat. Cat.',
+        'Cat. CAT. Dog.',
+        'Cat cat. Dog fox. Owl yak.',
+    ],
+)
+def test_character_count_unique_words_rejects_repeated_words(response: str) -> None:
+    checker = CharacterCountUniqueWordsChecker('ratio:sentence_words')
+
+    assert checker.check_following(response) is False
+
+
+@pytest.mark.parametrize(
+    'response',
+    [
+        'Cat. Dog. Fox.',
+        'Cat! Dog? Fox.',
+        'Cat, red. Dog, tan. Fox, sky.',
+    ],
+)
+def test_character_count_unique_words_accepts_equal_length_unique_sentences(response: str) -> None:
+    checker = CharacterCountUniqueWordsChecker('ratio:sentence_words')
+
+    assert checker.check_following(response) is True
+
+
+def test_character_count_unique_words_rejects_unequal_sentence_lengths() -> None:
+    checker = CharacterCountUniqueWordsChecker('ratio:sentence_words')
+
+    assert checker.check_following('Cat. Longer. Fox.') is False
+
+
+def test_character_count_unique_words_rejects_punctuation_only_sentences() -> None:
+    checker = CharacterCountUniqueWordsChecker('ratio:sentence_words')
+
+    assert checker.check_following('... ... ...') is False
+
+
+@pytest.mark.parametrize('response', ['Cat. Dog.', 'Cat. Dog. Fox. Owl.'])
+def test_character_count_unique_words_requires_three_sentences(response: str) -> None:
+    checker = CharacterCountUniqueWordsChecker('ratio:sentence_words')
+
+    assert checker.check_following(response) is False


### PR DESCRIPTION
## Summary

- enforce the `ratio:sentence_words` requirement that all words across the three sentences are distinct
- compare tokens case-insensitively with `casefold()` while reusing the existing punctuation-filtering tokenizer
- reject punctuation-only responses that contain no valid word tokens
- preserve the existing exact-three-sentences and equal-character-count checks
- bump IFBench `evaluation_version` from `v1.0` to `v1.1` so cached scores cannot cross the scoring-semantics change

## Why

`CharacterCountUniqueWordsChecker` currently checks only the sentence count and character lengths. As a result, responses such as `Cat. Cat. Cat.` receive a false-positive IFBench score even though the instruction explicitly requires all different words.

## Tests

- `pytest -q tests/benchmark/test_ifbench_instructions.py` - 11 passed
- `pytest -q tests/benchmark/test_eval.py -k ifbench` - 2 passed, 130 deselected
- `pytest -q tests/api/test_evaluation_versioning.py` - 10 passed
- `pre-commit run --files evalscope/benchmarks/ifbench/instructions.py evalscope/benchmarks/ifbench/ifbench_adapter.py tests/benchmark/test_ifbench_instructions.py` - passed

Fixes #1675
