### PR TITLE
fix(bridge): record upstream generate failures on the agent trace

### DIFF
--- a/evalscope/agent/external/bridge/server.py
+++ b/evalscope/agent/external/bridge/server.py
@@ -486,7 +486,7 @@ class ModelProxyServer:
                 config=gen_config,
             )
         except Exception as exc:  # pragma: no cover - upstream-dependent
-            _log_upstream_failure(session, exc, mode='json')
+            _handle_upstream_failure(session, exc, mode='json', latency_ms=(time.monotonic() - started) * 1000)
             return web.json_response(
                 {
                     'error': {
@@ -538,7 +538,7 @@ class ModelProxyServer:
             _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:  # pragma: no cover - upstream-dependent
             failure_handled = True
-            _log_upstream_failure(session, exc, mode='stream')
+            _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
             error_payload = {
                 'error': {
                     'type': 'api_error',
@@ -595,7 +595,7 @@ class ModelProxyServer:
                 config=gen_config,
             )
         except Exception as exc:  # pragma: no cover - upstream-dependent
-            _log_upstream_failure(session, exc, mode='json')
+            _handle_upstream_failure(session, exc, mode='json', latency_ms=(time.monotonic() - started) * 1000)
             return web.json_response(
                 {
                     'error': {
@@ -646,7 +646,7 @@ class ModelProxyServer:
             async for chunk in stream_responses_payload(payload):
                 await response.write(chunk)
         except Exception as exc:  # pragma: no cover - upstream-dependent
-            _log_upstream_failure(session, exc, mode='stream')
+            _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
             # Responses error frame shape per OpenAI SDK ``ResponseErrorEvent``:
             # event name ``error`` (NOT ``response.failed`` — that one requires
             # a fully-constructed ``Response`` object with id/created_at/output/usage,
@@ -724,7 +724,7 @@ class ModelProxyServer:
                 config=gen_config,
             )
         except Exception as exc:
-            _log_upstream_failure(session, exc, mode='json')
+            _handle_upstream_failure(session, exc, mode='json', latency_ms=(time.monotonic() - started) * 1000)
             return web.json_response(
                 {
                     'error': {
@@ -773,7 +773,7 @@ class ModelProxyServer:
             _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:
             failure_handled = True
-            _log_upstream_failure(session, exc, mode='stream')
+            _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
             error_data = json.dumps({'error': {'code': 502, 'message': repr(exc), 'status': 'UNAVAILABLE'}})
             try:
                 await response.write(f'data: {error_data}\n\n'.encode('utf-8'))
@@ -800,7 +800,7 @@ class ModelProxyServer:
                 config=gen_config,
             )
         except Exception as exc:  # pragma: no cover - upstream-dependent
-            _log_upstream_failure(session, exc, mode='json')
+            _handle_upstream_failure(session, exc, mode='json', latency_ms=(time.monotonic() - started) * 1000)
             return web.json_response(
                 {
                     'type': 'error',
@@ -854,7 +854,7 @@ class ModelProxyServer:
             _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:  # pragma: no cover - upstream-dependent
             failure_handled = True
-            _log_upstream_failure(session, exc, mode='stream')
+            _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
             error_payload = {
                 'type': 'error',
                 'error': {
@@ -969,6 +969,26 @@ def _log_upstream_failure(session: 'TrialSession', exc: BaseException, *, mode: 
         logger.warning(f'{tag} upstream {mode} {cls_name}: {str(exc)[:200]}')
         return
     logger.exception(f'{tag} {mode} generate failed')
+
+
+def _handle_upstream_failure(
+    session: 'TrialSession',
+    exc: BaseException,
+    *,
+    mode: str,
+    latency_ms: float,
+) -> None:
+    """Log an upstream failure *and* record it on the trace.
+
+    Downgrading routine upstream errors to a one-line WARNING (see
+    :func:`_log_upstream_failure`) keeps the eval log readable, but the log is
+    not the artifact anyone analyses afterwards: ``AgentTrace`` is. Recording
+    only the turns that succeeded leaves every retried attempt invisible, which
+    is what the native :class:`AgentLoop` already avoids by emitting
+    ``EventType.ERROR`` for its own failure modes.
+    """
+    _log_upstream_failure(session, exc, mode=mode)
+    session.recorder.record_turn_failure(mode=mode, exc=exc, latency_ms=latency_ms)
 
 
 def _log_turn(session: 'TrialSession', output, latency_ms: float, *, mode: str) -> None:

--- a/evalscope/agent/external/bridge/server.py
+++ b/evalscope/agent/external/bridge/server.py
@@ -525,17 +525,23 @@ class ModelProxyServer:
             )
         )
         failure_handled = False
+        client_disconnected = False
         try:
             async for chunk in stream_openai_response(
                 generate_task,
                 request_model=body.get('model'),
                 include_usage=include_usage,
             ):
-                await response.write(chunk)
-            output = await generate_task
-            latency_ms = (time.monotonic() - started) * 1000
-            session.recorder.record_openai_turn(body, output, latency_ms=latency_ms)
-            _log_turn(session, output, latency_ms, mode='stream')
+                try:
+                    await response.write(chunk)
+                except ConnectionResetError:
+                    client_disconnected = True
+                    break
+            if not client_disconnected:
+                output = await generate_task
+                latency_ms = (time.monotonic() - started) * 1000
+                session.recorder.record_openai_turn(body, output, latency_ms=latency_ms)
+                _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:  # pragma: no cover - upstream-dependent
             failure_handled = True
             _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
@@ -551,8 +557,9 @@ class ModelProxyServer:
             except ConnectionResetError:
                 pass
         finally:
-            await _finish_generation_task(generate_task, failure_handled=failure_handled)
-        await response.write_eof()
+            await _finish_generation_task(generate_task, failure_handled=failure_handled or client_disconnected)
+        if not client_disconnected:
+            await response.write_eof()
         return response
 
     async def _handle_openai_responses(self, request: web.Request) -> web.StreamResponse:
@@ -632,6 +639,7 @@ class ModelProxyServer:
         response = await self._prepare_sse_response(request)
 
         started = time.monotonic()
+        client_disconnected = False
         try:
             output = await session.model.generate_async(
                 input=chat_messages,
@@ -644,7 +652,11 @@ class ModelProxyServer:
             _log_turn(session, output, latency_ms, mode='stream')
             payload = model_output_to_responses_payload(output, request_model=body.get('model'))
             async for chunk in stream_responses_payload(payload):
-                await response.write(chunk)
+                try:
+                    await response.write(chunk)
+                except ConnectionResetError:
+                    client_disconnected = True
+                    break
         except Exception as exc:  # pragma: no cover - upstream-dependent
             _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
             # Responses error frame shape per OpenAI SDK ``ResponseErrorEvent``:
@@ -666,7 +678,8 @@ class ModelProxyServer:
                 await response.write(error_event)
             except ConnectionResetError:
                 pass
-        await response.write_eof()
+        if not client_disconnected:
+            await response.write_eof()
         return response
 
     # ---- Gemini routes ----------------------------------------------------
@@ -764,13 +777,19 @@ class ModelProxyServer:
             )
         )
         failure_handled = False
+        client_disconnected = False
         try:
             async for chunk in stream_gemini_response(generate_task, request_model=body.get('model')):
-                await response.write(chunk)
-            output = await generate_task
-            latency_ms = (time.monotonic() - started) * 1000
-            session.recorder.record_gemini_turn(body, output, latency_ms=latency_ms)
-            _log_turn(session, output, latency_ms, mode='stream')
+                try:
+                    await response.write(chunk)
+                except ConnectionResetError:
+                    client_disconnected = True
+                    break
+            if not client_disconnected:
+                output = await generate_task
+                latency_ms = (time.monotonic() - started) * 1000
+                session.recorder.record_gemini_turn(body, output, latency_ms=latency_ms)
+                _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:
             failure_handled = True
             _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
@@ -780,8 +799,9 @@ class ModelProxyServer:
             except ConnectionResetError:
                 pass
         finally:
-            await _finish_generation_task(generate_task, failure_handled=failure_handled)
-        await response.write_eof()
+            await _finish_generation_task(generate_task, failure_handled=failure_handled or client_disconnected)
+        if not client_disconnected:
+            await response.write_eof()
         return response
 
     async def _respond_json(
@@ -843,15 +863,21 @@ class ModelProxyServer:
             )
         )
         failure_handled = False
+        client_disconnected = False
         try:
             async for chunk in stream_anthropic_response(generate_task, request_model=body.get('model')):
-                await response.write(chunk)
-            # Recorder needs the resolved output; awaiting the task is a no-op
-            # because the streamer already drained it.
-            output = await generate_task
-            latency_ms = (time.monotonic() - started) * 1000
-            session.recorder.record_anthropic_turn(body, output, latency_ms=latency_ms)
-            _log_turn(session, output, latency_ms, mode='stream')
+                try:
+                    await response.write(chunk)
+                except ConnectionResetError:
+                    client_disconnected = True
+                    break
+            if not client_disconnected:
+                # Recorder needs the resolved output; awaiting the task is a no-op
+                # because the streamer already drained it.
+                output = await generate_task
+                latency_ms = (time.monotonic() - started) * 1000
+                session.recorder.record_anthropic_turn(body, output, latency_ms=latency_ms)
+                _log_turn(session, output, latency_ms, mode='stream')
         except Exception as exc:  # pragma: no cover - upstream-dependent
             failure_handled = True
             _handle_upstream_failure(session, exc, mode='stream', latency_ms=(time.monotonic() - started) * 1000)
@@ -868,8 +894,9 @@ class ModelProxyServer:
             except ConnectionResetError:
                 pass
         finally:
-            await _finish_generation_task(generate_task, failure_handled=failure_handled)
-        await response.write_eof()
+            await _finish_generation_task(generate_task, failure_handled=failure_handled or client_disconnected)
+        if not client_disconnected:
+            await response.write_eof()
         return response
 
     async def _auth_check_openai(self, request: web.Request) -> 'TrialSession | web.Response':

--- a/evalscope/agent/external/bridge/trace_recorder.py
+++ b/evalscope/agent/external/bridge/trace_recorder.py
@@ -135,6 +135,38 @@ class BridgeTraceRecorder:
             messages_key='contents',
         )
 
+    def record_turn_failure(
+        self,
+        *,
+        mode: str,
+        exc: BaseException,
+        latency_ms: Optional[float] = None,
+    ) -> None:
+        """Append an ``ERROR`` event for a generate call that produced no output.
+
+        Recorded at the step the attempt *would* have occupied (``_step + 1``)
+        without advancing ``_step``: the turn produced no assistant message, and
+        the agent client's retry -- once it succeeds -- claims that same step.
+        The failed attempt therefore sits next to the retry that replaced it
+        rather than shifting every later step by one.
+
+        Without this the trace only ever shows attempts that succeeded, so a run
+        served by a flaky endpoint reads as shorter and cheaper than the same run
+        on a stable one, and per-turn latency / token totals silently under-count.
+        """
+        with self._lock:
+            self._trace.add_event(
+                step=self._step + 1,
+                type=EventType.ERROR,
+                latency_ms=latency_ms,
+                payload={
+                    'source': 'upstream',
+                    'mode': mode,
+                    'error': type(exc).__name__,
+                    'message': f'{type(exc).__name__}: {str(exc)[:200]}',
+                },
+            )
+
     def _record_turn(
         self,
         request_body: Dict[str, Any],

--- a/tests/agent/external/test_bridge_lifecycle.py
+++ b/tests/agent/external/test_bridge_lifecycle.py
@@ -8,8 +8,24 @@ import aiohttp
 import pytest
 
 from evalscope.agent.external.bridge import ModelProxyServer
+from evalscope.agent.external.bridge.trace_recorder import BridgeTraceRecorder
 from evalscope.api.model import GenerateConfig
 from evalscope.utils.asyncio_runtime import AsyncioLoopRunner
+
+
+def _fake_session(model: Any) -> SimpleNamespace:
+    """A stand-in for :class:`TrialSession` with a real recorder.
+
+    ``TrialSession`` types ``recorder`` as a ``BridgeTraceRecorder``, so the
+    handlers are entitled to use it on every path -- including the failure
+    paths these tests drive.
+    """
+    return SimpleNamespace(
+        model=model,
+        framework='test',
+        trial_id='test-trial',
+        recorder=BridgeTraceRecorder(trial_id='test-trial', framework='test'),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -184,12 +200,7 @@ def test_stream_disconnect_waits_for_generation_task(
     async def run() -> None:
         owner_loop = asyncio.get_running_loop()
         proxy = ModelProxyServer('127.0.0.1', None, owner_loop)
-        session = SimpleNamespace(
-            model=BlockingModel(),
-            framework='test',
-            trial_id='test-trial',
-            recorder=None,
-        )
+        session = _fake_session(BlockingModel())
         body = {'model': 'test-model'}
         config = GenerateConfig()
 
@@ -245,12 +256,7 @@ def test_stream_disconnect_observes_already_failed_generation_task(
         loop = asyncio.get_running_loop()
         loop.set_exception_handler(lambda _loop, context: unhandled_contexts.append(context))
         proxy = ModelProxyServer('127.0.0.1', None, loop)
-        session = SimpleNamespace(
-            model=FailingModel(),
-            framework='test',
-            trial_id='test-trial',
-            recorder=None,
-        )
+        session = _fake_session(FailingModel())
 
         body = {'model': 'test-model'}
         config = GenerateConfig()
@@ -339,12 +345,7 @@ def test_stream_write_disconnect_waits_for_generation_task(monkeypatch: pytest.M
 
     async def run() -> None:
         proxy = ModelProxyServer('127.0.0.1', None, asyncio.get_running_loop())
-        session = SimpleNamespace(
-            model=BlockingModel(),
-            framework='test',
-            trial_id='test-trial',
-            recorder=None,
-        )
+        session = _fake_session(BlockingModel())
         await proxy._respond_streaming_openai(
             None,
             session,

--- a/tests/agent/external/test_bridge_lifecycle.py
+++ b/tests/agent/external/test_bridge_lifecycle.py
@@ -9,7 +9,8 @@ import pytest
 
 from evalscope.agent.external.bridge import ModelProxyServer
 from evalscope.agent.external.bridge.trace_recorder import BridgeTraceRecorder
-from evalscope.api.model import GenerateConfig
+from evalscope.api.agent.trace import EventType
+from evalscope.api.model import GenerateConfig, ModelOutput
 from evalscope.utils.asyncio_runtime import AsyncioLoopRunner
 
 
@@ -357,8 +358,79 @@ def test_stream_write_disconnect_waits_for_generation_task(monkeypatch: pytest.M
             include_usage=False,
         )
         assert generation_finished.is_set()
+        assert not [event for event in session.recorder.snapshot().events if event.type == EventType.ERROR]
         current_task = asyncio.current_task()
         assert all(task is current_task or task.done() for task in asyncio.all_tasks())
+
+    monkeypatch.setattr(ModelProxyServer, '_prepare_sse_response', staticmethod(prepare_response))
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize('protocol', ['openai', 'anthropic', 'gemini'])
+def test_completed_stream_disconnect_does_not_record_upstream_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    protocol: str,
+) -> None:
+    class SuccessfulModel:
+
+        async def generate_async(self, **kwargs: Any) -> ModelOutput:
+            return ModelOutput.from_content(model='test-model', content='done')
+
+    class DisconnectedResponse:
+
+        async def write(self, chunk: bytes) -> None:
+            raise ConnectionResetError
+
+        async def write_eof(self) -> None:
+            return None
+
+    async def prepare_response(request: Any) -> DisconnectedResponse:
+        return DisconnectedResponse()
+
+    async def run() -> None:
+        proxy = ModelProxyServer('127.0.0.1', None, asyncio.get_running_loop())
+        session = _fake_session(SuccessfulModel())
+        if protocol == 'openai':
+            await proxy._respond_streaming_openai(
+                None, session, {'model': 'test-model'}, [], [], None, GenerateConfig(), include_usage=False
+            )
+        elif protocol == 'gemini':
+            await proxy._respond_streaming_gemini(None, session, {'model': 'test-model'}, [], [], None, GenerateConfig())
+        else:
+            await proxy._respond_streaming(None, session, {'model': 'test-model'}, [], [], GenerateConfig())
+        events = session.recorder.snapshot().events
+        assert not [event for event in events if event.type == EventType.ERROR]
+
+    monkeypatch.setattr(ModelProxyServer, '_prepare_sse_response', staticmethod(prepare_response))
+    asyncio.run(run())
+
+
+def test_responses_stream_disconnect_does_not_record_upstream_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SuccessfulModel:
+
+        async def generate_async(self, **kwargs: Any) -> ModelOutput:
+            return ModelOutput.from_content(model='test-model', content='done')
+
+    class DisconnectedResponse:
+
+        async def write(self, chunk: bytes) -> None:
+            raise ConnectionResetError
+
+        async def write_eof(self) -> None:
+            return None
+
+    async def prepare_response(request: Any) -> DisconnectedResponse:
+        return DisconnectedResponse()
+
+    async def run() -> None:
+        proxy = ModelProxyServer('127.0.0.1', None, asyncio.get_running_loop())
+        session = _fake_session(SuccessfulModel())
+        await proxy._respond_streaming_responses(
+            None, session, {'model': 'test-model'}, [], [], None, GenerateConfig()
+        )
+        events = session.recorder.snapshot().events
+        assert any(event.type == EventType.MODEL_GENERATE for event in events)
+        assert not [event for event in events if event.type == EventType.ERROR]
 
     monkeypatch.setattr(ModelProxyServer, '_prepare_sse_response', staticmethod(prepare_response))
     asyncio.run(run())

--- a/tests/agent/external/test_responses_error_paths.py
+++ b/tests/agent/external/test_responses_error_paths.py
@@ -9,6 +9,12 @@ When ``Model.generate_async`` raises, the bridge must return:
 
 Reference: ``openai/types/responses/response_error_event.py`` in the openai
 Python SDK v2.x.
+
+The wire contract is only half of it: the bridge must also record the failed
+attempt on ``AgentTrace``. The log is not the artifact anyone analyses -- the
+trace is -- so a failure that is logged but not recorded makes the attempt
+disappear, and a run served by a flaky endpoint reads as shorter and cheaper
+than the same run on a stable one.
 """
 
 import asyncio
@@ -19,7 +25,8 @@ import urllib.request
 import pytest
 
 from evalscope.agent.external.bridge import ModelProxyServer
-from evalscope.api.model import GenerateConfig, Model
+from evalscope.api.agent.trace import EventType
+from evalscope.api.model import GenerateConfig, Model, ModelOutput
 from evalscope.models.mockllm import MockLLM
 from evalscope.utils.asyncio_runtime import AsyncioLoopRunner
 
@@ -42,8 +49,52 @@ def _build_raising_model(monkeypatch, exc: Exception) -> Model:
     return model
 
 
+def _build_model_failing_once(monkeypatch, exc: Exception) -> Model:
+    """A Model whose ``generate_async`` raises on the first call, then succeeds.
+
+    Mirrors what the agent client actually experiences: one transient upstream
+    error followed by its own retry.
+    """
+    api = MockLLM(model_name='mock-responses', custom_outputs=[])
+    model = Model(api=api, config=GenerateConfig())
+    calls = {'n': 0}
+
+    async def _flaky(*args, **kwargs):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise exc
+        return ModelOutput.from_content(model='mock-responses', content='recovered')
+
+    monkeypatch.setattr(model, 'generate_async', _flaky)
+    return model
+
+
 def _user_input(text: str) -> dict:
     return {'type': 'message', 'role': 'user', 'content': [{'type': 'input_text', 'text': text}]}
+
+
+def _post_responses(proxy, session, *, stream: bool) -> None:
+    """Fire one Responses request through the bridge, discarding the wire result.
+
+    The wire shape is asserted by the two contract tests in this module; the
+    trace tests only need the round-trip to have happened.
+    """
+    body = {'model': 'mock-responses', 'input': [_user_input('hi')]}
+    headers = {'Content-Type': 'application/json', 'Authorization': f'Bearer {session.token}'}
+    if stream:
+        body['stream'] = True
+        headers['Accept'] = 'text/event-stream'
+    req = urllib.request.Request(
+        f'{proxy.base_url}/openai/v1/responses',
+        data=json.dumps(body).encode('utf-8'),
+        headers=headers,
+        method='POST',
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+    except urllib.error.HTTPError as he:
+        he.read()
 
 
 def test_responses_json_upstream_failure_returns_502_api_error(monkeypatch):
@@ -135,3 +186,62 @@ def test_responses_streaming_upstream_failure_emits_openai_error_event(monkeypat
     # MUST NOT have data: [DONE] sentinel (Responses uses response.completed; on
     # failure no completion event is sent either — the error frame is terminal).
     assert '[DONE]' not in raw
+
+
+@pytest.mark.parametrize(('stream', 'mode'), [(False, 'json'), (True, 'stream')])
+def test_responses_upstream_failure_is_recorded_on_the_trace(monkeypatch, stream, mode):
+    """A generate that never returned must still leave an ``ERROR`` event.
+
+    Only recording the turns that succeeded is what the native
+    :class:`AgentLoop` already avoids -- it emits ``EventType.ERROR`` for its
+    own failure modes -- so the two paths would otherwise disagree about what a
+    trace means.
+    """
+    exc = RuntimeError('upstream went boom')
+
+    async def _go():
+        model = _build_raising_model(monkeypatch, exc)
+        proxy = await ModelProxyServer.get_or_start()
+        async with proxy.trial_session(model=model, framework='mock') as session:
+            await asyncio.get_running_loop().run_in_executor(
+                None, lambda: _post_responses(proxy, session, stream=stream)
+            )
+            return session.recorder.snapshot()
+
+    trace = AsyncioLoopRunner.run(_go())
+
+    errors = [e for e in trace.events if e.type == EventType.ERROR]
+    assert len(errors) == 1, f'expected one ERROR event, got {[e.type for e in trace.events]}'
+    assert errors[0].payload['source'] == 'upstream'
+    assert errors[0].payload['mode'] == mode
+    assert errors[0].payload['error'] == 'RuntimeError'
+    assert 'upstream went boom' in errors[0].payload['message']
+    assert errors[0].latency_ms is not None
+    assert not [e for e in trace.events if e.type == EventType.MODEL_GENERATE]
+
+
+def test_responses_retry_after_failure_lands_on_the_same_step(monkeypatch):
+    """The failed attempt shares its step with the retry that replaced it.
+
+    Recording a failure must not consume a step: the turn produced no assistant
+    message, so advancing would shift every later step by one and stop ``step``
+    lining up with the native loop's numbering.
+    """
+
+    async def _go():
+        model = _build_model_failing_once(monkeypatch, RuntimeError('transient'))
+        proxy = await ModelProxyServer.get_or_start()
+        async with proxy.trial_session(model=model, framework='mock') as session:
+            loop = asyncio.get_running_loop()
+            for _ in range(2):  # first attempt fails, the client retries
+                await loop.run_in_executor(None, lambda: _post_responses(proxy, session, stream=False))
+            return session.recorder.snapshot()
+
+    trace = AsyncioLoopRunner.run(_go())
+
+    errors = [e for e in trace.events if e.type == EventType.ERROR]
+    generates = [e for e in trace.events if e.type == EventType.MODEL_GENERATE]
+    assert len(errors) == 1, f'expected one ERROR event, got {[e.type for e in trace.events]}'
+    assert len(generates) == 1, f'expected one MODEL_GENERATE event, got {[e.type for e in trace.events]}'
+    assert errors[0].step == 0
+    assert generates[0].step == 0


### PR DESCRIPTION
## Problem

When `Model.generate_async` fails, the bridge writes an error frame to the agent client and a one-line WARNING to the log. It records nothing on `AgentTrace`.

The log is not the artifact anyone analyses afterwards — the trace is. So every attempt the agent client retried disappears from it.

### Evidence

**`BridgeTraceRecorder` has no failure-recording interface.** Its full set of record methods (`trace_recorder.py`):

```
record_anthropic_turn   :72      record_run_start  :207
record_openai_turn      :87      record_run_end    :219
record_responses_turn   :102
record_gemini_turn      :118
```

**All eight `recorder.` call sites sit on the success path.** In `server.py` they are at `501 / 537 / 610 / 643 / 740 / 772 / 816 / 853`, every one a `record_*_turn` placed after `await generate_task` inside the `try`. A failure never reaches them.

**`_log_upstream_failure` only logs** (`server.py:965-971`):

```python
if cls_name in _UPSTREAM_BUSINESS_ERRORS:
    logger.warning(f'{tag} upstream {mode} {cls_name}: {str(exc)[:200]}')
    return
logger.exception(f'{tag} {mode} generate failed')
```

**The external path emits no `EventType.ERROR` at all.** Before this change:

```
$ grep -rn "EventType.ERROR" evalscope/agent/ evalscope/api/agent/
evalscope/api/agent/loop.py:345      # native: parse error
evalscope/api/agent/loop.py:433      # native: max_steps_exceeded
evalscope/api/agent/loop.py:448      # native: context overflow
```

Nothing under `evalscope/agent/external/`. Same `AgentTrace` schema, two paths, and only one of them records its failures.

**The one failure signal that does exist is at the wrong granularity.** `record_run_end(error=run_error)` (`adapter.py:194-198`) captures a CLI subprocess crash or timeout. When the CLI exits cleanly after its own retries absorbed five failed model calls, `run_error is None`.

### Why this matters

A sample that made 12 model calls, four of them rate-limited and retried, leaves 8 `MODEL_GENERATE` events on the trace.

- Retries are invisible, so latency / token / cost totals under-count systematically.
- The failure is a hole in the trace, indistinguishable from the agent choosing not to call the model.
- Comparative evaluation is the one that worries me: a model served by a flaky endpoint produces a trace that looks *cleaner* and *faster* than the same model on a stable one, because the failed attempts and their latency were never recorded. An infrastructure difference reads as a model-quality difference.

### Why I think this is a gap rather than a decision

`tests/agent/external/test_responses_error_paths.py` specifies the client-facing contract carefully — status code, event name, `payload['code']`, `sequence_number`, presence of `[DONE]`. It asserts nothing about the trace.

I did read the position in `_log_upstream_failure`'s docstring: upstream `APIError` subclasses are business as usual, the bridge is a faithful conduit, tracebacks for them are noise. I agree with that — but it is an argument about log verbosity, not about what belongs in the artifact. Downgrading a traceback to a WARNING and omitting the event from the structured trace are two different decisions, and only the first one is argued there. The costs are asymmetric too: log noise is an annoyance, while silently under-counted latency and tokens contaminate the eval conclusions themselves.

If the omission *is* deliberate, say so and I'll close this.

## Changes

**`BridgeTraceRecorder.record_turn_failure()`** appends an `ERROR` event at the step the attempt *would* have occupied, without advancing `_step`. The turn produced no assistant message, and the retry that replaces it claims that same step — so a failed attempt sits beside its retry instead of shifting every later step by one and breaking alignment with the native loop's numbering.

**`_handle_upstream_failure()`** wraps the existing `_log_upstream_failure`, leaving its severity logic untouched. All eight failure paths (json + stream × anthropic / openai-chat / responses / gemini) route through it.

**Three `test_bridge_lifecycle` fixtures move off `recorder=None`.** `TrialSession` types `recorder` as a `BridgeTraceRecorder`, not `Optional`, so `None` was never a production state and the handlers are entitled to use it on failure paths too. No assertion in those tests changed — I'd rather make the fixture faithful than add a defensive `if recorder is not None`, which would reintroduce exactly the silent-skip this PR removes.

`EventType.ERROR` already exists and the wire contract is untouched, so this is additive observability only.

## Testing

```
tests/agent/external/test_responses_error_paths.py
  on main:   3 failed, 2 passed
             "expected one ERROR event, got []"
             retry case: got [MODEL_GENERATE]   <- the failed attempt is simply absent
  with this: 5 passed

tests/agent/   316 passed (313 on main), same 7 pre-existing failures
               (test_sandbox_service, test_strategy_parsers — unrelated to the bridge)

ruff check + ruff format --diff   clean
```

## Judgement calls, happy to change any of them

- **Payload shape** `{source: 'upstream', mode, error, message}`. I did not add a `TraceSources` constant: that module describes itself as private to the AgentLoop, and `trace_recorder.py`'s existing payloads use literals.
- **Step semantics**: the failure shares a step with the retry that replaced it. Giving it its own step is the alternative, at the cost of shifting everything after it.
- **No i18n key.** `LoopErrorRow` looks up `trace.loopMessage.${msg}` and falls back to the raw string, so the UI will show `RuntimeError: ...`. Say the word if you'd rather have a translated code.
- **The Responses streaming `except` also catches a write failure after a successful generate**, where `source='upstream'` is not accurate. I kept the existing framing rather than splitting the block — the comments already inside it (`sequence_number: 1`, `code: 'api_error'`) assume the failure happened before any frame went out, and splitting would change wire behaviour.

## Out of scope

`asyncio.CancelledError` still bypasses these handlers. `test_stream_disconnect_waits_for_generation_task` asserts that propagation deliberately, so recording on cancellation would change tested behaviour. Left alone.
