### PR TITLE
fix(agent): stop waiting on a sandbox that never returns

### DIFF
--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -19,6 +19,7 @@ shared ``atexit`` hook.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import shlex
 import time
@@ -132,6 +133,13 @@ class EnclaveAgentEnvironment(AgentEnvironment):
     """
 
     name: str = 'enclave'
+
+    #: Wall-clock grace allowed beyond the requested command timeout before the
+    #: environment stops waiting on the sandbox layer itself. The sandbox owns
+    #: the deadline and returns a ``TIMEOUT`` status with whatever output the
+    #: command produced, which is the better answer; this margin only decides
+    #: how long to wait for that answer before giving up on it.
+    _TIMEOUT_GRACE_S: float = 30.0
 
     def __init__(
         self,
@@ -247,13 +255,38 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         # ``None`` / ``0`` for shell_executor). Wall-time it locally so
         # ``ExecResult.duration`` always reflects real elapsed time.
         started = time.monotonic()
-        result = await handle.execute_tool(
-            'shell_executor',
-            {
-                'command': shell_argv,
-                'timeout': timeout_s,
-            },
-        )
+        deadline = timeout_s + self._TIMEOUT_GRACE_S
+        try:
+            result = await asyncio.wait_for(
+                handle.execute_tool(
+                    'shell_executor',
+                    {
+                        'command': shell_argv,
+                        'timeout': timeout_s,
+                    },
+                ),
+                timeout=deadline,
+            )
+        except asyncio.TimeoutError:
+            # The sandbox is expected to enforce ``timeout_s`` and report a
+            # TIMEOUT status; when it does not come back at all there is
+            # nothing above this call that bounds the wait, so a single stuck
+            # command would hang the whole evaluation. Give up on the sandbox
+            # instead and report the sample as timed out.
+            elapsed = time.monotonic() - started
+            logger.warning(
+                f'EnclaveAgentEnvironment: sandbox {handle.sandbox_id} did not return within {deadline:g}s '
+                f'for a command with timeout={timeout_s:g}s; abandoning the execution.'
+            )
+            return ExecResult(
+                returncode=-1,
+                timed_out=True,
+                duration=elapsed,
+                stderr=(
+                    f'[evalscope] the sandbox did not return within {deadline:g}s for a command with '
+                    f'timeout={timeout_s:g}s. The command was abandoned; its output is unavailable.'
+                ),
+            )
         elapsed = time.monotonic() - started
 
         stdout = str(result.output or '')

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -11,6 +11,7 @@ Test plan:
   TestNativeAgentEnvironmentConfig – legacy-compatible Agent environment config
 """
 
+import asyncio
 import os
 import sys
 import tempfile
@@ -330,6 +331,79 @@ class TestEnclaveEnvironmentInterpreter:
 
         assert result.timed_out
         assert result.returncode == -1
+
+    def test_exec_gives_up_when_the_sandbox_never_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sandbox that never answers must not hang the whole evaluation.
+
+        ``timeout`` is handed to ms_enclave's shell_executor, and nothing above
+        this call bounds the wait, so before the backstop a single stuck command
+        (an interactive CLI re-prompting forever, a wedged exec channel) blocked
+        the sample and every sample behind it.
+        """
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        monkeypatch.setattr(type(env), '_TIMEOUT_GRACE_S', 0.2)
+        entered = asyncio.Event()
+
+        async def _never_returns(tool_name: str, payload: Dict[str, Any]) -> Any:
+            entered.set()
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(handle, 'execute_tool', _never_returns)
+
+        started = time.monotonic()
+        result = self._run(env.exec(['bash', '-c', 'sphinx-quickstart'], timeout=0.1))
+        elapsed = time.monotonic() - started
+
+        assert entered.is_set()
+        assert result.timed_out
+        assert result.returncode == -1
+        assert 'did not return' in result.stderr
+        assert elapsed < 5, f'exec should give up near the grace window, took {elapsed:.1f}s'
+
+    def test_exec_waits_for_the_sandbox_to_report_its_own_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The backstop must not pre-empt the sandbox's own, better answer.
+
+        ms_enclave reports TIMEOUT together with whatever the command printed
+        before the deadline; that output is worth waiting the grace window for.
+        """
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        monkeypatch.setattr(type(env), '_TIMEOUT_GRACE_S', 5.0)
+
+        async def _slow_timeout(tool_name: str, payload: Dict[str, Any]) -> Any:
+            await asyncio.sleep(0.2)  # sandbox answers a little after the command deadline
+            return types.SimpleNamespace(
+                output='partial output before the deadline',
+                error='Command timed out after 0.1 seconds',
+                status=_FakeExecutionStatus.TIMEOUT,
+                execution_time=0.1,
+            )
+
+        monkeypatch.setattr(handle, 'execute_tool', _slow_timeout)
+        result = self._run(env.exec(['bash', '-c', 'sleep 10'], timeout=0.1))
+
+        assert result.timed_out
+        assert result.stdout == 'partial output before the deadline'
+
+    def test_backstop_deadline_is_the_command_timeout_plus_the_grace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A long-running command still gets its full timeout, not the grace alone."""
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        monkeypatch.setattr(type(env), '_TIMEOUT_GRACE_S', 0.5)
+
+        async def _slower_than_the_grace(tool_name: str, payload: Dict[str, Any]) -> Any:
+            await asyncio.sleep(0.8)
+            return types.SimpleNamespace(
+                output='done', error='', status=_FakeExecutionStatus.SUCCESS, execution_time=0.8
+            )
+
+        monkeypatch.setattr(handle, 'execute_tool', _slower_than_the_grace)
+        result = self._run(env.exec(['bash', '-c', 'make'], timeout=5))
+
+        assert not result.timed_out
+        assert result.stdout == 'done'
 
     def test_empty_interpreter_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from evalscope.agent.environments.enclave import EnclaveAgentEnvironment


### PR DESCRIPTION
## Problem

Fixes the hang reported in #1685.

`EnclaveAgentEnvironment.exec` hands the deadline to ms_enclave's `shell_executor` and then awaits it with nothing bounding the wait:

```python
result = await handle.execute_tool(
    'shell_executor',
    {'command': shell_argv, 'timeout': timeout_s},
)
```

If the sandbox layer never answers — an unkillable command, a wedged exec channel, a lost reply — that `await` never returns. The sample blocks its worker for the rest of the run, with no traceback and no progress.

`LocalAgentEnvironment` does not have this problem: it wraps the subprocess in `asyncio.wait_for` and returns `timed_out=True` on expiry. Only the enclave path trusts the layer below it to honour the timeout it was handed.

In #1685 the model ran `sphinx-quickstart` inside the sandbox — an interactive CLI whose log tail is `* Please enter some text.` repeated forever, i.e. a prompt loop that never terminates on its own.

### Reproduction

No Docker, no ms_enclave, just a stubbed handle:

```python
class HangingHandle:
    sandbox_id = 'stub'
    async def execute_tool(self, name, args):
        await asyncio.sleep(3600)      # the sandbox never answers

env = EnclaveAgentEnvironment.__new__(EnclaveAgentEnvironment)
env._handle = HangingHandle(); env._timeout = 60.0; env._interpreter = ['bash', '-c']
await asyncio.wait_for(env.exec(['/bin/bash', '-c', 'sphinx-quickstart'], timeout=1.0), timeout=5)
```

```
STILL RUNNING after 5.0s despite exec(timeout=1.0)
```

## Change

`exec` stops waiting at `timeout + _TIMEOUT_GRACE_S` (30s) and returns a timed-out `ExecResult` carrying an explanatory `stderr`. The bash tool renders it as `[TIMEOUT]`, the model sees a failed command, and the run moves on.

The grace is waited out on purpose rather than cutting at the command deadline: ms_enclave reports `TIMEOUT` **together with whatever the command printed before its own deadline**, and that output is the more useful answer. The backstop only decides how long to wait for it before giving up.

## Scope

This bounds the damage. It does not explain why a sandbox would fail to enforce the timeout it was given — that still needs the reporter's `instance_id` and `pip show ms-enclave`, which I asked for on the issue.

Two related gaps I found while reading this code are **not** in this PR, both noted on #1685:

- `exec` accepts `input=` and never uses it, so stdin is silently dropped in a sandbox. `runners/mock.py` passes it; `runners/codex.py` already carries a comment working around it.
- `LocalAgentEnvironment` runs with `stdin=None`, so a child inherits the parent's stdin. Under a pty an interactive command blocks on it for the whole tool timeout (verified locally). `DEVNULL` would make those fail fast.

Happy to send either separately.

## Testing

```
tests/agent/test_t2_environment.py   3 new cases, 57 passed, 10 skipped
  - a handle that never returns is abandoned near the grace window rather
    than hanging (fails on main)
  - a sandbox reporting its own TIMEOUT slightly late is still waited for,
    so its partial output survives
  - a legitimately long command gets timeout + grace, not the grace alone

tests/agent                          344 passed, 21 skipped, same 7 pre-existing
                                     failures (test_sandbox_service,
                                     test_strategy_parsers: optional deps)
tests/cli/test_all.py::TestRun::test_ci_lite   passed
ruff 0.16.4 check + format --diff    clean
```
