### PR TITLE
fix(agent): stop sandboxed commands from inheriting the evaluator's stdin

### DIFF
--- a/evalscope/agent/environments/local.py
+++ b/evalscope/agent/environments/local.py
@@ -59,7 +59,12 @@ class LocalAgentEnvironment(AgentEnvironment):
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,
-            stdin=asyncio.subprocess.PIPE if input is not None else None,
+            # Without an explicit stdin the child inherits the evaluator's own,
+            # so a model-generated command that reads stdin blocks on the
+            # operator's terminal (and can swallow their keystrokes) until the
+            # tool timeout fires. Nothing in a sandbox should be able to read
+            # from there; DEVNULL makes such a command see EOF and fail fast.
+            stdin=asyncio.subprocess.PIPE if input is not None else asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=effective_cwd,

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -525,6 +525,35 @@ class TestLocalEnvironmentExec:
         assert 'err' in result.stderr
         assert result.returncode != 0
 
+    def test_exec_does_not_inherit_the_evaluator_stdin(self):
+        """A sandboxed command must not be able to read the evaluator's stdin.
+
+        Without an explicit stdin the child inherits fd 0 from the evalscope
+        process. Attached to a terminal that means a model-generated command
+        which reads stdin blocks on the operator's keyboard until the tool
+        timeout, and can consume what they type; #1685 is that shape of
+        failure inside a sandbox.
+        """
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b'EVALUATOR STDIN\n')
+        os.close(write_fd)
+        saved_stdin = os.dup(0)
+        try:
+            os.dup2(read_fd, 0)
+            result = self._run(self._env().exec(['bash', '-c', 'cat']))
+        finally:
+            os.dup2(saved_stdin, 0)
+            os.close(saved_stdin)
+            os.close(read_fd)
+
+        assert result.returncode == 0
+        assert result.stdout == '', f'the command read the evaluator stdin: {result.stdout!r}'
+
+    def test_exec_still_pipes_explicit_input(self):
+        env = self._env()
+        result = self._run(env.exec(['bash', '-c', 'cat'], input='piped payload'))
+        assert result.stdout == 'piped payload'
+
     def test_exec_timeout(self):
         env = self._env()
         result = self._run(env.exec(['sleep', '10'], timeout=0.3))


### PR DESCRIPTION
## Problem

`LocalAgentEnvironment.exec` passes `stdin=None` when no `input` is supplied:

```python
stdin=asyncio.subprocess.PIPE if input is not None else None,
```

`None` means *inherit*, so the child gets fd 0 of the evalscope process. A sandbox should not be able to read from there.

Three consequences, all reachable with model-generated commands:

- **Attached to a terminal**, a command that reads stdin blocks on the operator's keyboard for the whole tool timeout. Verified under a pty: `read -p "prompt: " x` waits the full 3s and comes back `timed_out=True`.
- **Whatever the operator types** can be consumed by that command instead of by evalscope.
- **With a pipe on stdin**, the command reads the evaluator's own input stream — which is what the regression test demonstrates, deterministically and without a pty.

This is the same hazard as #1685 (a model ran `sphinx-quickstart`, an interactive CLI, and the run stopped making progress), on the local path rather than the sandbox one. It does not fix that report — #1717 addresses the sandbox side — but a stuck interactive command burns the full timeout here too.

## Change

Default `stdin` to `DEVNULL`. A command that reads stdin now sees EOF and fails fast. Explicit `input=` still gets a `PIPE` and is unchanged.

Before / after, same command under a pty:

| | `timed_out` | stdout | elapsed |
|---|---|---|---|
| before | `True` | — | 3.01s (the full timeout) |
| after | `False` | `got=[]` | 0.01s |

## Testing

```
tests/agent/test_t2_environment.py
  test_exec_does_not_inherit_the_evaluator_stdin   fails on main with
      assert 'EVALUATOR STDIN\n' == ''
  test_exec_still_pipes_explicit_input             input= unchanged

tests/agent   343 passed, 21 skipped, same 7 pre-existing failures
              (test_sandbox_service, test_strategy_parsers: optional deps)
ruff 0.16.4 check + format --diff   clean
```
