### PR TITLE
fix(longbench-v2): reject unsupported few-shot config

### DIFF
--- a/evalscope/benchmarks/longbench_v2/longbench_v2_adapter.py
+++ b/evalscope/benchmarks/longbench_v2/longbench_v2_adapter.py
@@ -72,6 +72,10 @@ LongBench v2 is a challenging benchmark for evaluating long-context understandin
 class LongBenchV2Adapter(MultiChoiceAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        if self.few_shot_num != 0:
+            raise ValueError(
+                f'LongBench-v2 received few_shot_num={self.few_shot_num}, but only supports 0-shot evaluation.'
+            )
         self.reformat_subset = True  # Split samples by 'length' field into short/medium/long subsets
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:

--- a/tests/benchmark/test_longbench_v2_adapter.py
+++ b/tests/benchmark/test_longbench_v2_adapter.py
@@ -1,0 +1,40 @@
+import pytest
+
+from evalscope.api.dataset import Sample
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.longbench_v2.longbench_v2_adapter import LongBenchV2Adapter
+from evalscope.config import TaskConfig
+
+
+def make_adapter(few_shot_num: int) -> LongBenchV2Adapter:
+    adapter = get_benchmark(
+        'longbench_v2',
+        TaskConfig(
+            datasets=['longbench_v2'],
+            dataset_args={'longbench_v2': {'few_shot_num': few_shot_num}},
+        ),
+    )
+    assert isinstance(adapter, LongBenchV2Adapter)
+    return adapter
+
+
+def test_rejects_few_shot_without_training_examples() -> None:
+    with pytest.raises(ValueError, match=r'LongBench-v2.*few_shot_num=1.*0-shot'):
+        make_adapter(few_shot_num=1)
+
+
+def test_zero_shot_prompt_keeps_document_question_and_choices() -> None:
+    adapter = make_adapter(few_shot_num=0)
+    sample = Sample(
+        input='Which option is correct?',
+        choices=['First', 'Second', 'Third', 'Fourth'],
+        target='B',
+        metadata={'context': 'Relevant document context.'},
+    )
+
+    prompt = adapter.format_prompt_template(sample)
+
+    assert '<text>\nRelevant document context.\n</text>' in prompt
+    assert 'Which option is correct?' in prompt
+    assert 'A) First\nB) Second\nC) Third\nD) Fourth' in prompt
+    assert "'ANSWER: [LETTER]'" in prompt


### PR DESCRIPTION
## Summary

- reject unsupported non-zero `few_shot_num` values for LongBench-v2 during adapter construction
- preserve the benchmark's documented 0-shot prompt behavior
- add regression coverage through the public `dataset_args -> get_benchmark()` configuration path

## Root cause

LongBench-v2 has no training split and only defines a 0-shot prompt. When `few_shot_num` was overridden to a non-zero value, the generic loader correctly skipped loading a few-shot dataset, but prompt processing still entered `MultiChoiceAdapter.format_fewshot_template()` with an empty `fewshot` value. The helper then omitted the `fewshot` formatting argument while using a template that required it, resulting in the reported `KeyError: 'fewshot'`.

The validation is intentionally local to LongBench-v2. Other benchmarks such as DROP and BBH legitimately use built-in few-shot examples while declaring no training split, so a global `train_split is None` check would be incompatible.

## Validation

- RED: regression test failed with `DID NOT RAISE ValueError` before the fix
- `pytest tests/benchmark/test_longbench_v2_adapter.py tests/api/test_default_data_adapter.py -v` — 11 passed
- `pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings` — 1 passed
- `make lint` — passed all pre-commit hooks
- `git diff --check` — passed

## Upstream note

Current `main` has an unrelated missing import target in `llm_judge_mixin.py`, already fixed by #1711 with green CI. For local pytest execution, that exact one-line import correction was applied temporarily and restored after each run. This PR does not include or modify the #1711 fix.

Closes #1707
