### PR TITLE
fix(eval): correct judge rendering, metric scoring, and bootstrap RNG

### DIFF
--- a/evalscope/api/benchmark/adapters/default_data_adapter.py
+++ b/evalscope/api/benchmark/adapters/default_data_adapter.py
@@ -12,7 +12,7 @@ from evalscope.api.messages import ChatMessage, ChatMessageSystem, ChatMessageUs
 from evalscope.api.metric import AggScore, SampleScore, Score
 from evalscope.api.model import Model, ModelOutput
 from evalscope.api.registry import get_aggregation, get_metric
-from evalscope.constants import HubType, JudgeStrategy
+from evalscope.constants import HubType, JudgeStrategy, ScoreStatus
 from evalscope.report import Report, ReportGenerator
 from evalscope.utils import get_logger
 
@@ -651,16 +651,19 @@ class DefaultDataAdapter(DataAdapter):
         )
 
         # Calculate scores for each configured metric
+        metric_failed = False
         for metric in self.metric_list:
             try:
                 if isinstance(metric, str):
                     metric_name = metric
-                    metric_scorer = get_metric(metric)  # Get metric implementation from registry
-                    metric_func = metric_scorer()  # Instantiate the metric scorer
+                    metric_args = {}
                 elif isinstance(metric, dict):
                     metric_name = list(metric.keys())[0]
-                    metric_cls = get_metric(metric_name)
-                    metric_func = metric_cls(**metric[metric_name])  # Initialize with parameters
+                    metric_args = metric[metric_name]
+                if score.main_score_name is None:
+                    score.main_score_name = metric_name
+                metric_cls = get_metric(metric_name)
+                metric_func = metric_cls(**metric_args)
                 metric_score = metric_func(
                     prediction=filtered_prediction,
                     reference=reference,
@@ -668,8 +671,11 @@ class DefaultDataAdapter(DataAdapter):
                 score.value[metric_name] = metric_score
             except Exception as e:
                 logger.error(f'Error calculating metric {metric}: {e}')
-                score.value[metric_name] = 0
+                metric_failed = True
                 score.metadata[metric_name] = f'error: {str(e)}'
+
+        if metric_failed:
+            score.status = ScoreStatus.DEGRADED if score.value else ScoreStatus.EXCLUDED
 
         return score
 
@@ -711,7 +717,10 @@ class DefaultDataAdapter(DataAdapter):
                 task_state=task_state,
             )
 
-            if float(rule_based_score.main_value or 0.0) > 0.99:
+            rule_main_available = rule_based_score.status.is_usable and (
+                rule_based_score.main_score_name is None or rule_based_score.main_score_name in rule_based_score.value
+            )
+            if rule_main_available and float(rule_based_score.main_value or 0.0) > 0.99:
                 final_score = rule_based_score
             else:
                 # A valid judge may raise the rule score; an unavailable judge preserves it.

--- a/evalscope/api/mixin/llm_judge_mixin.py
+++ b/evalscope/api/mixin/llm_judge_mixin.py
@@ -8,6 +8,7 @@ from evalscope.api.evaluator import TaskState
 from evalscope.api.metric import Score
 from evalscope.constants import JudgeScoreType, JudgeStrategy, ScoreStatus, ScoringPolicy
 from evalscope.metrics import LLMJudge
+from evalscope.metrics.semantics.identity import canonicalize_producer_identity
 from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.deprecation_utils import deprecated_warning
 from evalscope.utils.logger import get_logger
@@ -305,9 +306,13 @@ class LLMJudgeMixin:
     def fallback_to_rule_score(self, rule_based_score: Score, judge_score: Score) -> Score:
         """Retain rule evidence when a ``JUDGE_DEFAULT`` review is unavailable."""
         fallback = rule_based_score.model_copy(deep=True)
-        fallback.status = ScoreStatus.DEGRADED
+        fallback.status = (
+            ScoreStatus.DEGRADED
+            if rule_based_score.status.is_usable and rule_based_score.value
+            else ScoreStatus.EXCLUDED
+        )
         fallback.judge_summary = (
-            judge_score.judge_summary.model_copy(update={'status': ScoreStatus.DEGRADED})
+            judge_score.judge_summary.model_copy(update={'status': fallback.status})
             if judge_score.judge_summary is not None
             else None
         )
@@ -324,11 +329,17 @@ class LLMJudgeMixin:
         ``llm_recall`` exists to recover rule-based misses, so the judge can only raise the
         score: the result is ``max(rule, judge)``. A failed judge must not erase rule evidence.
         """
+        if not rule_based_score.status.is_usable or not rule_based_score.value:
+            merged = llm_score.model_copy(deep=True)
+            merged.metadata = {**(rule_based_score.metadata or {}), **(llm_score.metadata or {})}
+            return merged
+
         if not llm_score.status.is_usable or not llm_score.value:
             # The rule score stands, so the sample is still scored -- it just fell back.
-            rule_based_score.status = ScoreStatus.FALLBACK
+            if rule_based_score.status is not ScoreStatus.DEGRADED:
+                rule_based_score.status = ScoreStatus.FALLBACK
             rule_based_score.judge_summary = (
-                llm_score.judge_summary.model_copy(update={'status': ScoreStatus.FALLBACK})
+                llm_score.judge_summary.model_copy(update={'status': rule_based_score.status})
                 if llm_score.judge_summary is not None
                 else None
             )
@@ -338,12 +349,28 @@ class LLMJudgeMixin:
             }
             return rule_based_score
 
-        rule_value = float(rule_based_score.main_value or 0.0)
-        judge_value = float(llm_score.main_value or 0.0)
-        rule_based_score.main_value = max(rule_value, judge_value)
+        if rule_based_score.main_score_name and rule_based_score.main_score_name not in rule_based_score.value:
+            # A missing primary metric must not redirect the judge into a surviving metric.
+            metric_keys = {canonicalize_producer_identity(name, None): name for name in rule_based_score.value}
+            for name, value in llm_score.value.items():
+                key = metric_keys.setdefault(canonicalize_producer_identity(name, None), name)
+                if key in rule_based_score.value:
+                    value = max(rule_based_score.value[key], value)
+                rule_based_score.value[key] = value
+            judge_main = llm_score.main_score_name or next(iter(llm_score.value))
+            rule_based_score.main_score_name = metric_keys[canonicalize_producer_identity(judge_main, None)]
+        else:
+            rule_value = float(rule_based_score.main_value or 0.0)
+            judge_value = float(llm_score.main_value or 0.0)
+            rule_based_score.main_value = max(rule_value, judge_value)
         rule_based_score.explanation = llm_score.explanation
         rule_based_score.metadata = {**(rule_based_score.metadata or {}), **(llm_score.metadata or {})}
-        rule_based_score.status = llm_score.status
-        rule_based_score.judge_summary = llm_score.judge_summary
+        if rule_based_score.status is not ScoreStatus.DEGRADED:
+            rule_based_score.status = llm_score.status
+        rule_based_score.judge_summary = (
+            llm_score.judge_summary.model_copy(update={'status': rule_based_score.status})
+            if llm_score.judge_summary is not None
+            else None
+        )
 
         return rule_based_score

--- a/evalscope/api/mixin/llm_judge_mixin.py
+++ b/evalscope/api/mixin/llm_judge_mixin.py
@@ -329,6 +329,13 @@ class LLMJudgeMixin:
         ``llm_recall`` exists to recover rule-based misses, so the judge can only raise the
         score: the result is ``max(rule, judge)``. A failed judge must not erase rule evidence.
         """
+        rule_main_missing = (
+            rule_based_score.main_score_name is not None
+            and rule_based_score.main_score_name not in rule_based_score.value
+        )
+        if not rule_based_score.status.is_usable or not rule_based_score.value or rule_main_missing:
+            llm_score = self._align_recovered_judge_metrics(rule_based_score, llm_score)
+
         if not rule_based_score.status.is_usable or not rule_based_score.value:
             merged = llm_score.model_copy(deep=True)
             merged.metadata = {**(rule_based_score.metadata or {}), **(llm_score.metadata or {})}
@@ -349,16 +356,13 @@ class LLMJudgeMixin:
             }
             return rule_based_score
 
-        if rule_based_score.main_score_name and rule_based_score.main_score_name not in rule_based_score.value:
+        if rule_main_missing:
             # A missing primary metric must not redirect the judge into a surviving metric.
-            metric_keys = {canonicalize_producer_identity(name, None): name for name in rule_based_score.value}
             for name, value in llm_score.value.items():
-                key = metric_keys.setdefault(canonicalize_producer_identity(name, None), name)
-                if key in rule_based_score.value:
-                    value = max(rule_based_score.value[key], value)
-                rule_based_score.value[key] = value
-            judge_main = llm_score.main_score_name or next(iter(llm_score.value))
-            rule_based_score.main_score_name = metric_keys[canonicalize_producer_identity(judge_main, None)]
+                if name in rule_based_score.value:
+                    value = max(rule_based_score.value[name], value)
+                rule_based_score.value[name] = value
+            rule_based_score.main_score_name = llm_score.main_score_name or next(iter(llm_score.value))
         else:
             rule_value = float(rule_based_score.main_value or 0.0)
             judge_value = float(llm_score.main_value or 0.0)
@@ -374,3 +378,21 @@ class LLMJudgeMixin:
         )
 
         return rule_based_score
+
+    def _align_recovered_judge_metrics(self, rule_score: Score, judge_score: Score) -> Score:
+        """Keep aliases on the rule metric's raw key so aggregation combines samples."""
+        metric_keys = {canonicalize_producer_identity(name, None): name for name in rule_score.value}
+        for metric in self._benchmark_meta.metric_list:
+            name = metric if isinstance(metric, str) else next(iter(metric))
+            metric_keys.setdefault(canonicalize_producer_identity(name, None), name)
+
+        aligned = judge_score.model_copy(deep=True)
+        aligned.value = {}
+        for name, value in judge_score.value.items():
+            key = metric_keys.get(canonicalize_producer_identity(name, None), name)
+            aligned.value[key] = max(aligned.value[key], value) if key in aligned.value else value
+        if judge_score.main_score_name is not None:
+            aligned.main_score_name = metric_keys.get(
+                canonicalize_producer_identity(judge_score.main_score_name, None), judge_score.main_score_name
+            )
+        return aligned

--- a/evalscope/benchmarks/general_arena/general_arena_adapter.py
+++ b/evalscope/benchmarks/general_arena/general_arena_adapter.py
@@ -48,6 +48,7 @@ GRADER_TEMPLATE = "<|User Prompt|>\n{question}\n\n<|The Start of Assistant A's A
 @register_benchmark(
     BenchmarkMeta(
         name='general_arena',
+        evaluation_version='v1.1',
         pretty_name='GeneralArena',
         tags=[Tags.CUSTOM, Tags.ARENA],
         description="""
@@ -340,7 +341,7 @@ class GeneralArenaAdapter(DefaultDataAdapter):
         bt_model_coef = compute_mle_elo(battles, baseline_model=self.baseline)
 
         bootstrap_model_coef = get_bootstrap_result(
-            battles, func_compute_elo=compute_mle_elo, num_round=100, baseline_model=self.baseline
+            battles, func_compute_elo=compute_mle_elo, num_round=100, baseline_model=self.baseline, seed=self.seed
         )
 
         stats = pd.DataFrame()

--- a/evalscope/benchmarks/general_arena/utils.py
+++ b/evalscope/benchmarks/general_arena/utils.py
@@ -2,6 +2,7 @@ import inspect
 import math
 import re
 from collections import defaultdict
+from typing import Callable, Optional
 
 import numpy as np
 import pandas as pd
@@ -185,13 +186,21 @@ def compute_mle_elo(df, scale=400, base=10, init_rating=1000, baseline_model='gp
     return pd.Series(elo_scores, index=models.index).sort_values(ascending=False)
 
 
-def get_bootstrap_result(battles, func_compute_elo, num_round, baseline_model='gpt-4-0314'):
+def get_bootstrap_result(
+    battles: pd.DataFrame,
+    func_compute_elo: Callable[..., Optional[pd.Series]],
+    num_round: int,
+    baseline_model: str = 'gpt-4-0314',
+    seed: Optional[int] = 42,
+) -> pd.DataFrame:
+    """Bootstrap ELO ratings with an isolated RNG; None uses fresh entropy."""
+    rng = np.random.default_rng(seed)
     rows = []
     kwargs = {}
     if 'baseline_model' in inspect.signature(func_compute_elo).parameters:
         kwargs['baseline_model'] = baseline_model
     for _ in tqdm(range(num_round), desc='bootstrap'):
-        res = func_compute_elo(battles.sample(frac=1.0, replace=True), **kwargs)
+        res = func_compute_elo(battles.sample(frac=1.0, replace=True, random_state=rng), **kwargs)
         if res is not None:
             rows.append(res)
     df = pd.DataFrame(rows)

--- a/evalscope/benchmarks/mmlu_redux/mmlu_redux_adapter.py
+++ b/evalscope/benchmarks/mmlu_redux/mmlu_redux_adapter.py
@@ -75,6 +75,7 @@ SUBSET_LIST = list(SUBJECT_MAPPING.keys())
 @register_benchmark(
     BenchmarkMeta(
         name='mmlu_redux',
+        evaluation_version='v1.1',
         pretty_name='MMLU-Redux',
         tags=[Tags.MULTIPLE_CHOICE, Tags.KNOWLEDGE],
         description="""

--- a/evalscope/benchmarks/trivia_qa/trivia_qa_adapter.py
+++ b/evalscope/benchmarks/trivia_qa/trivia_qa_adapter.py
@@ -27,6 +27,7 @@ The last line of your response should be of the form "ANSWER: [ANSWER]" (without
 @register_benchmark(
     BenchmarkMeta(
         name='trivia_qa',
+        evaluation_version='v1.1',
         pretty_name='TriviaQA',
         dataset_id='evalscope/trivia_qa',
         tags=[Tags.QA, Tags.READING_COMPREHENSION],

--- a/evalscope/evaluation_versioning.py
+++ b/evalscope/evaluation_versioning.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from evalscope.config import TaskConfig
 
 EVALUATION_IDENTITY_SCHEMA_VERSION = 1
+SHARED_SCORING_VERSION = 'v1.1'
+"""Version of shared judge rendering and metric failure semantics used in cache identities."""
 _VERSION_RE = re.compile(r'^v\d+\.\d+$')
 _SECRET_KEYS = {
     'api-key',
@@ -164,6 +166,7 @@ def build_benchmark_identity(
     """Build a stable cache identity from effective evaluation semantics."""
     validate_evaluation_version(evaluation_version)
     payload = {
+        'shared_scoring_version': SHARED_SCORING_VERSION,
         'evaluation_version': evaluation_version,
         'benchmark': spec.model_dump(mode='json'),
         'task': _fingerprint_task_config(task_config),

--- a/evalscope/metrics/judge/llm_judge.py
+++ b/evalscope/metrics/judge/llm_judge.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 from evalscope.api.messages import ChatMessage
@@ -120,15 +121,9 @@ class LLMJudge:
         return self.model.generate(messages)
 
     def build_prompt(self, pred: str, gold: str, question: Optional[str] = None) -> str:
+        """Render supported placeholders once, preserving inserted values verbatim."""
         if question is None:
             question = 'Not provided'
 
-        # check variables in prompt_template
-        prompt = self.prompt_template
-        if '{question}' in self.prompt_template:
-            prompt = prompt.replace('{question}', question)
-        if '{pred}' in self.prompt_template:
-            prompt = prompt.replace('{pred}', pred)
-        if '{gold}' in self.prompt_template:
-            prompt = prompt.replace('{gold}', gold)
-        return prompt
+        values = {'question': question, 'pred': pred, 'gold': gold}
+        return re.sub(r'\{(question|pred|gold)\}', lambda match: values[match.group(1)], self.prompt_template)

--- a/evalscope/metrics/nlp/metrics.py
+++ b/evalscope/metrics/nlp/metrics.py
@@ -23,18 +23,22 @@ class ExactMatch(Metric):
 
 @register_metric(name=['accuracy', 'acc'])
 class Accuracy(ExactMatch):
-    def __init__(self, allow_inclusion: bool = False, numeric: bool = False):
+    """Score exact answers, optionally accepting any normalized reference alternative."""
+
+    def __init__(self, allow_inclusion: bool = False, numeric: bool = False) -> None:
         self.allow_inclusion = allow_inclusion
         self.numeric = numeric
 
-    def apply(self, predictions, references):
+    def apply(self, predictions: list[str], references: list[str | list[str]]) -> list[float]:
+        """Match complete answers; inclusion treats a string reference as one alternative."""
         if self.allow_inclusion:
             results = []
             for prediction, reference in zip(predictions, references):
-                if prediction and prediction in reference:
-                    results.append(1.0)
-                else:
-                    results.append(0.0)
+                prediction = normalize_text(prediction)
+                alternatives = [reference] if isinstance(reference, str) else reference
+                results.append(
+                    float(bool(prediction) and any(prediction == normalize_text(answer) for answer in alternatives))
+                )
             return results
         elif self.numeric:
             from evalscope.metrics.math.parser import math_equal, strip_answer_string

--- a/tests/api/test_evaluation_versioning.py
+++ b/tests/api/test_evaluation_versioning.py
@@ -229,7 +229,7 @@ def test_native_rerun_review_records_the_prediction_source(tmp_path) -> None:
     assert prediction_path.read_text() == previous_prediction
 
 
-def test_legacy_full_meta_snapshot_infers_v1_identity() -> None:
+def test_legacy_full_meta_snapshot_preserves_pre_fix_identity() -> None:
     config = _task_config()
     spec = ResolvedBenchmarkSpec.from_meta(_meta(), config)
     previous_config = config.to_dict()
@@ -239,8 +239,29 @@ def test_legacy_full_meta_snapshot_infers_v1_identity() -> None:
 
     assert identity is not None
     assert identity.evaluation_version == 'v1.0'
-    assert identity.fingerprint == build_benchmark_identity(spec, 'v1.0', config).fingerprint
+    assert identity.fingerprint != build_benchmark_identity(spec, 'v1.0', config).fingerprint
     assert validate_cached_evaluation_identity(previous_config, _identity({'demo': identity}), rerun_review=False) == {}
+
+
+@pytest.mark.parametrize('legacy_snapshot', [False, True])
+def test_shared_scoring_fix_requires_review_rerun_for_old_cache(legacy_snapshot: bool) -> None:
+    config = _task_config()
+    spec = ResolvedBenchmarkSpec.from_meta(_meta(), config)
+    previous_config = config.to_dict()
+    previous_config['dataset_args'] = {'demo': spec.model_dump(mode='json')}
+    previous = legacy_identity_from_config(previous_config, 'demo')
+    assert previous is not None
+    if not legacy_snapshot:
+        previous_config['evaluation_identity'] = _identity({'demo': previous}).model_dump(mode='json')
+    current = build_benchmark_identity(spec, 'v1.0', config)
+
+    with pytest.raises(ValueError, match='rerun_review=True'):
+        validate_cached_evaluation_identity(previous_config, _identity({'demo': current}), rerun_review=False)
+
+    sources = validate_cached_evaluation_identity(previous_config, _identity({'demo': current}), rerun_review=True)
+    assert sources['demo'].fingerprint == previous.fingerprint
+    assert sources['demo'].prediction_reused is True
+    assert sources['demo'].inferred_legacy is legacy_snapshot
 
 
 def test_analysis_uses_compact_context_without_full_meta_or_perf(monkeypatch) -> None:

--- a/tests/api/test_metric_failure_status.py
+++ b/tests/api/test_metric_failure_status.py
@@ -1,0 +1,221 @@
+"""Metric failures must not become successful zero scores."""
+from typing import Any, List
+
+import pytest
+
+from evalscope.api.benchmark import BenchmarkMeta, DefaultDataAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessage
+from evalscope.api.metric import JudgeSummary, Metric, SampleScore, Score
+from evalscope.api.model import ModelOutput
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeScoreType, ScoreStatus, ScoringPolicy
+from evalscope.metrics.aggregators.aggregators import Mean
+from evalscope.metrics.judge.llm_judge import DEFAULT_PROMPT_TEMPLATE, LLMJudge
+
+
+class FailingMetric(Metric):
+    """Simulate a plugin that fails on a particular sample."""
+
+    def apply(self, predictions: List[str], references: List[str]) -> List[float]:
+        if predictions[0] == 'crash':
+            raise RuntimeError('metric unavailable')
+        return [1.0]
+
+
+class BrokenConstructorMetric(FailingMetric):
+    """Simulate a plugin that cannot initialize."""
+
+    def __init__(self) -> None:
+        raise RuntimeError('initialization failed')
+
+
+def make_adapter(
+    monkeypatch: pytest.MonkeyPatch, metrics: List[Any], strategy: str = 'auto'
+) -> DefaultDataAdapter:
+    """Install local metric doubles without changing the registry."""
+    from evalscope.api.benchmark.adapters import default_data_adapter
+
+    original_get_metric = default_data_adapter.get_metric
+
+    def get_metric(name: str) -> Any:
+        if name == 'flaky':
+            return FailingMetric
+        if name == 'broken_init':
+            return BrokenConstructorMetric
+        return original_get_metric(name)
+
+    monkeypatch.setattr(default_data_adapter, 'get_metric', get_metric)
+    return DefaultDataAdapter(
+        benchmark_meta=BenchmarkMeta(name='metric_failure', dataset_id='unused', metric_list=metrics),
+        task_config=TaskConfig(
+            datasets=['metric_failure'], judge={'strategy': strategy, 'models': [{'model_id': 'offline'}]}
+        ),
+    )
+
+
+def calculate(adapter: DefaultDataAdapter, prediction: str, sample_id: int = 0) -> SampleScore:
+    """Exercise the complete per-sample rule scoring path."""
+    state = TaskState(
+        model='offline',
+        sample=Sample(id=sample_id, input='question', target='answer'),
+        output=ModelOutput.from_content('offline', prediction),
+        completed=True,
+    )
+    return adapter.calculate_metrics(state)
+
+
+@pytest.mark.parametrize('metric', ['flaky', {'flaky': {}}, 'broken_init', 'issue1697_unknown_metric'])
+def test_metric_errors_are_unavailable(monkeypatch: pytest.MonkeyPatch, metric: Any) -> None:
+    adapter = make_adapter(monkeypatch, [metric])
+    score = calculate(adapter, 'crash').score
+    metric_name = metric if isinstance(metric, str) else next(iter(metric))
+
+    assert score.value == {}
+    assert score.status is ScoreStatus.EXCLUDED
+    assert score.metadata[metric_name].startswith('error: ')
+    assert score.prediction == 'crash'
+
+
+@pytest.mark.parametrize('metrics', [['flaky', 'accuracy'], ['accuracy', 'flaky']])
+def test_partial_metric_failure_retains_other_scores(
+    monkeypatch: pytest.MonkeyPatch, metrics: List[str]
+) -> None:
+    adapter = make_adapter(monkeypatch, metrics)
+    score = calculate(adapter, 'crash').score
+
+    assert score.value == {'accuracy': 0.0}
+    assert score.status is ScoreStatus.DEGRADED
+    assert score.metadata['flaky'] == 'error: metric unavailable'
+
+
+def test_failed_metric_is_excluded_only_from_its_own_denominator(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = make_adapter(monkeypatch, ['flaky', 'accuracy'])
+    samples = [calculate(adapter, 'answer', 0), calculate(adapter, 'crash', 1)]
+    results = {result.metric_name: result for result in Mean()(samples)}
+
+    assert results['flaky'].score == 1.0
+    assert results['flaky'].num == 1
+    assert results['flaky'].ids == [0]
+    assert results['accuracy'].score == 0.5
+    assert results['accuracy'].num == 2
+    assert samples[0].score.status is ScoreStatus.SUCCESS
+
+
+def test_unavailable_rule_and_judge_stay_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = make_adapter(monkeypatch, ['flaky'])
+    rule = calculate(adapter, 'crash').score
+    judge = Score(status=ScoreStatus.PARSE_ERROR, judge_summary=JudgeSummary(status=ScoreStatus.PARSE_ERROR))
+
+    for score in [adapter.fallback_to_rule_score(rule, judge), adapter._merge_scores(rule, judge)]:
+        assert score.value == {}
+        assert not score.status.is_usable
+        assert not score.judge_summary.status.is_usable
+        assert score.metadata['flaky'] == 'error: metric unavailable'
+
+
+def test_judge_recovers_failed_rule_using_the_judge_metric_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = make_adapter(monkeypatch, ['flaky'])
+    rule = calculate(adapter, 'crash').score
+    judge = Score(value={'acc': 1.0})
+
+    score = adapter._merge_scores(rule, judge)
+
+    assert score.value == {'acc': 1.0}
+    assert score.status is ScoreStatus.SUCCESS
+    assert score.metadata['flaky'] == 'error: metric unavailable'
+
+
+class ScriptedJudge:
+    """Exercise the judge executor with a deterministic offline response."""
+
+    score_type = JudgeScoreType.PATTERN
+    score_mapping = {'A': 1.0, 'B': 0.0}
+    prompt_template = DEFAULT_PROMPT_TEMPLATE
+    system_prompt = None
+    judge_id = model_id = 'offline'
+    build_prompt = LLMJudge.build_prompt
+
+    def __init__(self, reply: str) -> None:
+        self.reply = reply
+        self.calls = 0
+
+    def generate(self, messages: List[ChatMessage]) -> ModelOutput:
+        """Return the configured reply without contacting an external service."""
+        self.calls += 1
+        return ModelOutput.from_content('offline', self.reply)
+
+
+@pytest.mark.parametrize(('prediction', 'surviving_value'), [('answer', 1.0), ('wrong', 0.0)])
+def test_recall_does_not_replace_a_failed_primary_metric_with_a_surviving_metric(
+    monkeypatch: pytest.MonkeyPatch, prediction: str, surviving_value: float
+) -> None:
+    adapter = make_adapter(monkeypatch, ['broken_init', 'exact_match'], strategy='llm_recall')
+    judge = ScriptedJudge('{"verdict":"A"}')
+    adapter.llm_judge = judge
+
+    score = calculate(adapter, prediction).score
+
+    assert judge.calls == 1
+    assert score.value == {'acc': 1.0, 'exact_match': surviving_value}
+    assert score.status is ScoreStatus.DEGRADED
+    assert score.judge_summary.status is ScoreStatus.DEGRADED
+    assert score.metadata['broken_init'] == 'error: initialization failed'
+
+
+@pytest.mark.parametrize(('prediction', 'reply'), [('wrong', '{"verdict":"A"}'), ('answer', '{"verdict":"B"}')])
+def test_recall_merges_judge_alias_into_the_existing_metric(
+    monkeypatch: pytest.MonkeyPatch, prediction: str, reply: str
+) -> None:
+    adapter = make_adapter(monkeypatch, ['broken_init', 'accuracy'], strategy='llm_recall')
+    judge = ScriptedJudge(reply)
+    adapter.llm_judge = judge
+
+    sample_score = calculate(adapter, prediction)
+
+    assert judge.calls == 1
+    assert sample_score.score.value == {'accuracy': 1.0}
+    assert sample_score.score.main_score_name == 'accuracy'
+    assert sample_score.score.status is ScoreStatus.DEGRADED
+    aggregated = Mean()([sample_score])
+    assert len(aggregated) == 1
+    assert aggregated[0].metric_name == 'accuracy'
+    assert aggregated[0].score == 1.0
+    assert aggregated[0].num == 1
+
+
+@pytest.mark.parametrize(('prediction', 'judge_calls'), [('answer', 0), ('wrong', 1)])
+def test_recall_preserves_secondary_metric_failures(
+    monkeypatch: pytest.MonkeyPatch, prediction: str, judge_calls: int
+) -> None:
+    adapter = make_adapter(monkeypatch, ['accuracy', 'broken_init'], strategy='llm_recall')
+    judge = ScriptedJudge('{"verdict":"A"}')
+    adapter.llm_judge = judge
+
+    score = calculate(adapter, prediction).score
+
+    assert judge.calls == judge_calls
+    assert score.value == {'accuracy': 1.0}
+    assert score.status is ScoreStatus.DEGRADED
+    if score.judge_summary is not None:
+        assert score.judge_summary.status is ScoreStatus.DEGRADED
+
+
+@pytest.mark.parametrize('strategy', ['llm_recall', 'auto'])
+@pytest.mark.parametrize('metrics', [['broken_init', 'accuracy'], ['accuracy', 'broken_init']])
+def test_failed_judge_preserves_partial_rule_evidence(
+    monkeypatch: pytest.MonkeyPatch, strategy: str, metrics: List[str]
+) -> None:
+    adapter = make_adapter(monkeypatch, metrics, strategy=strategy)
+    adapter.scoring_policy = ScoringPolicy.JUDGE_DEFAULT
+    judge = ScriptedJudge('not JSON')
+    adapter.llm_judge = judge
+
+    score = calculate(adapter, 'wrong').score
+
+    assert judge.calls == 1
+    assert score.value == {'accuracy': 0.0}
+    assert score.status is ScoreStatus.DEGRADED
+    assert score.judge_summary.status is ScoreStatus.DEGRADED
+    assert score.metadata['broken_init'] == 'error: initialization failed'

--- a/tests/api/test_metric_failure_status.py
+++ b/tests/api/test_metric_failure_status.py
@@ -219,3 +219,76 @@ def test_failed_judge_preserves_partial_rule_evidence(
     assert score.status is ScoreStatus.DEGRADED
     assert score.judge_summary.status is ScoreStatus.DEGRADED
     assert score.metadata['broken_init'] == 'error: initialization failed'
+
+
+@pytest.mark.parametrize(('rule_name', 'judge_name'), [('accuracy', 'acc'), ('acc', 'accuracy')])
+@pytest.mark.parametrize('secondary_metric', [False, True])
+@pytest.mark.parametrize('configured_as_dict', [False, True])
+def test_recovered_judge_alias_keeps_one_cross_sample_denominator(
+    monkeypatch: pytest.MonkeyPatch,
+    rule_name: str,
+    judge_name: str,
+    secondary_metric: bool,
+    configured_as_dict: bool,
+) -> None:
+    """A failed rule recovered by its judge alias still belongs to the same metric."""
+    from evalscope.api.benchmark.adapters import default_data_adapter
+
+    metrics = [{rule_name: {}} if configured_as_dict else rule_name]
+    if secondary_metric:
+        metrics.append('exact_match')
+    adapter = make_adapter(monkeypatch, metrics, strategy='llm_recall')
+    # BenchmarkMeta normalizes legacy aliases before DefaultDataAdapter scores them.
+    configured_metric = adapter.metric_list[0]
+    effective_name = configured_metric if isinstance(configured_metric, str) else next(iter(configured_metric))
+    original_get_metric = default_data_adapter.get_metric
+    monkeypatch.setattr(
+        default_data_adapter, 'get_metric',
+        lambda name: FailingMetric if name == effective_name else original_get_metric(name),
+    )
+    adapter.judge_metric_name = judge_name
+    adapter.llm_judge = ScriptedJudge('{"verdict":"B"}')
+
+    samples = [calculate(adapter, 'answer', 0), calculate(adapter, 'crash', 1)]
+    results = adapter.aggregate_scores(samples)
+    accuracy = [result for result in results if result.metric_name == 'accuracy']
+
+    assert samples[1].score.value[effective_name] == 0.0
+    assert len(accuracy) == 1
+    assert accuracy[0].score == 0.5
+    assert accuracy[0].num == 2
+    assert accuracy[0].ids == [0, 1]
+    if secondary_metric:
+        exact_match = next(result for result in results if result.metric_name == 'exact_match')
+        assert exact_match.score == 0.5
+        assert exact_match.num == 2
+
+
+def test_recovered_judge_retains_a_surviving_rule_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom rule producers may still emit an alias despite canonical metadata."""
+    adapter = make_adapter(monkeypatch, ['flaky', 'accuracy'])
+    rule = Score(value={'acc': 0.0}, main_score_name='flaky', status=ScoreStatus.DEGRADED)
+    merged = adapter._merge_scores(rule, Score(value={'accuracy': 1.0}))
+    samples = [SampleScore(sample_id=0, score=Score(value={'acc': 0.0})), SampleScore(sample_id=1, score=merged)]
+
+    assert merged.value == {'acc': 1.0}
+    result, = adapter.aggregate_scores(samples)
+    assert result.metric_name == 'accuracy'
+    assert result.score == 0.5
+    assert result.num == 2
+
+
+def test_recovered_judge_does_not_fill_an_unrelated_failed_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Judge accuracy cannot contribute to an unrelated plugin metric's denominator."""
+    adapter = make_adapter(monkeypatch, ['flaky'], strategy='llm_recall')
+    adapter.llm_judge = ScriptedJudge('{"verdict":"B"}')
+
+    samples = [calculate(adapter, 'answer', 0), calculate(adapter, 'crash', 1)]
+    results = {result.metric_name: result for result in adapter.aggregate_scores(samples)}
+
+    assert samples[1].score.value == {'acc': 0.0}
+    assert results['flaky'].score == 1.0
+    assert results['flaky'].ids == [0]
+    assert results['flaky'].num == 1
+    assert results['accuracy'].ids == [1]
+    assert results['accuracy'].num == 1

--- a/tests/benchmark/test_arena_bootstrap.py
+++ b/tests/benchmark/test_arena_bootstrap.py
@@ -1,0 +1,94 @@
+"""Regression tests for arena bootstrap RNG isolation (issue #1697)."""
+
+from typing import Callable, Iterator, Optional
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.general_arena import utils
+from evalscope.config import TaskConfig
+
+
+@pytest.fixture(autouse=True)
+def restore_numpy_rng() -> Iterator[None]:
+    state = np.random.get_state()
+    yield
+    np.random.set_state(state)
+
+
+def _statistic(battles: pd.DataFrame) -> pd.Series:
+    return pd.Series({'candidate': battles['value'].mean()})
+
+
+def _battles() -> pd.DataFrame:
+    return pd.DataFrame({'value': np.arange(50)})
+
+
+def test_bootstrap_default_is_independent_of_global_rng() -> None:
+    np.random.seed(42)
+    first = utils.get_bootstrap_result(_battles(), _statistic, 20)
+    np.random.random(1000)
+    second = utils.get_bootstrap_result(_battles(), _statistic, 20)
+    pd.testing.assert_frame_equal(first, second)
+
+
+@pytest.mark.parametrize('seed', [42, 7, None])
+def test_bootstrap_preserves_global_rng(seed: Optional[int]) -> None:
+    np.random.seed(123)
+    expected = np.random.random(10)
+    np.random.seed(123)
+    utils.get_bootstrap_result(_battles(), _statistic, 20, seed=seed)
+    np.testing.assert_array_equal(np.random.random(10), expected)
+
+
+def test_bootstrap_seed_controls_samples_and_rounds_vary() -> None:
+    first = utils.get_bootstrap_result(_battles(), _statistic, 20, seed=7)
+    repeated = utils.get_bootstrap_result(_battles(), _statistic, 20, seed=7)
+    different = utils.get_bootstrap_result(_battles(), _statistic, 20, seed=8)
+    pd.testing.assert_frame_equal(first, repeated)
+    assert not first.equals(different)
+    assert first['candidate'].nunique() > 1
+
+
+@pytest.mark.parametrize('seed', [42, 7, None])
+def test_adapter_uses_task_seed_for_confidence_intervals(seed: Optional[int], monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip('sklearn')
+    config = TaskConfig(
+        model='candidate',
+        datasets=['general_arena'],
+        dataset_args={'general_arena': {'extra_params': {'baseline': 'baseline'}}},
+        **({} if seed == 42 else {'seed': seed}),
+    )
+    adapter = get_benchmark('general_arena', config)
+    scores = [
+        SampleScore(
+            score=Score(
+                metadata={
+                    'battle_result': {
+                        'games': [{'model_a': 'candidate', 'model_b': 'baseline', 'judgment': judgment}],
+                    },
+                }
+            )
+        )
+        for judgment in ['A>B'] * 55 + ['B>A'] * 30 + ['A=B'] * 15
+    ]
+    original_bootstrap = utils.get_bootstrap_result
+    missing = object()
+
+    def bootstrap(
+        battles: pd.DataFrame, func_compute_elo: Callable, num_round: int, **kwargs: object
+    ) -> pd.DataFrame:
+        assert kwargs.get('seed', missing) == seed
+        return original_bootstrap(battles, func_compute_elo, num_round, **kwargs)
+
+    monkeypatch.setattr(utils, 'get_bootstrap_result', bootstrap)
+    np.random.seed(42)
+    first = adapter.aggregate_scores(scores)
+    assert {score.metric_name for score in first} == {'win_rate', 'win_rate_lower', 'win_rate_upper'}
+    if seed is not None:
+        np.random.random(1000)
+        second = adapter.aggregate_scores(scores)
+        assert first == second

--- a/tests/metrics/test_accuracy_inclusion.py
+++ b/tests/metrics/test_accuracy_inclusion.py
@@ -1,0 +1,77 @@
+import pytest
+
+from evalscope.api.registry import BENCHMARK_REGISTRY
+from evalscope.benchmarks.mmlu_redux.mmlu_redux_adapter import MMLUReduxAdapter
+from evalscope.benchmarks.trivia_qa.trivia_qa_adapter import TriviaQaAdapter
+from evalscope.metrics.nlp.metrics import Accuracy
+
+
+@pytest.mark.parametrize(
+    ('prediction', 'reference', 'expected'),
+    [
+        ('A', ['A', 'B'], 1.0),
+        ('B', ['A', 'B'], 1.0),
+        ('AB', ['A', 'B'], 0.0),
+        ('C', ['A', 'B'], 0.0),
+        (' a\n', [' A ', 'B'], 1.0),
+        ('PARIS', ['London', 'Paris'], 1.0),
+        ('Paris', ['London', ' PARIS\t'], 1.0),
+        ('York', ['New York'], 0.0),
+        ('York', 'New York', 0.0),
+        ('A', 'AB', 0.0),
+        (' New York\n', 'new york', 1.0),
+        ('New York', 'New York', 1.0),
+        ('', [''], 0.0),
+        (' ', [' '], 0.0),
+        (' ', ' ', 0.0),
+        ('', '', 0.0),
+        ('A', [], 0.0),
+    ],
+)
+def test_inclusion_matches_one_complete_normalized_answer(
+    prediction: str, reference: str | list[str], expected: float
+) -> None:
+    assert Accuracy(allow_inclusion=True).apply([prediction], [reference]) == [expected]
+
+
+def test_inclusion_scores_mixed_reference_types_in_order() -> None:
+    assert Accuracy(allow_inclusion=True).apply(
+        [' PARIS ', 'York', ' b '], [['London', 'Paris'], 'New York', ['A', 'B']]
+    ) == [1.0, 0.0, 1.0]
+
+
+def test_default_accuracy_keeps_exact_match_behavior() -> None:
+    assert Accuracy().apply([' PARIS ', 'York', ''], ['paris', 'New York', '']) == [1.0, 0.0, 1.0]
+
+
+def test_mmlu_redux_accepts_each_correct_single_choice() -> None:
+    adapter = MMLUReduxAdapter(benchmark_meta=BENCHMARK_REGISTRY['mmlu_redux'])
+    sample = adapter.record_to_sample(
+        {
+            'question': 'Which option is acceptable?',
+            'choices': ['First', 'Second', 'Third', 'Fourth'],
+            'answer': 0,
+            'error_type': 'multiple_correct_answers',
+            'correct_answer': '0 or 1',
+        }
+    )
+    assert sample.target == ['A', 'B']
+    assert Accuracy(allow_inclusion=True).apply(['A', 'B', 'AB'], [sample.target] * 3) == [1.0, 1.0, 0.0]
+
+
+def test_trivia_qa_accepts_normalized_aliases() -> None:
+    adapter = TriviaQaAdapter(benchmark_meta=BENCHMARK_REGISTRY['trivia_qa'])
+    sample = adapter.record_to_sample(
+        {
+            'question': 'What city?',
+            'question_id': 'example',
+            'answer': {'aliases': ['New York City'], 'normalized_aliases': ['new york city', 'nyc']},
+            'entity_pages': {'wiki_context': 'A city in the United States.'},
+        }
+    )
+    assert Accuracy(allow_inclusion=True).apply([' NYC\n', 'York'], [sample.target] * 2) == [1.0, 0.0]
+
+
+@pytest.mark.parametrize('benchmark', ['mmlu_redux', 'trivia_qa'])
+def test_inclusion_benchmark_evaluation_version(benchmark: str) -> None:
+    assert BENCHMARK_REGISTRY[benchmark].evaluation_version == 'v1.1'

--- a/tests/metrics/test_accuracy_inclusion.py
+++ b/tests/metrics/test_accuracy_inclusion.py
@@ -72,6 +72,6 @@ def test_trivia_qa_accepts_normalized_aliases() -> None:
     assert Accuracy(allow_inclusion=True).apply([' NYC\n', 'York'], [sample.target] * 2) == [1.0, 0.0]
 
 
-@pytest.mark.parametrize('benchmark', ['mmlu_redux', 'trivia_qa'])
-def test_inclusion_benchmark_evaluation_version(benchmark: str) -> None:
-    assert BENCHMARK_REGISTRY[benchmark].evaluation_version == 'v1.1'
+@pytest.mark.parametrize('benchmark_name', ['mmlu_redux', 'trivia_qa'])
+def test_inclusion_benchmark_evaluation_version(benchmark_name: str) -> None:
+    assert BENCHMARK_REGISTRY[benchmark_name].evaluation_version == 'v1.1'

--- a/tests/metrics/test_judge_prompt_rendering.py
+++ b/tests/metrics/test_judge_prompt_rendering.py
@@ -1,0 +1,99 @@
+"""Regression coverage for literal values in judge prompt templates."""
+
+from typing import List, Optional
+
+import pytest
+
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.messages import ChatMessage
+from evalscope.api.model import ModelOutput
+from evalscope.api.registry import get_benchmark
+from evalscope.config import TaskConfig
+from evalscope.constants import JudgeScoreType, ScoreStatus
+from evalscope.metrics.judge.llm_judge import DEFAULT_NUMERIC_SCORE_TEMPLATE, DEFAULT_PROMPT_TEMPLATE, LLMJudge
+
+
+def make_judge(template: str) -> LLMJudge:
+    """Create a prompt renderer without initializing a model or network client."""
+    judge = object.__new__(LLMJudge)
+    judge.prompt_template = template
+    return judge
+
+
+@pytest.mark.parametrize('field', ['question', 'pred', 'gold'])
+@pytest.mark.parametrize('placeholder', ['{question}', '{pred}', '{gold}'])
+def test_inserted_placeholders_remain_literal(field: str, placeholder: str) -> None:
+    values = {'question': 'QUESTION', 'pred': 'PREDICTION', 'gold': 'REFERENCE'}
+    values[field] = placeholder
+    judge = make_judge('Q={question}\nP={pred}\nG={gold}')
+
+    assert judge.build_prompt(**values) == f"Q={values['question']}\nP={values['pred']}\nG={values['gold']}"
+
+
+@pytest.mark.parametrize('question', [None, '', 'Question?'])
+@pytest.mark.parametrize('template', [DEFAULT_PROMPT_TEMPLATE, DEFAULT_NUMERIC_SCORE_TEMPLATE], ids=['pattern', 'numeric'])
+def test_default_templates_preserve_answer_content(template: str, question: Optional[str]) -> None:
+    prediction = '{gold} {pred} {question}'
+    reference = 'REFERENCE'
+    prompt = make_judge(template).build_prompt(prediction, reference, question)
+
+    assert f"[Question]\n{'Not provided' if question is None else question}\n" in prompt
+    section = '[Predicted Answer]' if template == DEFAULT_PROMPT_TEMPLATE else '[Response]'
+    assert f'{section}\n{prediction}' in prompt
+    if template == DEFAULT_PROMPT_TEMPLATE:
+        assert f'[Reference Answer]\n{reference}' in prompt
+
+
+def test_custom_template_preserves_json_unknown_fields_and_backslashes() -> None:
+    template = '{"verdict": "A", "metadata": {}}\n{unknown}\n{pred}\n{pred}\n{gold}'
+    prediction = r'\1\g<gold> {gold} {"answer": {}}'
+
+    assert make_judge(template).build_prompt(prediction, 'REFERENCE') == (
+        '{"verdict": "A", "metadata": {}}\n{unknown}\n'
+        f'{prediction}\n{prediction}\nREFERENCE'
+    )
+
+
+class CapturingJudge:
+    """Capture the real scoring request and return a fixed offline verdict."""
+
+    score_type = JudgeScoreType.PATTERN
+    score_mapping = {'A': 1.0, 'B': 0.0}
+    prompt_template = DEFAULT_PROMPT_TEMPLATE
+    system_prompt = None
+    judge_id = model_id = 'offline'
+    build_prompt = LLMJudge.build_prompt
+
+    def __init__(self) -> None:
+        self.prompts: List[str] = []
+
+    def generate(self, messages: List[ChatMessage]) -> ModelOutput:
+        """Record the outgoing prompt without contacting a model."""
+        self.prompts.append(messages[-1].content)
+        return ModelOutput.from_content('offline', '{"verdict":"B"}')
+
+
+def test_scoring_chain_sends_the_original_prediction_to_judge() -> None:
+    config = TaskConfig(
+        model='m',
+        eval_type='mock_llm',
+        datasets=['general_qa'],
+        judge={'strategy': 'llm', 'models': [{'model_id': 'offline'}]},
+    )
+    adapter = get_benchmark('general_qa', config)
+    judge = CapturingJudge()
+    adapter.llm_judge = judge
+    sample = Sample(id=0, input='Question?', target='CANARY_REFERENCE_1697')
+    state = TaskState(
+        model='m', sample=sample, output=ModelOutput.from_content('m', '{gold}'), completed=True
+    )
+
+    score = adapter.calculate_metrics(state).score
+
+    assert len(judge.prompts) == 1
+    assert '[Predicted Answer]\n{gold}\n\n' in judge.prompts[0]
+    assert '[Reference Answer]\nCANARY_REFERENCE_1697\n\n' in judge.prompts[0]
+    assert score.prediction == '{gold}'
+    assert score.status is ScoreStatus.SUCCESS
+    assert score.value == {'acc': 0.0}


### PR DESCRIPTION
Fixes #1697.

This fixes four scoring correctness issues: model text can expand judge-template placeholders, arena confidence intervals depend on unrelated global RNG activity, metric exceptions count as successful zero scores, and inclusion accuracy uses different matching rules for strings and lists.

- Render judge placeholders in one pass over the original template. Inserted questions, predictions, and references remain literal, including `{gold}`, JSON, and backslashes.
- Give `general_arena` bootstrap its own RNG, seeded from `TaskConfig.seed`. Fixed seeds reproduce confidence intervals regardless of global RNG consumption; explicit `None` retains nondeterministic sampling without modifying global RNG state.
- Omit failed metric keys and mark fully failed samples `EXCLUDED` or partially failed samples `DEGRADED`. Preserve valid metrics and their denominators through judge fallback and LLM recall, including a missing primary metric and equivalent metric names. When the judge recovers a completely failed rule, align equivalent metric names with the rule declaration so `acc` and `accuracy` do not split the cross-sample aggregation denominator.
- Match one complete, normalized acceptable answer for `allow_inclusion`. Lists remain alternatives (including MMLU-Redux single-choice answers); string references become a single alternative, so `York` no longer matches `New York`. Case and surrounding whitespace follow the existing normalization rules, and blank predictions do not receive credit.

The bootstrap issue is global-RNG coupling, not an absence of seeding in the standard entry point: `run_task` already defaults to seed 42. This does not change `arena_hard`, whose current aggregation does not call bootstrap. The AIME/AIR-Bench parsing defects in #1578 were already fixed by #1588 and subsequently migrated to JSON contracts in #1601; those adapters are unchanged here.

### Compatibility

`general_arena`, `mmlu_redux`, and `trivia_qa` move to evaluation version `v1.1`. A shared scoring version is also included in native cache fingerprints so old scores cannot bypass the common judge and metric fixes. This invalidates existing native score-cache identities, including benchmarks outside these three: use `rerun_review=True` to reuse predictions and recompute reviews. Legacy fingerprints remain calculated with their original algorithm for provenance tracking.

### Validation

Four of the 10 new cross-sample aggregation cases fail against `e0400d03`: equivalent judge and rule names produce duplicate accuracy aggregates with one sample each instead of one aggregate with two samples.

The results below are from the current revision unless marked as earlier. Regression tests were run against the old behavior and rerun after each fix. All judge responses use offline doubles.

- Python 3.13: **281 passed** across judge contracts/execution, adapter scoring, evaluation versioning, metrics/aggregators, and arena bootstrap:
  ```sh
  python -m pytest tests/api/judge tests/api/test_metric_failure_status.py tests/api/test_default_data_adapter.py tests/api/test_scoring_policy.py tests/api/test_evaluation_versioning.py tests/metrics tests/benchmark/test_arena_bootstrap.py -q --tb=short
  ```
- Earlier Python 3.12 focused regressions: **64 passed, 3 skipped**; the three real-ELO adapter cases were skipped because scikit-learn is unavailable in that environment, and passed under Python 3.13.
- `python -m pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings`: **1 passed**, using the mock model.
- `make lint`: **passed**.
