### PR TITLE
feat(agent): stall the loop when the model repeats the identical tool call

### DIFF
--- a/docs/en/user_guides/agent/native.md
+++ b/docs/en/user_guides/agent/native.md
@@ -62,6 +62,7 @@ Most-used `NativeAgentConfig` fields:
 | `max_steps` | Max iterations per sample | Math/QA `5-10`, code fixes `100+` |
 | `skills_dir` | Optional host Agent Skills directory | EvalScope makes the skills available before the agent loop starts |
 | `validate_tool_arguments` | Reject tool calls whose arguments violate the JSON schema advertised to the model; the model sees the violation as a `parsing` tool error and can retry | `False` (default); enable when the run should measure whether the model produces schema-valid calls |
+| `max_repeated_tool_calls` | Stall the loop when the model issues the identical call (same name and arguments) this many times in a row, instead of letting it burn every remaining step | `None` (default, off); `3`-`5` for long budgets such as SWE-bench |
 | `kwargs` | Strategy kwargs | Most commonly `{'system_prompt': '...'}` to steer the model |
 
 Available `strategy` values:

--- a/docs/zh/user_guides/agent/native.md
+++ b/docs/zh/user_guides/agent/native.md
@@ -62,6 +62,7 @@ EvalScope 自动给模型注入 `python_exec` 工具定义，在 Docker 容器�
 | `max_steps` | 单样本最大轮数 | 数学/QA `5-10`，代码修复 `100+` |
 | `skills_dir` | 可选的本机 Agent Skills 目录 | EvalScope 会在 agent loop 开始前让 skills 可用 |
 | `validate_tool_arguments` | 拒绝参数不符合下发 JSON schema 的工具调用；模型会收到 `parsing` 类型的工具错误并可重试 | `False`（默认）；需要衡量模型能否产出合规参数时开启 |
+| `max_repeated_tool_calls` | 模型连续发出完全相同的调用（工具名与参数都相同）达到该次数时打断本轮，避免把剩余步数全部烧掉 | `None`（默认关闭）；SWE-bench 这类大步数预算建议 `3`-`5` |
 | `kwargs` | 策略参数 | 最常用 `{'system_prompt': '...'}` 引导模型行为 |
 
 可选的 `strategy` 值：

--- a/evalscope/agent/runner.py
+++ b/evalscope/agent/runner.py
@@ -123,6 +123,7 @@ def run_native_agent(
         mcp_configs=list(cfg.mcp_servers) or None,
         close_environment=owns_environment,
         validate_tool_arguments=cfg.validate_tool_arguments,
+        max_repeated_tool_calls=cfg.max_repeated_tool_calls,
     )
 
     final_text = extract_final_answer(result, strategy)

--- a/evalscope/api/agent/constants.py
+++ b/evalscope/api/agent/constants.py
@@ -61,6 +61,7 @@ class TraceSources:
     PARSE = 'parse'
     NUDGE = 'nudge'
     LOOP = 'loop'
+    REPEATED_TOOL_CALLS = 'repeated_tool_calls'
 
 
 NUDGE_PROMPT = 'No tool was called. Please use an available tool or call the submit tool with your final answer.'

--- a/evalscope/api/agent/loop.py
+++ b/evalscope/api/agent/loop.py
@@ -14,12 +14,14 @@ streaming generation in the future.  ``AgentAdapter._on_inference`` bridges
 it into the synchronous evaluation pipeline through ``AsyncioLoopRunner``.
 """
 
+import json
 import logging
 import time
 from typing import Any, List, Optional, Tuple
 
 from evalscope.api.messages import ChatMessage, ChatMessageSystem, ChatMessageUser
 from evalscope.api.model import Model, ModelOutput, ModelUsage
+from evalscope.api.tool import ToolCall
 from evalscope.utils.logger import get_logger
 
 from .constants import LoopMessages, MetadataKeys, SubmissionSources, ToolSchemaModes, TraceSources
@@ -49,12 +51,14 @@ class AgentLoop:
         environment: Optional[AgentEnvironment] = None,
         max_steps: int = 10,
         trace: Optional[AgentTrace] = None,
+        max_repeated_tool_calls: Optional[int] = None,
     ) -> None:
         self.model = model
         self.strategy = strategy
         self.tool_executor = tool_executor
         self.environment = environment
         self.max_steps = max_steps
+        self.max_repeated_tool_calls = max_repeated_tool_calls
         self.trace = trace or AgentTrace(
             framework='native',
             strategy=getattr(strategy, 'name', None),
@@ -100,8 +104,16 @@ class AgentLoop:
 
             # ---- parse ----
             parsed = self.strategy.parse_output(output, ctx)
+            repeating = self._track_repeated_calls(parsed, ctx)
+            if repeating is not None:
+                parsed = repeating
             if parsed.error:
-                self._emit_parse_error(ctx, assistant_msg, parsed)
+                self._emit_parse_error(
+                    ctx,
+                    assistant_msg,
+                    parsed,
+                    source=(TraceSources.REPEATED_TOOL_CALLS if repeating is not None else TraceSources.PARSE),
+                )
 
             # ---- terminate from parse? ----
             if self.strategy.is_done(parsed, ctx):
@@ -180,6 +192,48 @@ class AgentLoop:
         ``output.message`` object that lives in ``ctx.messages``.
         """
         return output.message.model_copy(deep=True)
+
+    def _track_repeated_calls(self, parsed: ParsedAction, ctx: AgentContext) -> Optional[ParsedAction]:
+        """Update the identical-call streak and stall the turn once it is too long.
+
+        Returns a replacement :class:`ParsedAction` when the guard fires, else
+        ``None``. The replacement carries an ``error`` and no tool calls, so the
+        turn takes the loop's existing malformed path: the tools are not run,
+        the model is told what it keeps repeating, and a model that never
+        changes course ends the episode on the malformed-nudge budget rather
+        than on ``max_steps``. Reusing that budget is deliberate -- both mean
+        "recoverable turn that made no progress", and a third counter would let
+        either failure consume the other's retries.
+
+        The streak is not reset here after firing: the guard keeps stalling
+        every further repetition, and the loop's own reset on a genuine ACT turn
+        clears it as soon as the model changes its call.
+        """
+        if parsed.outcome is not TurnOutcome.ACT:
+            ctx.repeated_call_streak = 0
+            ctx.last_tool_call_signature = None
+            return None
+
+        signature = _tool_call_signature(parsed.tool_calls)
+        if signature == ctx.last_tool_call_signature:
+            ctx.repeated_call_streak += 1
+        else:
+            ctx.last_tool_call_signature = signature
+            ctx.repeated_call_streak = 1
+
+        if self.max_repeated_tool_calls is None or ctx.repeated_call_streak < self.max_repeated_tool_calls:
+            return None
+
+        names = ', '.join(sorted({call.function.name for call in parsed.tool_calls}))
+        self._dbg(ctx, f'repeated call guard fired: {names} x{ctx.repeated_call_streak}')
+        return ParsedAction(
+            error=(
+                f'You have issued the identical call to {names} {ctx.repeated_call_streak} times in a row '
+                f'and it is not making progress. Change the arguments, use a different tool, '
+                f'or give your final answer.'
+            ),
+            raw_text=parsed.raw_text,
+        )
 
     def _try_nudge(self, parsed: ParsedAction, ctx: AgentContext) -> bool:
         """Inject a 'please call a tool' reminder if the strategy allows it.
@@ -338,6 +392,7 @@ class AgentLoop:
         ctx: AgentContext,
         assistant_msg: ChatMessage,
         parsed: ParsedAction,
+        source: str = TraceSources.PARSE,
     ) -> None:
         self._dbg(ctx, f'parse_error: {parsed.error}')
         self.trace.add_event(
@@ -345,7 +400,7 @@ class AgentLoop:
             type=EventType.ERROR,
             message_id=assistant_msg.id,
             payload={
-                'source': TraceSources.PARSE,
+                'source': source,
                 'message': parsed.error,
             },
         )
@@ -463,6 +518,22 @@ class AgentLoop:
         """Emit a DEBUG log line with a uniform sample/step prefix."""
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f'[AgentLoop] sample={ctx.sample_id} step={ctx.step} {msg}')
+
+
+def _tool_call_signature(tool_calls: List[ToolCall]) -> Tuple[Tuple[str, str], ...]:
+    """Order-independent identity of a turn's tool calls: name plus arguments.
+
+    Arguments are part of the key so a poll that advances an offset, or a retry
+    that changes a parameter, reads as progress rather than as a repeat.
+    ``default=str`` keeps the signature total for arguments a model may emit
+    that are not plain JSON.
+    """
+    return tuple(
+        sorted(
+            (call.function.name, json.dumps(call.function.arguments, sort_keys=True, default=str))
+            for call in tool_calls
+        )
+    )
 
 
 def _extract_usage(output: ModelOutput) -> Optional[dict]:

--- a/evalscope/api/agent/runner.py
+++ b/evalscope/api/agent/runner.py
@@ -47,6 +47,7 @@ def run_agent_loop(
     mcp_configs: Optional[List['MCPServerConfig']] = None,
     close_environment: bool = True,
     validate_tool_arguments: bool = False,
+    max_repeated_tool_calls: Optional[int] = None,
 ) -> AgentLoopResult:
     """Drive a single :class:`AgentLoop` to completion and return its result.
 
@@ -76,6 +77,9 @@ def run_agent_loop(
             tool call against the ``ToolInfo`` schema advertised to the model
             (native and MCP tools alike) and refuses to dispatch violating
             calls. See :attr:`NativeAgentConfig.validate_tool_arguments`.
+        max_repeated_tool_calls: Stall the loop once the model has issued the
+            identical call this many times in a row. See
+            :attr:`NativeAgentConfig.max_repeated_tool_calls`.
 
     Returns:
         AgentLoopResult: Completed result with ``messages``, ``trace`` and
@@ -128,6 +132,7 @@ def run_agent_loop(
                     environment=environment,
                     max_steps=max_steps,
                     trace=trace,
+                    max_repeated_tool_calls=max_repeated_tool_calls,
                 )
                 return await loop.run(ctx)
             finally:

--- a/evalscope/api/agent/types.py
+++ b/evalscope/api/agent/types.py
@@ -8,7 +8,7 @@ import from ``evalscope.api.agent`` to participate.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -82,6 +82,18 @@ class NativeAgentConfig(BaseAgentConfig):
     means use each tool's built-in default.
     """
 
+    max_repeated_tool_calls: Optional[int] = Field(default=None)
+    """Stall the loop when the model repeats the identical call this many times.
+
+    Counts consecutive turns whose tool calls match the previous turn's by
+    name *and* arguments, so a genuine poll that advances an offset or a retry
+    counter never trips it. On reaching the threshold the turn is not executed:
+    the model is told what it is repeating and can correct itself, and a model
+    that keeps repeating ends the episode through the existing malformed-turn
+    budget instead of burning every remaining step. ``None`` (default)
+    disables the guard.
+    """
+
     validate_tool_arguments: bool = Field(default=False)
     """Reject tool calls whose arguments violate the tool's advertised JSON schema.
 
@@ -102,6 +114,13 @@ class NativeAgentConfig(BaseAgentConfig):
     :class:`MCPServer.__aenter__`, so configurations with empty
     ``mcp_servers`` (the default) do not require ``pip install mcp``.
     """
+
+    @field_validator('max_repeated_tool_calls')
+    @classmethod
+    def _validate_max_repeated_tool_calls(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v <= 1:
+            raise ValueError('max_repeated_tool_calls must be greater than 1.')
+        return v
 
     @field_validator('max_steps')
     @classmethod
@@ -226,6 +245,20 @@ class AgentContext:
     whenever the reminder wording or shape changes, which reads as "never
     nudged" and lets a stuck model burn the whole step budget.
     """
+
+    repeated_call_streak: int = 0
+    """Consecutive turns that produced exactly the same set of tool calls.
+
+    Owned by :class:`AgentLoop`, which recomputes it from each turn's parsed
+    action and resets it whenever the calls change or a turn produces none.
+    It cannot be derived from ``messages``: a strategy may synthesise the
+    calls during parsing rather than read them off the assistant message
+    (``swe_bench_backticks`` builds a ``bash`` call out of a fenced block),
+    so the message history has no tool calls to compare for those runs.
+    """
+
+    last_tool_call_signature: Optional[Tuple[Tuple[str, str], ...]] = None
+    """Signature of the previous turn's tool calls; see :attr:`repeated_call_streak`."""
 
     parse_error_nudge_count: int = 0
     """Malformed-turn nudges since the last turn that produced tool calls.

--- a/evalscope/api/benchmark/adapters/agent_adapter.py
+++ b/evalscope/api/benchmark/adapters/agent_adapter.py
@@ -214,6 +214,10 @@ class AgentLoopAdapter(AgentAdapter):
     def _resolve_validate_tool_arguments(ac: Any) -> bool:
         return isinstance(ac, NativeAgentConfig) and ac.validate_tool_arguments
 
+    @staticmethod
+    def _resolve_max_repeated_tool_calls(ac: Any) -> Optional[int]:
+        return ac.max_repeated_tool_calls if isinstance(ac, NativeAgentConfig) else None
+
     # ------------------------------------------------------------------
     # Overridden inference hook
     # ------------------------------------------------------------------
@@ -262,6 +266,7 @@ class AgentLoopAdapter(AgentAdapter):
             trace_env_name=environment.name if environment else None,
             mcp_configs=mcp_configs,
             validate_tool_arguments=self._resolve_validate_tool_arguments(ac),
+            max_repeated_tool_calls=self._resolve_max_repeated_tool_calls(ac),
         )
 
         finalization_prompt = self.build_max_steps_finalization_message(sample)

--- a/tests/agent/test_repeated_tool_calls.py
+++ b/tests/agent/test_repeated_tool_calls.py
@@ -1,0 +1,300 @@
+"""Guard against a model that keeps issuing the same tool call.
+
+The loop budgets two ways of failing to make progress: a turn that produces no
+tool call at all, and a turn that breaks the output protocol. A model that
+repeats one valid call forever is neither -- every turn is a well-formed ACT
+turn, which resets both budgets -- so it runs to ``max_steps``, executing the
+same tool each time. ``NativeAgentConfig.max_repeated_tool_calls`` closes that
+gap by turning an over-long streak into a malformed turn, which reuses the
+existing nudge budget and terminal reason.
+"""
+
+import asyncio
+import unittest
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pydantic import ValidationError
+
+import evalscope  # noqa: F401 - trigger strategy registration
+from evalscope.agent.runner import run_native_agent
+from evalscope.api.agent import AgentContext, AgentLoop, AgentLoopResult, AgentTrace, EventType, ToolExecutor
+from evalscope.api.agent.constants import SubmissionSources, TraceSources
+from evalscope.api.agent.runner import run_agent_loop
+from evalscope.api.agent.types import NativeAgentConfig
+from evalscope.api.benchmark.adapters import AgentLoopAdapter
+from evalscope.api.dataset import Sample
+from evalscope.api.messages import ChatMessageAssistant, ChatMessageUser
+from evalscope.api.model.model_output import ChatCompletionChoice, ModelOutput
+from evalscope.api.registry import get_strategy
+from evalscope.api.tool import ToolCall, ToolFunction
+from evalscope.config import TaskConfig
+
+
+def _call(name: str = 'lookup', args: Optional[Dict[str, Any]] = None, call_id: str = 'c') -> ToolCall:
+    return ToolCall(id=call_id, function=ToolFunction(name=name, arguments=args if args is not None else {'q': 'x'}))
+
+
+def _submit(answer: str = 'done') -> ToolCall:
+    return ToolCall(id='s', function=ToolFunction(name='submit', arguments={'answer': answer}))
+
+
+def _output(tool_calls: Optional[List[ToolCall]] = None, content: str = '') -> ModelOutput:
+    msg = ChatMessageAssistant(content=content, tool_calls=tool_calls)
+    return ModelOutput(model='mock', choices=[ChatCompletionChoice(message=msg, stop_reason='stop')])
+
+
+class _Runner:
+    """Drive a loop over a scripted sequence of model outputs.
+
+    Once the script runs out the last output repeats, so a test only has to
+    state what the model does rather than count how many turns the loop will
+    take to give up on it.
+    """
+
+    def __init__(self, outputs: List[ModelOutput], *, max_repeated_tool_calls=None, max_steps=12):
+        self.executed: List[Dict[str, Any]] = []
+        self.generated = 0
+
+        async def handler(call: ToolCall, env: Any) -> str:
+            self.executed.append(call.function.arguments)
+            return 'observation'
+
+        remaining = list(outputs)
+
+        def next_output(*_: Any, **__: Any) -> ModelOutput:
+            self.generated += 1
+            return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+        model = MagicMock()
+        model.generate_async = AsyncMock(side_effect=next_output)
+        self.loop = AgentLoop(
+            model=model,
+            strategy=get_strategy('function_calling')(),
+            tool_executor=ToolExecutor(handlers={'lookup': handler, 'other': handler}, environment=None),
+            max_steps=max_steps,
+            max_repeated_tool_calls=max_repeated_tool_calls,
+        )
+
+    def run(self) -> AgentLoopResult:
+        ctx = AgentContext(sample_id='s', messages=[ChatMessageUser(content='go')])
+        return asyncio.run(self.loop.run(ctx))
+
+
+def _errors(result: AgentLoopResult, source: str) -> List[Any]:
+    return [ev for ev in result.trace.events if ev.type == EventType.ERROR and ev.payload.get('source') == source]
+
+
+class TestStreakSemantics(unittest.TestCase):
+    """What counts as a repeat, and what resets the streak."""
+
+    def test_identical_calls_trip_the_guard_at_the_threshold(self):
+        runner = _Runner([_output([_call()])], max_repeated_tool_calls=3)
+        result = runner.run()
+
+        # Two calls executed, then the third identical turn is stalled instead.
+        self.assertEqual(runner.executed, [{'q': 'x'}, {'q': 'x'}])
+        repeats = _errors(result, TraceSources.REPEATED_TOOL_CALLS)
+        self.assertTrue(repeats)
+        self.assertIn('identical call to lookup', repeats[0].payload['message'])
+
+    def test_changing_arguments_resets_the_streak(self):
+        """A poll that advances an offset is progress, not a repeat."""
+        outputs = [_output([_call(args={'offset': i})]) for i in range(5)] + [_output([_submit()])]
+        runner = _Runner(outputs, max_repeated_tool_calls=2)
+        result = runner.run()
+
+        self.assertEqual(runner.executed, [{'offset': i} for i in range(5)])
+        self.assertEqual(_errors(result, TraceSources.REPEATED_TOOL_CALLS), [])
+
+    def test_changing_tool_name_resets_the_streak(self):
+        outputs = [
+            _output([_call('lookup')]),
+            _output([_call('other')]),
+            _output([_call('lookup')]),
+            _output([_submit()]),
+        ]
+        runner = _Runner(outputs, max_repeated_tool_calls=2)
+        result = runner.run()
+
+        self.assertEqual(len(runner.executed), 3)
+        self.assertEqual(_errors(result, TraceSources.REPEATED_TOOL_CALLS), [])
+
+    def test_a_turn_without_tool_calls_resets_the_streak(self):
+        outputs = [
+            _output([_call()]),
+            _output(content='thinking out loud'),  # idle turn -> nudged
+            _output([_call()]),
+            _output([_submit()]),
+        ]
+        runner = _Runner(outputs, max_repeated_tool_calls=2)
+        result = runner.run()
+
+        self.assertEqual(len(runner.executed), 2)
+        self.assertEqual(_errors(result, TraceSources.REPEATED_TOOL_CALLS), [])
+
+    def test_call_order_within_a_turn_does_not_matter(self):
+        a, b = _call('lookup', {'q': 'a'}, 'c1'), _call('other', {'q': 'b'}, 'c2')
+        runner = _Runner([_output([a, b]), _output([b, a])], max_repeated_tool_calls=2)
+        result = runner.run()
+
+        self.assertTrue(_errors(result, TraceSources.REPEATED_TOOL_CALLS))
+
+
+class TestLoopBehaviour(unittest.TestCase):
+
+    def test_guarded_turn_does_not_execute_its_tools(self):
+        runner = _Runner([_output([_call()])], max_repeated_tool_calls=2)
+        runner.run()
+        # Only the first turn of the streak reached the handler.
+        self.assertEqual(runner.executed, [{'q': 'x'}])
+        self.assertGreater(runner.generated, 1)
+
+    def test_the_model_is_told_and_can_recover(self):
+        outputs = [
+            _output([_call(args={'q': 'x'})]),
+            _output([_call(args={'q': 'x'})]),  # stalled by the guard
+            _output([_call(args={'q': 'y'})]),  # corrected
+            _output([_submit('recovered')]),
+        ]
+        runner = _Runner(outputs, max_repeated_tool_calls=2)
+        result = runner.run()
+
+        reminder = next(m for m in result.messages if isinstance(m, ChatMessageUser) and 'identical call' in m.text)
+        self.assertIn('Change the arguments', reminder.text)
+        self.assertEqual(runner.executed, [{'q': 'x'}, {'q': 'y'}])
+        submit = [ev for ev in result.trace.events if ev.type == EventType.SUBMIT]
+        self.assertEqual(submit[-1].payload.get('final_answer'), 'recovered')
+
+    def test_a_model_that_never_changes_ends_on_the_nudge_budget_not_max_steps(self):
+        runner = _Runner([_output([_call()])], max_repeated_tool_calls=2, max_steps=30)
+        result = runner.run()
+
+        submit = [ev for ev in result.trace.events if ev.type == EventType.SUBMIT]
+        self.assertEqual(submit[-1].payload['source'], SubmissionSources.PARSE_ERROR_EXHAUSTED)
+        self.assertEqual(_errors(result, TraceSources.LOOP), [])  # never reached max_steps
+        self.assertLess(len(result.messages), 30)
+
+    def test_disabled_by_default(self):
+        runner = _Runner([_output([_call()]) for _ in range(4)] + [_output([_submit()])])
+        result = runner.run()
+
+        # All four identical calls ran; only the submit ended the episode.
+        self.assertEqual(runner.executed, [{'q': 'x'}] * 4)
+        self.assertEqual(_errors(result, TraceSources.REPEATED_TOOL_CALLS), [])
+
+    def test_genuine_parse_errors_keep_their_own_source(self):
+        strategy = get_strategy('function_calling')(max_tool_calls_per_turn=1)
+        model = MagicMock()
+        model.generate_async = AsyncMock(
+            side_effect=[_output([_call('lookup', call_id='c1'), _call('other', call_id='c2')]), _output([_submit()])]
+        )
+        loop = AgentLoop(
+            model=model,
+            strategy=strategy,
+            tool_executor=ToolExecutor(handlers={}, environment=None),
+            max_steps=5,
+            max_repeated_tool_calls=2,
+        )
+        result = asyncio.run(loop.run(AgentContext(sample_id='s', messages=[ChatMessageUser(content='go')])))
+
+        self.assertTrue(_errors(result, TraceSources.PARSE))
+        self.assertEqual(_errors(result, TraceSources.REPEATED_TOOL_CALLS), [])
+
+
+class TestConfigPlumbing(unittest.TestCase):
+
+    def test_defaults_to_disabled(self):
+        self.assertIsNone(NativeAgentConfig().max_repeated_tool_calls)
+
+    def test_threshold_below_two_is_rejected(self):
+        """A threshold of 1 would stall the first call of every kind."""
+        for value in (1, 0, -1):
+            with self.assertRaises(ValidationError):
+                NativeAgentConfig(max_repeated_tool_calls=value)
+
+    def test_run_agent_loop_forwards_the_threshold(self):
+        built: Dict[str, Any] = {}
+        real_loop = AgentLoop
+
+        def recording_loop(*args: Any, **kwargs: Any) -> AgentLoop:
+            built.update(kwargs)
+            return real_loop(*args, **kwargs)
+
+        model = MagicMock()
+        model.generate_async = AsyncMock(return_value=_output([_submit()]))
+        with patch('evalscope.api.agent.runner.AgentLoop', side_effect=recording_loop):
+            run_agent_loop(
+                model=model,
+                strategy=get_strategy('function_calling')(),
+                handlers={},
+                environment=None,
+                initial_messages=[ChatMessageUser(content='go')],
+                all_tools=[],
+                max_steps=2,
+                sample_id='s',
+                trace_strategy_name='function_calling',
+                trace_env_name=None,
+                max_repeated_tool_calls=4,
+            )
+        self.assertEqual(built['max_repeated_tool_calls'], 4)
+
+    def test_run_native_agent_forwards_the_threshold(self):
+        seen: Dict[str, Any] = {}
+
+        def fake_run_agent_loop(**kwargs: Any) -> AgentLoopResult:
+            seen.update(kwargs)
+            return AgentLoopResult(
+                messages=[ChatMessageAssistant(content='raw')],
+                final_output=_output(content='raw'),
+                trace=AgentTrace(strategy='fake', max_steps=1),
+            )
+
+        class FakeStrategy:
+
+            def __init__(self, **_: Any) -> None:
+                pass
+
+        with (
+            patch('evalscope.agent.runner.get_strategy', lambda name: FakeStrategy),
+            patch('evalscope.agent.runner.resolve_tools', lambda tools: {}),
+            patch('evalscope.agent.runner.resolve_tool_infos', lambda tools: []),
+            patch('evalscope.agent.runner.run_agent_loop', fake_run_agent_loop),
+        ):
+            run_native_agent(
+                task_config=TaskConfig(
+                    datasets=['demo'],
+                    agent_config=NativeAgentConfig(strategy='fake', max_steps=1, max_repeated_tool_calls=5),
+                ),
+                model=object(),
+                sample=Sample(id=1, input='do work', target='', metadata={}),
+                build_sandbox_config=lambda _: None,
+                extract_final_answer=lambda loop_result, strategy: 'final',
+            )
+        self.assertEqual(seen['max_repeated_tool_calls'], 5)
+
+    def test_agent_loop_adapter_forwards_the_threshold(self):
+        adapter = AgentLoopAdapter.__new__(AgentLoopAdapter)
+        adapter._task_config = TaskConfig(model='dummy', agent_config=NativeAgentConfig(max_repeated_tool_calls=3))
+        adapter.max_steps = 30
+        loop_result = AgentLoopResult(
+            messages=[],
+            final_output=_output(content='answer'),
+            trace=AgentTrace(strategy='function_calling', max_steps=30),
+        )
+        with patch('evalscope.api.agent.run_agent_loop', return_value=loop_result) as run_loop:
+            adapter._on_inference(MagicMock(), Sample(input='hi'))
+        self.assertEqual(run_loop.call_args.kwargs['max_repeated_tool_calls'], 3)
+
+    def test_agent_loop_adapter_defaults_to_none(self):
+        adapter = AgentLoopAdapter.__new__(AgentLoopAdapter)
+        adapter._task_config = TaskConfig(model='dummy')
+        adapter.max_steps = 30
+        loop_result = AgentLoopResult(
+            messages=[],
+            final_output=_output(content='answer'),
+            trace=AgentTrace(strategy='function_calling', max_steps=30),
+        )
+        with patch('evalscope.api.agent.run_agent_loop', return_value=loop_result) as run_loop:
+            adapter._on_inference(MagicMock(), Sample(input='hi'))
+        self.assertIsNone(run_loop.call_args.kwargs['max_repeated_tool_calls'])


### PR DESCRIPTION
## Problem

`AgentLoop` budgets two ways of failing to make progress:

| failure | budget |
|---|---|
| turn produces no tool call | `max_nudges` (2) |
| turn breaks the output protocol | `max_parse_error_nudges` (3) |

A model that keeps issuing one *valid* call is neither. Every turn is a well-formed `ACT` turn, and an `ACT` turn resets both counters, so the streak never accumulates and the only remaining exit is `max_steps` — with the same tool executed on every step along the way.

That budget is not small:

| benchmark | `max_steps_default` |
|---|---|
| `swe_bench_*_agentic`, `swe_bench_pro`, `gdpval`, `job_bench` | 250 |
| `mcp_atlas` | 100 |
| `gaia`, `wide_search`, `researchrubrics` | 50 |

A model that starts repeating at step 3 of SWE-bench spends the other 247 on real model calls and real sandbox executions. The trace it leaves is shaped exactly like a sample that genuinely needed every step, so "this task was hard" and "the model got stuck immediately" are indistinguishable without reading the turns by hand.

## Change

`NativeAgentConfig.max_repeated_tool_calls`, **default `None` (off)**. It counts consecutive turns whose tool calls match the previous turn's by name *and* arguments. On reaching the threshold the turn is converted into a malformed one: the tools are not executed, the model is told what it keeps repeating, and a model that never changes course ends on the existing malformed-nudge budget.

Measured on a stuck model with `max_steps=250`:

| threshold | model calls | tool executions | terminal reason |
|---|---|---|---|
| `None` | 250 | 250 | `max_steps_exceeded` |
| `3` | 6 | 2 | `parse_error_exhausted` |
| `5` | 8 | 4 | `parse_error_exhausted` |

Nothing changes unless the threshold is set.

## Judgement calls, happy to change any of them

- **In the loop, not in a strategy.** `FunctionCallingStrategy.max_tool_calls_per_turn` is the closest precedent and is strategy-level, but it is a per-turn rule while this one spans turns. Putting the guard in the loop covers all four strategies at once — including `swe_bench_toolcall`, which drives the 250-step benchmarks and would otherwise need its own copy.
- **Reuses the malformed-turn budget** rather than adding a third counter. Both mean "recoverable turn that made no progress", and separate counters would let either failure consume the other's retries — the reason `nudge_count` and `parse_error_nudge_count` were split in the first place.
- **The streak lives on `AgentContext`,** next to those two counters and owned by the loop for the same reason given in their docstrings. It cannot be derived from `ctx.messages`: `swe_bench_backticks` synthesises its `bash` call while parsing a fenced block, so its assistant messages carry no `tool_calls` to compare.
- **Arguments are part of the signature.** A poll that advances an offset, or a retry that changes a parameter, reads as progress. Call *order within* a turn is not part of it, so `{A, B}` and `{B, A}` count as the same turn.
- **`TraceSources.REPEATED_TOOL_CALLS`** marks the `ERROR` event so the guard is distinguishable from a genuine parse error without matching message text. `_emit_parse_error` gained a `source` parameter defaulting to the existing `'parse'`; no existing payload changes.
- **Thresholds below 2 are rejected** by a validator — `1` would stall the first call of every kind.

## Testing

```
tests/agent/test_repeated_tool_calls.py   16 passed
  streak semantics — identical calls trip at the threshold; changed arguments,
                     changed tool name and an idle turn each reset it; order
                     within a turn is irrelevant
  loop behaviour   — the guarded turn does not reach the handler, the model is
                     told and recovers, a model that never changes ends on the
                     nudge budget rather than max_steps, off by default,
                     genuine parse errors keep source='parse'
  plumbing         — the threshold reaches the loop from run_agent_loop,
                     run_native_agent and AgentLoopAdapter, and defaults to None

tests/agent                              357 passed, 21 skipped, same 7 pre-existing
                                         failures (test_sandbox_service,
                                         test_strategy_parsers: optional deps)
tests/cli/test_all.py::TestRun::test_ci_lite   passed
ruff 0.16.4 check + format --diff        clean
```

## Follow-up, not in this PR

The `ERROR` event this emits is a natural input for a trace-derived "degenerate loop rate" alongside tool-error rate and nudge counts, which today are recorded per sample but never aggregated into the report. Happy to open an issue for that separately if it sounds useful.
