### PR TITLE
fix(agent): forward exec stdin into the sandbox instead of dropping it

### DIFF
--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -79,6 +79,7 @@ def _render_command(
     interpreter: Sequence[str],
     cwd: Optional[str],
     env: Optional[Dict[str, str]],
+    stdin: Optional[str] = None,
 ) -> str:
     unwrapped_command = _unwrap_bash_c(cmd) if _interpreter_is_bash(interpreter) else None
     if unwrapped_command is not None:
@@ -92,6 +93,17 @@ def _render_command(
     if env:
         prefix = _render_env_exports(env)
         command = f'{prefix} {command}' if prefix else command
+    if stdin is not None:
+        if not _interpreter_is_bash(interpreter):
+            raise NotImplementedError(
+                f'EnclaveAgentEnvironment cannot supply stdin through interpreter {list(interpreter)!r}; '
+                'it is rendered as a shell pipeline. Use a bash interpreter or pass the payload in the command.'
+            )
+        # ms_enclave's shell_executor takes a command and no stdin, so the
+        # payload is piped in by the shell instead. The subshell keeps the
+        # pipe attached to the whole command: without it a rendered
+        # ``cd /w && foo`` would feed ``cd`` rather than ``foo``.
+        command = f'printf %s {shlex.quote(stdin)} | ( {command} )'
     return command
 
 
@@ -232,7 +244,7 @@ class EnclaveAgentEnvironment(AgentEnvironment):
         env: Optional[Dict[str, str]] = None,
     ) -> ExecResult:
         handle = await self._ensure_sandbox()
-        command = _render_command(cmd, interpreter=self._interpreter, cwd=cwd, env=env)
+        command = _render_command(cmd, interpreter=self._interpreter, cwd=cwd, env=env, stdin=input)
 
         # ms_enclave's shell_executor splits a bare string with no shell
         # wrapping; use an explicit interpreter so cd/&&/env-prefix/quoting

--- a/evalscope/agent/environments/enclave.py
+++ b/evalscope/agent/environments/enclave.py
@@ -46,6 +46,7 @@ _DEFAULT_WORKDIR = '/workspace'
 _DEFAULT_TOOLS: List[str] = ['shell_executor', 'python_executor']
 _DEFAULT_INTERPRETER: List[str] = ['bash', '-c']
 _ENV_KEY_PATTERN = r'[A-Za-z_][A-Za-z0-9_]*'
+_POSIX_SHELL_EXECUTABLES = frozenset({'ash', 'bash', 'dash', 'ksh', 'sh', 'zsh'})
 
 
 def _unwrap_bash_c(cmd: Any) -> Optional[str]:
@@ -59,8 +60,23 @@ def _unwrap_bash_c(cmd: Any) -> Optional[str]:
 
 
 def _interpreter_is_bash(interpreter: Sequence[str]) -> bool:
-    executable = interpreter[0]
-    return executable == 'bash' or executable.endswith('/bash')
+    return _interpreter_basename(interpreter) == 'bash'
+
+
+def _interpreter_basename(interpreter: Sequence[str]) -> str:
+    """Executable name of the interpreter, with any container path stripped."""
+    return interpreter[0].rsplit('/', 1)[-1]
+
+
+def _interpreter_is_posix_shell(interpreter: Sequence[str]) -> bool:
+    """Whether the interpreter speaks POSIX shell command language.
+
+    Gates the ``printf ... | ( ... )`` rendering used to supply stdin, which
+    is plain POSIX syntax rather than a bash extension. Verified against
+    bash, sh, dash, ksh and zsh; ``ash`` is included as the busybox sh that
+    slim container images ship.
+    """
+    return _interpreter_basename(interpreter) in _POSIX_SHELL_EXECUTABLES
 
 
 def _render_env_exports(env: Dict[str, str]) -> str:
@@ -94,10 +110,12 @@ def _render_command(
         prefix = _render_env_exports(env)
         command = f'{prefix} {command}' if prefix else command
     if stdin is not None:
-        if not _interpreter_is_bash(interpreter):
+        if not _interpreter_is_posix_shell(interpreter):
             raise NotImplementedError(
                 f'EnclaveAgentEnvironment cannot supply stdin through interpreter {list(interpreter)!r}; '
-                'it is rendered as a shell pipeline. Use a bash interpreter or pass the payload in the command.'
+                f'it is rendered as a shell pipeline, which needs one of '
+                f'{sorted(_POSIX_SHELL_EXECUTABLES)}. Use a shell interpreter or pass the payload '
+                'inside the command instead.'
             )
         # ms_enclave's shell_executor takes a command and no stdin, so the
         # payload is piped in by the shell instead. The subshell keeps the

--- a/evalscope/agent/external/runners/codex.py
+++ b/evalscope/agent/external/runners/codex.py
@@ -11,9 +11,8 @@ Responses API — the bridge's ``/openai/v1/responses`` route is the only
 endpoint codex can actually hit.
 
 The prompt is passed as the trailing positional argument (codex ``exec
-"<prompt>"``) so this runner works in both ``LocalAgentEnvironment``
-(stdin is fully supported) and ``EnclaveAgentEnvironment`` (whose
-``exec`` does not forward ``input=`` to the underlying shell executor).
+"<prompt>"``) rather than on stdin: it keeps the invocation visible in the
+run logs and independent of how each environment supplies stdin.
 """
 
 import tempfile
@@ -204,8 +203,8 @@ class CodexRunner(AgentRunner):
         cmd.append('--dangerously-bypass-approvals-and-sandbox')
         cmd.extend(['--output-last-message', _CODEX_OUTPUT_FILE])
         cmd.extend(self._extra_args)
-        # Positional prompt avoids the Enclave stdin gap (ms_enclave's
-        # shell_executor does not pipe stdin to the child process).
+        # Positional prompt keeps the invocation visible in the run logs and
+        # independent of how each environment supplies stdin.
         cmd.append(task.instruction)
 
         sample_id = (task.metadata or {}).get('sample_id')

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -331,6 +331,57 @@ class TestEnclaveEnvironmentInterpreter:
         assert result.timed_out
         assert result.returncode == -1
 
+    def test_exec_forwards_input_as_a_shell_pipe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``input=`` used to be accepted and silently dropped inside a sandbox.
+
+        ms_enclave's shell_executor takes a command and no stdin, so a runner
+        that piped its prompt (``runners/mock.py``) had it vanish; only the
+        local environment honoured the argument.
+        """
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        self._run(env.exec(['/bin/bash', '-c', 'cat'], input='piped payload'))
+
+        assert handle.payload is not None
+        assert handle.payload['command'][-1] == "printf %s 'piped payload' | ( cat )"
+
+    def test_input_pipe_survives_cwd_and_env_prefixes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The subshell must keep the pipe attached to the command, not to ``cd``."""
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        self._run(env.exec(['/bin/bash', '-c', 'cat'], input='payload', cwd='/w', env={'FOO': 'bar'}))
+
+        assert handle.payload['command'][-1] == "printf %s payload | ( export FOO=bar; cd /w && cat )"
+
+    def test_rendered_input_pipe_runs_in_a_real_shell(self):
+        """Render as the sandbox would, then prove the construct in an actual bash."""
+        from evalscope.agent.environments.enclave import _render_command
+        from evalscope.agent.environments.local import LocalAgentEnvironment
+
+        payload = 'multi\nline with $vars `cmd` \'quotes\' "dquotes" 100%'
+        rendered = _render_command(
+            ['/bin/bash', '-c', 'cat; echo "[$FOO]"'],
+            interpreter=['bash', '-c'],
+            cwd='/tmp',
+            env={'FOO': 'bar'},
+            stdin=payload,
+        )
+        result = self._run(LocalAgentEnvironment().exec(['bash', '-c', rendered], timeout=10))
+
+        assert result.returncode == 0
+        assert result.stdout == f'{payload}[bar]\n'
+
+    def test_exec_without_input_is_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        env, handle = self._env_with_fake_handle(monkeypatch)
+        self._run(env.exec(['/bin/bash', '-c', 'cat'], cwd='/w'))
+
+        assert handle.payload['command'][-1] == 'cd /w && cat'
+
+    def test_input_is_rejected_for_a_non_shell_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pipe is shell syntax; refuse rather than drop the payload again."""
+        env, _ = self._env_with_fake_handle(monkeypatch, interpreter=['python3', '-c'])
+
+        with pytest.raises(NotImplementedError, match='cannot supply stdin'):
+            self._run(env.exec(['print(1)'], input='payload'))
+
     def test_empty_interpreter_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from evalscope.agent.environments.enclave import EnclaveAgentEnvironment
 

--- a/tests/agent/test_t2_environment.py
+++ b/tests/agent/test_t2_environment.py
@@ -351,23 +351,40 @@ class TestEnclaveEnvironmentInterpreter:
 
         assert handle.payload['command'][-1] == "printf %s payload | ( export FOO=bar; cd /w && cat )"
 
-    def test_rendered_input_pipe_runs_in_a_real_shell(self):
-        """Render as the sandbox would, then prove the construct in an actual bash."""
+    @pytest.mark.parametrize('shell', ['bash', 'sh'])
+    def test_rendered_input_pipe_runs_in_a_real_shell(self, shell: str) -> None:
+        """Render as the sandbox would, then round-trip it through an actual shell.
+
+        ``sh`` is covered because the pipeline is POSIX syntax, not a bash
+        extension, and ``['sh', '-c']`` is a valid interpreter configuration.
+        On CI ``/bin/sh`` is dash, so this exercises a strict POSIX shell.
+        """
         from evalscope.agent.environments.enclave import _render_command
         from evalscope.agent.environments.local import LocalAgentEnvironment
 
         payload = 'multi\nline with $vars `cmd` \'quotes\' "dquotes" 100%'
         rendered = _render_command(
             ['/bin/bash', '-c', 'cat; echo "[$FOO]"'],
-            interpreter=['bash', '-c'],
+            interpreter=[shell, '-c'],
             cwd='/tmp',
             env={'FOO': 'bar'},
             stdin=payload,
         )
-        result = self._run(LocalAgentEnvironment().exec(['bash', '-c', rendered], timeout=10))
+        result = self._run(LocalAgentEnvironment().exec([shell, '-c', rendered], timeout=10))
 
         assert result.returncode == 0
         assert result.stdout == f'{payload}[bar]\n'
+
+    @pytest.mark.parametrize('interpreter', [['sh', '-c'], ['/bin/sh', '-c'], ['dash', '-c'], ['zsh', '-c']])
+    def test_input_is_rendered_for_any_posix_shell_interpreter(
+        self, monkeypatch: pytest.MonkeyPatch, interpreter: List[str]
+    ) -> None:
+        """Non-bash POSIX shells are valid interpreters and must not be refused."""
+        env, handle = self._env_with_fake_handle(monkeypatch, interpreter=interpreter)
+        self._run(env.exec(['cat'], input='piped payload'))
+
+        assert handle.payload['command'][:2] == interpreter
+        assert handle.payload['command'][-1] == "printf %s 'piped payload' | ( cat )"
 
     def test_exec_without_input_is_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         env, handle = self._env_with_fake_handle(monkeypatch)
@@ -375,9 +392,12 @@ class TestEnclaveEnvironmentInterpreter:
 
         assert handle.payload['command'][-1] == 'cd /w && cat'
 
-    def test_input_is_rejected_for_a_non_shell_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize('interpreter', [['python3', '-c'], ['node', '-e']])
+    def test_input_is_rejected_for_a_non_shell_interpreter(
+        self, monkeypatch: pytest.MonkeyPatch, interpreter: List[str]
+    ) -> None:
         """The pipe is shell syntax; refuse rather than drop the payload again."""
-        env, _ = self._env_with_fake_handle(monkeypatch, interpreter=['python3', '-c'])
+        env, _ = self._env_with_fake_handle(monkeypatch, interpreter=interpreter)
 
         with pytest.raises(NotImplementedError, match='cannot supply stdin'):
             self._run(env.exec(['print(1)'], input='payload'))


### PR DESCRIPTION
## Problem

`EnclaveAgentEnvironment.exec` accepts `input=` and never reads it — the only occurrence of the name in the file is the signature:

```python
async def exec(
    self,
    cmd: List[str],
    *,
    cwd: Optional[str] = None,
    input: Optional[str] = None,  # noqa: A002 - mirrors ABC signature
    ...
```

`input` is part of the `AgentEnvironment` contract and `LocalAgentEnvironment` honours it, so a caller that pipes a payload gets it in one environment and silently loses it in the other.

- `runners/mock.py` passes `input=task.instruction` and would run against empty stdin in a sandbox.
- `runners/codex.py` carries a comment routing around the gap: *"EnclaveAgentEnvironment (whose `exec` does not forward `input=` to the underlying shell executor)"*.

The base class documents the policy for the analogous case — a subclass that cannot honour `env` *"should raise `NotImplementedError` rather than silently dropping the request"*. Neither branch was taken for `input`.

Found while investigating #1685; unrelated to the hang itself.

## Change

ms_enclave's `shell_executor` takes a command and no stdin, so the payload is piped in by the shell that already runs the rendered command:

```
printf %s <quoted payload> | ( <command> )
```

The subshell is load-bearing. The renderer prepends env exports and a `cd`, so without it a rendered `cd /w && cat` would feed `cd` rather than `cat`:

```
printf %s payload | ( export FOO=bar; cd /w && cat )
```

Supplying stdin this way is shell syntax, so a non-shell `interpreter` now raises `NotImplementedError` rather than dropping the payload a second time.

The two `codex.py` comments describing the gap are dropped since it no longer holds. The positional prompt stays as it is — it keeps the invocation visible in run logs.

## Testing

Verified in a real bash across every shape the renderer produces — bare command, cwd prefix, env prefix, pipelines, and payloads containing newlines, quotes, backticks, `$` and `%`.

```
tests/agent/test_t2_environment.py   5 cases, 4 of them fail on main
  input is rendered as a pipe
  the pipe survives cwd and env prefixes
  the rendered command runs in a real bash and round-trips a payload with
    newlines and shell metacharacters
  no input leaves the command unchanged
  a non-shell interpreter raises instead of dropping the payload

tests/agent   346 passed, 21 skipped, same 7 pre-existing failures
              (test_sandbox_service, test_strategy_parsers: optional deps)
ruff 0.16.4 check + format --diff   clean
```

I don't have ms_enclave installed, so the sandbox side is covered by asserting the exact command string handed to `shell_executor` plus executing that same string in a real shell. If there is a reason `shell_executor` would reject a pipeline, say so and I'll switch to raising `NotImplementedError` instead.
