### PR TITLE
refactor(models): move litellm imports to module level

### DIFF
--- a/evalscope/models/litellm_compatible.py
+++ b/evalscope/models/litellm_compatible.py
@@ -11,6 +11,14 @@ See https://docs.litellm.ai/docs/providers for the full list.
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type
 
+import litellm
+from litellm.exceptions import (
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+    UnprocessableEntityError,
+)
 from openai.types.chat import ChatCompletion
 
 from evalscope.api.messages import ChatMessage
@@ -35,24 +43,17 @@ from .utils.openai import (
 logger = get_logger()
 
 
-def _litellm_no_retry_exceptions() -> Tuple[Type[Exception], ...]:
-    """LiteLLM 4xx client-error types that must not be retried.
-
-    LiteLLM maps provider client errors (context length exceeded, bad credentials, unknown
-    model, invalid parameters, ...) onto its own exception types. Retrying them only burns
-    retries * retry_interval per failing sample, so pass them as no-retry exceptions.
-    Transient errors (timeouts, connection failures, 429/5xx) stay retryable.
-    The litellm import stays lazy to keep this module importable without litellm.
-    """
-    from litellm.exceptions import (
-        AuthenticationError,
-        BadRequestError,
-        NotFoundError,
-        PermissionDeniedError,
-        UnprocessableEntityError,
-    )
-
-    return (AuthenticationError, BadRequestError, NotFoundError, PermissionDeniedError, UnprocessableEntityError)
+# LiteLLM maps provider client errors (context length exceeded, bad credentials, unknown
+# model, invalid parameters, ...) onto its own exception types. Retrying them only burns
+# retries * retry_interval per failing sample, so pass them as no-retry exceptions.
+# Transient errors (timeouts, connection failures, 429/5xx) stay retryable.
+NON_RETRYABLE_LITELLM_ERRORS: Tuple[Type[Exception], ...] = (
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+    UnprocessableEntityError,
+)
 
 
 class LiteLLMAPI(ModelAPI):
@@ -83,8 +84,6 @@ class LiteLLMAPI(ModelAPI):
         tool_choice: ToolChoice,
         config: GenerateConfig,
     ) -> ModelOutput:
-        import litellm
-
         request: Dict[str, Any] = {}
 
         messages = openai_chat_messages(
@@ -118,7 +117,7 @@ class LiteLLMAPI(ModelAPI):
                 litellm.completion,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                no_retry_exceptions=_litellm_no_retry_exceptions(),
+                no_retry_exceptions=NON_RETRYABLE_LITELLM_ERRORS,
                 **request,
             )
 
@@ -160,8 +159,6 @@ class LiteLLMAPI(ModelAPI):
         construction and response parsing are identical to the synchronous
         ``generate()``.
         """
-        import litellm
-
         messages = openai_chat_messages(
             input, reasoning_format=(config.reasoning_history or 'reasoning_field'), base_url=self.base_url
         )
@@ -192,7 +189,7 @@ class LiteLLMAPI(ModelAPI):
                 litellm.acompletion,
                 retries=config.retries,
                 sleep_interval=config.retry_interval,
-                no_retry_exceptions=_litellm_no_retry_exceptions(),
+                no_retry_exceptions=NON_RETRYABLE_LITELLM_ERRORS,
                 **request,
             )
 


### PR DESCRIPTION
Closes #1677

## What I noticed

`evalscope/models/litellm_compatible.py` imports litellm inside `generate()`, inside `generate_async()`, and inside `_litellm_no_retry_exceptions()`. The helper's docstring gives the reason:

> The litellm import stays lazy to keep this module importable without litellm.

That isn't true in this repo.

**litellm is a base dependency, not an extra.** It's in `requirements/framework.txt`, which `pyproject.toml` maps straight to `dependencies`:

```toml
[tool.setuptools.dynamic]
dependencies = {file = ["requirements/framework.txt"]}
```

So it installs with a plain `pip install evalscope`. There is no supported setup where this module exists but litellm doesn't.

**The registry already gates it anyway**, one layer up in `evalscope/models/model_apis.py`:

```python
@register_model_api(name='litellm')
def litellm_api() -> type[ModelAPI]:
    check_import('litellm', package='litellm', raise_error=True, feature_name='litellm')

    from .litellm_compatible import LiteLLMAPI
```

`check_import(..., raise_error=True)` runs *before* the module is imported. By the time the module body executes, litellm is guaranteed importable — and a missing litellm still gets the same clean, feature-named error instead of an `ImportError` surfacing from inside `generate()` mid-run.

## The neighbouring provider already does it the other way

`anthropic_compatible.py` imports its SDK at module level:

```python
from anthropic import (Anthropic, APIStatusError, AsyncAnthropic, ...)
```

And `anthropic` is a *harder* case than litellm — it isn't in any requirements file at all, so it's fully optional, install-your-own. It relies on the same `check_import` gate in `model_apis.py` and that works fine.

So the mandatory dependency is being treated more defensively than the fully optional one. It's backwards.

## What about import cost?

`import litellm` is genuinely slow — I measured **2.086 s**. That would be a good reason to defer it, except the registry already does: this module isn't imported at all unless someone selects `eval_type='litellm'`. The laziness is already at the right layer, so hoisting adds nothing to startup.

For completeness, calling `_litellm_no_retry_exceptions()` per request costs **0.152 µs**, which is nothing against multi-second requests. This is a readability issue, not a performance one.

## Suggested change

With the laziness redundant, the helper can be a module constant — which is how the sibling module states the same thing:

```python
# openai_compatible.py
NON_RETRYABLE_OPENAI_ERRORS: Tuple[Type[Exception], ...] = (...)
```

So:

```python
import litellm
from litellm.exceptions import (
    AuthenticationError, BadRequestError, NotFoundError,
    PermissionDeniedError, UnprocessableEntityError,
)

NON_RETRYABLE_LITELLM_ERRORS: Tuple[Type[Exception], ...] = (
    AuthenticationError, BadRequestError, NotFoundError,
    PermissionDeniedError, UnprocessableEntityError,
)
```

No behaviour change — same five exception types, both call sites pass the constant unchanged.

## Scope

I checked whether this pattern is widespread before proposing anything. It is: there are ~93 nested imports of base dependencies across the codebase. Most are defensible — deferring something heavy like `pandas`, `transformers`, `PIL` or `plotly` inside a module that *is* imported eagerly genuinely saves startup time.

`evalscope/models/` is different. It has only three other nested third-party imports:

- `modelscope.py:169` — `StopStringCriteria` inside an `if config.stop_seqs is not None:` branch. A conditional, rarely-taken path; fine as is.
- `utils/anthropic.py:697,867` — `anthropic` inside the stream collectors.

So this isn't a call to change the convention everywhere. It's one module where the stated reason doesn't hold, the module is already deferred, and the sibling provider does it the other way.

I've deliberately kept this PR to that single file so it stays easy to review. The same thing does show up in a few other places — the two `utils/anthropic.py` sites above being the closest — and I'm happy to raise a follow-up PR for those if you agree with the direction here. Equally happy to leave the convention alone if you'd rather; just let me know which you'd prefer.

## Verification

`pytest tests/models/` → 92 passed. `ruff check` and `ruff format` clean. No remaining references to the removed helper.

https://claude.ai/code/session_0195nPGwxPjJGtQukF28BJfS
