### PR TITLE
fix(bridge): keep the model output intact on reconstructed assistant messages

### DIFF
--- a/evalscope/agent/external/bridge/trace_recorder.py
+++ b/evalscope/agent/external/bridge/trace_recorder.py
@@ -511,19 +511,7 @@ class BridgeTraceRecorder:
 
     @staticmethod
     def _build_assistant_message(output: ModelOutput) -> ChatMessageAssistant:
-        """Snapshot the assistant message as the model returned it.
-
-        Mirrors :meth:`AgentLoop._snapshot_assistant_message`: the transcript
-        carries a deep copy of ``output.message`` so ``perf_metrics``,
-        reasoning blocks, ``model`` and ``metadata`` survive the bridge.
-        ``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off these
-        messages, so rebuilding them from text alone left the perf table
-        empty for every external-agent run.
-
-        Only ``tool_calls`` is rebuilt: some upstream paths leave
-        ``ToolCall.function`` as a bare string (see :func:`unpack_tool_call`)
-        and the transcript must carry proper :class:`ToolFunction` objects.
-        """
+        """Deep-copy model output while normalizing tool calls for the transcript."""
         if not output.choices:
             return ChatMessageAssistant(content='')
         src = output.message

--- a/evalscope/agent/external/bridge/trace_recorder.py
+++ b/evalscope/agent/external/bridge/trace_recorder.py
@@ -511,6 +511,19 @@ class BridgeTraceRecorder:
 
     @staticmethod
     def _build_assistant_message(output: ModelOutput) -> ChatMessageAssistant:
+        """Snapshot the assistant message as the model returned it.
+
+        Mirrors :meth:`AgentLoop._snapshot_assistant_message`: the transcript
+        carries a deep copy of ``output.message`` so ``perf_metrics``,
+        reasoning blocks, ``model`` and ``metadata`` survive the bridge.
+        ``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off these
+        messages, so rebuilding them from text alone left the perf table
+        empty for every external-agent run.
+
+        Only ``tool_calls`` is rebuilt: some upstream paths leave
+        ``ToolCall.function`` as a bare string (see :func:`unpack_tool_call`)
+        and the transcript must carry proper :class:`ToolFunction` objects.
+        """
         if not output.choices:
             return ChatMessageAssistant(content='')
         src = output.message
@@ -524,10 +537,7 @@ class BridgeTraceRecorder:
                     type='function',
                 )
             )
-        return ChatMessageAssistant(
-            content=src.text or '',
-            tool_calls=tool_calls or None,
-        )
+        return src.model_copy(deep=True, update={'tool_calls': tool_calls or None})
 
 
 def _user_text_from_content(content: Any) -> str:

--- a/tests/agent/external/test_external_perf_metrics.py
+++ b/tests/agent/external/test_external_perf_metrics.py
@@ -1,11 +1,4 @@
-"""External-agent runs must keep per-turn ``perf_metrics`` on the transcript.
-
-``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off the assistant
-messages in ``TaskState.messages`` and only falls back to ``task_state.output``.
-For bridge-driven runs both come from the bridge, so a recorder that drops the
-field leaves the perf table empty for every external-agent evaluation while
-``collect_perf`` defaults to True.
-"""
+"""Regression coverage for perf metrics in external-agent transcripts."""
 
 import pytest
 

--- a/tests/agent/external/test_external_perf_metrics.py
+++ b/tests/agent/external/test_external_perf_metrics.py
@@ -1,0 +1,42 @@
+"""External-agent runs must keep per-turn ``perf_metrics`` on the transcript.
+
+``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off the assistant
+messages in ``TaskState.messages`` and only falls back to ``task_state.output``.
+For bridge-driven runs both come from the bridge, so a recorder that drops the
+field leaves the perf table empty for every external-agent evaluation while
+``collect_perf`` defaults to True.
+"""
+
+import pytest
+
+from evalscope.agent.external import ExternalAgentConfig
+from evalscope.agent.external.adapter import run_external_agent
+from evalscope.api.dataset import Sample
+from evalscope.api.messages import ChatMessageAssistant
+from evalscope.api.messages.perf_metrics import PerformanceMetrics
+from evalscope.api.model import GenerateConfig, Model, ModelOutput
+from evalscope.models.mockllm import MockLLM
+from evalscope.utils.asyncio_runtime import AsyncioLoopRunner
+
+
+@pytest.fixture(autouse=True)
+def _release_bridge_loop():
+    yield
+    AsyncioLoopRunner.shutdown_for_thread()
+
+
+def test_external_run_keeps_per_turn_perf_metrics_on_the_transcript():
+    perf = PerformanceMetrics(latency=0.123, ttft=0.05, input_tokens=10, output_tokens=2)
+    output = ModelOutput.from_content(model='mock-model', content='42')
+    output.message.perf_metrics = perf
+    model = Model(api=MockLLM(model_name='mock-model', custom_outputs=[output]), config=GenerateConfig())
+
+    result = run_external_agent(
+        ExternalAgentConfig(framework='mock', environment='local', timeout=60.0),
+        model,
+        Sample(input='What is 6 * 7?', id=1),
+    )
+
+    assistants = [m for m in result.messages if isinstance(m, ChatMessageAssistant)]
+    assert [m.perf_metrics for m in assistants] == [perf]
+    assert result.output.completion == '42'

--- a/tests/agent/external/test_trace_schema.py
+++ b/tests/agent/external/test_trace_schema.py
@@ -9,7 +9,15 @@ import pytest
 
 from evalscope.agent.external.bridge.trace_recorder import BridgeTraceRecorder
 from evalscope.api.agent import AgentTrace, EventType
-from evalscope.api.messages import ChatMessageAssistant, ChatMessageSystem, ChatMessageTool, ChatMessageUser
+from evalscope.api.messages import (
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    ContentReasoning,
+    ContentText,
+)
+from evalscope.api.messages.perf_metrics import PerformanceMetrics
 from evalscope.api.model import ModelOutput, ModelUsage
 from evalscope.api.model.model_output import ChatCompletionChoice
 from evalscope.api.tool import ToolCall, ToolFunction
@@ -251,3 +259,72 @@ def test_responses_first_turn_ingests_instructions_when_user_message_empty():
     msgs = rec.messages()
     assert [m.role for m in msgs] == ['system', 'user', 'assistant']
     assert msgs[0].text == '<full task description>'
+
+
+def test_assistant_message_is_a_copy_of_the_model_output():
+    """The transcript must carry what the model returned, not a text-only rebuild.
+
+    ``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off the assistant
+    messages, so a rebuild that drops the field leaves the perf table empty
+    for every external-agent run. Reasoning blocks, ``model`` and ``metadata``
+    went missing the same way. The native loop deep-copies ``output.message``
+    (``AgentLoop._snapshot_assistant_message``) and the bridge is supposed to
+    produce the same transcript shape.
+    """
+    perf = PerformanceMetrics(latency=0.25, ttft=0.1, input_tokens=12, output_tokens=3)
+    call = ToolCall(id='call-1', function=ToolFunction(name='lookup', arguments={'q': 'x'}), type='function')
+    msg = ChatMessageAssistant(
+        content=[ContentReasoning(reasoning='6 * 7'), ContentText(text='42')],
+        tool_calls=[call],
+        model='qwen3-max',
+        metadata={'finish_reason': 'stop'},
+    )
+    msg.perf_metrics = perf
+    output = ModelOutput(model='qwen3-max', choices=[ChatCompletionChoice(message=msg, stop_reason='stop')])
+
+    rec = BridgeTraceRecorder(trial_id='t9', framework='mock')
+    rec.record_anthropic_turn(
+        request_body={'messages': [{'role': 'user', 'content': 'q'}]},
+        output=output,
+        latency_ms=250.0,
+    )
+
+    recorded = rec.messages()[1]
+    assert isinstance(recorded, ChatMessageAssistant)
+    assert recorded.perf_metrics == perf
+    assert recorded.model == 'qwen3-max'
+    assert recorded.metadata == {'finish_reason': 'stop'}
+    assert [type(block) for block in recorded.content] == [ContentReasoning, ContentText]
+    assert recorded.text == '42'
+    assert recorded.tool_calls == [call]
+
+
+def test_assistant_message_does_not_alias_the_model_output():
+    """Mutating ``output.message`` after the turn was recorded must not rewrite history."""
+    output = _output('world')
+    rec = BridgeTraceRecorder(trial_id='t10', framework='mock')
+    rec.record_anthropic_turn(request_body={'messages': [{'role': 'user', 'content': 'hello'}]}, output=output)
+
+    output.message.text = 'rewritten after recording'
+
+    assert rec.messages()[1].text == 'world'
+
+
+def test_assistant_message_normalizes_bare_string_tool_function():
+    """Some upstream paths leave ``ToolCall.function`` as a bare string.
+
+    Whatever else is copied from the model output, the transcript must carry
+    a proper :class:`ToolFunction` and the TOOL_CALL event must name the tool.
+    """
+    raw_call = ToolCall.model_construct(id='call-2', function='lookup')
+    rec = BridgeTraceRecorder(trial_id='t11', framework='mock')
+    rec.record_anthropic_turn(
+        request_body={'messages': [{'role': 'user', 'content': 'use a tool'}]},
+        output=_output('', tool_calls=[raw_call]),
+    )
+
+    recorded = rec.messages()[1]
+    assert recorded.tool_calls == [ToolCall(id='call-2', function=ToolFunction(name='lookup', arguments={}), type='function')]
+    event = [ev for ev in rec.snapshot().events if ev.type == EventType.TOOL_CALL][0]
+    assert event.payload['name'] == 'lookup'
+    assert event.payload['arguments'] == {}

--- a/tests/agent/external/test_trace_schema.py
+++ b/tests/agent/external/test_trace_schema.py
@@ -262,15 +262,7 @@ def test_responses_first_turn_ingests_instructions_when_user_message_empty():
 
 
 def test_assistant_message_is_a_copy_of_the_model_output():
-    """The transcript must carry what the model returned, not a text-only rebuild.
-
-    ``DefaultEvaluator._record_perf`` reads ``perf_metrics`` off the assistant
-    messages, so a rebuild that drops the field leaves the perf table empty
-    for every external-agent run. Reasoning blocks, ``model`` and ``metadata``
-    went missing the same way. The native loop deep-copies ``output.message``
-    (``AgentLoop._snapshot_assistant_message``) and the bridge is supposed to
-    produce the same transcript shape.
-    """
+    """The bridge transcript preserves the complete model message."""
     perf = PerformanceMetrics(latency=0.25, ttft=0.1, input_tokens=12, output_tokens=3)
     call = ToolCall(id='call-1', function=ToolFunction(name='lookup', arguments={'q': 'x'}), type='function')
     msg = ChatMessageAssistant(
@@ -311,11 +303,7 @@ def test_assistant_message_does_not_alias_the_model_output():
 
 
 def test_assistant_message_normalizes_bare_string_tool_function():
-    """Some upstream paths leave ``ToolCall.function`` as a bare string.
-
-    Whatever else is copied from the model output, the transcript must carry
-    a proper :class:`ToolFunction` and the TOOL_CALL event must name the tool.
-    """
+    """Tool calls remain normalized when the model message is copied."""
     raw_call = ToolCall.model_construct(id='call-2', function='lookup')
     rec = BridgeTraceRecorder(trial_id='t11', framework='mock')
     rec.record_anthropic_turn(


### PR DESCRIPTION
## Problem

Fixes #1709.

In bridge mode the transcript is rebuilt by `BridgeTraceRecorder._build_assistant_message`, which creates a fresh `ChatMessageAssistant(content=src.text, tool_calls=...)`. Everything else on `output.message` is dropped: `perf_metrics`, reasoning blocks, `model`, `metadata`.

`DefaultEvaluator._record_perf` (`evaluator.py:424-441`) reads `perf_metrics` off the assistant messages of the transcript and only falls back to `task_state.output`, which the bridge adapter also builds from plain text. So every external-agent evaluation ends with an empty perf table and `requests_with_metrics = 0`, while `collect_perf` defaults to `True`. The trace view of a bridge run also cannot show the model's reasoning.

The native loop snapshots the message with `output.message.model_copy(deep=True)` (`AgentLoop._snapshot_assistant_message`), and the recorder's module docstring says both paths emit the same shape. Only the bridge lost data.

### Reproduction

Zero external dependencies, recorder level plus end-to-end through the `mock` runner: script in #1709. Before / after this change:

| | before | after |
|---|---|---|
| `perf_metrics` on the recorded assistant message | `None` | `latency=0.123 ttft=0.05 tokens=10+2` |
| requests `_record_perf` can count (1 turn) | 0 / 1 | 1 / 1 |
| content blocks | collapsed to `str`, reasoning gone | `ContentReasoning` + `ContentText` |
| `model` | `None` | preserved |
| final text picked by the adapter | `'42'` | `'42'` |

## Changes

`_build_assistant_message` now returns `src.model_copy(deep=True, update={'tool_calls': ...})`. The `tool_calls` normalisation is kept as-is: `unpack_tool_call` exists because some upstream paths leave `ToolCall.function` as a bare string, and the transcript must carry proper `ToolFunction` objects. The deep copy keeps the existing guarantee that the recorder never aliases `output.message`.

No wire behaviour changes: the response written back to the CLI is still synthesised from the original `ModelOutput`.

## Tests

- `test_trace_schema.py::test_assistant_message_is_a_copy_of_the_model_output`: fails on main (`perf_metrics is None`, content collapsed to `str`), passes here.
- `test_trace_schema.py::test_assistant_message_does_not_alias_the_model_output`: guards the deep copy.
- `test_trace_schema.py::test_assistant_message_normalizes_bare_string_tool_function`: pins the one thing that must still be rebuilt.
- `test_external_perf_metrics.py`: end-to-end through the `mock` runner and `LocalAgentEnvironment`; fails on main, passes here.

```
tests/agent/external   84 passed, 8 skipped
tests/agent            324 passed, 21 skipped, same 7 pre-existing failures
                       (test_sandbox_service x6, test_strategy_parsers x1: optional deps, unrelated)
ruff 0.16.4 check + format --diff   clean
```

## Notes

- Downstream consumers read assistant content through `.text`, and the native path already stores list content (reasoning + text) on the same cache and web surfaces, so the transcript shape this PR restores is not new to them.
- `main` is currently import-broken since #1702: `evalscope/api/mixin/llm_judge_mixin.py:11` imports `evalscope.metrics.semantics.identity`, which #1705 moved to `naming.py`, so `CI Tests Lite` is red on `c31f0f9`. I ran the suites above with that one-line import corrected locally; it is not part of this PR. Happy to send it separately if nobody has it in flight.
