### PR TITLE
fix(web): stop score-matrix model name wrapping character-by-character

### DIFF
--- a/evalscope/web/src/components/compare/ScoreMatrixTab.tsx
+++ b/evalscope/web/src/components/compare/ScoreMatrixTab.tsx
@@ -58,7 +58,11 @@ export default function ScoreMatrixTab({
     isBaseline: boolean,
   ): ReactNode => {
     if (score == null || !Number.isFinite(score)) {
-      return <span className="text-[var(--text-dim)]">—</span>
+      return (
+        <div className="flex min-h-12 flex-col items-center justify-center px-3 py-1 font-mono">
+          <span className="text-[var(--text-dim)]">—</span>
+        </div>
+      )
     }
     const hasBaseline = baselineScore != null && Number.isFinite(baselineScore)
     const delta = hasBaseline ? score - baselineScore : null
@@ -170,7 +174,9 @@ export default function ScoreMatrixTab({
             <table className="w-full table-fixed border-collapse text-sm">
               <colgroup>
                 <col style={{ width: 'clamp(280px, 34%, 420px)' }} />
-                {dataRows.map((row) => <col key={String(row.dataset_id)} />)}
+                {dataRows.map((row) => (
+                  <col key={String(row.dataset_id)} style={{ minWidth: 120 }} />
+                ))}
               </colgroup>
               <thead className="bg-[var(--bg-card2)]">
                 <tr className="border-b border-[var(--border-strong)]">
@@ -215,7 +221,10 @@ export default function ScoreMatrixTab({
                             {rkIdx + 1}
                           </span>
                         )}
-                        <span className="min-w-0 break-words leading-5 text-[var(--text)]" title={modelLabel}>
+                        <span
+                          className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap leading-5 text-[var(--text)]"
+                          title={modelLabel}
+                        >
                           {modelLabel}
                         </span>
                         {isBaseline && (


### PR DESCRIPTION
## Context

On the "Score Comparison" (`Vs Baseline`) table, a row where every score cell is empty (no primary metric resolved for any dataset in that comparison) renders its model name wrapped one character per line instead of on a single line — the row collapses to a degenerate width because none of its cells carry any sizing.

## Root cause

- The no-score placeholder (`renderScoreCell`) returned a bare `—` with none of the padding/height a populated cell gets.
- The model-name `<span>` used `min-w-0 break-words`, which lets a long underscore-joined name wrap at arbitrary character boundaries once its available width collapses.
- The per-dataset `<col>` under `table-layout: fixed` had no floor width, so an all-empty row could push the table's width negotiation into a degenerate state.

## Fix

- Give the empty-cell placeholder the same `flex min-h-12 ... px-3 py-1` box as a populated cell, so empty rows aren't structurally thinner than populated ones.
- Keep the model name on one line (`whitespace-nowrap overflow-hidden text-ellipsis`, still `title`-attributed for the full name on hover) instead of letting it wrap.
- Give each dataset `<col>` a `minWidth: 120` floor matching the header/cell's existing `min-w-[120px]`.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run` (462 passed)
- [x] `npx eslint src/components/compare/ScoreMatrixTab.tsx` clean
