### PR TITLE
feat(agent): validate tool-call arguments against the advertised schema

### DIFF
--- a/docs/en/user_guides/agent/native.md
+++ b/docs/en/user_guides/agent/native.md
@@ -61,6 +61,7 @@ Most-used `NativeAgentConfig` fields:
 | `environment_extra` | Agent environment constructor options | Docker image, timeout, mounts, and other environment-specific settings |
 | `max_steps` | Max iterations per sample | Math/QA `5-10`, code fixes `100+` |
 | `skills_dir` | Optional host Agent Skills directory | EvalScope makes the skills available before the agent loop starts |
+| `validate_tool_arguments` | Reject tool calls whose arguments violate the JSON schema advertised to the model; the model sees the violation as a `parsing` tool error and can retry | `False` (default); enable when the run should measure whether the model produces schema-valid calls |
 | `kwargs` | Strategy kwargs | Most commonly `{'system_prompt': '...'}` to steer the model |
 
 Available `strategy` values:

--- a/docs/zh/user_guides/agent/native.md
+++ b/docs/zh/user_guides/agent/native.md
@@ -61,6 +61,7 @@ EvalScope 自动给模型注入 `python_exec` 工具定义，在 Docker 容器�
 | `environment_extra` | Agent 环境构造参数 | Docker 镜像、超时、挂载等环境专属设置 |
 | `max_steps` | 单样本最大轮数 | 数学/QA `5-10`，代码修复 `100+` |
 | `skills_dir` | 可选的本机 Agent Skills 目录 | EvalScope 会在 agent loop 开始前让 skills 可用 |
+| `validate_tool_arguments` | 拒绝参数不符合下发 JSON schema 的工具调用；模型会收到 `parsing` 类型的工具错误并可重试 | `False`（默认）；需要衡量模型能否产出合规参数时开启 |
 | `kwargs` | 策略参数 | 最常用 `{'system_prompt': '...'}` 引导模型行为 |
 
 可选的 `strategy` 值：

--- a/evalscope/agent/runner.py
+++ b/evalscope/agent/runner.py
@@ -122,6 +122,7 @@ def run_native_agent(
         trace_env_name=cfg.environment,
         mcp_configs=list(cfg.mcp_servers) or None,
         close_environment=owns_environment,
+        validate_tool_arguments=cfg.validate_tool_arguments,
     )
 
     final_text = extract_final_answer(result, strategy)

--- a/evalscope/agent/strategies/_submit.py
+++ b/evalscope/agent/strategies/_submit.py
@@ -1,0 +1,31 @@
+"""Shared parsing for schema-validated ``submit`` tool calls."""
+
+from typing import List, Optional
+
+from evalscope.agent.tools.submit import SUBMIT_TOOL_INFO
+from evalscope.api.agent import AgentContext, ParsedAction
+from evalscope.api.tool import ToolCall, validate_tool_arguments
+
+
+def parse_submit_action(
+    tool_calls: List[ToolCall],
+    raw_text: str,
+    ctx: AgentContext,
+    *,
+    enabled: bool = True,
+) -> Optional[ParsedAction]:
+    """Return the terminal action for a submit call, or ``None`` if absent.
+
+    Invalid submits remain executable actions when schema validation is enabled,
+    allowing :class:`ToolExecutor` to return the standard parsing observation.
+    """
+    if not enabled:
+        return None
+
+    submit_call = next((call for call in tool_calls if call.function.name == 'submit'), None)
+    if submit_call is None:
+        return None
+
+    if ctx.validate_tool_arguments and validate_tool_arguments(submit_call, SUBMIT_TOOL_INFO) is not None:
+        return ParsedAction(tool_calls=[submit_call], raw_text=raw_text)
+    return ParsedAction(final_answer=submit_call.function.arguments.get('answer', ''), raw_text=raw_text)

--- a/evalscope/agent/strategies/function_calling.py
+++ b/evalscope/agent/strategies/function_calling.py
@@ -15,7 +15,7 @@ from evalscope.api.agent.constants import NUDGE_PROMPT
 from evalscope.api.messages import ChatMessage, ChatMessageTool
 from evalscope.api.model import ModelOutput
 from evalscope.api.registry import register_strategy
-from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo
+from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo, validate_tool_arguments
 
 # Reminder used when this strategy is configured without the ``submit`` tool
 # (e.g. BrowserGym single-action mode); the default prompt would otherwise tell
@@ -59,10 +59,14 @@ class FunctionCallingStrategy(AgentStrategy):
         message = output.message
         tool_calls = list(message.tool_calls or [])
 
-        # Intercept ``submit`` → treat as final answer.
+        # Intercept a schema-valid ``submit`` → treat as final answer. An invalid
+        # submit remains a tool call so ToolExecutor can return a parsing error.
         submit_calls = [tc for tc in tool_calls if self._include_submit_tool and tc.function.name == 'submit']
         if submit_calls:
-            answer = submit_calls[0].function.arguments.get('answer', '')
+            submit_call = submit_calls[0]
+            if ctx.validate_tool_arguments and validate_tool_arguments(submit_call, SUBMIT_TOOL_INFO) is not None:
+                return ParsedAction(tool_calls=[submit_call], raw_text=message.text)
+            answer = submit_call.function.arguments.get('answer', '')
             return ParsedAction(final_answer=answer, raw_text=message.text)
 
         if self._max_tool_calls_per_turn is not None and len(tool_calls) > self._max_tool_calls_per_turn:

--- a/evalscope/agent/strategies/function_calling.py
+++ b/evalscope/agent/strategies/function_calling.py
@@ -15,7 +15,9 @@ from evalscope.api.agent.constants import NUDGE_PROMPT
 from evalscope.api.messages import ChatMessage, ChatMessageTool
 from evalscope.api.model import ModelOutput
 from evalscope.api.registry import register_strategy
-from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo, validate_tool_arguments
+from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo
+
+from ._submit import parse_submit_action
 
 # Reminder used when this strategy is configured without the ``submit`` tool
 # (e.g. BrowserGym single-action mode); the default prompt would otherwise tell
@@ -59,15 +61,14 @@ class FunctionCallingStrategy(AgentStrategy):
         message = output.message
         tool_calls = list(message.tool_calls or [])
 
-        # Intercept a schema-valid ``submit`` → treat as final answer. An invalid
-        # submit remains a tool call so ToolExecutor can return a parsing error.
-        submit_calls = [tc for tc in tool_calls if self._include_submit_tool and tc.function.name == 'submit']
-        if submit_calls:
-            submit_call = submit_calls[0]
-            if ctx.validate_tool_arguments and validate_tool_arguments(submit_call, SUBMIT_TOOL_INFO) is not None:
-                return ParsedAction(tool_calls=[submit_call], raw_text=message.text)
-            answer = submit_call.function.arguments.get('answer', '')
-            return ParsedAction(final_answer=answer, raw_text=message.text)
+        submit_action = parse_submit_action(
+            tool_calls,
+            message.text,
+            ctx,
+            enabled=self._include_submit_tool,
+        )
+        if submit_action is not None:
+            return submit_action
 
         if self._max_tool_calls_per_turn is not None and len(tool_calls) > self._max_tool_calls_per_turn:
             label = 'tool call' if self._max_tool_calls_per_turn == 1 else 'tool calls'

--- a/evalscope/agent/strategies/react.py
+++ b/evalscope/agent/strategies/react.py
@@ -23,6 +23,8 @@ from evalscope.api.model import ModelOutput
 from evalscope.api.registry import register_strategy
 from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo
 
+from ._submit import parse_submit_action
+
 # ---------------------------------------------------------------------------
 # Prompt helpers
 # ---------------------------------------------------------------------------
@@ -89,11 +91,9 @@ class ReactStrategy(AgentStrategy):
         message = output.message
         tool_calls = list(message.tool_calls or [])
 
-        # Intercept ``submit`` → treat as final answer.
-        submit_calls = [tc for tc in tool_calls if tc.function.name == 'submit']
-        if submit_calls:
-            answer = submit_calls[0].function.arguments.get('answer', '')
-            return ParsedAction(final_answer=answer, raw_text=message.text)
+        submit_action = parse_submit_action(tool_calls, message.text, ctx)
+        if submit_action is not None:
+            return submit_action
 
         if tool_calls:
             return ParsedAction(tool_calls=tool_calls, raw_text=message.text)

--- a/evalscope/api/agent/runner.py
+++ b/evalscope/api/agent/runner.py
@@ -46,6 +46,7 @@ def run_agent_loop(
     trace_env_name: Optional[str],
     mcp_configs: Optional[List['MCPServerConfig']] = None,
     close_environment: bool = True,
+    validate_tool_arguments: bool = False,
 ) -> AgentLoopResult:
     """Drive a single :class:`AgentLoop` to completion and return its result.
 
@@ -71,6 +72,10 @@ def run_agent_loop(
         close_environment: Whether this helper owns and closes ``environment``.
             Set to ``False`` when the caller needs to reuse the same
             environment after the agent loop, for example to run a verifier.
+        validate_tool_arguments: Whether :class:`ToolExecutor` checks every
+            tool call against the ``ToolInfo`` schema advertised to the model
+            (native and MCP tools alike) and refuses to dispatch violating
+            calls. See :attr:`NativeAgentConfig.validate_tool_arguments`.
 
     Returns:
         AgentLoopResult: Completed result with ``messages``, ``trace`` and
@@ -93,7 +98,12 @@ def run_agent_loop(
                 merged_tools.extend(mcp_tool_infos)
 
             try:
-                tool_executor = ToolExecutor(handlers=merged_handlers, environment=environment)
+                tool_executor = ToolExecutor(
+                    handlers=merged_handlers,
+                    environment=environment,
+                    tool_infos=merged_tools,
+                    validate_arguments=validate_tool_arguments,
+                )
                 ctx = AgentContext(
                     sample_id=sample_id,
                     messages=initial_messages,

--- a/evalscope/api/agent/runner.py
+++ b/evalscope/api/agent/runner.py
@@ -98,17 +98,23 @@ def run_agent_loop(
                 merged_tools.extend(mcp_tool_infos)
 
             try:
-                tool_executor = ToolExecutor(
-                    handlers=merged_handlers,
-                    environment=environment,
-                    tool_infos=merged_tools,
-                    validate_arguments=validate_tool_arguments,
-                )
                 ctx = AgentContext(
                     sample_id=sample_id,
                     messages=initial_messages,
                     tools=merged_tools,
                     max_steps=max_steps,
+                    validate_tool_arguments=validate_tool_arguments,
+                )
+                strategy_tools = getattr(strategy, 'tools', None)
+                if strategy_tools is not None:
+                    advertised_tools = strategy_tools(ctx)
+                    advertised_names = {tool.name for tool in merged_tools}
+                    merged_tools.extend(tool for tool in advertised_tools if tool.name not in advertised_names)
+                tool_executor = ToolExecutor(
+                    handlers=merged_handlers,
+                    environment=environment,
+                    tool_infos=merged_tools,
+                    validate_arguments=validate_tool_arguments,
                 )
                 trace = AgentTrace(
                     strategy=trace_strategy_name,

--- a/evalscope/api/agent/tool_executor.py
+++ b/evalscope/api/agent/tool_executor.py
@@ -66,6 +66,12 @@ class ToolExecutor:
         correct the call on its next turn.
         """
         started = time.time()
+        if self._validate_arguments:
+            violation = self._schema_violation(call)
+            if violation is not None:
+                err = ToolCallError(type='parsing', message=violation)
+                return err.message, err, time.time() - started
+
         handler = self._handlers.get(call.function.name)
         if handler is None:
             err = ToolCallError(
@@ -73,12 +79,6 @@ class ToolExecutor:
                 message=f"Tool '{call.function.name}' is not registered. Available: {sorted(self._handlers.keys())}",
             )
             return err.message, err, time.time() - started
-
-        if self._validate_arguments:
-            violation = self._schema_violation(call)
-            if violation is not None:
-                err = ToolCallError(type='parsing', message=violation)
-                return err.message, err, time.time() - started
 
         try:
             observation = await handler(call, self._environment)

--- a/evalscope/api/agent/tool_executor.py
+++ b/evalscope/api/agent/tool_executor.py
@@ -3,12 +3,17 @@
 Tool handlers are registered under ``evalscope/agent/tools/`` via
 ``@register_agent_tool('name')`` and must expose an async
 ``run(call: ToolCall, env: AgentEnvironment | None) -> ToolObservation`` callable.
+
+With ``validate_arguments=True`` the executor also checks every call against
+the ``ToolInfo`` schema the model was shown and refuses to dispatch a call
+that violates it, returning a ``parsing`` :class:`ToolCallError` the same way
+an unregistered tool yields an ``unknown`` one.
 """
 
 import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
-from evalscope.api.tool import ToolCall, ToolCallError
+from evalscope.api.tool import ToolCall, ToolCallError, ToolInfo, validate_tool_arguments
 
 from .environment import AgentEnvironment
 from .types import ToolExecutionOutput
@@ -31,9 +36,14 @@ class ToolExecutor:
         self,
         handlers: Dict[str, ToolHandler],
         environment: Optional[AgentEnvironment] = None,
+        *,
+        tool_infos: Optional[List[ToolInfo]] = None,
+        validate_arguments: bool = False,
     ) -> None:
         self._handlers = handlers
         self._environment = environment
+        self._tool_infos: Dict[str, ToolInfo] = {tool.name: tool for tool in tool_infos or []}
+        self._validate_arguments = validate_arguments
 
     @property
     def environment(self) -> Optional[AgentEnvironment]:
@@ -49,6 +59,11 @@ class ToolExecutor:
         Returns ``(observation, error, duration_seconds)``. Existing handlers
         return strings; attachment-producing tools may return
         :class:`ToolExecutionOutput`.
+
+        When argument validation is enabled and the call violates the schema
+        advertised for its tool, the handler is not invoked: the violation is
+        returned as a ``parsing`` :class:`ToolCallError` so the model can
+        correct the call on its next turn.
         """
         started = time.time()
         handler = self._handlers.get(call.function.name)
@@ -59,6 +74,12 @@ class ToolExecutor:
             )
             return err.message, err, time.time() - started
 
+        if self._validate_arguments:
+            violation = self._schema_violation(call)
+            if violation is not None:
+                err = ToolCallError(type='parsing', message=violation)
+                return err.message, err, time.time() - started
+
         try:
             observation = await handler(call, self._environment)
             return observation, None, time.time() - started
@@ -68,6 +89,23 @@ class ToolExecutor:
             return str(exc), ToolCallError(type='permission', message=str(exc)), time.time() - started
         except Exception as exc:  # noqa: BLE001 - generic boundary
             return str(exc), ToolCallError(type='unknown', message=str(exc)), time.time() - started
+
+    def _schema_violation(self, call: ToolCall) -> Optional[str]:
+        """Describe how ``call`` violates its tool's schema, or ``None``.
+
+        Tools without a registered :class:`ToolInfo` cannot be validated and
+        are dispatched as-is.
+        """
+        tool = self._tool_infos.get(call.function.name)
+        if tool is None:
+            return None
+        violation = validate_tool_arguments(call, tool)
+        if violation is None:
+            return None
+        return (
+            f"Invalid arguments for tool '{call.function.name}': {violation}. "
+            "Arguments must match the tool's parameter schema."
+        )
 
 
 __all__ = ['ToolExecutor', 'ToolHandler', 'ToolObservation']

--- a/evalscope/api/agent/types.py
+++ b/evalscope/api/agent/types.py
@@ -82,6 +82,17 @@ class NativeAgentConfig(BaseAgentConfig):
     means use each tool's built-in default.
     """
 
+    validate_tool_arguments: bool = Field(default=False)
+    """Reject tool calls whose arguments violate the tool's advertised JSON schema.
+
+    When enabled, :class:`ToolExecutor` checks every call against the
+    ``ToolInfo.parameters`` shown to the model before dispatching it. A
+    violating call is not executed: the model receives the violation as a
+    ``parsing`` tool error observation and can correct itself on the next
+    turn, and the ``TOOL_RESULT`` trace event carries ``error='parsing'``.
+    Off by default so existing benchmark scores are unaffected.
+    """
+
     mcp_servers: List[MCPServerConfig] = Field(default_factory=list)
     """List of MCP servers spawned alongside this agent's per-sample loop.
 

--- a/evalscope/api/agent/types.py
+++ b/evalscope/api/agent/types.py
@@ -211,6 +211,9 @@ class AgentContext:
     tools: List[ToolInfo] = field(default_factory=list)
     step: int = 0
     max_steps: int = 10
+    validate_tool_arguments: bool = False
+    """Whether tool calls must satisfy their advertised JSON schemas."""
+
     last_output: Optional[ModelOutput] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
     nudge_count: int = 0

--- a/evalscope/api/benchmark/adapters/agent_adapter.py
+++ b/evalscope/api/benchmark/adapters/agent_adapter.py
@@ -210,6 +210,10 @@ class AgentLoopAdapter(AgentAdapter):
             return ac.mcp_servers or None
         return None
 
+    @staticmethod
+    def _resolve_validate_tool_arguments(ac: Any) -> bool:
+        return isinstance(ac, NativeAgentConfig) and ac.validate_tool_arguments
+
     # ------------------------------------------------------------------
     # Overridden inference hook
     # ------------------------------------------------------------------
@@ -257,6 +261,7 @@ class AgentLoopAdapter(AgentAdapter):
             trace_strategy_name=getattr(strategy, 'name', None),
             trace_env_name=environment.name if environment else None,
             mcp_configs=mcp_configs,
+            validate_tool_arguments=self._resolve_validate_tool_arguments(ac),
         )
 
         finalization_prompt = self.build_max_steps_finalization_message(sample)

--- a/evalscope/api/tool/__init__.py
+++ b/evalscope/api/tool/__init__.py
@@ -1,3 +1,3 @@
 from .tool_call import ToolCall, ToolCallContent, ToolCallError, ToolCallView, ToolChoice, ToolFunction
 from .tool_info import Tool, ToolDescription, ToolInfo, ToolParams, set_tool_description, tool_description
-from .utils import parse_tool_call, tool_parse_error_message
+from .utils import parse_tool_call, tool_parse_error_message, validate_tool_arguments

--- a/evalscope/api/tool/utils.py
+++ b/evalscope/api/tool/utils.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 import yaml
+from jsonschema import SchemaError, ValidationError, validate
 
 from evalscope.utils import get_logger
 
@@ -64,3 +65,29 @@ def parse_tool_call(id: str, function: str, arguments: str, tools: Optional[List
 
 def tool_parse_error_message(arguments: str, ex: Exception) -> str:
     return f'Error parsing the following tool call arguments:\n\n{arguments}\n\nError details: {ex}'
+
+
+def validate_tool_arguments(call: ToolCall, tool: ToolInfo) -> Optional[str]:
+    """Check ``call.function.arguments`` against the schema advertised in ``tool``.
+
+    Returns ``None`` when the arguments satisfy ``tool.parameters``, otherwise a
+    short description of the first violation, for example
+    ``"'query' is a required property"`` or
+    ``"'abc' is not of type 'integer' (at 'limit')"``.
+
+    The schema is ``tool.parameters.model_dump(exclude_none=True)``: exactly
+    the JSON Schema the model was shown, so a call is judged against the
+    contract it was given rather than against a handler's private
+    expectations. A schema jsonschema cannot compile is treated as
+    unconstrained, so a broken declaration never blocks a well-formed call.
+    """
+    schema = tool.parameters.model_dump(exclude_none=True)
+    try:
+        validate(instance=call.function.arguments, schema=schema)
+    except ValidationError as exc:
+        path = '/'.join(str(part) for part in exc.absolute_path)
+        return f'{exc.message} (at {path!r})' if path else exc.message
+    except SchemaError as exc:
+        logger.debug(f'validate_tool_arguments: schema of tool {tool.name!r} is invalid, skipping: {exc.message}')
+        return None
+    return None

--- a/tests/agent/test_tool_argument_validation.py
+++ b/tests/agent/test_tool_argument_validation.py
@@ -1,0 +1,258 @@
+"""Tool-call argument validation against the schema advertised to the model.
+
+``NativeAgentConfig.validate_tool_arguments`` makes :class:`ToolExecutor` check
+every call against the ``ToolInfo.parameters`` the model was shown before
+dispatching it. A violating call is not executed; the model receives the
+violation as a ``parsing`` tool error, the same path an unregistered tool
+already takes, so the loop keeps going and the trace shows what happened.
+"""
+
+import asyncio
+import unittest
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import evalscope  # noqa: F401 - trigger strategy registration
+from evalscope.agent.runner import run_native_agent
+from evalscope.api.agent import AgentContext, AgentLoop, AgentLoopResult, AgentTrace, EventType, ToolExecutor
+from evalscope.api.agent.runner import run_agent_loop
+from evalscope.api.agent.types import NativeAgentConfig
+from evalscope.api.benchmark.adapters import AgentLoopAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageTool, ChatMessageUser
+from evalscope.api.model.model_output import ChatCompletionChoice, ModelOutput
+from evalscope.api.registry import get_strategy
+from evalscope.api.tool import ToolCall, ToolCallError, ToolFunction, ToolInfo, ToolParams, validate_tool_arguments
+from evalscope.config import TaskConfig
+from evalscope.utils.json_schema import JSONSchema
+
+LOOKUP = ToolInfo(
+    name='lookup',
+    description='Look something up.',
+    parameters=ToolParams(
+        properties={'query': JSONSchema(type='string'), 'limit': JSONSchema(type='integer')},
+        required=['query'],
+    ),
+)
+
+
+def _call(args: Dict[str, Any], *, name: str = 'lookup', call_id: str = 'c1') -> ToolCall:
+    return ToolCall(id=call_id, function=ToolFunction(name=name, arguments=args))
+
+
+def _submit(answer: str = 'done') -> ToolCall:
+    return ToolCall(id='submit', function=ToolFunction(name='submit', arguments={'answer': answer}))
+
+
+def _output(tool_calls: Optional[List[ToolCall]] = None, content: str = '') -> ModelOutput:
+    msg = ChatMessageAssistant(content=content, tool_calls=tool_calls)
+    return ModelOutput(model='mock', choices=[ChatCompletionChoice(message=msg, stop_reason='stop')])
+
+
+class TestValidateToolArguments(unittest.TestCase):
+    """The validator judges a call against exactly the schema the model was shown."""
+
+    def test_valid_arguments_pass(self):
+        self.assertIsNone(validate_tool_arguments(_call({'query': 'x', 'limit': 3}), LOOKUP))
+
+    def test_missing_required_property_is_reported(self):
+        self.assertEqual(validate_tool_arguments(_call({'limit': 3}), LOOKUP), "'query' is a required property")
+
+    def test_wrong_type_reports_the_property_path(self):
+        violation = validate_tool_arguments(_call({'query': 'x', 'limit': 'abc'}), LOOKUP)
+        self.assertEqual(violation, "'abc' is not of type 'integer' (at 'limit')")
+
+    def test_unexpected_property_is_rejected(self):
+        """``ToolParams`` advertises ``additionalProperties: false``, so an extra key breaks the contract too."""
+        violation = validate_tool_arguments(_call({'query': 'x', 'page': 2}), LOOKUP)
+        self.assertIn("'page' was unexpected", violation)
+
+    def test_uncompilable_schema_is_treated_as_unconstrained(self):
+        """A duplicated ``required`` entry violates the metaschema; the call must still go through."""
+        broken = ToolInfo(
+            name='broken',
+            description='d',
+            parameters=ToolParams(properties={'query': JSONSchema(type='string')}, required=['query', 'query']),
+        )
+        self.assertIsNone(validate_tool_arguments(_call({'anything': 1}, name='broken'), broken))
+
+
+class TestToolExecutorValidation(unittest.TestCase):
+    """A violating call is refused before the handler runs; everything else is unchanged."""
+
+    def setUp(self):
+        self.calls: List[Dict[str, Any]] = []
+
+        async def lookup(call: ToolCall, env: Any) -> str:
+            self.calls.append(call.function.arguments)
+            return 'found'
+
+        async def echo(call: ToolCall, env: Any) -> str:
+            self.calls.append(call.function.arguments)
+            return 'echo'
+
+        self.handlers = {'lookup': lookup, 'echo': echo}
+
+    def _executor(self) -> ToolExecutor:
+        return ToolExecutor(handlers=self.handlers, environment=None, tool_infos=[LOOKUP], validate_arguments=True)
+
+    def test_valid_call_is_dispatched(self):
+        observation, error, _ = asyncio.run(self._executor().execute(_call({'query': 'x'})))
+        self.assertIsNone(error)
+        self.assertEqual(observation, 'found')
+        self.assertEqual(self.calls, [{'query': 'x'}])
+
+    def test_violating_call_is_not_dispatched(self):
+        observation, error, _ = asyncio.run(self._executor().execute(_call({'limit': 3})))
+        self.assertIsInstance(error, ToolCallError)
+        self.assertEqual(error.type, 'parsing')
+        self.assertIn("Invalid arguments for tool 'lookup'", observation)
+        self.assertIn("'query' is a required property", observation)
+        self.assertEqual(self.calls, [])
+
+    def test_tool_without_schema_is_dispatched_unvalidated(self):
+        observation, error, _ = asyncio.run(self._executor().execute(_call({'whatever': 1}, name='echo')))
+        self.assertIsNone(error)
+        self.assertEqual(observation, 'echo')
+
+    def test_validation_is_off_by_default(self):
+        executor = ToolExecutor(handlers=self.handlers, environment=None, tool_infos=[LOOKUP])
+        _, error, _ = asyncio.run(executor.execute(_call({'limit': 3})))
+        self.assertIsNone(error)
+        self.assertEqual(self.calls, [{'limit': 3}])
+
+    def test_unknown_tool_still_reports_unknown(self):
+        _, error, _ = asyncio.run(self._executor().execute(_call({'query': 'x'}, name='missing')))
+        self.assertEqual(error.type, 'unknown')
+
+
+class TestLoopIntegration(unittest.TestCase):
+
+    def test_rejected_call_reaches_the_model_and_the_trace(self):
+        seen: List[Dict[str, Any]] = []
+
+        async def lookup(call: ToolCall, env: Any) -> str:
+            seen.append(call.function.arguments)
+            return 'found'
+
+        model = MagicMock()
+        model.generate_async = AsyncMock(
+            side_effect=[
+                _output([_call({'limit': 3}, call_id='bad')]),
+                _output([_call({'query': 'x'}, call_id='good')]),
+                _output([_submit('x')]),
+            ]
+        )
+        executor = ToolExecutor(
+            handlers={'lookup': lookup}, environment=None, tool_infos=[LOOKUP], validate_arguments=True
+        )
+        loop = AgentLoop(
+            model=model, strategy=get_strategy('function_calling')(), tool_executor=executor, max_steps=5
+        )
+        ctx = AgentContext(sample_id='s', messages=[ChatMessageUser(content='go')], tools=[LOOKUP])
+
+        result = asyncio.run(loop.run(ctx))
+
+        rejected = result.messages[2]
+        self.assertIsInstance(rejected, ChatMessageTool)
+        self.assertEqual(rejected.error.type, 'parsing')
+        self.assertIn("'query' is a required property", rejected.text)
+        # The handler only ever saw the corrected call.
+        self.assertEqual(seen, [{'query': 'x'}])
+        tool_results = [ev for ev in result.trace.events if ev.type == EventType.TOOL_RESULT]
+        self.assertEqual([ev.payload['error'] for ev in tool_results], ['parsing', None])
+        self.assertEqual(result.final_output.message.tool_calls[0].function.name, 'submit')
+
+
+class TestConfigPlumbing(unittest.TestCase):
+    """The flag travels from NativeAgentConfig to the executor on both entry points."""
+
+    def test_native_agent_config_defaults_to_off(self):
+        self.assertFalse(NativeAgentConfig().validate_tool_arguments)
+
+    def test_run_agent_loop_builds_a_validating_executor(self):
+        built: Dict[str, Any] = {}
+        real_executor = ToolExecutor
+
+        def recording_executor(*args: Any, **kwargs: Any) -> ToolExecutor:
+            built.update(kwargs)
+            return real_executor(*args, **kwargs)
+
+        model = MagicMock()
+        model.generate_async = AsyncMock(return_value=_output([_submit()]))
+        with patch('evalscope.api.agent.runner.ToolExecutor', side_effect=recording_executor):
+            run_agent_loop(
+                model=model,
+                strategy=get_strategy('function_calling')(),
+                handlers={},
+                environment=None,
+                initial_messages=[ChatMessageUser(content='go')],
+                all_tools=[LOOKUP],
+                max_steps=2,
+                sample_id='s',
+                trace_strategy_name='function_calling',
+                trace_env_name=None,
+                validate_tool_arguments=True,
+            )
+        self.assertTrue(built['validate_arguments'])
+        self.assertEqual([tool.name for tool in built['tool_infos']], ['lookup'])
+
+    def test_run_native_agent_forwards_the_flag(self):
+        seen: Dict[str, Any] = {}
+
+        def fake_run_agent_loop(**kwargs: Any) -> AgentLoopResult:
+            seen.update(kwargs)
+            return AgentLoopResult(
+                messages=[ChatMessageAssistant(content='raw')],
+                final_output=_output(content='raw'),
+                trace=AgentTrace(strategy='fake', max_steps=1),
+            )
+
+        class FakeStrategy:
+
+            def __init__(self, **_: Any) -> None:
+                pass
+
+        with (
+            patch('evalscope.agent.runner.get_strategy', lambda name: FakeStrategy),
+            patch('evalscope.agent.runner.resolve_tools', lambda tools: {}),
+            patch('evalscope.agent.runner.resolve_tool_infos', lambda tools: []),
+            patch('evalscope.agent.runner.run_agent_loop', fake_run_agent_loop),
+        ):
+            run_native_agent(
+                task_config=TaskConfig(
+                    datasets=['demo'],
+                    agent_config=NativeAgentConfig(strategy='fake', max_steps=1, validate_tool_arguments=True),
+                ),
+                model=object(),
+                sample=Sample(id=1, input='do work', target='', metadata={}),
+                build_sandbox_config=lambda _: None,
+                extract_final_answer=lambda loop_result, strategy: 'final',
+            )
+        self.assertTrue(seen['validate_tool_arguments'])
+
+    def test_agent_loop_adapter_forwards_the_flag(self):
+        adapter = AgentLoopAdapter.__new__(AgentLoopAdapter)
+        adapter._task_config = TaskConfig(model='dummy', agent_config=NativeAgentConfig(validate_tool_arguments=True))
+        adapter.max_steps = 30
+        loop_result = AgentLoopResult(
+            messages=[],
+            final_output=_output(content='answer'),
+            trace=AgentTrace(strategy='function_calling', max_steps=30),
+        )
+        with patch('evalscope.api.agent.run_agent_loop', return_value=loop_result) as run_loop:
+            adapter._on_inference(MagicMock(), Sample(input='hi'))
+        self.assertTrue(run_loop.call_args.kwargs['validate_tool_arguments'])
+
+    def test_agent_loop_adapter_defaults_to_off_without_native_config(self):
+        adapter = AgentLoopAdapter.__new__(AgentLoopAdapter)
+        adapter._task_config = TaskConfig(model='dummy')
+        adapter.max_steps = 30
+        loop_result = AgentLoopResult(
+            messages=[],
+            final_output=_output(content='answer'),
+            trace=AgentTrace(strategy='function_calling', max_steps=30),
+        )
+        with patch('evalscope.api.agent.run_agent_loop', return_value=loop_result) as run_loop:
+            adapter._on_inference(MagicMock(), Sample(input='hi'))
+        self.assertFalse(run_loop.call_args.kwargs['validate_tool_arguments'])

--- a/tests/agent/test_tool_argument_validation.py
+++ b/tests/agent/test_tool_argument_validation.py
@@ -173,31 +173,34 @@ class TestLoopIntegration(unittest.TestCase):
             ({'answer': 1}, "1 is not of type 'string' (at 'answer')"),
             ({'answer': 'done', 'extra': True}, "'extra' was unexpected"),
         ]
-        for arguments, expected_error in cases:
-            with self.subTest(arguments=arguments):
-                model = MagicMock()
-                model.generate_async = AsyncMock(side_effect=[_output([_submit_with(arguments)]), _output([_submit('done')])])
-                result = run_agent_loop(
-                    model=model,
-                    strategy=get_strategy('function_calling')(),
-                    handlers={},
-                    environment=None,
-                    initial_messages=[ChatMessageUser(content='go')],
-                    all_tools=[],
-                    max_steps=3,
-                    sample_id='s',
-                    trace_strategy_name='function_calling',
-                    trace_env_name=None,
-                    validate_tool_arguments=True,
-                )
+        for strategy_name in ('function_calling', 'react'):
+            for arguments, expected_error in cases:
+                with self.subTest(strategy=strategy_name, arguments=arguments):
+                    model = MagicMock()
+                    model.generate_async = AsyncMock(
+                        side_effect=[_output([_submit_with(arguments)]), _output([_submit('done')])]
+                    )
+                    result = run_agent_loop(
+                        model=model,
+                        strategy=get_strategy(strategy_name)(),
+                        handlers={},
+                        environment=None,
+                        initial_messages=[ChatMessageUser(content='go')],
+                        all_tools=[],
+                        max_steps=3,
+                        sample_id='s',
+                        trace_strategy_name=strategy_name,
+                        trace_env_name=None,
+                        validate_tool_arguments=True,
+                    )
 
-                tool_message = result.messages[2]
-                self.assertIsInstance(tool_message, ChatMessageTool)
-                self.assertEqual(tool_message.error.type, 'parsing')
-                self.assertIn(expected_error, tool_message.text)
-                tool_results = [event for event in result.trace.events if event.type == EventType.TOOL_RESULT]
-                self.assertEqual([event.payload['error'] for event in tool_results], ['parsing'])
-                self.assertEqual(result.final_output.message.tool_calls[0].function.arguments, {'answer': 'done'})
+                    tool_message = next(message for message in result.messages if isinstance(message, ChatMessageTool))
+                    self.assertIsInstance(tool_message, ChatMessageTool)
+                    self.assertEqual(tool_message.error.type, 'parsing')
+                    self.assertIn(expected_error, tool_message.text)
+                    tool_results = [event for event in result.trace.events if event.type == EventType.TOOL_RESULT]
+                    self.assertEqual([event.payload['error'] for event in tool_results], ['parsing'])
+                    self.assertEqual(result.final_output.message.tool_calls[0].function.arguments, {'answer': 'done'})
 
 
 class TestConfigPlumbing(unittest.TestCase):

--- a/tests/agent/test_tool_argument_validation.py
+++ b/tests/agent/test_tool_argument_validation.py
@@ -44,6 +44,10 @@ def _submit(answer: str = 'done') -> ToolCall:
     return ToolCall(id='submit', function=ToolFunction(name='submit', arguments={'answer': answer}))
 
 
+def _submit_with(args: Dict[str, Any]) -> ToolCall:
+    return ToolCall(id='submit', function=ToolFunction(name='submit', arguments=args))
+
+
 def _output(tool_calls: Optional[List[ToolCall]] = None, content: str = '') -> ModelOutput:
     msg = ChatMessageAssistant(content=content, tool_calls=tool_calls)
     return ModelOutput(model='mock', choices=[ChatCompletionChoice(message=msg, stop_reason='stop')])
@@ -163,6 +167,38 @@ class TestLoopIntegration(unittest.TestCase):
         self.assertEqual([ev.payload['error'] for ev in tool_results], ['parsing', None])
         self.assertEqual(result.final_output.message.tool_calls[0].function.name, 'submit')
 
+    def test_invalid_submit_is_rejected_before_termination(self):
+        cases = [
+            ({}, "'answer' is a required property"),
+            ({'answer': 1}, "1 is not of type 'string' (at 'answer')"),
+            ({'answer': 'done', 'extra': True}, "'extra' was unexpected"),
+        ]
+        for arguments, expected_error in cases:
+            with self.subTest(arguments=arguments):
+                model = MagicMock()
+                model.generate_async = AsyncMock(side_effect=[_output([_submit_with(arguments)]), _output([_submit('done')])])
+                result = run_agent_loop(
+                    model=model,
+                    strategy=get_strategy('function_calling')(),
+                    handlers={},
+                    environment=None,
+                    initial_messages=[ChatMessageUser(content='go')],
+                    all_tools=[],
+                    max_steps=3,
+                    sample_id='s',
+                    trace_strategy_name='function_calling',
+                    trace_env_name=None,
+                    validate_tool_arguments=True,
+                )
+
+                tool_message = result.messages[2]
+                self.assertIsInstance(tool_message, ChatMessageTool)
+                self.assertEqual(tool_message.error.type, 'parsing')
+                self.assertIn(expected_error, tool_message.text)
+                tool_results = [event for event in result.trace.events if event.type == EventType.TOOL_RESULT]
+                self.assertEqual([event.payload['error'] for event in tool_results], ['parsing'])
+                self.assertEqual(result.final_output.message.tool_calls[0].function.arguments, {'answer': 'done'})
+
 
 class TestConfigPlumbing(unittest.TestCase):
     """The flag travels from NativeAgentConfig to the executor on both entry points."""
@@ -195,7 +231,7 @@ class TestConfigPlumbing(unittest.TestCase):
                 validate_tool_arguments=True,
             )
         self.assertTrue(built['validate_arguments'])
-        self.assertEqual([tool.name for tool in built['tool_infos']], ['lookup'])
+        self.assertEqual([tool.name for tool in built['tool_infos']], ['lookup', 'submit'])
 
     def test_run_native_agent_forwards_the_flag(self):
         seen: Dict[str, Any] = {}


### PR DESCRIPTION
## Problem

`ToolExecutor` dispatches every call straight to its handler. Nothing checks `call.function.arguments` against the `ToolInfo.parameters` the model was shown, so a call with a missing required field or a wrong type is only noticed if the handler happens to crash on it.

That leaves two states indistinguishable in the results: *the model picked the right tool but wrote malformed arguments*, and *the tool itself failed*. For a run whose purpose is to measure tool use, the first one is the interesting signal and it is currently invisible.

The schemas are already in hand — `AgentContext.tools` carries them and the loop passes them to `model.generate`. The only place that validates against them today is the single-turn `FunctionCallAdapter` (`general_fc`, `k2_verifier`, …); the multi-turn loop never does.

```
$ grep -rn "jsonschema" evalscope/api/agent/ evalscope/agent/
(nothing)
```

## Change

`NativeAgentConfig.validate_tool_arguments`, **default `False`**. When enabled, `ToolExecutor` checks each call before dispatching it and refuses the ones that violate their schema.

- **`api/tool/utils.py`** — `validate_tool_arguments(call, tool)` validates with `jsonschema` against `tool.parameters.model_dump(exclude_none=True)`, i.e. exactly the schema the model was given, and returns the first violation as text with its property path (`"'abc' is not of type 'integer' (at 'limit')"`). A schema `jsonschema` cannot compile is treated as unconstrained, so a broken declaration never blocks a well-formed call.
- **`api/agent/tool_executor.py`** — `ToolExecutor(tool_infos=..., validate_arguments=...)`. A violating call is not executed; it returns a `ToolCallError(type='parsing')` through the same path an unregistered tool already takes. The model receives the violation as its observation and can correct itself on the next turn; the `TOOL_RESULT` trace event carries `error='parsing'`.
- The flag is threaded through `run_agent_loop`, `run_native_agent` and `AgentLoopAdapter._on_inference`. MCP tools are covered for free because `run_agent_loop` hands the merged `ToolInfo` list to the executor.
- One row added to the `NativeAgentConfig` table in `docs/{en,zh}/user_guides/agent/native.md`.

Nothing changes unless the flag is set, so existing benchmark scores are unaffected.

## Judgement calls, happy to change any of them

- **Executor rather than strategy.** The executor is already the place that refuses an unregistered tool without executing it, and putting the check there covers every strategy and MCP tools in one spot instead of once per strategy. The cost is threading one boolean through three call sites.
- **Reuses `ToolCallError(type='parsing')`** rather than adding an enum member, so no public contract changes and existing consumers of `TOOL_RESULT.payload.error` keep working.
- **Extra properties are rejected too.** `ToolParams` advertises `additionalProperties: false`, so an unexpected key is a violation of the contract the model was shown. Say the word if you would rather only enforce `required` + types.
- **Bridge mode is out of scope.** There the CLI executes its own tools and EvalScope only observes, so the same flag cannot refuse a call; annotating bridge `TOOL_CALL` events with a validation result would be a separate, observation-only change.

## Testing

```
tests/agent/test_tool_argument_validation.py   16 passed
  - validator: valid / missing required / wrong type / unexpected key / uncompilable schema
  - executor:  refuses without dispatching, passes valid calls through, leaves
               schemaless tools alone, off by default, unknown tool still 'unknown'
  - loop:      model gets the violation, corrects itself, handler only ever sees the
               corrected call, trace shows error=['parsing', None]
  - plumbing:  flag reaches the executor from run_agent_loop / run_native_agent /
               AgentLoopAdapter, and defaults to off without a NativeAgentConfig

tests/agent                                    336 passed, 21 skipped, same 7 pre-existing
                                               failures (test_sandbox_service,
                                               test_strategy_parsers: optional deps)
tests/cli/test_all.py::TestRun::test_ci_lite   passed (mock_llm, 6m39s)
ruff 0.16.4 check + format --diff              clean
```

Sanity-checked against the built-in tools with the flag on: `bash {'command': 'ls'}` and `{'command': 'ls', 'timeout': 30}` pass, `{'timeout': '30'}` and `{}` are refused with the messages above.

## Note on CI

`main` is import-broken at `c31f0f9` (#1702 imports `evalscope.metrics.semantics.identity`, which #1705 moved to `naming.py`), so `unit-tests` fails here for a reason unrelated to this PR. #1711 fixes that one line; I ran the suites above with it applied locally.
