### PR TITLE
fix(judge): import canonicalize_producer_identity from its new module

### DIFF
--- a/evalscope/api/mixin/llm_judge_mixin.py
+++ b/evalscope/api/mixin/llm_judge_mixin.py
@@ -8,7 +8,7 @@ from evalscope.api.evaluator import TaskState
 from evalscope.api.metric import Score
 from evalscope.constants import JudgeScoreType, JudgeStrategy, ScoreStatus, ScoringPolicy
 from evalscope.metrics import LLMJudge
-from evalscope.metrics.semantics.identity import canonicalize_producer_identity
+from evalscope.metrics.semantics.naming import canonicalize_producer_identity
 from evalscope.utils.argument_utils import get_secret_value
 from evalscope.utils.deprecation_utils import deprecated_warning
 from evalscope.utils.logger import get_logger


### PR DESCRIPTION
## Problem

`import evalscope` fails on `main`:

```
File "evalscope/api/mixin/llm_judge_mixin.py", line 11, in <module>
    from evalscope.metrics.semantics.identity import canonicalize_producer_identity
ModuleNotFoundError: No module named 'evalscope.metrics.semantics.identity'
```

#1705 moved `canonicalize_producer_identity` into `evalscope/metrics/semantics/naming.py` and removed `identity.py`. #1702 merged afterwards and still imports the old path, so every entry point that touches the benchmark registry is unusable on `c31f0f9`.

`CI Tests Lite` is red on `main` for this reason, and every open PR inherits the failure.

## Change

One line: import `canonicalize_producer_identity` from `evalscope.metrics.semantics.naming`, where #1705 put it.

## Testing

```
python -c "import evalscope"                 ok (fails on main)
tests/api/judge                              27 passed, 3 pre-existing failures
                                             (test_migrated_adapters arena_hard: `sklearn` not installed)
tests/metrics/test_judge_prompt_rendering.py 4 passed
tests/agent                                  336 passed, 21 skipped, same 7 pre-existing failures
                                             (test_sandbox_service, test_strategy_parsers: optional deps)
```
