### PR TITLE
fix(perf): hand off multi-turn warmup without draining

### DIFF
--- a/evalscope/perf/core/strategies/multi_turn.py
+++ b/evalscope/perf/core/strategies/multi_turn.py
@@ -46,21 +46,24 @@ class MultiTurnStrategy(BenchmarkStrategy):
         super().__init__(args, api_plugin, client, queue)
         self._all_conversations = all_conversations
         # Conversation cycling index – safe without a lock because asyncio is
-        # single-threaded/cooperative.  Continuous across phases so warmup
-        # consumes the first ``warmup_count`` conversations and benchmark
-        # picks up from there (preserves dataset uniqueness contract).
+        # single-threaded/cooperative.  Warmup and benchmark still pull disjoint
+        # conversations from the dataset; the hand-off fix changes only when
+        # workers move from warmup work to measured work, not which conversations
+        # are measured.
         self._conv_index = 0
         self._warmup_count = self.args.warmup_count
 
-        # Per-phase dispatch state.  Reset at the start of every phase by
-        # ``_run_phase``.  ``_phase_counter`` tracks how many conversations
-        # this phase has already claimed; ``_phase_budget`` caps that count;
-        # ``_phase_is_warmup`` tags every enqueued ``BenchmarkData``;
-        # ``_phase_deadline`` is the trace-soft-exit cutoff (None disables it).
+        # Shared dispatch state.  ``_phase_counter`` claims work items from one
+        # ordered stream: first ``_phase_warmup_budget`` warmup conversations,
+        # then measured conversations up to ``_phase_budget``.  ``_phase_duration``
+        # is armed lazily when the first measured conversation is claimed so
+        # warmup does not consume the timed budget.
         self._phase_counter = 0
         self._phase_budget = 0
+        self._phase_warmup_budget = 0
         self._phase_is_warmup = False
         self._phase_deadline: Optional[float] = None
+        self._phase_duration: Optional[float] = None
 
         # Trace identity:  monotonic across phases; each claimed conversation
         # gets a unique ``trace_id`` string for trace-level metric aggregation.
@@ -82,20 +85,25 @@ class MultiTurnStrategy(BenchmarkStrategy):
         return f'{"warmup" if is_warmup else "bench"}-{seq}'
 
     async def _worker(self, worker_id: int) -> None:
-        """Process conversations until the current phase budget is reached."""
+        """Process conversations until the current work stream is exhausted."""
         while True:
-            # Trace-level soft exit: stop claiming new conversations once the
-            # duration deadline has elapsed.  An already-claimed conversation
-            # below will still run all its remaining turns to completion so
-            # trace-level metrics stay coherent (matches trie's semantics).
-            if self._phase_deadline is not None and time.perf_counter() >= self._phase_deadline:
-                return
             # Atomically claim a conversation slot before awaiting to prevent
-            # other workers from overshooting the phase budget.
+            # other workers from overshooting the stream budget.
             if self._phase_counter >= self._phase_budget:
                 return
+            work_index = self._phase_counter
+            is_warmup = work_index < self._phase_warmup_budget
+
+            # Trace-level soft exit: warmup is exempt.  The measured deadline is
+            # armed by the first measured conversation claim, which keeps all
+            # warmup service time outside the measured window.
+            if not is_warmup:
+                if self._phase_deadline is not None and time.perf_counter() >= self._phase_deadline:
+                    return
+                if self._phase_deadline is None and self._phase_duration is not None:
+                    self._phase_deadline = self._compute_deadline(self._phase_duration)
+
             self._phase_counter += 1
-            is_warmup = self._phase_is_warmup
             conversation = self._next_conversation()
             trace_id = self._next_trace_id(is_warmup)
 
@@ -221,34 +229,56 @@ class MultiTurnStrategy(BenchmarkStrategy):
                 )
 
     async def run(self) -> None:
-        # Two-phase dispatch: warmup conversations complete in full before any
-        # benchmark conversation starts.  ``_conv_index`` persists across
-        # phases so warmup and benchmark pull disjoint conversations from the
-        # dataset (first ``warmup_count`` vs. the rest).
-        if self._warmup_count > 0:
-            # Warmup ignores --duration (warmup must finish in full before
-            # the timed benchmark window begins, mirroring trie's model).
-            await self._run_phase(budget=self._warmup_count, is_warmup=True, deadline=None)
+        self._log_warmup_handoff()
         await self._run_phase(
-            budget=self.args.number,
+            budget=self._warmup_count + self.args.number,
             is_warmup=False,
-            deadline=self._compute_deadline(self.args.duration),
+            warmup_budget=self._warmup_count,
+            duration=self.args.duration,
         )
 
-    async def _run_phase(self, budget: int, is_warmup: bool, deadline: Optional[float] = None) -> None:
-        """Spawn ``args.parallel`` workers and drain them within one phase.
+    def _log_warmup_handoff(self) -> None:
+        """Warn when warmup cannot cover the opening multi-turn cohort."""
+        if self.args.parallel <= 1:
+            return
+        if self._warmup_count <= 0:
+            logger.warning(
+                'Multi-turn warmup is disabled; the first measured cohort may start against an idle server. '
+                f'Use --warmup-num {self.args.parallel} or higher to cover every concurrency slot.'
+            )
+            return
+        if self._warmup_count < self.args.parallel:
+            uncovered = self.args.parallel - self._warmup_count
+            logger.warning(
+                f'Multi-turn warmup covers only {self._warmup_count} of the {self.args.parallel} '
+                f'concurrency slots; {uncovered} measured conversation(s) may still be released '
+                'in the opening cohort.'
+            )
 
-        When ``deadline`` is set, workers stop claiming new conversations once
-        wall-clock crosses it, but any conversation already in progress is
-        allowed to finish all its turns (trace-level soft exit, matches trie).
-        ``budget`` is still honoured as an upper bound on the number of
-        conversations claimed; whichever limit (count or wall-clock) is hit
-        first ends the phase.
+    async def _run_phase(
+        self,
+        budget: int,
+        is_warmup: bool,
+        deadline: Optional[float] = None,
+        warmup_budget: Optional[int] = None,
+        duration: Optional[float] = None,
+    ) -> None:
+        """Spawn ``args.parallel`` workers and drain one ordered work stream.
+
+        By default this keeps the historical single-phase behaviour used by
+        lifecycle tests.  ``warmup_budget`` turns the phase into a hand-off
+        stream: the first N claimed conversations are warmup, and following
+        claims are measured without stopping the workers in between.
         """
         self._phase_counter = 0
         self._phase_budget = budget
+        if warmup_budget is None and is_warmup:
+            self._phase_warmup_budget = budget
+        else:
+            self._phase_warmup_budget = warmup_budget or 0
         self._phase_is_warmup = is_warmup
         self._phase_deadline = deadline
+        self._phase_duration = duration
         workers = [asyncio.create_task(self._worker(worker_id=i)) for i in range(self.args.parallel)]
         try:
             await asyncio.gather(*workers)
@@ -257,3 +287,5 @@ class MultiTurnStrategy(BenchmarkStrategy):
                 if not worker.done():
                     worker.cancel()
             await asyncio.gather(*workers, return_exceptions=True)
+            self._phase_duration = None
+            self._phase_warmup_budget = 0

--- a/tests/perf/test_multi_turn_warmup_handoff.py
+++ b/tests/perf/test_multi_turn_warmup_handoff.py
@@ -1,0 +1,223 @@
+"""Multi-turn warmup hand-off tests.
+
+Warmup conversations must occupy the server until measured conversations take
+over.  A phase barrier would drain occupancy to zero and release the opening
+measured cohort against an idle server, which is the defect tracked by #1648.
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import time
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.core.pipeline import run_benchmark_pipeline
+from evalscope.perf.core.strategies import multi_turn as multi_turn_module
+from evalscope.perf.core.strategies.multi_turn import MultiTurnStrategy
+from evalscope.perf.plugin.datasets.base import Conversation, Turn
+from evalscope.perf.utils.benchmark_util import BenchmarkData
+
+
+def _make_args(**kwargs: Any) -> Arguments:
+    number = kwargs.pop('number', 6)
+    parallel = kwargs.pop('parallel', 3)
+    warmup_num = kwargs.pop('warmup_num', 0)
+    args = Arguments(
+        model='test-model',
+        api='openai',
+        number=number,
+        parallel=parallel,
+        rate=-1,
+        warmup_num=warmup_num,
+        multi_turn=True,
+        **kwargs,
+    )
+    args.number = number
+    args.parallel = parallel
+    args.rate = -1
+    return args
+
+
+def _conversations(count: int) -> List[Conversation]:
+    return [[Turn(messages=[{'role': 'user', 'content': f'conv-{i}'}])] for i in range(count)]
+
+
+class _ApiPlugin:
+
+    def build_request(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {'messages': messages, 'stream': True}
+
+    def parse_responses(self, response_messages: List[Any], request: Optional[str] = None) -> tuple[int, int]:
+        return 1, 1
+
+
+class _RecordingClient:
+    """Fake server that records occupancy when each request starts."""
+
+    def __init__(self) -> None:
+        self.in_flight = 0
+        self.events: List[Dict[str, Any]] = []
+        self._seq = 0
+
+    async def post(self, request: Dict[str, Any]) -> BenchmarkData:
+        seq = self._seq
+        self._seq += 1
+        conv_id = request['messages'][0]['content']
+        start_time = time.perf_counter()
+        self.events.append({
+            'conv_id': conv_id,
+            'occupancy_at_start': self.in_flight,
+            'order': seq,
+        })
+        self.in_flight += 1
+        try:
+            for _ in range(2 * (seq + 1)):
+                await asyncio.sleep(0)
+        finally:
+            self.in_flight -= 1
+        completed_time = time.perf_counter()
+        return BenchmarkData(
+            request=json.dumps(request),
+            start_time=start_time,
+            completed_time=completed_time,
+            query_latency=completed_time - start_time,
+            first_chunk_latency=0.001,
+            success=True,
+            is_stream=True,
+            prompt_tokens=1,
+            completion_tokens=1,
+            generated_text='ok',
+        )
+
+
+def _run_strategy(args: Arguments) -> _RecordingClient:
+    client = _RecordingClient()
+
+    async def main() -> None:
+        strategy = MultiTurnStrategy(args, _ApiPlugin(), client, asyncio.Queue(), _conversations(args.total_count))
+        await strategy.run()
+
+    asyncio.run(main())
+    return client
+
+
+def _conv_index(conv_id: str) -> int:
+    return int(conv_id.removeprefix('conv-'))
+
+
+def test_measured_portion_starts_without_draining() -> None:
+    parallel = 4
+    args = _make_args(number=6, parallel=parallel, warmup_num=parallel)
+    client = _run_strategy(args)
+
+    measured = [event for event in client.events if _conv_index(event['conv_id']) >= parallel]
+    assert measured, 'no measured conversation was dispatched'
+    first_measured = min(measured, key=lambda event: event['order'])
+    assert first_measured['occupancy_at_start'] == parallel - 1
+
+    later_occupancies = [event['occupancy_at_start'] for event in client.events if event['order'] > 0]
+    assert later_occupancies and all(occupancy > 0 for occupancy in later_occupancies)
+
+
+def test_partial_warmup_degrades_gracefully() -> None:
+    parallel = 4
+    warmup = 2
+    args = _make_args(number=6, parallel=parallel, warmup_num=warmup)
+    client = _run_strategy(args)
+
+    opening = sorted(client.events, key=lambda event: event['order'])[:parallel]
+    assert [event['occupancy_at_start'] for event in opening] == list(range(parallel))
+    assert sum(1 for event in opening if _conv_index(event['conv_id']) >= warmup) == parallel - warmup
+
+
+def test_zero_warmup_keeps_all_opening_work_measured() -> None:
+    parallel = 3
+    args = _make_args(number=5, parallel=parallel, warmup_num=0)
+    client = _run_strategy(args)
+
+    opening = sorted(client.events, key=lambda event: event['order'])[:parallel]
+    assert [event['occupancy_at_start'] for event in opening] == list(range(parallel))
+    assert all(_conv_index(event['conv_id']) < args.number for event in opening)
+
+
+def test_duration_exempts_warmup_and_caps_measured() -> None:
+    parallel = 2
+    measured = 20
+    args = _make_args(number=measured, parallel=parallel, warmup_num=parallel, duration=0.0)
+    client = _run_strategy(args)
+
+    dispatched = {_conv_index(event['conv_id']) for event in client.events}
+    assert {0, 1}.issubset(dispatched)
+    measured_dispatched = {idx for idx in dispatched if idx >= parallel}
+    assert 1 <= len(measured_dispatched) < measured
+
+
+class _RecordingLogger:
+
+    def __init__(self) -> None:
+        self.warnings: List[str] = []
+
+    def warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def info(self, msg: str) -> None:
+        pass
+
+
+def test_warns_when_multi_turn_warmup_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(multi_turn_module, 'logger', recorder)
+
+    strategy = MultiTurnStrategy(_make_args(number=10, parallel=4, warmup_num=0), _ApiPlugin(), None, asyncio.Queue(), [])
+    strategy._log_warmup_handoff()
+
+    assert len(recorder.warnings) == 1
+    assert 'Multi-turn warmup is disabled' in recorder.warnings[0]
+    assert '--warmup-num 4' in recorder.warnings[0]
+
+
+def test_warns_when_multi_turn_warmup_smaller_than_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(multi_turn_module, 'logger', recorder)
+
+    strategy = MultiTurnStrategy(_make_args(number=10, parallel=4, warmup_num=2), _ApiPlugin(), None, asyncio.Queue(), [])
+    strategy._log_warmup_handoff()
+
+    assert len(recorder.warnings) == 1
+    assert 'covers only 2 of the 4 concurrency slots' in recorder.warnings[0]
+    assert '2 measured conversation(s)' in recorder.warnings[0]
+
+
+def test_silent_when_multi_turn_warmup_covers_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(multi_turn_module, 'logger', recorder)
+
+    strategy = MultiTurnStrategy(_make_args(number=10, parallel=4, warmup_num=4), _ApiPlugin(), None, asyncio.Queue(), [])
+    strategy._log_warmup_handoff()
+
+    assert recorder.warnings == []
+
+
+def test_warmup_reaches_producer_but_stays_out_of_result_db(tmp_path) -> None:
+    parallel = 3
+    number = 5
+    output_dir = tmp_path / 'multi-turn-e2e'
+    output_dir.mkdir()
+    args = _make_args(number=number, parallel=parallel, warmup_num=parallel, outputs_dir=str(output_dir))
+    client = _RecordingClient()
+    queue: asyncio.Queue = asyncio.Queue()
+    strategy = MultiTurnStrategy(args, _ApiPlugin(), client, queue, _conversations(args.total_count))
+
+    async def main() -> None:
+        await run_benchmark_pipeline(strategy.run(), queue, args, _ApiPlugin())
+
+    asyncio.run(main())
+
+    assert len(client.events) == parallel + number
+    with sqlite3.connect(os.path.join(str(output_dir), 'benchmark_data.db')) as con:
+        rows = con.execute('SELECT COUNT(*) FROM result').fetchone()[0]
+    assert rows == number


### PR DESCRIPTION
## Summary

- Hand multi-turn warmup conversations directly over to measured conversations without draining all workers between phases.
- Keep the existing separate-conversation semantics: warmup and measured work still use disjoint conversations, and this PR does not add first-turn reuse or new CLI options.
- Add deterministic fake-client tests that assert the first measured conversation starts while warmup work is still in flight, plus coverage for partial/disabled warmup warnings, duration anchoring, and DB metric exclusion.

## Relation to #1648

This addresses the no-barrier handoff part of #1648 for the multi-turn path. It mirrors the closed-loop single-turn fix in #1641 by removing the explicit phase drain before measured work begins.

It deliberately does not implement first-turn reuse. That behavior changes the measured workload from full conversations starting at turn 1 to warmed conversation continuations, and should be handled as a separate follow-up if desired.

## Validation

- `/mnt/nas2/anaconda3/envs/eval/bin/python -m pytest tests/perf/test_multi_turn_warmup_handoff.py tests/perf/test_async_lifecycle.py::test_multi_turn_strategy_failure_cancels_workers tests/perf/test_closed_loop_warmup_handoff.py -q`
  - `21 passed, 1 warning`
- pre-commit during commit:
  - `ruff check` passed
  - `ruff format` passed
  - whitespace/yaml/merge-conflict/line-ending checks passed
- Local vLLM smoke against `http://127.0.0.1:8801/v1/chat/completions` succeeded with 16/16 measured turns.
