### PR TITLE
fix(dep): remove dependency `overrides`; type check instead of runtime

### DIFF
--- a/evalscope/api/benchmark/adapters/default_data_adapter.py
+++ b/evalscope/api/benchmark/adapters/default_data_adapter.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
-from overrides import override
+from typing_extensions import override
 
 from evalscope.api.agent import AgentLoopResult
 from evalscope.api.dataset import DataLoader, Dataset, DatasetDict, LocalDataLoader, RemoteDataLoader, Sample

--- a/evalscope/models/modelscope.py
+++ b/evalscope/models/modelscope.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple, Union, c
 
 import torch  # type: ignore
 from modelscope import AutoModelForCausalLM, AutoTokenizer
-from torch import Tensor  # type: ignore
 from typing_extensions import override
 
 from evalscope.api.messages import (
@@ -255,7 +254,6 @@ class ModelScopeAPI(ModelAPI):
         """Default is 2048, bump it up to a value suitable for evals."""
         return 2048
 
-    @override
     def max_connections(self) -> int:
         """Effectively the batch size."""
         return 8
@@ -308,20 +306,20 @@ def message_content_to_string(messages: List[ChatMessage]) -> List[ChatMessage]:
 
 # return value from generate as a result of specifying return_dict_in_generate
 class ModelGenerateOutput:
-    sequences: Tensor
-    logits: tuple[Tensor]
+    sequences: torch.Tensor
+    logits: tuple[torch.Tensor]
 
 
 class Tokenizer(Protocol):
-    def __call__(self, input: List[str]) -> Dict[Literal['input_ids', 'attention_mask'], Tensor]: ...
+    def __call__(self, input: List[str]) -> Dict[Literal['input_ids', 'attention_mask'], torch.Tensor]: ...
 
 
 class Generator(Protocol):
-    def __call__(self, input_ids: Tensor, attention_mask: Tensor) -> Tensor: ...
+    def __call__(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor: ...
 
 
 class Decoder(Protocol):
-    def __call__(self, sequences: Tensor) -> list[str]: ...
+    def __call__(self, sequences: torch.Tensor) -> list[str]: ...
 
 
 @dataclass

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -15,7 +15,6 @@ modelscope[datasets]>=1.34
 more_itertools
 nltk
 openai
-overrides
 pandas
 pillow
 plotly


### PR DESCRIPTION
## Summary

- [x] remove `overrides` dependency and use existing `typing_extension` instead: `@override` now checks during development type check, instead of runtime.
- [x] modify `evalscope/api/benchmark/adapters/default_data_adapter.py` to match `evalscope/models/modelscope.py`.
- [x] use torch.Tensor instead of Tensor, removing a `from import` to clean code.
- [x] no test update needed.
- [x] no doc update needed.