### PR TITLE
chore: enforce F401 in evalscope/utils

### DIFF
--- a/evalscope/utils/data_utils.py
+++ b/evalscope/utils/data_utils.py
@@ -4,7 +4,7 @@ Data loading and processing utilities for reports and predictions.
 
 import glob
 import os
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 import pandas as pd
 from pydantic import ValidationError
@@ -13,7 +13,7 @@ from evalscope.api.evaluator import CacheManager, ReviewResult
 from evalscope.constants import DataCollection
 from evalscope.metrics.semantics import format_metric_value
 from evalscope.metrics.semantics.ranking import bounded_quality_ratio
-from evalscope.report import Report, ReportKey, ReportRef, get_data_frame, get_report_list
+from evalscope.report import Report, ReportKey, ReportRef, get_report_list
 from evalscope.utils.io_utils import OutputsStructure, jsonl_to_list, yaml_to_dict
 from evalscope.utils.logger import get_logger
 

--- a/evalscope/utils/doc_utils/benchmark_stats.py
+++ b/evalscope/utils/doc_utils/benchmark_stats.py
@@ -36,7 +36,7 @@ from evalscope.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from evalscope.api.benchmark import DataAdapter
-    from evalscope.api.dataset import DatasetDict, Sample
+    from evalscope.api.dataset import Sample
 
 logger = get_logger()
 

--- a/evalscope/utils/doc_utils/generate_dataset_md.py
+++ b/evalscope/utils/doc_utils/generate_dataset_md.py
@@ -26,7 +26,7 @@ from . import (
     load_benchmark_data,
     save_benchmark_data,
 )
-from .readme_generator import _format_sample_count, _format_tags, generate_readme_from_dict
+from .readme_generator import _format_tags, generate_readme_from_dict
 
 if TYPE_CHECKING:
     from evalscope.api.benchmark import BenchmarkMeta, DataAdapter

--- a/evalscope/utils/doc_utils/readme_generator.py
+++ b/evalscope/utils/doc_utils/readme_generator.py
@@ -9,7 +9,7 @@ and usage instructions.
 
 import json
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from evalscope.utils.logger import get_logger
 

--- a/evalscope/utils/function_utils.py
+++ b/evalscope/utils/function_utils.py
@@ -1,9 +1,9 @@
 import asyncio
 import threading
 import time
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, wait
 from functools import wraps
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Awaitable, Callable, List, Optional, Sequence, Tuple, Type, TypeVar
 
 from evalscope.utils import asyncio_runtime
 from evalscope.utils.logger import get_logger

--- a/evalscope/utils/json_schema.py
+++ b/evalscope/utils/json_schema.py
@@ -21,7 +21,7 @@ from typing import (
     is_typeddict,
 )
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 JSONType = Literal['string', 'integer', 'number', 'boolean', 'array', 'object', 'null']
 """Valid types within JSON schema."""

--- a/evalscope/utils/model_utils.py
+++ b/evalscope/utils/model_utils.py
@@ -1,6 +1,6 @@
 import random
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict
 
 import numpy as np
 

--- a/evalscope/utils/ner.py
+++ b/evalscope/utils/ner.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 from evalscope.utils.logger import get_logger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,10 +123,12 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
-ignore = ["E501", "F401"]
+ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E402"]
+"__init__.py" = ["F401"]
+"!evalscope/{utils}/**/*.py" = ["F401"]
 
 [tool.ruff.format]
 exclude = ["tests/**/*.py"]


### PR DESCRIPTION
## Summary

- [x] remove unused imports in `evalscope/utils`
- [x] `__init__.py` now ignores rule F401 to prevent c
- [x] no doc update needed
- [x] no test update needed

## Tests

```sh
# regression test 1: checks for uses of undefined names.
# to ensure we dont remove used imports
ruff check --select=F821
```

## Criteria

ruff auto-fix is reliable if the removed import satisfies any of:
1. is imported from typing
2. is conditioned under `if TYPE_CHECKING:`
3. has no decorators (a counterexample would be registration of benchmarks, which must NOT be lazy loaded or non-imported).

Different from the *F401 is safe except `__init__.py`* claim in [ruff doc](https://docs.astral.sh/ruff/rules/unused-import/), decorators for registry requires import to tigger.

In our case, we have a few `register_*()` functions serving as decorators. Removing imports with these decorators will be unsafe.