### PR TITLE
chore: tighten ruff rule baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ run_task(TaskConfig(model='Qwen/Qwen2.5-0.5B-Instruct', datasets=['gsm8k'], limi
 | Handler function | `handle_` prefix |
 | Benchmark adapter file | `<name>_adapter.py` |
 
-**Ruff ignore list** (`pyproject.toml`): `E501, E741, F401, F403, F405, F541, F821`. Do not expand — new ignores must be justified in the PR.
+**Ruff ignore list** (`pyproject.toml`): `E501, F401`. Do not expand — new ignores must be justified in the PR.
 
 ## Design rules
 

--- a/evalscope/__init__.py
+++ b/evalscope/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 from evalscope import agent  # noqa: F401  # registered agent strategies
-from evalscope.benchmarks import *  # registered benchmarks
+from evalscope.benchmarks import *  # noqa: F403 - registered benchmarks
 from evalscope.config import TaskConfig
-from evalscope.evaluator import *  # registered evaluators
+from evalscope.evaluator import *  # noqa: F403 - registered evaluators
 from evalscope.filters import extraction, selection  # registered filters
 from evalscope.metrics import aggregators, audio, nlp, vision  # noqa: F401  # registered metrics & aggregators
 from evalscope.models import model_apis  # need for register model apis

--- a/evalscope/agent/external/runners/codex.py
+++ b/evalscope/agent/external/runners/codex.py
@@ -184,11 +184,11 @@ class CodexRunner(AgentRunner):
         # escaped double quotes; the list-form ``cmd`` carries them as a
         # single argv entry, which env.exec quotes for the shell.
         config_pairs: List[str] = [
-            f'model_provider="evalscope"',
-            f'model_providers.evalscope.name="EvalScope Bridge"',
+            'model_provider="evalscope"',
+            'model_providers.evalscope.name="EvalScope Bridge"',
             f'model_providers.evalscope.base_url="{bridge.base_url}/openai/v1"',
-            f'model_providers.evalscope.env_key="EVALSCOPE_BRIDGE_TOKEN"',
-            f'model_providers.evalscope.wire_api="responses"',
+            'model_providers.evalscope.env_key="EVALSCOPE_BRIDGE_TOKEN"',
+            'model_providers.evalscope.wire_api="responses"',
         ]
         if self._model_name:
             config_pairs.append(f'model="{self._model_name}"')

--- a/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
+++ b/evalscope/benchmarks/bfcl/v4/bfcl_v4_adapter.py
@@ -297,7 +297,7 @@ class BFCLV4Adapter(AgentAdapter):
                 )
                 idx += 1
 
-        total_lat = float(sum(l or 0.0 for l in lat_list))
+        total_lat = float(sum(latency or 0.0 for latency in lat_list))
         output.message.perf_metrics = PerformanceMetrics(
             latency=total_lat,
             ttft=None,

--- a/evalscope/benchmarks/drivelology/drivelology_binary_adapter.py
+++ b/evalscope/benchmarks/drivelology/drivelology_binary_adapter.py
@@ -120,7 +120,7 @@ class DrivelologyBinaryClassificationAdapter(DefaultDataAdapter):
         super().__init__(**kwargs)
         self.add_overall_metric = False
         if self.few_shot_num not in [0, 4]:
-            logger.warning(f'For DrivelologyBinaryClassification, use 4-shot by default.')
+            logger.warning('For DrivelologyBinaryClassification, use 4-shot by default.')
             self.few_shot_num = 4
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:

--- a/evalscope/benchmarks/openai_mrcr/openai_mrcr_adapter.py
+++ b/evalscope/benchmarks/openai_mrcr/openai_mrcr_adapter.py
@@ -271,12 +271,12 @@ class OpenAIMRCRAdapter(DefaultDataAdapter):
         for i, vals in bin_scores.items():
             if not vals:
                 continue
-            l, r = OPENAI_MRCR_BINS[i]
+            min_tokens, max_tokens = OPENAI_MRCR_BINS[i]
             agg.append(
                 AggScore(
                     metric_name='mrcr_score',
                     aggregation='mean',
-                    dimensions={'min_tokens': l, 'max_tokens': r},
+                    dimensions={'min_tokens': min_tokens, 'max_tokens': max_tokens},
                     score=sum(vals) / len(vals),
                     num=len(vals),
                 )

--- a/evalscope/benchmarks/openai_mrcr/utils.py
+++ b/evalscope/benchmarks/openai_mrcr/utils.py
@@ -63,12 +63,12 @@ def bin_index_for(total_tokens: int, bins=OPENAI_MRCR_BINS) -> int:
     First and last bins inclusive both ends, middle bins left-inclusive right-exclusive.
     """
     last = len(bins) - 1
-    for i, (l, r) in enumerate(bins):
+    for i, (left, right) in enumerate(bins):
         if i == 0 or i == last:
-            if l <= total_tokens <= r:
+            if left <= total_tokens <= right:
                 return i
         else:
-            if l <= total_tokens < r:
+            if left <= total_tokens < right:
                 return i
     return 0  # fallback
 

--- a/evalscope/cli/benchmark_info.py
+++ b/evalscope/cli/benchmark_info.py
@@ -292,7 +292,7 @@ class BenchmarkInfoCMD(CLICommand):
             workers=self.args.workers,
         )
 
-        print(f'\nTranslation complete:')
+        print('\nTranslation complete:')
         print(f'  Total: {result.get("total", 0)}')
         print(f'  Translated: {result.get("translated", 0)}')
         print(f'  Skipped: {result.get("skipped", 0)}')
@@ -343,18 +343,18 @@ class BenchmarkInfoCMD(CLICommand):
         # Metrics
         if meta.metric_list:
             formatted_metrics = self._format_metric_list(meta.metric_list)
-            print(f'\nMetrics:')
+            print('\nMetrics:')
             for m in formatted_metrics:
                 print(f'  - {m}')
 
         if meta.description:
-            print(f'\nDescription:')
+            print('\nDescription:')
             for line in meta.description.split('\n'):
                 print(f'  {line}')
 
         # Prompt template (truncated for readability)
         if meta.prompt_template:
-            print(f'\nPrompt Template:')
+            print('\nPrompt Template:')
             template = meta.prompt_template
             if len(template) > 200:
                 template = template[:200] + '... [TRUNCATED]'
@@ -363,7 +363,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         # System prompt (truncated for readability)
         if meta.system_prompt:
-            print(f'\nSystem Prompt:')
+            print('\nSystem Prompt:')
             prompt = meta.system_prompt
             if len(prompt) > 200:
                 prompt = prompt[:200] + '... [TRUNCATED]'
@@ -372,7 +372,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         # Configurable parameters (extra_params with full spec)
         if meta.extra_params:
-            print(f'\nConfigurable Parameters:')
+            print('\nConfigurable Parameters:')
             for param_name, param_spec in meta.extra_params.items():
                 print(f'  {param_name}:')
                 if meta._is_spec_entry(param_spec):
@@ -386,7 +386,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         if meta.data_statistics:
             stats = meta.data_statistics
-            print(f'\nStatistics:')
+            print('\nStatistics:')
             print(f'  Total samples:        {stats.total_samples:,}')
             print(f'  Prompt length (mean): {stats.prompt_length_mean:.1f}')
             print(f'  Prompt length (range): {stats.prompt_length_min} - {stats.prompt_length_max}')

--- a/evalscope/config.py
+++ b/evalscope/config.py
@@ -753,7 +753,7 @@ class TaskConfig(BaseArgument):
 
     def dump_yaml(self, output_dir: str, generated_metadata: Optional[Dict[str, Any]] = None) -> None:
         """Dump the task configuration and optional generated runtime metadata to YAML."""
-        task_cfg_file = os.path.join(output_dir, f'task_config.yaml')
+        task_cfg_file = os.path.join(output_dir, 'task_config.yaml')
         try:
             logger.info(f'Dump task config to {task_cfg_file}')
             payload = self.to_dict()

--- a/evalscope/filters/__init__.py
+++ b/evalscope/filters/__init__.py
@@ -1,2 +1,2 @@
-from .extraction import *
-from .selection import *
+from .extraction import *  # noqa: F403 - public filter exports
+from .selection import *  # noqa: F403 - public filter exports

--- a/evalscope/perf/plugin/__init__.py
+++ b/evalscope/perf/plugin/__init__.py
@@ -1,3 +1,3 @@
-from .api import *
-from .datasets import *
+from .api import *  # noqa: F403 - public plugin exports
+from .datasets import *  # noqa: F403 - public plugin exports
 from .registry import ApiRegistry, DatasetRegistry

--- a/evalscope/report/generator.py
+++ b/evalscope/report/generator.py
@@ -8,7 +8,7 @@ from evalscope.constants import DataCollection
 from evalscope.metrics.semantics import get_semantics_resolver
 from evalscope.metrics.semantics.identity import canonicalize_producer_identity
 from evalscope.metrics.semantics.resolver import select_primary_identity
-from evalscope.report.report import *
+from evalscope.report.report import Category, Metric, Report, Subset
 
 if TYPE_CHECKING:
     from evalscope.api.benchmark import DataAdapter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,10 +123,10 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
-ignore = ["E501", "E741", "F401", "F403", "F405", "F541"]
+ignore = ["E501", "F401"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["E", "F", "W"]
+"tests/**/*.py" = ["E402"]
 
 [tool.ruff.format]
 exclude = ["tests/**/*.py"]

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -869,11 +869,8 @@ class TestDefaultAdapterEnvPath:
 
         output = adapter._on_inference(model, sample)
 
-        # Verify model was called with bash ToolInfo in the tools list
-        call_args = model.generate_async.call_args
-        tools_passed = call_args[1].get('tools') or call_args[0][1] if len(call_args[0]) > 1 else None
-        # tools_passed may be None if strategy decided not to pass them;
-        # at minimum verify execution completed without error.
+        model.generate_async.assert_awaited_once()
+        assert model.generate_async.call_args.kwargs['tools']
         assert output is not None
 
     def test_environment_extra_forwarded(self):

--- a/tests/benchmark/test_eval.py
+++ b/tests/benchmark/test_eval.py
@@ -271,22 +271,6 @@ class TestNativeBenchmark(TestBenchmark):
         }
         self._run_dataset_test('chinese_simpleqa', dataset_args)
 
-    # Code datasets
-    def test_live_code_bench(self):
-        """Test LiveCodeBench dataset."""
-        dataset_args = {
-            'extra_params': {
-                'start_date': '2024-08-01',
-                'end_date': '2025-02-28'
-            },
-            'local_path': '/root/.cache/modelscope/hub/datasets/evalscope/livecodebench_code_generation_lite_parquet'
-        }
-        self._run_dataset_test('live_code_bench', dataset_args)
-
-    def test_humaneval(self):
-        """Test HumanEval dataset."""
-        self._run_dataset_test('humaneval')
-
     # Custom & specialized datasets
     def test_general_qa(self):
         """Test custom general QA dataset."""
@@ -358,10 +342,6 @@ class TestNativeBenchmark(TestBenchmark):
         }
         self._run_dataset_test('needle_haystack', dataset_args)
 
-    def test_ifeval(self):
-        """Test IFEval dataset."""
-        self._run_dataset_test('ifeval')
-
     def test_ifeval_load(self):
         """Test IFEval dataset loading."""
         self._run_dataset_load_test('ifeval')
@@ -385,10 +365,7 @@ class TestNativeBenchmark(TestBenchmark):
 
     def test_humaneval(self):
         """Test HumanEval dataset."""
-        dataset_args = {
-            # 'metric_list': ['Pass@1']
-        }
-        self._run_dataset_test('humaneval', dataset_args, limit=10, repeats=3)
+        self._run_dataset_test('humaneval', {}, limit=10, repeats=3)
 
     def test_live_code_bench(self):
         """Test LiveCodeBench dataset."""

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -99,8 +99,3 @@ class TestModels(TestBenchmark):
             }
         }
         self._run_dataset_test('bfcl_v4', dataset_args=dataset_args)
-
-    def test_chartqa(self):
-        """Test ChartQA math reasoning dataset."""
-
-        self._run_dataset_test('chartqa')

--- a/tests/perf/test_async_lifecycle.py
+++ b/tests/perf/test_async_lifecycle.py
@@ -240,7 +240,7 @@ class TestSignalHandlerGracefulShutdown:
                 in_flight_cleanup.append('ran')
 
         async def benchmark_coroutine() -> None:
-            task = asyncio.create_task(in_flight_request())
+            _task = asyncio.create_task(in_flight_request())
             await asyncio.sleep(0)  # let the in-flight request start
             loop.call_soon(signal_handler, 'SIGTERM', loop)
             await asyncio.sleep(30)

--- a/tests/perf/test_perf_basic.py
+++ b/tests/perf/test_perf_basic.py
@@ -375,6 +375,7 @@ class TestPerfBasic(PerfTestBase):
             stream=True,
         )
         results = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(results)
 
     def test_warmup_multi_turn_absolute(self):
         """Multi-turn warmup with absolute count (warmup_num=2).

--- a/tests/perf/test_perf_embedding_rerank.py
+++ b/tests/perf/test_perf_embedding_rerank.py
@@ -40,7 +40,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
             max_prompt_length=256,
             tokenizer_path='Qwen/Qwen3-Embedding-0.6B',
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
     def test_embedding_from_dataset(self):
         """Embedding from a custom queries dataset.
@@ -62,7 +62,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
             tokenizer_path='Qwen/Qwen3-Embedding-0.6B',
             dataset_path='custom_eval/text/retrieval/queries.jsonl',
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
     def test_embedding_random_batch(self):
         """Random batch embedding sweep.
@@ -87,7 +87,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
             tokenizer_path='Qwen/Qwen3-Embedding-0.6B',
             extra_args={'batch_size': 8},
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
     def test_embedding_batch_from_dataset(self):
         """Batch embedding from a custom queries dataset.
@@ -110,7 +110,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
             tokenizer_path='Qwen/Qwen3-Embedding-0.6B',
             dataset_path='custom_eval/text/retrieval/queries.jsonl',
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
     # ------------------------------------------------------------------
     # Rerank tests
@@ -141,7 +141,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
                 'document_length_ratio': 3,
             },
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
     def test_rerank_from_dataset(self):
         """Rerank from a custom example dataset.
@@ -163,7 +163,7 @@ class TestPerfEmbeddingRerank(PerfTestBase):
             tokenizer_path='Qwen/Qwen3-Embedding-0.6B',
             dataset_path='custom_eval/text/rerank/example.jsonl',
         )
-        result = run_perf_benchmark(task_cfg)
+        self.assertIsNotNone(run_perf_benchmark(task_cfg))
 
 
 if __name__ == '__main__':

--- a/tests/perf/test_rich_display.py
+++ b/tests/perf/test_rich_display.py
@@ -196,8 +196,8 @@ class TestPerRequestMetrics(unittest.TestCase):
         self.assertIn('Input Tokens', text)
         self.assertIn('Output Tokens', text)
         # max column header and max latency value from fixture
-        lines = [l for l in text.splitlines() if 'max' in l.lower()]
-        self.assertTrue(any('max' in l for l in lines), 'max column should appear in Per-Request Metrics')
+        lines = [line for line in text.splitlines() if 'max' in line.lower()]
+        self.assertTrue(any('max' in line for line in lines), 'max column should appear in Per-Request Metrics')
         self.assertIn('5', text)  # max latency from _make_percentiles
 
     def test_multi_turn_rows(self):

--- a/tests/test_run_all.py
+++ b/tests/test_run_all.py
@@ -3,7 +3,7 @@
 import subprocess
 
 if __name__ == '__main__':
-    cmd = f'TEST_LEVEL_LIST=0,1 python3 -m unittest discover tests'
+    cmd = 'TEST_LEVEL_LIST=0,1 python3 -m unittest discover tests'
     run_res = subprocess.run(cmd, text=True, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if run_res.returncode == 0:


### PR DESCRIPTION
## Summary

- tighten Ruff's enforced baseline by removing `E741`, `F403`, `F405`, and `F541` from the global ignore list
- keep `E501` and `F401` ignored for now after auditing the current baseline
- narrow the `tests/**/*.py` lint exemption from all `E/F/W` rules to `E402` only
- fix newly enforced lint findings in maintained source and tests

## Rule audit

- `F541`: low-risk mechanical cleanup; now enabled.
- `E741`: only a few ambiguous local names; renamed to clearer names and enabled.
- `F403/F405`: only a small number of star imports. One internal import was made explicit; public export shims now use targeted `noqa` comments and the rules are enabled globally.
- `F401`: still has a large baseline with many public re-exports and registry side-effect imports, so it remains ignored pending a dedicated cleanup.
- `E501`: still has a large baseline and remains ignored.
- `tests`: full formatting is intentionally deferred, but lint coverage now catches `F/W` issues and all `E` rules except the current `E402` import-position baseline.

## Validation

- `/Users/yunlin/Code/eval-scope/.venv/bin/ruff check . --output-format concise`
- `/Users/yunlin/Code/eval-scope/.venv/bin/ruff format . --check`
- `/Users/yunlin/Code/eval-scope/.venv/bin/pre-commit run --all-files`
- `/Users/yunlin/Code/eval-scope/.venv/bin/python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`
- `/Users/yunlin/Code/eval-scope/.venv/bin/python -m pytest tests/agent/test_t2_environment.py::TestDefaultAdapterEnvPath::test_tool_infos_merged_into_ctx -v -s -p no:warnings`
- `/Users/yunlin/Code/eval-scope/.venv/bin/python -m pytest tests/benchmark/test_eval.py tests/benchmark/test_models.py --collect-only -q`
- `/Users/yunlin/Code/eval-scope/.venv/bin/python -m pytest tests/perf/test_rich_display.py::TestPerRequestMetrics::test_single_run -q`
- `/Users/yunlin/Code/eval-scope/.venv/bin/python -c "import evalscope; from evalscope.report.generator import ReportGenerator; from evalscope.filters import RegexFilter; from evalscope.perf.plugin import ApiRegistry, OpenaiPlugin, DatasetPluginBase"`
- `python3 -m py_compile tests/perf/test_async_lifecycle.py tests/perf/test_perf_basic.py tests/perf/test_perf_embedding_rerank.py tests/perf/test_rich_display.py tests/test_run_all.py`

Note: `make lint` could not run in this shell because `pre-commit` is not on `PATH`; the equivalent virtualenv command above passed. Perf test collection for files importing `evalscope.perf.main` is blocked in the local env by missing optional dependency `uvicorn`.

Refs #1631
