### PR TITLE
fix(cli): enforce F401 in cli and fix benchmark info import errors

### DIFF
--- a/evalscope/cli/base.py
+++ b/evalscope/cli/base.py
@@ -1,7 +1,10 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
 from abc import ABC, abstractmethod
-from argparse import ArgumentParser
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
 
 
 class CLICommand(ABC):
@@ -12,7 +15,7 @@ class CLICommand(ABC):
 
     @staticmethod
     @abstractmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         raise NotImplementedError()
 
     @abstractmethod

--- a/evalscope/cli/base.py
+++ b/evalscope/cli/base.py
@@ -1,14 +1,12 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Protocol
-
-if TYPE_CHECKING:
-    from argparse import ArgumentParser
+from argparse import ArgumentParser
+from typing import Any, Protocol
 
 
 class ArgumentParserWithSubParsers(Protocol):
-    def add_parser(self, name, **kwargs) -> 'ArgumentParser': ...
+    def add_parser(self, name: str, **kwargs: Any) -> ArgumentParser: ...
 
 
 class CLICommand(ABC):
@@ -19,7 +17,7 @@ class CLICommand(ABC):
 
     @staticmethod
     @abstractmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         raise NotImplementedError()
 
     @abstractmethod

--- a/evalscope/cli/base.py
+++ b/evalscope/cli/base.py
@@ -1,10 +1,14 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from argparse import ArgumentParser
+
+
+class ArgumentParserWithSubParsers(Protocol):
+    def add_parser(self, name, **kwargs) -> 'ArgumentParser': ...
 
 
 class CLICommand(ABC):
@@ -15,7 +19,7 @@ class CLICommand(ABC):
 
     @staticmethod
     @abstractmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         raise NotImplementedError()
 
     @abstractmethod

--- a/evalscope/cli/benchmark_info.py
+++ b/evalscope/cli/benchmark_info.py
@@ -39,9 +39,16 @@ Usage:
 
 import json
 from argparse import ArgumentParser, Namespace
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from evalscope.cli.base import CLICommand
 from evalscope.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
+
+    from evalscope.api.benchmark import BenchmarkMeta, DataAdapter
+
 
 logger = get_logger()
 
@@ -76,7 +83,7 @@ class BenchmarkInfoCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         parser = parsers.add_parser(
             BenchmarkInfoCMD.name,
             help='Display benchmark information and manage documentation',
@@ -209,7 +216,7 @@ class BenchmarkInfoCMD(CLICommand):
                     raise
 
     @staticmethod
-    def _format_metric_list(metric_list):
+    def _format_metric_list(metric_list: List[Union[str, Dict[str, Any]]]):
         """Format metric_list (mixed strings and dicts) into readable strings."""
         formatted = []
         for item in metric_list or []:
@@ -307,7 +314,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         generate_docs()
 
-    def _display_info(self, adapter):
+    def _display_info(self, adapter: 'DataAdapter'):
         """Display benchmark information."""
         from evalscope.utils.doc_utils.generate_dataset_md import get_adapter_category
 
@@ -321,7 +328,7 @@ class BenchmarkInfoCMD(CLICommand):
         else:
             self._display_text(meta, category)
 
-    def _display_text(self, meta, category=None):
+    def _display_text(self, meta: 'BenchmarkMeta', category: Optional[str] = None):
         """Display info in text format."""
         print(f'\n{"=" * 60}')
         print(f'Benchmark: {meta.pretty_name or meta.name}')
@@ -393,7 +400,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         print()
 
-    def _display_json(self, adapter, category=None):
+    def _display_json(self, adapter: 'DataAdapter', category: Optional[str] = None):
         """Display info in JSON format."""
         from evalscope.utils.doc_utils import load_benchmark_data
 
@@ -432,10 +439,9 @@ class BenchmarkInfoCMD(CLICommand):
         }
         print(json.dumps(data, indent=2, ensure_ascii=False))
 
-    def _display_markdown(self, adapter):
+    def _display_markdown(self, adapter: 'DataAdapter'):
         """Display info in markdown format."""
         from evalscope.utils.doc_utils import load_benchmark_data
-        from evalscope.utils.doc_utils.generate_dataset_md import generate_readme_content
 
         # Try to load from persisted data first
         try:
@@ -449,7 +455,12 @@ class BenchmarkInfoCMD(CLICommand):
             pass
 
         # Fall back to generating from adapter
-        from evalscope.utils.readme_generator import generate_benchmark_readme
+        from evalscope.utils.doc_utils.generate_dataset_md import extract_adapter_meta
+        from evalscope.utils.doc_utils.readme_generator import generate_readme_from_dict
 
-        readme = generate_benchmark_readme(adapter, compute_if_missing=False)
+        readme = generate_readme_from_dict(
+            adapter.name,
+            extract_adapter_meta(adapter),
+            lang='en',
+        )
         print(readme)

--- a/evalscope/cli/benchmark_info.py
+++ b/evalscope/cli/benchmark_info.py
@@ -38,16 +38,16 @@ Usage:
 """
 
 import json
-from argparse import ArgumentParser, Namespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from evalscope.cli.base import CLICommand
 from evalscope.utils.logger import get_logger
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from argparse import Namespace
 
     from evalscope.api.benchmark import BenchmarkMeta, DataAdapter
+    from evalscope.cli.base import ArgumentParserWithSubParsers
 
 
 logger = get_logger()
@@ -79,11 +79,11 @@ class BenchmarkInfoCMD(CLICommand):
 
     name = 'benchmark-info'
 
-    def __init__(self, args: Namespace):
+    def __init__(self, args: 'Namespace'):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         parser = parsers.add_parser(
             BenchmarkInfoCMD.name,
             help='Display benchmark information and manage documentation',

--- a/evalscope/cli/benchmark_info.py
+++ b/evalscope/cli/benchmark_info.py
@@ -38,17 +38,12 @@ Usage:
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from argparse import Namespace
+from typing import Any, Dict, List, Optional, Union
 
-from evalscope.cli.base import CLICommand
+from evalscope.api.benchmark import BenchmarkMeta, DataAdapter
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
 from evalscope.utils.logger import get_logger
-
-if TYPE_CHECKING:
-    from argparse import Namespace
-
-    from evalscope.api.benchmark import BenchmarkMeta, DataAdapter
-    from evalscope.cli.base import ArgumentParserWithSubParsers
-
 
 logger = get_logger()
 
@@ -79,11 +74,11 @@ class BenchmarkInfoCMD(CLICommand):
 
     name = 'benchmark-info'
 
-    def __init__(self, args: 'Namespace'):
+    def __init__(self, args: Namespace):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         parser = parsers.add_parser(
             BenchmarkInfoCMD.name,
             help='Display benchmark information and manage documentation',
@@ -314,7 +309,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         generate_docs()
 
-    def _display_info(self, adapter: 'DataAdapter'):
+    def _display_info(self, adapter: DataAdapter) -> None:
         """Display benchmark information."""
         from evalscope.utils.doc_utils.generate_dataset_md import get_adapter_category
 
@@ -328,7 +323,7 @@ class BenchmarkInfoCMD(CLICommand):
         else:
             self._display_text(meta, category)
 
-    def _display_text(self, meta: 'BenchmarkMeta', category: Optional[str] = None):
+    def _display_text(self, meta: BenchmarkMeta, category: Optional[str] = None) -> None:
         """Display info in text format."""
         print(f'\n{"=" * 60}')
         print(f'Benchmark: {meta.pretty_name or meta.name}')
@@ -400,7 +395,7 @@ class BenchmarkInfoCMD(CLICommand):
 
         print()
 
-    def _display_json(self, adapter: 'DataAdapter', category: Optional[str] = None):
+    def _display_json(self, adapter: DataAdapter, category: Optional[str] = None) -> None:
         """Display info in JSON format."""
         from evalscope.utils.doc_utils import load_benchmark_data
 
@@ -439,7 +434,7 @@ class BenchmarkInfoCMD(CLICommand):
         }
         print(json.dumps(data, indent=2, ensure_ascii=False))
 
-    def _display_markdown(self, adapter: 'DataAdapter'):
+    def _display_markdown(self, adapter: DataAdapter) -> None:
         """Display info in markdown format."""
         from evalscope.utils.doc_utils import load_benchmark_data
 

--- a/evalscope/cli/start_app.py
+++ b/evalscope/cli/start_app.py
@@ -5,9 +5,12 @@ The 'app' command is deprecated.  Use 'evalscope service' instead.
 """
 
 import warnings
-from argparse import ArgumentParser
+from typing import TYPE_CHECKING
 
 from evalscope.cli.base import CLICommand
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
 
 
 def subparser_func(args):
@@ -22,7 +25,7 @@ class StartAppCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         """Define args for app command (deprecated alias for service)."""
         parser = parsers.add_parser(
             StartAppCMD.name,

--- a/evalscope/cli/start_app.py
+++ b/evalscope/cli/start_app.py
@@ -5,12 +5,8 @@ The 'app' command is deprecated.  Use 'evalscope service' instead.
 """
 
 import warnings
-from typing import TYPE_CHECKING
 
-from evalscope.cli.base import CLICommand
-
-if TYPE_CHECKING:
-    from evalscope.cli.base import ArgumentParserWithSubParsers
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
 
 
 def subparser_func(args):
@@ -25,7 +21,7 @@ class StartAppCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         """Define args for app command (deprecated alias for service)."""
         parser = parsers.add_parser(
             StartAppCMD.name,

--- a/evalscope/cli/start_app.py
+++ b/evalscope/cli/start_app.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from evalscope.cli.base import CLICommand
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from evalscope.cli.base import ArgumentParserWithSubParsers
 
 
 def subparser_func(args):
@@ -25,7 +25,7 @@ class StartAppCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         """Define args for app command (deprecated alias for service)."""
         parser = parsers.add_parser(
             StartAppCMD.name,

--- a/evalscope/cli/start_eval.py
+++ b/evalscope/cli/start_eval.py
@@ -1,5 +1,8 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
-from argparse import ArgumentParser
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
 
 from evalscope.cli.base import CLICommand
 
@@ -16,7 +19,7 @@ class EvalCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         """define args for create pipeline template command."""
         from evalscope.arguments import add_argument
 

--- a/evalscope/cli/start_eval.py
+++ b/evalscope/cli/start_eval.py
@@ -2,7 +2,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from evalscope.cli.base import ArgumentParserWithSubParsers
 
 from evalscope.cli.base import CLICommand
 
@@ -19,7 +19,7 @@ class EvalCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         """define args for create pipeline template command."""
         from evalscope.arguments import add_argument
 

--- a/evalscope/cli/start_eval.py
+++ b/evalscope/cli/start_eval.py
@@ -1,10 +1,5 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from evalscope.cli.base import ArgumentParserWithSubParsers
-
-from evalscope.cli.base import CLICommand
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
 
 
 def subparser_func(args):
@@ -19,7 +14,7 @@ class EvalCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         """define args for create pipeline template command."""
         from evalscope.arguments import add_argument
 

--- a/evalscope/cli/start_perf.py
+++ b/evalscope/cli/start_perf.py
@@ -1,6 +1,8 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
-import os
-from argparse import ArgumentParser
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
 
 from evalscope.cli.base import CLICommand
 
@@ -17,7 +19,7 @@ class PerfBenchCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         """define args for create pipeline template command."""
         from evalscope.perf.arguments import add_argument
 

--- a/evalscope/cli/start_perf.py
+++ b/evalscope/cli/start_perf.py
@@ -1,10 +1,5 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from evalscope.cli.base import ArgumentParserWithSubParsers
-
-from evalscope.cli.base import CLICommand
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
 
 
 def subparser_func(args):
@@ -19,7 +14,7 @@ class PerfBenchCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         """define args for create pipeline template command."""
         from evalscope.perf.arguments import add_argument
 

--- a/evalscope/cli/start_perf.py
+++ b/evalscope/cli/start_perf.py
@@ -2,7 +2,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from evalscope.cli.base import ArgumentParserWithSubParsers
 
 from evalscope.cli.base import CLICommand
 
@@ -19,7 +19,7 @@ class PerfBenchCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         """define args for create pipeline template command."""
         from evalscope.perf.arguments import add_argument
 

--- a/evalscope/cli/start_service.py
+++ b/evalscope/cli/start_service.py
@@ -2,9 +2,13 @@
 """CLI command for starting the EvalScope Flask service."""
 
 import os
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentTypeError
+from typing import TYPE_CHECKING
 
 from evalscope.cli.base import CLICommand
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _SubParsersAction
 
 
 def subparser_func(args):
@@ -27,7 +31,7 @@ class ServiceCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: ArgumentParser):
+    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
         """Define args for service command."""
         parser = parsers.add_parser(
             ServiceCMD.name, help='Start the EvalScope Flask service for eval and perf endpoints'

--- a/evalscope/cli/start_service.py
+++ b/evalscope/cli/start_service.py
@@ -3,12 +3,8 @@
 
 import os
 from argparse import ArgumentTypeError
-from typing import TYPE_CHECKING
 
-from evalscope.cli.base import CLICommand
-
-if TYPE_CHECKING:
-    from evalscope.cli.base import ArgumentParserWithSubParsers
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
 
 
 def subparser_func(args):
@@ -31,7 +27,7 @@ class ServiceCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: 'ArgumentParserWithSubParsers'):
+    def define_args(parsers: ArgumentParserWithSubParsers) -> None:
         """Define args for service command."""
         parser = parsers.add_parser(
             ServiceCMD.name, help='Start the EvalScope Flask service for eval and perf endpoints'

--- a/evalscope/cli/start_service.py
+++ b/evalscope/cli/start_service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from evalscope.cli.base import CLICommand
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, _SubParsersAction
+    from evalscope.cli.base import ArgumentParserWithSubParsers
 
 
 def subparser_func(args):
@@ -31,7 +31,7 @@ class ServiceCMD(CLICommand):
         self.args = args
 
     @staticmethod
-    def define_args(parsers: '_SubParsersAction[ArgumentParser]'):
+    def define_args(parsers: 'ArgumentParserWithSubParsers'):
         """Define args for service command."""
         parser = parsers.add_parser(
             ServiceCMD.name, help='Start the EvalScope Flask service for eval and perf endpoints'

--- a/evalscope/report/combinator.py
+++ b/evalscope/report/combinator.py
@@ -3,7 +3,7 @@
 import glob
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from tabulate import tabulate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E402"]
 "__init__.py" = ["F401"]
-"!evalscope/{utils,cli}/**/*.py" = ["F401"]
+"!evalscope/{utils,cli,report}/**/*.py" = ["F401"]
 
 [tool.ruff.format]
 exclude = ["tests/**/*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E402"]
 "__init__.py" = ["F401"]
-"!evalscope/{utils}/**/*.py" = ["F401"]
+"!evalscope/{utils,cli}/**/*.py" = ["F401"]
 
 [tool.ruff.format]
 exclude = ["tests/**/*.py"]

--- a/tests/cli/test_benchmark_info.py
+++ b/tests/cli/test_benchmark_info.py
@@ -1,0 +1,18 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from evalscope.api.registry import get_benchmark
+from evalscope.cli.benchmark_info import BenchmarkInfoCMD
+
+
+def test_markdown_fallback_uses_adapter_metadata(capsys) -> None:
+    adapter = get_benchmark('mmlu')
+
+    with patch('evalscope.utils.doc_utils.load_benchmark_data', return_value={}):
+        BenchmarkInfoCMD(Namespace())._display_markdown(adapter)
+
+    output = capsys.readouterr().out
+    assert '# MMLU' in output
+    assert '## Overview' in output

--- a/tests/cli/test_type_hints.py
+++ b/tests/cli/test_type_hints.py
@@ -1,0 +1,22 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from argparse import ArgumentParser
+from typing import get_type_hints
+
+import pytest
+
+from evalscope.cli.base import ArgumentParserWithSubParsers, CLICommand
+from evalscope.cli.benchmark_info import BenchmarkInfoCMD
+from evalscope.cli.start_app import StartAppCMD
+from evalscope.cli.start_eval import EvalCMD
+from evalscope.cli.start_perf import PerfBenchCMD
+from evalscope.cli.start_service import ServiceCMD
+
+
+@pytest.mark.parametrize('command', [CLICommand, BenchmarkInfoCMD, StartAppCMD, EvalCMD, PerfBenchCMD, ServiceCMD])
+def test_cli_define_args_type_hints_are_runtime_resolvable(command: type[CLICommand]) -> None:
+    assert get_type_hints(command.define_args)['parsers'] is ArgumentParserWithSubParsers
+
+
+def test_subparser_protocol_type_hints_are_runtime_resolvable() -> None:
+    assert get_type_hints(ArgumentParserWithSubParsers.add_parser)['return'] is ArgumentParser


### PR DESCRIPTION
## Summary

- [x] CICD: enforce F401 in `evalscope/cli/` and `evalscope/report/` (#1631)
- [x] fix: benchmark-info raises import error when `--format markdown` is passed
- [x] typing: fix typing issues for `CLICommand` and its subclasses.
- [x] typing: add type hints to method in `BenchmarkInfoCMD`.
- [x] no doc update needed
- [x] no test update needed, CLI functions not affected, only type checks and hints.

## Test

```sh
evalscope benchmark-info mmlu --format markdown
```