### PR TITLE
fix(benchmark): prevent SWE-bench agent command hangs

### DIFF
--- a/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
+++ b/evalscope/benchmarks/swe_bench/swe_bench_agentic_adapter.py
@@ -22,8 +22,11 @@ from __future__ import annotations
 
 import ast
 import json
+import math
+import shlex
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from evalscope.agent.strategies.swe_bench import SUBMIT_SENTINEL
 from evalscope.agent.tools.bash import BASH_TOOL_INFO, run_bash
 from evalscope.api.agent import AgentEnvironment
 from evalscope.api.benchmark import BenchmarkMeta
@@ -34,6 +37,7 @@ from evalscope.api.messages import ChatMessageUser
 from evalscope.api.metric import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.api.sandbox import merge_sandbox_config_dicts
+from evalscope.api.tool import ToolCall
 from evalscope.constants import Tags
 from evalscope.utils.import_utils import check_import, is_build_doc
 from evalscope.utils.logger import get_logger
@@ -47,6 +51,43 @@ logger = get_logger()
 # SWE-bench images activate their per-instance testbed from shell startup files;
 # mini-swe-agent's DockerEnvironment therefore runs commands through bash -lc.
 _SWE_BENCH_INTERPRETER: tuple[str, ...] = ('bash', '-lc')
+_SWE_BENCH_COMMAND_TIMEOUT = 60.0
+_SWE_BENCH_MAX_COMMAND_OUTPUT_BYTES = 100_000
+_SWE_BENCH_OUTPUT_SAMPLER_PYTHON = r"""
+import sys
+
+max_bytes = int(sys.argv[1])
+head_bytes = max_bytes // 2
+tail_bytes = max_bytes - head_bytes
+head_remaining = head_bytes
+tail = bytearray()
+total = 0
+source = sys.stdin.buffer
+sink = sys.stdout.buffer
+
+while True:
+    chunk = source.read(65536)
+    if not chunk:
+        break
+    total += len(chunk)
+    if head_remaining:
+        head_part = chunk[:head_remaining]
+        sink.write(head_part)
+        sink.flush()
+        head_remaining -= len(head_part)
+        chunk = chunk[len(head_part):]
+    if chunk:
+        tail.extend(chunk)
+        if len(tail) > tail_bytes:
+            del tail[:-tail_bytes]
+
+captured_head = head_bytes - head_remaining
+if total > max_bytes:
+    omitted = total - captured_head - len(tail)
+    marker = f'\n[OUTPUT TRUNCATED: {omitted} bytes omitted while command continued]\n'
+    sink.write(marker.encode())
+sink.write(tail)
+""".strip()
 
 # ---------------------------------------------------------------------------
 # instance_template — mirrors mini-swe-agent swebench.yaml
@@ -204,6 +245,7 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
 
     strategy_name = 'swe_bench_toolcall'
     max_steps_default = 250
+    command_timeout_default = _SWE_BENCH_COMMAND_TIMEOUT
 
     @staticmethod
     def _parse_test_list(value: Any) -> List[str]:
@@ -310,9 +352,86 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
     # AgentAdapter hooks
     # ------------------------------------------------------------------
 
-    def build_tools(self, sample: Sample):
-        # Only ``bash`` — sentinel protocol replaces the ``submit`` tool.
-        return {'bash': run_bash}
+    def _command_timeout_limit(self) -> float:
+        configured_timeout = self._native_command_timeout()
+        if configured_timeout is not None:
+            return configured_timeout
+        return _SWE_BENCH_COMMAND_TIMEOUT
+
+    @staticmethod
+    def _sample_command_output(command: str) -> str:
+        submit_prefix = f'echo {SUBMIT_SENTINEL}'
+        if command.lstrip().startswith(submit_prefix) and 'git diff' in command:
+            return command
+        sampler_program = shlex.quote(_SWE_BENCH_OUTPUT_SAMPLER_PYTHON)
+        command_script = shlex.quote(command)
+        return (
+            'evalscope_python=$(command -v python3 || command -v python) || {\n'
+            f'    bash -c {command_script}\n'
+            '    exit $?\n'
+            '}\n'
+            'evalscope_capture_dir=$(mktemp -d) || exit 1\n'
+            'evalscope_capture_fifo="$evalscope_capture_dir/command-output"\n'
+            'evalscope_command_pid=\n'
+            'evalscope_sampler_pid=\n'
+            'evalscope_cleanup() {\n'
+            '    if [ -n "$evalscope_command_pid" ]; then\n'
+            '        kill -KILL -- -"$evalscope_command_pid" 2>/dev/null '
+            '|| kill -KILL "$evalscope_command_pid" 2>/dev/null || true\n'
+            '        wait "$evalscope_command_pid" 2>/dev/null || true\n'
+            '    fi\n'
+            '    if [ -n "$evalscope_sampler_pid" ]; then\n'
+            '        kill -KILL "$evalscope_sampler_pid" 2>/dev/null || true\n'
+            '        wait "$evalscope_sampler_pid" 2>/dev/null || true\n'
+            '    fi\n'
+            '    rm -f "$evalscope_capture_fifo"\n'
+            '    rmdir "$evalscope_capture_dir" 2>/dev/null || true\n'
+            '}\n'
+            'trap evalscope_cleanup EXIT\n'
+            "trap 'exit 143' HUP INT TERM\n"
+            'mkfifo "$evalscope_capture_fifo" || exit 1\n'
+            f'setsid bash -c {command_script} >"$evalscope_capture_fifo" 2>&1 &\n'
+            'evalscope_command_pid=$!\n'
+            f'"$evalscope_python" -S -c {sampler_program} {_SWE_BENCH_MAX_COMMAND_OUTPUT_BYTES} '
+            '<"$evalscope_capture_fifo" &\n'
+            'evalscope_sampler_pid=$!\n'
+            'wait "$evalscope_sampler_pid"\n'
+            'evalscope_sampler_status=$?\n'
+            'evalscope_sampler_pid=\n'
+            'if [ "$evalscope_sampler_status" -ne 0 ]; then exit "$evalscope_sampler_status"; fi\n'
+            'wait "$evalscope_command_pid"\n'
+            'evalscope_command_status=$?\n'
+            'evalscope_command_pid=\n'
+            'exit "$evalscope_command_status"'
+        )
+
+    def build_tools(self, sample: Sample) -> Dict[str, Any]:
+        # Only ``bash`` — sentinel protocol replaces the ``submit`` tool. The
+        # timeout is a harness safety boundary, so model-provided arguments may
+        # shorten it but cannot disable or extend it indefinitely.
+        timeout_limit = self._command_timeout_limit()
+
+        async def run_bash_with_timeout_limit(call: ToolCall, env: Optional[AgentEnvironment]) -> str:
+            arguments = dict(call.function.arguments or {})
+            command = arguments.get('command')
+            if isinstance(command, str):
+                arguments['command'] = self._sample_command_output(command)
+            try:
+                requested_timeout = float(arguments.get('timeout', timeout_limit))
+            except (TypeError, ValueError):
+                requested_timeout = timeout_limit
+            if not math.isfinite(requested_timeout) or requested_timeout <= 0 or requested_timeout > timeout_limit:
+                requested_timeout = timeout_limit
+            bounded_call = call.model_copy(
+                update={
+                    'function': call.function.model_copy(
+                        update={'arguments': {**arguments, 'timeout': requested_timeout}}
+                    )
+                }
+            )
+            return await run_bash(bounded_call, env)
+
+        return {'bash': run_bash_with_timeout_limit}
 
     def _forced_docker_platform(self) -> Optional[str]:
         """Return the Docker platform matching the forced SWE-bench image arch."""
@@ -351,7 +470,7 @@ class _SWEBenchAgenticAdapterBase(AgentLoopAdapter):
         return EnclaveAgentEnvironment(
             engine='docker',
             sandbox_config=sandbox_config,
-            timeout=self._native_command_timeout(),
+            timeout=self._command_timeout_limit(),
             interpreter=_SWE_BENCH_INTERPRETER,
         )
 

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -11,6 +11,7 @@ Test plan:
   TestNativeAgentEnvironmentConfig – legacy-compatible Agent environment config
 """
 
+import asyncio
 import os
 import sys
 import tempfile
@@ -386,6 +387,129 @@ class TestEnclaveEnvironmentInterpreter:
             'PIP_PROGRESS_BAR': 'off',
             'TQDM_DISABLE': '1',
         }
+
+    @pytest.mark.parametrize(
+        ('requested_timeout', 'expected_timeout'),
+        [
+            (-1, 60.0),
+            (0, 60.0),
+            (float('inf'), 60.0),
+            (3600, 60.0),
+            (5, 5.0),
+        ],
+    )
+    def test_swe_bench_agentic_caps_model_requested_command_timeout(
+        self,
+        requested_timeout: float,
+        expected_timeout: float,
+    ) -> None:
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(model='dummy')
+        environment = AsyncMock(spec=AgentEnvironment)
+        environment.exec.return_value = ExecResult()
+        call = _tool_call('bash', {'command': 'sleep 1', 'timeout': requested_timeout})
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        self._run(handler(call, environment))
+
+        assert environment.exec.await_count == 1
+        assert environment.exec.await_args.kwargs['timeout'] == expected_timeout
+
+    def test_swe_bench_agentic_uses_explicit_command_timeout_as_limit(self) -> None:
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(
+            model='dummy',
+            agent_config=NativeAgentConfig(command_timeout=90),
+        )
+        environment = AsyncMock(spec=AgentEnvironment)
+        environment.exec.return_value = ExecResult()
+        call = _tool_call('bash', {'command': 'sleep 1', 'timeout': 3600})
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        self._run(handler(call, environment))
+
+        assert environment.exec.await_count == 1
+        assert environment.exec.await_args.kwargs['timeout'] == 90
+
+    def test_swe_bench_agentic_samples_excessive_output_without_terminating_command(self) -> None:
+        from evalscope.agent.environments.local import LocalAgentEnvironment
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(model='dummy')
+        call = _tool_call(
+            'bash',
+            {
+                'command': (
+                    'python3 -c "import sys; sys.stdout.write(\'x\' * 200000)"; '
+                    "printf '\\nCOMMAND_COMPLETED\\n'"
+                )
+            },
+        )
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        output = self._run(asyncio.wait_for(handler(call, LocalAgentEnvironment()), timeout=2))
+
+        assert '[OUTPUT TRUNCATED:' in output
+        assert 'COMMAND_COMPLETED' in output
+        assert '[exit' not in output
+        assert len(output) < 101_000
+
+    def test_swe_bench_agentic_times_out_infinite_output_without_model_override(self) -> None:
+        from evalscope.agent.environments.local import LocalAgentEnvironment
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(
+            model='dummy',
+            agent_config=NativeAgentConfig(command_timeout=0.2),
+        )
+        call = _tool_call('bash', {'command': "yes 'repeated output'", 'timeout': -1})
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        output = self._run(asyncio.wait_for(handler(call, LocalAgentEnvironment()), timeout=2))
+
+        assert '[TIMEOUT]' in output
+        assert '[OUTPUT LIMIT EXCEEDED:' not in output
+
+    def test_swe_bench_agentic_output_sampler_preserves_exit_status(self) -> None:
+        from evalscope.agent.environments.local import LocalAgentEnvironment
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(model='dummy')
+        call = _tool_call(
+            'bash',
+            {'command': 'python3 -c "import sys; sys.stdout.write(\'failed command\\n\' * 20000)"; exit 7'},
+        )
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        output = self._run(handler(call, LocalAgentEnvironment()))
+
+        assert 'failed command' in output
+        assert '[OUTPUT TRUNCATED:' in output
+        assert '[exit 7]' in output
+
+    def test_swe_bench_agentic_does_not_truncate_submission_command(self) -> None:
+        from evalscope.agent.strategies.swe_bench import SUBMIT_SENTINEL
+        from evalscope.benchmarks.swe_bench.swe_bench_agentic_adapter import _SWEBenchAgenticAdapterBase
+
+        adapter = object.__new__(_SWEBenchAgenticAdapterBase)
+        adapter._task_config = TaskConfig(model='dummy')
+        environment = AsyncMock(spec=AgentEnvironment)
+        environment.exec.return_value = ExecResult()
+        command = f'echo {SUBMIT_SENTINEL} && git diff'
+        call = _tool_call('bash', {'command': command})
+
+        handler = adapter.build_tools(types.SimpleNamespace())['bash']
+        self._run(handler(call, environment))
+
+        assert environment.exec.await_count == 1
+        assert environment.exec.await_args.args[0] == ['/bin/bash', '-c', command]
 
     def test_swe_bench_pro_adapter_uses_login_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from evalscope.benchmarks.swe_bench_pro.swe_bench_pro_agentic_adapter import SWEBenchProAgenticAdapter


### PR DESCRIPTION
Fixes https://github.com/modelscope/evalscope/issues/1685

## Summary

SWE-bench agent commands can hang when a model supplies `timeout=-1` or an excessive timeout. In the reported Sphinx case, repeated blank input to `sphinx-quickstart` also produced unbounded output, which was accumulated before observation truncation.

Enforce a 60-second command limit, configurable through `NativeAgentConfig.command_timeout`. Smaller positive model-supplied timeouts are respected; invalid or larger values use the configured ceiling. Run commands in a separate process group for timeout cleanup.

When Python is available in the sandbox, continuously drain output while retaining its first and last 50 KB. Exceeding that window does not kill the command: completion, side effects and exit status are preserved. Submission commands retain their sentinel and full `git diff` output. The limit applies to SWE-bench commands, not whole evaluation samples.

## Reproduction

The original validation used `sphinx-doc__sphinx-9320` with Kimi K3 in the official SWE-bench image:

- Before the fix, the looping command with `timeout=-1` exceeded a 60-second outer watchdog.
- With a 5-second configured ceiling, it returned `[TIMEOUT]` after about 5.5 seconds, with no sandbox process left behind.
- A finite 200,000-byte command without newlines completed in about 0.7 seconds. The bounded output retained its trailing completion marker and successful exit status.

## Validation

Results recorded during the original PR validation:

```bash
pytest -q \
  tests/agent/test_t2_environment.py \
  tests/agent/test_agent_integration.py \
  tests/agent/test_agent_loop.py \
  -p no:warnings
# 112 passed, 10 skipped

pytest tests/cli/test_all.py::TestRun::test_ci_lite -q -p no:warnings
# 1 passed

make lint
# passed
```

The Docker reproduction used `ms-enclave==0.0.8` and `swebench/sweb.eval.x86_64.sphinx-doc_1776_sphinx-9320:latest`. The original validation also reported passing GitHub unit tests, perf tests, and pre-commit checks.
