### PR TITLE
fix(mcp): preserve initialization errors and support service stdio

### DIFF
--- a/evalscope/api/agent/mcp/client.py
+++ b/evalscope/api/agent/mcp/client.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import datetime
 from contextlib import AsyncExitStack
-from typing import Any, Dict, List, Optional
+from types import TracebackType
+from typing import Any, Dict, List, Optional, Type
 
 from evalscope.utils.import_utils import check_import
 from evalscope.utils.logger import get_logger
@@ -100,21 +101,26 @@ class MCPServer:
             await self._session.initialize()
             logger.info(f'MCPServer[{self.name}]: initialised')
             return self
-        except Exception:
-            # Make sure we don't leak any process / socket on partial init failure.
-            await self._stack.aclose()
-            self._stack = None
-            self._session = None
+        except BaseException as exc:
+            # MCP transport failures cancel the initializing task. Exit their
+            # task groups in this same task to surface the underlying error.
+            await self.__aexit__(type(exc), exc, exc.__traceback__)
             raise
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
         if self._stack is not None:
             try:
-                await self._stack.aclose()
+                return await self._stack.__aexit__(exc_type, exc_val, exc_tb)
             finally:
                 self._stack = None
                 self._session = None
                 logger.debug(f'MCPServer[{self.name}]: closed')
+        return False
 
     async def list_tools(self) -> List[Any]:
         """Return the raw ``mcp.types.Tool`` list from the server."""

--- a/evalscope/service/utils/process.py
+++ b/evalscope/service/utils/process.py
@@ -1,10 +1,11 @@
 import contextlib
-import io
 import multiprocessing
 import queue
 import sys
+import tempfile
 import threading
 import traceback
+from typing import Iterator, TextIO
 
 from evalscope.config import TaskConfig
 from evalscope.perf.arguments import Arguments as PerfArguments
@@ -96,19 +97,20 @@ def stop_process(task_id: str) -> bool:
 
 
 @contextlib.contextmanager
-def _capture_stderr():
-    """Context manager that redirects sys.stderr to a StringIO buffer.
+def _capture_stderr() -> Iterator[TextIO]:
+    """Redirect stderr to a temporary text file usable by nested subprocesses.
 
-    Yields the buffer so the caller can read captured output after the block.
-    Always restores the original sys.stderr on exit.
+    The file stays open for the worker's entire task, including libraries
+    that bind sys.stderr when lazily imported. Read it before leaving the
+    context; exit restores sys.stderr and closes the temporary file.
     """
-    buf = io.StringIO()
-    original = sys.stderr
-    sys.stderr = buf
-    try:
-        yield buf
-    finally:
-        sys.stderr = original
+    with tempfile.TemporaryFile(mode='w+', encoding='utf-8', errors='replace', buffering=1) as buf:
+        original = sys.stderr
+        sys.stderr = buf
+        try:
+            yield buf
+        finally:
+            sys.stderr = original
 
 
 def _process_worker(func, result_queue, *args, **kwargs):
@@ -122,12 +124,14 @@ def _process_worker(func, result_queue, *args, **kwargs):
             result = func(*args, **kwargs)
             result_queue.put({'status': 'success', 'result': result})
         except BaseException as e:
+            stderr_buf.flush()
+            stderr_buf.seek(0)
             result_queue.put(
                 {
                     'status': 'error',
                     'error': str(e),
                     'traceback': traceback.format_exc(),
-                    'stderr': stderr_buf.getvalue(),
+                    'stderr': stderr_buf.read(),
                 }
             )
 

--- a/tests/agent/test_mcp_lifecycle.py
+++ b/tests/agent/test_mcp_lifecycle.py
@@ -1,0 +1,86 @@
+"""MCP initialization failures must preserve errors and release transport resources."""
+
+import asyncio
+import unittest
+from typing import List
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytest.importorskip('mcp')
+
+from evalscope.api.agent.mcp import MCPServer, MCPServerConfigHTTP
+from evalscope.utils.asyncio_runtime import AsyncioLoopRunner
+
+
+def _exception_leaves(error: BaseException) -> List[BaseException]:
+    children = getattr(error, 'exceptions', None)
+    if children is None:
+        return [error]
+    return [leaf for child in children for leaf in _exception_leaves(child)]
+
+
+class TestMCPInitialization(unittest.TestCase):
+    """Exercise the real MCP SDK with deterministic HTTP transports."""
+
+    def tearDown(self) -> None:
+        AsyncioLoopRunner.shutdown_for_thread()
+
+    def test_http_failure_preserves_cause(self) -> None:
+        """The synchronous bridge must expose connection and HTTP errors, not cancellation."""
+        for status in (None, 401, 500):
+            with self.subTest(status=status):
+                def respond(request: httpx.Request) -> httpx.Response:
+                    if status is None:
+                        raise httpx.ConnectError('connection refused', request=request)
+                    return httpx.Response(status, request=request)
+
+                client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+                server = MCPServer(MCPServerConfigHTTP(url='http://mcp.test/mcp'))
+
+                async def run() -> None:
+                    async with server:
+                        self.fail('Initialization must fail')
+
+                with patch('httpx.AsyncClient', return_value=client):
+                    with self.assertRaises(BaseException) as caught:
+                        AsyncioLoopRunner.run(run(), timeout=5)
+
+                expected = httpx.ConnectError if status is None else httpx.HTTPStatusError
+                leaves = _exception_leaves(caught.exception)
+                self.assertTrue(any(isinstance(error, expected) for error in leaves), repr(caught.exception))
+                self.assertTrue(client.is_closed)
+                with self.assertRaisesRegex(RuntimeError, 'MCPServer not entered'):
+                    AsyncioLoopRunner.run(server.list_tools(), timeout=5)
+
+    def test_cancel_initialization_closes_transport(self) -> None:
+        """External cancellation stays cancellation, while the HTTP client is closed."""
+        async def run() -> None:
+            started = asyncio.Event()
+
+            async def respond(request: httpx.Request) -> httpx.Response:
+                started.set()
+                await asyncio.Future()
+                raise AssertionError('Request must be cancelled')
+
+            client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+            server = MCPServer(MCPServerConfigHTTP(url='http://mcp.test/mcp'))
+
+            async def connect() -> None:
+                async with server:
+                    self.fail('Initialization must be cancelled')
+
+            with patch('httpx.AsyncClient', return_value=client):
+                task = asyncio.create_task(connect())
+                try:
+                    await asyncio.wait_for(started.wait(), timeout=5)
+                finally:
+                    task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+            self.assertTrue(client.is_closed)
+            with self.assertRaisesRegex(RuntimeError, 'MCPServer not entered'):
+                await server.list_tools()
+
+        AsyncioLoopRunner.run(run(), timeout=10)

--- a/tests/service/test_process_stderr.py
+++ b/tests/service/test_process_stderr.py
@@ -1,0 +1,72 @@
+"""Regression tests for stderr capture in service task subprocesses."""
+
+import asyncio
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from evalscope.service.utils.process import _capture_stderr, run_in_subprocess
+
+
+def _call_stdio_echo() -> list[str]:
+    # The SDK must first import inside the worker's stderr capture context.
+    assert 'mcp.client.stdio' not in sys.modules
+    from evalscope.api.agent.mcp import MCPServer, MCPServerConfigStdio
+
+    async def run() -> list[str]:
+        config = MCPServerConfigStdio(
+            command=sys.executable,
+            args=[str(Path(__file__).resolve().parents[1] / 'agent' / 'mcp_echo_server.py')],
+        )
+        results = []
+        for message in ('first sample', 'second sample'):
+            async with MCPServer(config) as server:
+                tool_names = [tool.name for tool in await server.list_tools()]
+                assert 'echo' in tool_names
+                results.append(await server.call_tool('echo', {'message': message}))
+        return results
+
+    return asyncio.run(asyncio.wait_for(run(), timeout=30))
+
+
+def _fail_with_stderr() -> None:
+    print('task stderr: 诊断信息', file=sys.stderr)
+    subprocess.run(
+        [sys.executable, '-c', "import sys; print('nested process stderr', file=sys.stderr)"],
+        stderr=sys.stderr,
+        check=True,
+        timeout=10,
+    )
+    raise ValueError('task failed')
+
+
+class TestProcessStderr(unittest.TestCase):
+    """Capture supports subprocess file descriptors and preserves diagnostics."""
+
+    @unittest.skipUnless(importlib.util.find_spec('mcp'), 'mcp extra not installed')
+    def test_spawned_worker_can_start_stdio_mcp(self) -> None:
+        """Lazy SDK imports and repeated MCP sessions work in a service worker."""
+        self.assertEqual(
+            run_in_subprocess(_call_stdio_echo),
+            ['echoed: first sample', 'echoed: second sample'],
+        )
+
+    def test_worker_forwards_task_and_nested_process_stderr(self) -> None:
+        """Task failures retain stderr from Python and nested subprocesses."""
+        with self.assertRaises(RuntimeError) as raised:
+            run_in_subprocess(_fail_with_stderr)
+        message = str(raised.exception)
+        self.assertIn('ValueError: task failed', message)
+        self.assertIn('[stderr]', message)
+        self.assertIn('task stderr: 诊断信息', message)
+        self.assertIn('nested process stderr', message)
+
+    def test_capture_restores_stderr_on_exception(self) -> None:
+        """An exception must not leave the process using redirected stderr."""
+        original = sys.stderr
+        with self.assertRaisesRegex(ValueError, 'capture failed'):
+            with _capture_stderr():
+                raise ValueError('capture failed')
+        self.assertIs(sys.stderr, original)


### PR DESCRIPTION
MCP HTTP initialization failures currently surface as `concurrent.futures.CancelledError`, hiding the underlying connection or HTTP error. Handle cancellation during initialization and unwind the async exit stack in the owning task, preserving the original exception and releasing transport resources.

Service workers also capture stderr with `StringIO`, which prevents lazily imported MCP stdio clients from starting subprocesses (`UnsupportedOperation: fileno`). Capture stderr in a temporary text file with a real file descriptor while retaining diagnostics in task errors.

Fixes #1693.

Validation:
- Regression tests fail before the fix and pass afterward, covering connection failures, HTTP 401/500, external cancellation, repeated stdio MCP sessions in spawned workers, and stderr forwarding.
- 60 related agent/service tests passed with MCP 1.29.1; CI smoke test and `make lint` passed.
- Actual `POST /api/v1/eval/invoke` checks with `mock_llm`, a local single-sample dataset, and MCP 1.29.0: stdio and healthy HTTP complete successfully; failed HTTP connections retain `httpx.ConnectError` in the error response.

Healthy HTTP transport worked before the fix as well; this change corrects failure reporting and cleanup rather than claiming every HTTP endpoint was broken.
