### PR TITLE
fix(clip_benchmark): remove __main__ block that always raises TypeError

### DIFF
--- a/evalscope/backend/rag_eval/clip_benchmark/task_template.py
+++ b/evalscope/backend/rag_eval/clip_benchmark/task_template.py
@@ -102,7 +102,3 @@ def evaluate(args: ClipBenchmarkEvalConfig):
             logger.info(f'Dump results to: {output_file}')
         with open(output_file, 'w') as f:
             json.dump(dump, f)
-
-
-if __name__ == '__main__':
-    evaluate()


### PR DESCRIPTION
## Problem

`evalscope/backend/rag_eval/clip_benchmark/task_template.py` ends with:

```python
def evaluate(args: ClipBenchmarkEvalConfig):
    models = args.models
    ...

if __name__ == '__main__':
    evaluate()
```

`evaluate` requires its config argument, so running the module directly can only ever produce:

```
TypeError: evaluate() missing 1 required positional argument: 'args'
```

## Fix

Remove the two-line `__main__` block.

The function itself is correct and is not the problem — `RAGEvalBackendManager.run_clip_benchmark` calls it properly:

```python
# evalscope/backend/rag_eval/backend_manager.py:125
from evalscope.backend.rag_eval.clip_benchmark import evaluate

evaluate(config.eval)
```

so nothing that works today changes.

## Why remove rather than repair it

The other `__main__` blocks in this package are runnable demos that build their own inputs — `rag_eval/utils/clip.py:141` instantiates a `CLIPModel`, `clip_benchmark/utils/webdataset_convert.py:200` loads a real `MsDataset`. This one never did: it passes nothing at all.

Making it runnable would mean inventing a `ClipBenchmarkEvalConfig` — a model, a dataset name and a `data_dir` — and `ClipBenchmarkEvalConfig()` with its defaults has `models=[]` and `dataset_name=[]`, so the `product(models, dataset_names)` loop would do nothing anyway. The two sibling task templates in the same `rag_eval/` package, `mteb/task_template.py` and `ragas/task_template.py`, define no `__main__` at all, which seems like the intended shape for a template module driven by the backend manager.

Happy to turn it into a real demo instead if you'd rather keep an entry point — just let me know which model/dataset pair you'd want it pinned to.

## Testing

- Module compiles; `evaluate` is untouched and its only real caller is unchanged.
- Lint with the pinned `ruff v0.16.4` from `.pre-commit-config.yaml`, run from the repo root:

```console
$ ruff check evalscope/backend/rag_eval/clip_benchmark/task_template.py
All checks passed!
$ ruff format --diff evalscope/backend/rag_eval/clip_benchmark/task_template.py
1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
