### PR TITLE
fix(perf): measure TTFT from reasoning output

### DIFF
--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -15,6 +15,37 @@ from evalscope.utils.logger import get_logger
 logger = get_logger()
 
 
+def _parse_chat_delta(delta: Any) -> tuple[str, bool]:
+    """Return concatenable text and whether a chat delta carries observable output."""
+    if not isinstance(delta, dict):
+        return '', False
+
+    content_value = delta.get('content')
+    content = content_value if isinstance(content_value, str) else ''
+
+    reasoning_value = delta.get('reasoning_content')
+    if not isinstance(reasoning_value, str) or not reasoning_value:
+        reasoning_value = delta.get('reasoning')
+    reasoning = reasoning_value if isinstance(reasoning_value, str) else ''
+
+    text = content + reasoning
+    if text:
+        return text, True
+
+    # Structured reasoning must only affect timing: providers disagree on whether
+    # these values are incremental or cumulative, so appending them would corrupt
+    # generated_text. Encrypted payloads and type-only records are metadata.
+    reasoning_details = delta.get('reasoning_details')
+    if isinstance(reasoning_details, list):
+        for detail in reasoning_details:
+            if not isinstance(detail, dict):
+                continue
+            if any(isinstance(detail.get(key), str) and detail[key] for key in ('text', 'summary')):
+                return '', True
+
+    return '', False
+
+
 class StreamedResponseHandler:
     """Handles streaming HTTP responses by accumulating chunks until complete
     messages are available."""
@@ -155,11 +186,11 @@ class DefaultApiPlugin(ApiPluginBase):
                                     if choices := data.get('choices'):
                                         if data.get('object') == 'text_completion':
                                             content = choices[0].get('text') or ''
+                                            has_output = bool(content)
                                         else:
                                             delta = choices[0].get('delta', {})
-                                            reasoning = delta.get('reasoning_content') or delta.get('reasoning') or ''
-                                            content = (delta.get('content') or '') + reasoning
-                                        if content:
+                                            content, has_output = _parse_chat_delta(delta)
+                                        if has_output:
                                             # First token
                                             if last_output_timestamp is None:
                                                 output.first_chunk_latency = timestamp - st

--- a/evalscope/perf/plugin/api/default_api.py
+++ b/evalscope/perf/plugin/api/default_api.py
@@ -157,9 +157,8 @@ class DefaultApiPlugin(ApiPluginBase):
                                             content = choices[0].get('text') or ''
                                         else:
                                             delta = choices[0].get('delta', {})
-                                            content = (delta.get('content') or '') + (
-                                                delta.get('reasoning_content') or ''
-                                            )
+                                            reasoning = delta.get('reasoning_content') or delta.get('reasoning') or ''
+                                            content = (delta.get('content') or '') + reasoning
                                         if content:
                                             # First token
                                             if last_output_timestamp is None:

--- a/tests/perf/test_perf_streaming.py
+++ b/tests/perf/test_perf_streaming.py
@@ -6,6 +6,7 @@ endpoint and the local model backend.
 """
 import json
 import unittest
+from typing import AsyncIterator
 from unittest.mock import MagicMock, patch
 
 from evalscope.perf.arguments import Arguments
@@ -104,7 +105,7 @@ class TestDefaultApiPluginMetrics(unittest.IsolatedAsyncioTestCase):
         ]
         stream = ''.join(f'data: {json.dumps(event)}\n\n' for event in events) + 'data: [DONE]\n\n'
 
-        async def iter_chunks():
+        async def iter_chunks() -> AsyncIterator[bytes]:
             yield stream.encode()
 
         response = MagicMock()
@@ -127,6 +128,43 @@ class TestDefaultApiPluginMetrics(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(output.query_latency, 0.9)
         self.assertEqual(output.response_messages, events)
         self.assertEqual((output.prompt_tokens, output.completion_tokens), (3, 2))
+
+    async def test_reasoning_alias_contributes_to_output_timings(self) -> None:
+        events = [
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'role': 'assistant'}}]},
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {'reasoning_content': '', 'reasoning': 'think'}}],
+            },
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'reasoning': 'ing'}}]},
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {}, 'finish_reason': 'length'}],
+                'usage': {'prompt_tokens': 3, 'completion_tokens': 2},
+            },
+        ]
+        stream = ''.join(f'data: {json.dumps(event)}\n\n' for event in events) + 'data: [DONE]\n\n'
+
+        async def iter_chunks() -> AsyncIterator[bytes]:
+            yield stream.encode()
+
+        response = MagicMock()
+        response.status = 200
+        response.headers = {'Content-Type': 'text/event-stream'}
+        response.content.iter_any.return_value = iter_chunks()
+        response.__aenter__.return_value = response
+        client_session = MagicMock()
+        client_session.post.return_value = response
+
+        plugin = OpenaiPlugin(Arguments(model='test-model'))
+        timestamps = [0.0, 0.1, 0.45, 0.65, 0.9]
+        with patch('evalscope.perf.plugin.api.default_api.time.perf_counter', side_effect=timestamps):
+            output = await plugin.process_request(client_session, 'http://localhost/v1/chat/completions', {}, {})
+
+        self.assertAlmostEqual(output.first_chunk_latency, 0.45)
+        self.assertEqual(len(output.inter_chunk_latency), 1)
+        self.assertAlmostEqual(output.inter_chunk_latency[0], 0.2)
+        self.assertEqual(output.generated_text, 'thinking')
 
 
 class TestPerfStreaming(PerfTestBase):

--- a/tests/perf/test_perf_streaming.py
+++ b/tests/perf/test_perf_streaming.py
@@ -166,6 +166,54 @@ class TestDefaultApiPluginMetrics(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(output.inter_chunk_latency[0], 0.2)
         self.assertEqual(output.generated_text, 'thinking')
 
+    async def test_structured_reasoning_contributes_to_output_timings(self) -> None:
+        events = [
+            {'object': 'chat.completion.chunk', 'choices': [{'delta': {'role': 'assistant'}}]},
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {'reasoning_details': [{'type': 'reasoning.text'}]}}],
+            },
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {'reasoning_details': [{'type': 'reasoning.text', 'text': 'think'}]}}],
+            },
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {'reasoning_details': [{'type': 'reasoning.encrypted', 'data': 'opaque'}]}}],
+            },
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {'reasoning_details': [{'type': 'reasoning.summary', 'summary': 'brief'}]}}],
+            },
+            {
+                'object': 'chat.completion.chunk',
+                'choices': [{'delta': {}, 'finish_reason': 'length'}],
+                'usage': {'prompt_tokens': 3, 'completion_tokens': 2},
+            },
+        ]
+        stream = ''.join(f'data: {json.dumps(event)}\n\n' for event in events) + 'data: [DONE]\n\n'
+
+        async def iter_chunks() -> AsyncIterator[bytes]:
+            yield stream.encode()
+
+        response = MagicMock()
+        response.status = 200
+        response.headers = {'Content-Type': 'text/event-stream'}
+        response.content.iter_any.return_value = iter_chunks()
+        response.__aenter__.return_value = response
+        client_session = MagicMock()
+        client_session.post.return_value = response
+
+        plugin = OpenaiPlugin(Arguments(model='test-model'))
+        timestamps = [0.0, 0.1, 0.2, 0.45, 0.65, 0.8, 0.9]
+        with patch('evalscope.perf.plugin.api.default_api.time.perf_counter', side_effect=timestamps):
+            output = await plugin.process_request(client_session, 'http://localhost/v1/chat/completions', {}, {})
+
+        self.assertAlmostEqual(output.first_chunk_latency, 0.45)
+        self.assertEqual(len(output.inter_chunk_latency), 1)
+        self.assertAlmostEqual(output.inter_chunk_latency[0], 0.35)
+        self.assertEqual(output.generated_text, '')
+
 
 class TestPerfStreaming(PerfTestBase):
     """Streaming (SSE) performance benchmarks."""


### PR DESCRIPTION
## Summary

Fix streamed-output timing in the `evalscope perf` OpenAI-compatible API path for multiple reasoning representations. Live endpoint validation has now been completed on both GLM and Kimi series models.

- Recognize `delta.content` and `delta.reasoning_content`, falling back to `delta.reasoning` when `reasoning_content` is not a non-empty string.
- Recognize displayable `delta.reasoning_details[*].text/summary` as output for TTFT and inter-chunk latency (ITL).
- Keep structured reasoning out of `generated_text`, since providers may return incremental or cumulative values.
- Continue ignoring role-only, usage-only, type-only, and encrypted-data-only chunks when measuring output timing.
- Add deterministic regression coverage for scalar reasoning aliases and structured reasoning streams.

## Root cause and relationship to #1463

This complements #1463, which fixed the same class of reasoning-field compatibility issue in the synchronous and asynchronous model stream collectors in `evalscope/models/utils/openai.py`.

Performance benchmarking uses a separate SSE processing path in `evalscope/perf/plugin/api/default_api.py`. The metadata-chunk fix in v1.11.1 only treated `content` and `reasoning_content` as output there. Servers returning `delta.reasoning` or displayable structured reasoning could therefore leave `first_chunk_latency` at its default `0.0` during reasoning-only output, distorting TTFT percentiles and derived decoding metrics.

This PR closes that remaining gap in the performance path and extends timing recognition to the structured text/summary representation. It does not change the TPOT formula or percentile calculation.

## Verification

### Live GLM and Kimi endpoint tests

Both series were tested with streaming requests, 8 measured requests per run, concurrency 4, `max_tokens=16`, `temperature=0`, and random prompts configured at 128 tokens using the same local tokenizer. The Kimi run used the `public/kimi-k3` model profile. These short runs validate reasoning-only stream timing rather than model throughput or answer quality.

| Tested model | Before: successful requests | Before: TTFT | After: successful requests | After: TTFT range | After: average TTFT |
| --- | --- | --- | --- | --- | --- |
| GLM-series deployment | 8/8 | 0.0 ms for all requests | 8/8 | 911.78–1609.51 ms | 1286.49 ms |
| Kimi series (`public/kimi-k3`) | 8/8 | 0.0 ms for all requests | 8/8 | 434.12–1062.84 ms | 776.05 ms |

- Saved response streams for both tested endpoints contain non-empty `delta.reasoning` output, directly exercising the alias handling.
- After the fix, every measured request has positive TTFT within its total latency, and both runs produce monotonic, non-zero TTFT percentiles.
- Kimi's corrected TTFT percentiles are p50 = 740.84 ms, p95 = 1062.84 ms, and p99 = 1062.84 ms; average ITL is 24.17 ms.
- The Kimi before/after comparison and the 31-test regression suite were run against PR head `3ee6b6d2` and the unpatched baseline as applicable. The earlier GLM results were rechecked against their saved per-request database and reports.
- Structured `reasoning_details` handling is covered by deterministic regression tests; the live GLM and Kimi streams above validate `delta.reasoning`.

### Automated checks

- `pytest tests/perf/test_perf_streaming.py::TestDefaultApiPluginMetrics tests/perf/test_stream_metrics.py tests/perf/test_percentile_metrics.py -q` — 31 passed, rerun on the current PR revision.
- `make lint` — passed during initial PR validation.
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings` — passed during initial PR validation.

Fixes #1694
Related to #1463
