### PR TITLE
docs: fix the benchmark smoke evaluation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,9 +303,11 @@ make docs-generate
 
 ### Verify your benchmark
 
+Replace `my_benchmark` with your registered benchmark name and configure its dataset before running the command below. The mock model checks the evaluation pipeline; its scores do not measure model quality.
+
 ```bash
-# Check it's registered
-evalscope eval --benchmarks my_benchmark --model dummy --limit 5
+# Run a smoke evaluation with the mock model (no model download or API key required)
+evalscope eval --datasets my_benchmark --model dummy --eval-type mock_llm --limit 5
 
 # Run via service
 evalscope service


### PR DESCRIPTION
The benchmark verification command uses the unsupported `--benchmarks` option. After correcting that option alone, `--model dummy` would still select checkpoint loading because no mock backend is specified.

Use `--datasets` with `--eval-type mock_llm`. Clarify that contributors must configure their registered benchmark's dataset and that mock scores do not measure model quality.

Validation: the old command fails argument parsing with exit code 2. Using the documented adapter with a temporary local dataset, the corrected command evaluates 5 of 7 records with zero errors and generates a report while socket connections are forbidden. Applicable pre-commit hooks and `git diff --check` pass.
