### PR TITLE
fix(audio): preserve empty ASR transcripts when scoring WER

### DIFF
--- a/evalscope/benchmarks/seed_tts_eval/seed_tts_eval_adapter.py
+++ b/evalscope/benchmarks/seed_tts_eval/seed_tts_eval_adapter.py
@@ -30,6 +30,7 @@ PROMPT_TEMPLATE = (
 @register_benchmark(
     BenchmarkMeta(
         name='seed_tts_eval',
+        evaluation_version='v1.1',
         pretty_name='Seed-TTS-Eval',
         dataset_id='evalscope/Seed-TTS-Eval',
         tags=[Tags.AUDIO, Tags.TEXT_TO_SPEECH],

--- a/evalscope/metrics/audio/metrics.py
+++ b/evalscope/metrics/audio/metrics.py
@@ -105,7 +105,9 @@ class AudioWER(Metric):
         if not isinstance(payload, dict):
             raise ValueError(f'Unexpected response payload format (expected dict): {payload}')
 
-        text = payload.get('text') or payload.get('transcription')
+        text = payload.get('text')
+        if text is None:
+            text = payload.get('transcription')
         if text is None and isinstance(payload.get('result'), dict):
             text = payload['result'].get('text')
         if text is None:

--- a/tests/api/test_seed_tts_eval_benchmark.py
+++ b/tests/api/test_seed_tts_eval_benchmark.py
@@ -1,7 +1,9 @@
 import base64
+import json
 from typing import Any, Optional
 
 import pytest
+import requests
 
 from evalscope.api.benchmark import BenchmarkMeta
 from evalscope.api.dataset import Sample
@@ -79,7 +81,8 @@ def test_inference_end_saves_audio_output(tmp_path: Any) -> None:
         assert f.read() == b'fake-audio'
 
 
-def test_match_score_uses_generated_audio_path(monkeypatch: Any) -> None:
+@pytest.mark.parametrize('transcript,expected_score', [('hello', 0.0), ('', 1.0)])
+def test_match_score_uses_generated_audio_path(monkeypatch: Any, transcript: str, expected_score: float) -> None:
     adapter = make_adapter(metric_list=[{'audio_wer': {'api_key': 'test-key', 'api_base': 'https://asr.test/v1'}}])
     sample = Sample(input=[ChatMessageUser(content='hello')], target='hello', metadata={'wer_language': 'en'})
     state = TaskState(model='mock', sample=sample, completed=True)
@@ -102,7 +105,7 @@ def test_match_score_uses_generated_audio_path(monkeypatch: Any) -> None:
                 pass
 
             def json(self) -> dict[str, str]:
-                return {'text': 'hello'}
+                return {'text': transcript}
 
         assert url == 'https://asr.test/v1/audio/transcriptions'
         assert headers['Authorization'] == 'Bearer test-key'
@@ -112,11 +115,15 @@ def test_match_score_uses_generated_audio_path(monkeypatch: Any) -> None:
     monkeypatch.setattr('requests.Session.post', mock_post)
     score = adapter.match_score('', '', 'hello', state)
 
-    assert score.value['audio_wer'] == 0.0
-    assert score.metadata['transcription'] == 'hello'
+    assert score.value['audio_wer'] == expected_score
+    assert score.metadata['transcription'] == transcript
+    assert 'audio_wer' not in score.metadata
 
 
-def test_audio_wer_accepts_full_transcription_endpoint(monkeypatch: Any) -> None:
+@pytest.mark.parametrize('transcript,expected_score', [('hello', 0.0), ('', 1.0)])
+def test_audio_wer_accepts_full_transcription_endpoint(
+    monkeypatch: Any, transcript: str, expected_score: float
+) -> None:
 
     def mock_post(
         self: Any,
@@ -135,7 +142,7 @@ def test_audio_wer_accepts_full_transcription_endpoint(monkeypatch: Any) -> None
                 pass
 
             def json(self) -> dict[str, str]:
-                return {'text': 'hello'}
+                return {'text': transcript}
 
         assert url == 'https://asr.test/v1/audio/transcriptions'
         return Response()
@@ -144,8 +151,76 @@ def test_audio_wer_accepts_full_transcription_endpoint(monkeypatch: Any) -> None
     metric = AudioWER(api_base='https://asr.test/v1/audio/transcriptions', api_key='test-key')
     score = metric('data:audio/wav;base64,' + base64.b64encode(b'audio').decode('utf-8'), 'hello')
 
-    assert score == 0.0
-    assert metric.transcriptions == ['hello']
+    assert score == expected_score
+    assert metric.transcriptions == [transcript]
+
+
+@pytest.mark.parametrize(
+    'payload,expected',
+    [
+        pytest.param({'text': 'hello', 'transcription': 'other'}, 'hello', id='primary-text'),
+        pytest.param({'text': '', 'transcription': 'other'}, '', id='empty-primary-text'),
+        pytest.param({'text': '', 'result': {'text': 'other'}}, '', id='empty-primary-before-nested'),
+        pytest.param({'transcription': 'hello'}, 'hello', id='missing-primary'),
+        pytest.param({'text': None, 'transcription': 'hello'}, 'hello', id='null-primary'),
+        pytest.param({'transcription': ''}, '', id='empty-fallback'),
+        pytest.param({'text': None, 'transcription': ''}, '', id='null-primary-empty-fallback'),
+        pytest.param({'transcription': '', 'result': {'text': 'other'}}, '', id='empty-fallback-before-nested'),
+        pytest.param({'result': {'text': 'hello'}}, 'hello', id='nested-fallback'),
+        pytest.param({'text': None, 'transcription': None, 'result': {'text': 'hello'}}, 'hello', id='both-null'),
+        pytest.param({'result': {'text': ''}}, '', id='empty-nested-fallback'),
+    ],
+)
+def test_audio_wer_transcription_field_precedence(monkeypatch: Any, payload: dict[str, Any], expected: str) -> None:
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode('utf-8')
+    monkeypatch.setattr('requests.Session.post', lambda *args, **kwargs: response)
+    metric = AudioWER(api_base='https://asr.test/v1', api_key='test-key', api_protocol='transcriptions')
+    audio = 'data:audio/wav;base64,' + base64.b64encode(b'audio').decode('utf-8')
+
+    assert metric._transcribe(audio) == expected
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [{}, {'text': None}, {'text': None, 'transcription': None}, {'result': {}}, {'result': {'text': None}}],
+)
+def test_audio_wer_missing_transcription_still_raises(monkeypatch: Any, payload: dict[str, Any]) -> None:
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode('utf-8')
+    monkeypatch.setattr('requests.Session.post', lambda *args, **kwargs: response)
+    metric = AudioWER(api_base='https://asr.test/v1', api_key='test-key', api_protocol='transcriptions')
+    audio = 'data:audio/wav;base64,' + base64.b64encode(b'audio').decode('utf-8')
+
+    with pytest.raises(ValueError, match='No transcription text found'):
+        metric._transcribe(audio)
+
+
+@pytest.mark.parametrize('payload', [None, [], 'hello'])
+def test_audio_wer_non_object_response_still_raises(monkeypatch: Any, payload: Any) -> None:
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode('utf-8')
+    monkeypatch.setattr('requests.Session.post', lambda *args, **kwargs: response)
+    metric = AudioWER(api_base='https://asr.test/v1', api_key='test-key', api_protocol='transcriptions')
+    audio = 'data:audio/wav;base64,' + base64.b64encode(b'audio').decode('utf-8')
+
+    with pytest.raises(ValueError, match='Unexpected response payload format'):
+        metric._transcribe(audio)
+
+
+def test_audio_wer_http_error_is_not_an_empty_transcription(monkeypatch: Any) -> None:
+    response = requests.Response()
+    response.status_code = 503
+    response._content = b'{"text": ""}'
+    monkeypatch.setattr('requests.Session.post', lambda *args, **kwargs: response)
+    metric = AudioWER(api_base='https://asr.test/v1', api_key='test-key', api_protocol='transcriptions')
+    audio = 'data:audio/wav;base64,' + base64.b64encode(b'audio').decode('utf-8')
+
+    with pytest.raises(requests.HTTPError):
+        metric._transcribe(audio)
 
 
 def test_audio_wer_supports_responses_protocol(monkeypatch: Any) -> None:


### PR DESCRIPTION
An ASR response containing `{"text": ""}` is currently treated as missing text. In Seed-TTS-Eval, the resulting exception is caught and recorded as WER=0, although an empty transcript against a nonempty reference should have WER=1.

Preserve empty primary transcripts and consult fallback fields only when the primary value is None. Add adapter-level coverage, field-precedence tests and error controls. Bump Seed-TTS-Eval's evaluation version to v1.1 because the scoring behavior changes.

Validation: the same expanded suite produces 4 failures and 24 passes with the baseline metric implementation, and 28 passes with the fix. The regressions cover adapter scoring, metric scoring, and empty primary text being overwritten by alternate fields. Missing/null fields, non-object JSON responses, and HTTP errors remain errors at the metric boundary. Applicable pre-commit hooks and `git diff --check` pass.

The scope is successful `/audio/transcriptions` responses with string text fields. HTTP responses are mocked; no production incident or live ASR response is claimed. The adapter's general error-to-zero fallback and empty Responses-protocol outputs are separate unresolved issues.
