### PR TITLE
fix(ifbench): remove duplicate evaluation version

### DIFF
--- a/evalscope/benchmarks/ifbench/ifbench_adapter.py
+++ b/evalscope/benchmarks/ifbench/ifbench_adapter.py
@@ -61,7 +61,6 @@ IFBench is a benchmark designed to evaluate how reliably AI models follow novel,
         few_shot_num=0,
         train_split=None,
         eval_split='train',
-        evaluation_version='v1.1',
     )
 )
 class IFBenchAdapter(DefaultDataAdapter):


### PR DESCRIPTION
## Summary

- Remove the duplicated `evaluation_version='v1.1'` argument from the IFBench metadata.
- Keep the existing `v1.1` evaluation version declaration unchanged.

## Motivation

PR #1676 added a second `evaluation_version` keyword argument even though the same version was already declared. Python rejects repeated keyword arguments at parse time, preventing the IFBench adapter from being imported.

## Verification

- `python -m compileall -q evalscope/benchmarks/ifbench/ifbench_adapter.py`
- `pre-commit run --files evalscope/benchmarks/ifbench/ifbench_adapter.py`
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings` — 1 passed
