### PR TITLE
fix(benchmark): validate few-shot capabilities

### DIFF
--- a/evalscope/api/benchmark/adapters/default_data_adapter.py
+++ b/evalscope/api/benchmark/adapters/default_data_adapter.py
@@ -122,8 +122,8 @@ class DefaultDataAdapter(DataAdapter):
             return self.load_from_remote()
 
     def _should_load_fewshot(self) -> bool:
-        """Check if few-shot dataset should be loaded."""
-        return self.few_shot_num > 0 and self.train_split is not None
+        """Check whether auto few-shot examples should be loaded from a split."""
+        return self.few_shot_mode == 'auto' and self.few_shot_num > 0
 
     def _post_process_samples(self):
         """Process all sample inputs with prompt formatting."""

--- a/evalscope/api/benchmark/benchmark.py
+++ b/evalscope/api/benchmark/benchmark.py
@@ -64,6 +64,21 @@ class DataAdapter(LLMJudgeMixin, ABC):
         # filters
         self._filter_ensemble: Optional[OrderedDict] = None
 
+        self._validate_few_shot_config()
+
+    def _validate_few_shot_config(self) -> None:
+        """Reject unsupported few-shot requests before any dataset I/O."""
+        if self.few_shot_num == 0:
+            return
+        if self.few_shot_mode == 'disabled' or (self.few_shot_mode == 'auto' and self.train_split is None):
+            raise ValueError(f'Benchmark {self.name!r} does not support few-shot evaluation; set few_shot_num=0.')
+        allowed_counts = self.allowed_few_shot_nums
+        if allowed_counts is not None and self.few_shot_num not in allowed_counts:
+            allowed = ', '.join(str(count) for count in allowed_counts)
+            raise ValueError(
+                f'Benchmark {self.name!r} supports few_shot_num values: {allowed}; got {self.few_shot_num}.'
+            )
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert the benchmark metadata to a dictionary."""
         return self._benchmark_meta.to_string_dict()
@@ -226,6 +241,16 @@ class DataAdapter(LLMJudgeMixin, ABC):
         Set the few shot number of the benchmark.
         """
         self._benchmark_meta.few_shot_num = value
+
+    @property
+    def few_shot_mode(self) -> str:
+        """Return the benchmark's few-shot capability mode."""
+        return self._benchmark_meta.few_shot_mode
+
+    @property
+    def allowed_few_shot_nums(self) -> Optional[tuple[int, ...]]:
+        """Return the explicitly allowed few-shot counts, if bounded."""
+        return self._benchmark_meta.allowed_few_shot_nums
 
     @property
     def few_shot_random(self) -> bool:

--- a/evalscope/api/benchmark/meta.py
+++ b/evalscope/api/benchmark/meta.py
@@ -1,7 +1,7 @@
 import copy
 from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel
 
@@ -41,6 +41,12 @@ class BenchmarkMeta:
 
     few_shot_num: int = 0
     """ Number of few-shot examples to use."""
+
+    few_shot_mode: Literal['auto', 'disabled', 'fixed'] = 'auto'
+    """Supported few-shot strategy for this benchmark."""
+
+    allowed_few_shot_nums: Optional[Tuple[int, ...]] = None
+    """Allowed few-shot counts, or ``None`` when every non-negative count is valid."""
 
     few_shot_random: bool = False
     """ Whether to use random few-shot examples."""
@@ -149,11 +155,33 @@ class BenchmarkMeta:
         from evalscope.evaluation_versioning import validate_evaluation_version
 
         validate_evaluation_version(self.evaluation_version)
-        if self.few_shot_num < 0:
-            raise ValueError('few_shot_num must be >= 0')
+        self._validate_few_shot_metadata()
         self._normalize_metric_list()
         self._normalize_primary_metric()
         self._validate_primary_metric()
+
+    def _validate_few_shot_metadata(self) -> None:
+        """Validate benchmark-declared few-shot capabilities."""
+        if self.few_shot_num < 0:
+            raise ValueError('few_shot_num must be >= 0')
+        if self.few_shot_mode not in {'auto', 'disabled', 'fixed'}:
+            raise ValueError(f'Unsupported few_shot_mode: {self.few_shot_mode}')
+        if self.few_shot_mode == 'disabled':
+            if self.allowed_few_shot_nums is not None:
+                raise ValueError('allowed_few_shot_nums requires few_shot_mode to be auto or fixed')
+            return
+        if self.few_shot_mode == 'fixed' and not self.allowed_few_shot_nums:
+            raise ValueError('fixed few_shot_mode requires allowed_few_shot_nums')
+        if self.allowed_few_shot_nums is not None:
+            if not self.allowed_few_shot_nums:
+                raise ValueError('allowed_few_shot_nums must not be empty')
+            if any(
+                not isinstance(count, int) or isinstance(count, bool) or count < 0
+                for count in self.allowed_few_shot_nums
+            ):
+                raise ValueError('allowed_few_shot_nums must contain non-negative integers')
+            if 0 not in self.allowed_few_shot_nums:
+                raise ValueError('allowed_few_shot_nums must include 0')
 
     def _normalize_metric_list(self) -> None:
         """Normalize unambiguous legacy scorer aliases at the adapter boundary.
@@ -294,10 +322,11 @@ class BenchmarkMeta:
         """Update instance with provided arguments, maintaining backward compatibility."""
         args = copy.deepcopy(args)
 
-        if 'evaluation_version' in args:
-            raise ValueError(
-                'evaluation_version must be declared by BenchmarkMeta, not overridden through dataset_args.'
-            )
+        protected_fields = {'evaluation_version', 'few_shot_mode', 'allowed_few_shot_nums'}
+        overridden_fields = protected_fields & args.keys()
+        if overridden_fields:
+            fields = ', '.join(sorted(overridden_fields))
+            raise ValueError(f'{fields} must be declared by BenchmarkMeta, not overridden through dataset_args.')
 
         if args.get('local_path'):
             self.dataset_id = args['local_path']
@@ -314,10 +343,9 @@ class BenchmarkMeta:
         # Update fields with validation
         for key, value in args.items():
             if hasattr(self, key):
-                setattr(self, key, value)  # Validate few_shot_num if it's being updated
-                if key == 'few_shot_num' and value < 0:
-                    raise ValueError('few_shot_num must be >= 0')
+                setattr(self, key, value)
 
+        self._validate_few_shot_metadata()
         self._normalize_metric_list()
         self._normalize_primary_metric()
         self._validate_primary_metric()

--- a/evalscope/benchmarks/agieval/agieval_adapter.py
+++ b/evalscope/benchmarks/agieval/agieval_adapter.py
@@ -63,6 +63,7 @@ MATH_PROMPT_TEMPLATE = '{question}\nPlease reason step by step, and put your fin
         subset_list=ALL_SUBSETS,
         metric_list=['acc'],
         few_shot_num=0,
+        few_shot_mode='disabled',
         train_split='dev',
         eval_split='test',
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,

--- a/evalscope/benchmarks/bbh/bbh_adapter.py
+++ b/evalscope/benchmarks/bbh/bbh_adapter.py
@@ -8,11 +8,8 @@ from evalscope.api.dataset import Sample
 from evalscope.api.evaluator import TaskState
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
 
 from .cot_prompts import COT_PROMPTS
-
-logger = get_logger()
 
 # BBH multiple choice subset list
 MULTIPLE_CHOICE = 'multiple_choice'
@@ -105,6 +102,8 @@ BBH (BIG-Bench Hard) is a subset of 23 challenging tasks from the BIG-Bench benc
 """,
         subset_list=SUBSET_LIST,
         few_shot_num=3,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 3),
         train_split=None,
         eval_split='test',
         metric_list=['acc'],
@@ -118,14 +117,6 @@ class BBHAdapter(DefaultDataAdapter):
     """
 
     def __init__(self, **kwargs):
-        few_shot_num = kwargs.get('few_shot_num', 3)
-
-        if few_shot_num != 3 and few_shot_num != 0:
-            logger.error(
-                f'BBH uses 3-shot examples with CoT or 0-shot by system, but got {few_shot_num}. Use 3-shot by default.'
-            )
-            kwargs['few_shot_num'] = 3
-
         super().__init__(**kwargs)
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:

--- a/evalscope/benchmarks/coin_flip/coin_flip_adapter.py
+++ b/evalscope/benchmarks/coin_flip/coin_flip_adapter.py
@@ -72,6 +72,7 @@ Here are some examples of how to solve similar problems:
         metric_list=['accuracy', 'precision', 'recall', 'f1_score', 'yes_ratio'],
         primary_metric='accuracy',
         few_shot_num=0,
+        few_shot_mode='disabled',
         train_split='validation',
         eval_split='test',
         prompt_template=PROMPT_TEMPLATE,

--- a/evalscope/benchmarks/drivelology/drivelology_binary_adapter.py
+++ b/evalscope/benchmarks/drivelology/drivelology_binary_adapter.py
@@ -8,7 +8,6 @@ from evalscope.api.messages import ChatMessageUser, Content, ContentText
 from evalscope.api.metric.scorer import AggScore, SampleScore, Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
 
 DESCRIPTION = """
 ## Overview
@@ -95,8 +94,6 @@ Here are some examples of how to solve similar problems:
 #Your Answer#:
 """.strip()  # noqa: E501
 
-logger = get_logger()
-
 
 @register_benchmark(
     BenchmarkMeta(
@@ -110,6 +107,8 @@ logger = get_logger()
         primary_metric='accuracy',
         aggregation='f1',
         few_shot_num=0,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 4),
         eval_split='test',
         prompt_template='{question}',
         few_shot_prompt_template='{question}',
@@ -119,9 +118,6 @@ class DrivelologyBinaryClassificationAdapter(DefaultDataAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.add_overall_metric = False
-        if self.few_shot_num not in [0, 4]:
-            logger.warning('For DrivelologyBinaryClassification, use 4-shot by default.')
-            self.few_shot_num = 4
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
         if self.few_shot_num > 0:

--- a/evalscope/benchmarks/drop/drop_adapter.py
+++ b/evalscope/benchmarks/drop/drop_adapter.py
@@ -8,9 +8,6 @@ from evalscope.api.evaluator import TaskState
 from evalscope.api.metric import Score
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
-
-logger = get_logger()
 
 DROP_EXAMPLES = """Some examples of passages and Q&A are provided below.
 
@@ -70,6 +67,8 @@ DROP (Discrete Reasoning Over Paragraphs) is a challenging reading comprehension
         metric_list=['em', 'f1'],
         primary_metric='f1',
         few_shot_num=3,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 3),
         train_split=None,
         eval_split='validation',
         prompt_template='You will be asked to read a passage and answer a question. {drop_examples}\n# Your Task\n\n---\n{query}\n\nThink step by step, then write a line of the form "Answer: [ANSWER]" at the end of your response.',  # noqa: E501
@@ -78,10 +77,6 @@ DROP (Discrete Reasoning Over Paragraphs) is a challenging reading comprehension
 class DROPAdapter(DefaultDataAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.few_shot_num != 0 and self.few_shot_num != 3:
-            self.few_shot_num = 3
-            logger.info(f'Few shot num is set to {self.few_shot_num} for DROP dataset by system.')
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
         """

--- a/evalscope/benchmarks/general_vmcq/general_vmcq_adapter.py
+++ b/evalscope/benchmarks/general_vmcq/general_vmcq_adapter.py
@@ -53,6 +53,7 @@ It uses MMMU-style format with image/video/audio placeholders in text, supportin
         subset_list=['default'],
         metric_list=['acc'],
         few_shot_num=0,
+        few_shot_mode='disabled',
         train_split='dev',
         eval_split='val',
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,

--- a/evalscope/benchmarks/gpqa/gpqa_adapter.py
+++ b/evalscope/benchmarks/gpqa/gpqa_adapter.py
@@ -9,10 +9,7 @@ from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter
 from evalscope.api.dataset import Sample
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import FEW_SHOT_TEMPLATE, MultipleChoiceTemplate
-
-logger = get_logger()
 
 
 @register_benchmark(
@@ -51,6 +48,8 @@ GPQA (Graduate-Level Google-Proof Q&A) Diamond is a challenging benchmark of 198
         dataset_id='AI-ModelScope/gpqa_diamond',
         metric_list=['acc'],
         few_shot_num=0,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 5),
         train_split=None,
         eval_split='train',  # only have train split
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
@@ -59,12 +58,6 @@ GPQA (Graduate-Level Google-Proof Q&A) Diamond is a challenging benchmark of 198
 class GPQAAdapter(MultiChoiceAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.few_shot_num > 0 and self.few_shot_num != 5:
-            logger.warning(
-                f'Only support few_shot_num 0 or 5 for {self.dataset_id}, but got {self.few_shot_num}. Use 5-shot by default.'  # noqa: E501
-            )
-            self.few_shot_num = 5
 
     def record_to_sample(self, record: Dict[str, Any]) -> Sample:
         # Process the input to create shuffled choices and correct answer

--- a/evalscope/benchmarks/mbpp/mbpp_adapter.py
+++ b/evalscope/benchmarks/mbpp/mbpp_adapter.py
@@ -92,6 +92,8 @@ MBPP (Mostly Basic Python Problems) is a benchmark consisting of approximately 1
         train_split='prompt',
         eval_split='test',
         few_shot_num=3,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 3),
         prompt_template=PROMPT,
         few_shot_prompt_template=FEWSHOT_PROMPT,
         review_timeout=20,

--- a/evalscope/benchmarks/race/race_adapter.py
+++ b/evalscope/benchmarks/race/race_adapter.py
@@ -4,12 +4,9 @@ from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter
 from evalscope.api.dataset import Sample
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import MultipleChoiceTemplate
 
 # flake8: noqa
-
-logger = get_logger()
 
 
 @register_benchmark(
@@ -49,6 +46,7 @@ RACE (ReAding Comprehension from Examinations) is a large-scale reading comprehe
         metric_list=['acc'],
         subset_list=['high', 'middle'],
         few_shot_num=3,
+        allowed_few_shot_nums=(0, 1, 2, 3),
         train_split='train',
         eval_split='test',
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
@@ -57,10 +55,6 @@ RACE (ReAding Comprehension from Examinations) is a large-scale reading comprehe
 class RACEAdapter(MultiChoiceAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.few_shot_num > 3:
-            logger.warning(f'few_shot_num <= 3 for RACE, but got {self.few_shot_num}. Use 3-shot by default.')
-            self.few_shot_num = 3
 
     def record_to_sample(self, record) -> Sample:
         # Format the article and question as context

--- a/evalscope/benchmarks/super_gpqa/super_gpqa_adapter.py
+++ b/evalscope/benchmarks/super_gpqa/super_gpqa_adapter.py
@@ -7,10 +7,7 @@ from evalscope.api.benchmark import BenchmarkMeta, MultiChoiceAdapter
 from evalscope.api.dataset import Sample
 from evalscope.api.registry import register_benchmark
 from evalscope.constants import Tags
-from evalscope.utils.logger import get_logger
 from evalscope.utils.multi_choices import FEW_SHOT_TEMPLATE, MultipleChoiceTemplate
-
-logger = get_logger()
 
 SUBSET_MAPPING = {
     'Electronic Science and Technology': ['Engineering'],
@@ -128,6 +125,8 @@ SuperGPQA is a large-scale multiple-choice question answering dataset designed t
         subset_list=list(SUBSET_MAPPING.keys()),
         metric_list=['acc'],
         few_shot_num=0,
+        few_shot_mode='fixed',
+        allowed_few_shot_nums=(0, 5),
         train_split=None,
         eval_split='train',  # only have train split
         prompt_template=MultipleChoiceTemplate.SINGLE_ANSWER_COT,
@@ -137,12 +136,6 @@ class SuperGPQAAdapter(MultiChoiceAdapter):
     def __init__(self, **kwargs):
 
         super().__init__(**kwargs)
-        if self.few_shot_num > 0 and self.few_shot_num != 5:
-            logger.warning(
-                f'Only support few_shot_num 0 or 5 for SuperGPQA, but got {self.few_shot_num}. Use 5-shot by default.'
-            )
-            self.few_shot_num = 5
-
         self.reformat_subset = True
         self.category_map = SUBSET_MAPPING
 

--- a/evalscope/benchmarks/zerobench/zerobench_adapter.py
+++ b/evalscope/benchmarks/zerobench/zerobench_adapter.py
@@ -57,6 +57,7 @@ ZeroBench is a challenging visual reasoning benchmark for Large Multimodal Model
         subset_list=SUBSET_LIST,
         metric_list=['acc'],
         eval_split='zerobench',
+        few_shot_mode='disabled',
         train_split='zerobench_subquestions',
         prompt_template=PROMPT_TEMPLATE,
     )

--- a/tests/api/test_benchmark_meta.py
+++ b/tests/api/test_benchmark_meta.py
@@ -6,6 +6,8 @@ import pytest
 
 from evalscope.api.benchmark import BenchmarkMeta
 from evalscope.api.metric.semantics import MetricSelector
+from evalscope.api.registry import get_benchmark
+from evalscope.config import TaskConfig
 from evalscope.utils.doc_utils.generate_dataset_md import extract_benchmark_meta
 
 
@@ -55,6 +57,64 @@ def test_runtime_metric_list_update_revalidates_primary_metric() -> None:
         meta._update({'metric_list': ['f1_score']})
 
 
+def test_few_shot_metadata_accepts_auto_without_a_train_split() -> None:
+    meta = BenchmarkMeta(name='auto_without_train_split', dataset_id='local', few_shot_num=1)
+
+    assert meta.few_shot_mode == 'auto'
+
+    with pytest.raises(ValueError, match='fixed few_shot_mode requires allowed_few_shot_nums'):
+        BenchmarkMeta(name='invalid_fixed', dataset_id='local', few_shot_mode='fixed')
+
+
+def test_few_shot_capabilities_cannot_be_overridden_at_runtime() -> None:
+    meta = BenchmarkMeta(name='protected_few_shot_mode', dataset_id='local')
+
+    with pytest.raises(ValueError, match='few_shot_mode'):
+        meta._update({'few_shot_mode': 'disabled'})
+
+
+@pytest.mark.parametrize('benchmark_name', ['longbench_v2', 'agieval', 'coin_flip', 'general_vmcq', 'zerobench'])
+def test_unsupported_benchmarks_reject_few_shot_before_loading_datasets(benchmark_name: str) -> None:
+    with pytest.raises(ValueError, match=f'Benchmark {benchmark_name!r} does not support few-shot'):
+        get_benchmark(
+            benchmark_name,
+            TaskConfig(
+                model='mock',
+                datasets=[benchmark_name],
+                dataset_args={benchmark_name: {'few_shot_num': 1}},
+            ),
+        )
+
+
+def test_benchmark_few_shot_modes_validate_before_loading_datasets() -> None:
+
+    fixed_adapter = get_benchmark(
+        'gpqa_diamond',
+        TaskConfig(model='mock', datasets=['gpqa_diamond'], dataset_args={'gpqa_diamond': {'few_shot_num': 5}}),
+    )
+    assert fixed_adapter.few_shot_mode == 'fixed'
+    assert not fixed_adapter._should_load_fewshot()
+
+    auto_adapter = get_benchmark(
+        'mmlu',
+        TaskConfig(model='mock', datasets=['mmlu'], dataset_args={'mmlu': {'few_shot_num': 2}}),
+    )
+    assert auto_adapter.few_shot_mode == 'auto'
+    assert auto_adapter._should_load_fewshot()
+
+    with pytest.raises(ValueError, match='supports few_shot_num values: 0, 5; got 2'):
+        get_benchmark(
+            'gpqa_diamond',
+            TaskConfig(model='mock', datasets=['gpqa_diamond'], dataset_args={'gpqa_diamond': {'few_shot_num': 2}}),
+        )
+
+    with pytest.raises(ValueError, match='supports few_shot_num values: 0, 1, 2, 3; got 4'):
+        get_benchmark(
+            'race',
+            TaskConfig(model='mock', datasets=['race'], dataset_args={'race': {'few_shot_num': 4}}),
+        )
+
+
 def test_doc_metadata_extraction_does_not_instantiate_adapter() -> None:
 
     class RuntimeOnlyAdapter:
@@ -72,6 +132,8 @@ def test_doc_metadata_extraction_does_not_instantiate_adapter() -> None:
     extracted = extract_benchmark_meta(meta, RuntimeOnlyAdapter)
 
     assert extracted['metrics'] == ['accuracy']
+    assert 'few_shot_mode' not in extracted
+    assert 'allowed_few_shot_nums' not in extracted
     assert 'primary_metric' not in extracted
     assert extracted['category'] == 'llm'
 


### PR DESCRIPTION
## Summary
- add auto, fixed, and disabled few-shot capability handling
- reject unsupported configurations before dataset I/O
- preserve fixed official demonstrations and dynamic train-split examples

## Validation
- `pytest tests/api/test_benchmark_meta.py -q`
- `make lint`

Closes #1707
Supersedes #1713