### PR TITLE
[Draft] feat(benchmark): add MADQA evaluation adapter

### DIFF
--- a/docs/en/benchmarks/madqa.md
+++ b/docs/en/benchmarks/madqa.md
@@ -1,0 +1,149 @@
+# MADQA
+
+
+## Overview
+
+MADQA (Multimodal Agentic Document QA) evaluates document-retrieval agents on human-authored
+questions grounded in a heterogeneous collection of PDF documents. EvalScope loads the ModelScope
+mirror, `evalscope/MADQA`.
+
+## Task Description
+
+- **Task Type**: Agentic multimodal document question answering
+- **Input**: A natural-language question over a collection of PDF documents accessed through retrieval tools
+- **Output**: A concise list of answer values and document/page citations in JSON
+- **Domain**: Heterogeneous real-world documents across financial, legal, reference, technical, and public-record domains
+
+## Key Features
+
+- Contains 2,250 questions over 800 PDF documents; the public ModelScope mirror provides 1,550 train, 200 dev, and 500 hidden-label test questions
+- Separates single-page, cross-page, and cross-document questions using the official evidence annotations
+- Supports native and external EvalScope agent runs when retrieval tools are supplied through `TaskConfig.agent_config`
+- Preserves the official answer-and-citation JSON contract, including an optional retrieval-step count
+
+## Evaluation Notes
+
+- The default `dev` split is the public scored split. The mirrored `test` split intentionally omits answer and evidence labels and cannot be scored locally
+- Reports official deterministic metrics: ANLS*, accuracy at ANLS* >= 0.5, document F1, and page F1
+- Kuiper statistic and Wasted Effort Ratio are additionally reported when predictions provide `iterations` or a native agent trace records retrieval tool calls
+- The official optional Gemini semantic-accuracy mode is not enabled: its fixed Gemini judge and published calibration are not portable to EvalScope judge configurations
+- EvalScope does not bundle the official BM25/OCR retrieval baseline. Configure compatible native tools, MCP servers, or an external agent that can access the published document URLs
+- [Paper](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)
+
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Benchmark Name** | `madqa` |
+| **Dataset ID** | [evalscope/MADQA](https://modelscope.cn/datasets/evalscope/MADQA/summary) |
+| **Paper** | [Paper](https://arxiv.org/abs/2603.12180) |
+| **Tags** | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |
+| **Metrics** | `anls`, `accuracy`, `document_f1`, `page_f1`, `kuiper_statistic`, `wasted_effort_ratio` |
+| **Default Shots** | 0-shot |
+| **Evaluation Split** | `dev` |
+
+
+## Data Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total Samples | 200 |
+| Prompt Length (Mean) | 680.35 chars |
+| Prompt Length (Min/Max) | 625 / 806 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `single` | 163 | 677.05 | 625 | 806 |
+| `cross_page` | 18 | 686.11 | 638 | 739 |
+| `cross_doc` | 19 | 703.21 | 644 | 776 |
+
+## Sample Example
+
+**Subset**: `single`
+
+```json
+{
+  "input": [
+    {
+      "id": "b3dc7205",
+      "content": "You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations."
+    },
+    {
+      "id": "1e14dcbf",
+      "content": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{\"answer\": [\"short answer\"], \"citations\": [{\"document\": \"filename.pdf\", \"page\": 1}], \"iterations\": 0}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known."
+    }
+  ],
+  "target": "[[\"For First Street through Twelfth Street, spell-out the number\", \"For 28th Street and above (e.g. 44th Street), use numbers\", \"For Three Mile Road, Four Mile Road, etc., spell-out the number\"], [\"spell-out numbers for First Street through Twelfth Street\", \"use numbers for 28th Street and above (e.g. 44th Street)\", \"spell-out numbers for Three Mile Road, Four Mile Road, etc.\"]]",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "single",
+  "metadata": {
+    "id": "dev/0",
+    "question": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?",
+    "evidence": [
+      {
+        "document": "24514009.pdf",
+        "page": 7
+      }
+    ],
+    "document_category": "Guide",
+    "domain": "Reference",
+    "hop_type": "single"
+  }
+}
+```
+
+## Prompt Template
+
+**System Prompt:**
+```text
+You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.
+```
+
+**Prompt Template:**
+```text
+{question}
+
+Use the available document-retrieval tools to find evidence before answering. Return only a JSON object:
+{{"answer": ["short answer"], "citations": [{{"document": "filename.pdf", "page": 1}}], "iterations": 0}}
+
+The answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.
+```
+
+## Usage
+
+### Using CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets madqa \
+    --limit 10  # Remove this line for formal evaluation
+```
+
+### Using Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['madqa'],
+    dataset_args={
+        'madqa': {
+            # subset_list: ['single', 'cross_page', 'cross_doc']  # optional, evaluate specific subsets
+        }
+    },
+    limit=10,  # Remove this line for formal evaluation
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/en/get_started/supported_dataset/agent.md
+++ b/docs/en/get_started/supported_dataset/agent.md
@@ -18,6 +18,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 | `job_bench` | [JobBench](../../benchmarks/job_bench.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `k2_verifier` | [K2-Vendor-Verifier](../../benchmarks/k2_verifier.md) | `Agent`, `FunctionCalling` |
 | `kimi_verifier` | [Kimi-Vendor-Verifier](../../benchmarks/kimi_verifier.md) | `Agent`, `FunctionCalling` |
+| `madqa` | [MADQA](../../benchmarks/madqa.md) | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |
 | `mcp_atlas` | [MCP-Atlas](../../benchmarks/mcp_atlas.md) | `Agent`, `MultiTurn` |
 | `minimax_verifier` | [MiniMax-Vendor-Verifier](../../benchmarks/minimax_verifier.md) | `Agent`, `FunctionCalling` |
 | `miniwob` | [MiniWoB](../../benchmarks/miniwob.md) | `Agent`, `FunctionCalling`, `MultiModal`, `MultiTurn` |
@@ -55,6 +56,7 @@ Below is the list of supported AGENT benchmarks. Click on a benchmark name for d
 ../../benchmarks/job_bench.md
 ../../benchmarks/k2_verifier.md
 ../../benchmarks/kimi_verifier.md
+../../benchmarks/madqa.md
 ../../benchmarks/mcp_atlas.md
 ../../benchmarks/minimax_verifier.md
 ../../benchmarks/miniwob.md

--- a/docs/zh/benchmarks/madqa.md
+++ b/docs/zh/benchmarks/madqa.md
@@ -1,0 +1,147 @@
+# MADQA
+
+
+## 概述
+
+MADQA（Multimodal Agentic Document QA）评估文档检索智能体在基于异构 PDF 文档集合的人工编写问题上的表现。EvalScope 加载 ModelScope 镜像 `evalscope/MADQA`。
+
+## 任务描述
+
+- **任务类型**：智能体驱动的多模态文档问答
+- **输入**：针对通过检索工具访问的一组 PDF 文档提出的自然语言问题
+- **输出**：包含简洁答案值及文档/页码引用的 JSON 格式列表
+- **领域**：涵盖金融、法律、参考资料、技术文档和公共记录等多个领域的异构真实世界文档
+
+## 关键特性
+
+- 包含 800 份 PDF 文档上的 2,250 个问题；公开的 ModelScope 镜像提供 1,550 个训练问题、200 个开发集问题和 500 个隐藏标签的测试问题
+- 利用官方证据标注，将问题划分为单页、跨页和跨文档三类
+- 当通过 `TaskConfig.agent_config` 提供检索工具时，支持原生和外部 EvalScope 智能体运行
+- 保留官方定义的答案与引用 JSON 格式规范，包括可选的检索步骤计数
+
+## 评估说明
+
+- 默认的 `dev` 划分是公开评分的数据集。镜像中的 `test` 划分故意省略了答案和证据标签，无法在本地评分
+- 报告官方确定性指标：ANLS*、ANLS* >= 0.5 的准确率、文档 F1 和页面 F1
+- 当预测结果包含 `iterations` 字段或原生智能体轨迹记录了检索工具调用时，额外报告 Kuiper 统计量和浪费努力比率（Wasted Effort Ratio）
+- 官方可选的 Gemini 语义准确性模式未启用：其固定的 Gemini 评判器和已发布的校准无法移植到 EvalScope 的评判器配置中
+- EvalScope 未捆绑官方的 BM25/OCR 检索基线。请配置兼容的原生工具、MCP 服务器，或一个能够访问已发布文档 URL 的外部智能体
+- [论文](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)
+
+
+## 属性
+
+| 属性 | 值 |
+|----------|-------|
+| **基准测试名称** | `madqa` |
+| **数据集ID** | [evalscope/MADQA](https://modelscope.cn/datasets/evalscope/MADQA/summary) |
+| **论文** | [Paper](https://arxiv.org/abs/2603.12180) |
+| **标签** | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |
+| **指标** | `anls`, `accuracy`, `document_f1`, `page_f1`, `kuiper_statistic`, `wasted_effort_ratio` |
+| **默认示例数** | 0-shot |
+| **评估划分** | `dev` |
+
+
+## 数据统计
+
+| 指标 | 值 |
+|--------|-------|
+| 总样本数 | 200 |
+| 提示词长度（平均） | 680.35 字符 |
+| 提示词长度（最小/最大） | 625 / 806 字符 |
+
+**各子集统计信息：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `single` | 163 | 677.05 | 625 | 806 |
+| `cross_page` | 18 | 686.11 | 638 | 739 |
+| `cross_doc` | 19 | 703.21 | 644 | 776 |
+
+## 样例示例
+
+**子集**: `single`
+
+```json
+{
+  "input": [
+    {
+      "id": "b3dc7205",
+      "content": "You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations."
+    },
+    {
+      "id": "1e14dcbf",
+      "content": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{\"answer\": [\"short answer\"], \"citations\": [{\"document\": \"filename.pdf\", \"page\": 1}], \"iterations\": 0}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known."
+    }
+  ],
+  "target": "[[\"For First Street through Twelfth Street, spell-out the number\", \"For 28th Street and above (e.g. 44th Street), use numbers\", \"For Three Mile Road, Four Mile Road, etc., spell-out the number\"], [\"spell-out numbers for First Street through Twelfth Street\", \"use numbers for 28th Street and above (e.g. 44th Street)\", \"spell-out numbers for Three Mile Road, Four Mile Road, etc.\"]]",
+  "id": 0,
+  "group_id": 0,
+  "subset_key": "single",
+  "metadata": {
+    "id": "dev/0",
+    "question": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?",
+    "evidence": [
+      {
+        "document": "24514009.pdf",
+        "page": 7
+      }
+    ],
+    "document_category": "Guide",
+    "domain": "Reference",
+    "hop_type": "single"
+  }
+}
+```
+
+## 提示模板
+
+**系统提示：**
+```text
+You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.
+```
+
+**提示模板：**
+```text
+{question}
+
+Use the available document-retrieval tools to find evidence before answering. Return only a JSON object:
+{{"answer": ["short answer"], "citations": [{{"document": "filename.pdf", "page": 1}}], "iterations": 0}}
+
+The answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.
+```
+
+## 使用方法
+
+### 使用 CLI
+
+```bash
+evalscope eval \
+    --model YOUR_MODEL \
+    --api-url OPENAI_API_COMPAT_URL \
+    --api-key EMPTY_TOKEN \
+    --datasets madqa \
+    --limit 10  # 正式评估时请删除此行
+```
+
+### 使用 Python
+
+```python
+from evalscope import run_task
+from evalscope.config import TaskConfig
+
+task_cfg = TaskConfig(
+    model='YOUR_MODEL',
+    api_url='OPENAI_API_COMPAT_URL',
+    api_key='EMPTY_TOKEN',
+    datasets=['madqa'],
+    dataset_args={
+        'madqa': {
+            # subset_list: ['single', 'cross_page', 'cross_doc']  # 可选，用于评估特定子集
+        }
+    },
+    limit=10,  # 正式评估时请删除此行
+)
+
+run_task(task_cfg=task_cfg)
+```

--- a/docs/zh/get_started/supported_dataset/agent.md
+++ b/docs/zh/get_started/supported_dataset/agent.md
@@ -18,6 +18,7 @@
 | `job_bench` | [JobBench](../../benchmarks/job_bench.md) | `Agent`, `Knowledge`, `MultiTurn` |
 | `k2_verifier` | [K2-Vendor-Verifier](../../benchmarks/k2_verifier.md) | `Agent`, `FunctionCalling` |
 | `kimi_verifier` | [Kimi-Vendor-Verifier](../../benchmarks/kimi_verifier.md) | `Agent`, `FunctionCalling` |
+| `madqa` | [MADQA](../../benchmarks/madqa.md) | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |
 | `mcp_atlas` | [MCP-Atlas](../../benchmarks/mcp_atlas.md) | `Agent`, `MultiTurn` |
 | `minimax_verifier` | [MiniMax-Vendor-Verifier](../../benchmarks/minimax_verifier.md) | `Agent`, `FunctionCalling` |
 | `miniwob` | [MiniWoB](../../benchmarks/miniwob.md) | `Agent`, `FunctionCalling`, `MultiModal`, `MultiTurn` |
@@ -55,6 +56,7 @@
 ../../benchmarks/job_bench.md
 ../../benchmarks/k2_verifier.md
 ../../benchmarks/kimi_verifier.md
+../../benchmarks/madqa.md
 ../../benchmarks/mcp_atlas.md
 ../../benchmarks/minimax_verifier.md
 ../../benchmarks/miniwob.md

--- a/evalscope/benchmarks/_meta/madqa.json
+++ b/evalscope/benchmarks/_meta/madqa.json
@@ -1,0 +1,124 @@
+{
+  "meta": {
+    "pretty_name": "MADQA",
+    "dataset_id": "evalscope/MADQA",
+    "paper_url": "https://arxiv.org/abs/2603.12180",
+    "tags": [
+      "Agent",
+      "MultiModal",
+      "MultiTurn",
+      "Retrieval",
+      "QA"
+    ],
+    "metrics": [
+      "anls",
+      "accuracy",
+      "document_f1",
+      "page_f1",
+      "kuiper_statistic",
+      "wasted_effort_ratio"
+    ],
+    "few_shot_num": 0,
+    "eval_split": "dev",
+    "train_split": "",
+    "subset_list": [
+      "single",
+      "cross_page",
+      "cross_doc"
+    ],
+    "description": "\n## Overview\n\nMADQA (Multimodal Agentic Document QA) evaluates document-retrieval agents on human-authored\nquestions grounded in a heterogeneous collection of PDF documents. EvalScope loads the ModelScope\nmirror, `evalscope/MADQA`.\n\n## Task Description\n\n- **Task Type**: Agentic multimodal document question answering\n- **Input**: A natural-language question over a collection of PDF documents accessed through retrieval tools\n- **Output**: A concise list of answer values and document/page citations in JSON\n- **Domain**: Heterogeneous real-world documents across financial, legal, reference, technical, and public-record domains\n\n## Key Features\n\n- Contains 2,250 questions over 800 PDF documents; the public ModelScope mirror provides 1,550 train, 200 dev, and 500 hidden-label test questions\n- Separates single-page, cross-page, and cross-document questions using the official evidence annotations\n- Supports native and external EvalScope agent runs when retrieval tools are supplied through `TaskConfig.agent_config`\n- Preserves the official answer-and-citation JSON contract, including an optional retrieval-step count\n\n## Evaluation Notes\n\n- The default `dev` split is the public scored split. The mirrored `test` split intentionally omits answer and evidence labels and cannot be scored locally\n- Reports official deterministic metrics: ANLS*, accuracy at ANLS* >= 0.5, document F1, and page F1\n- Kuiper statistic and Wasted Effort Ratio are additionally reported when predictions provide `iterations` or a native agent trace records retrieval tool calls\n- The official optional Gemini semantic-accuracy mode is not enabled: its fixed Gemini judge and published calibration are not portable to EvalScope judge configurations\n- EvalScope does not bundle the official BM25/OCR retrieval baseline. Configure compatible native tools, MCP servers, or an external agent that can access the published document URLs\n- [Paper](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)\n",
+    "prompt_template": "{question}\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{{\"answer\": [\"short answer\"], \"citations\": [{{\"document\": \"filename.pdf\", \"page\": 1}}], \"iterations\": 0}}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.",
+    "system_prompt": "You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.",
+    "few_shot_prompt_template": "",
+    "aggregation": "mean",
+    "extra_params": {},
+    "sandbox_config": {},
+    "category": "agent",
+    "primary_metric": {
+      "name": "accuracy",
+      "aggregation": null,
+      "dimensions": {}
+    }
+  },
+  "statistics": {
+    "total_samples": 200,
+    "subset_stats": [
+      {
+        "name": "single",
+        "sample_count": 163,
+        "prompt_length_mean": 677.05,
+        "prompt_length_min": 625,
+        "prompt_length_max": 806,
+        "prompt_length_std": 30.55,
+        "target_length_mean": 70.1
+      },
+      {
+        "name": "cross_page",
+        "sample_count": 18,
+        "prompt_length_mean": 686.11,
+        "prompt_length_min": 638,
+        "prompt_length_max": 739,
+        "prompt_length_std": 27.85,
+        "target_length_mean": 176.72
+      },
+      {
+        "name": "cross_doc",
+        "sample_count": 19,
+        "prompt_length_mean": 703.21,
+        "prompt_length_min": 644,
+        "prompt_length_max": 776,
+        "prompt_length_std": 32.63,
+        "target_length_mean": 25.68
+      }
+    ],
+    "prompt_length": {
+      "mean": 680.35,
+      "min": 625,
+      "max": 806,
+      "std": 31.37
+    },
+    "target_length_mean": 75.48,
+    "computed_at": "2026-09-07T17:31:25.015203+08:00"
+  },
+  "sample_example": {
+    "data": {
+      "input": [
+        {
+          "id": "b3dc7205",
+          "content": "You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations."
+        },
+        {
+          "id": "1e14dcbf",
+          "content": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{\"answer\": [\"short answer\"], \"citations\": [{\"document\": \"filename.pdf\", \"page\": 1}], \"iterations\": 0}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known."
+        }
+      ],
+      "target": "[[\"For First Street through Twelfth Street, spell-out the number\", \"For 28th Street and above (e.g. 44th Street), use numbers\", \"For Three Mile Road, Four Mile Road, etc., spell-out the number\"], [\"spell-out numbers for First Street through Twelfth Street\", \"use numbers for 28th Street and above (e.g. 44th Street)\", \"spell-out numbers for Three Mile Road, Four Mile Road, etc.\"]]",
+      "id": 0,
+      "group_id": 0,
+      "subset_key": "single",
+      "metadata": {
+        "id": "dev/0",
+        "question": "What are the CAD Standards Guide requirements when it comes to numbered street name conventions?",
+        "evidence": [
+          {
+            "document": "24514009.pdf",
+            "page": 7
+          }
+        ],
+        "document_category": "Guide",
+        "domain": "Reference",
+        "hop_type": "single"
+      }
+    },
+    "subset": "single",
+    "truncated": false
+  },
+  "readme": {
+    "en": "# MADQA\n\n\n## Overview\n\nMADQA (Multimodal Agentic Document QA) evaluates document-retrieval agents on human-authored\nquestions grounded in a heterogeneous collection of PDF documents. EvalScope loads the ModelScope\nmirror, `evalscope/MADQA`.\n\n## Task Description\n\n- **Task Type**: Agentic multimodal document question answering\n- **Input**: A natural-language question over a collection of PDF documents accessed through retrieval tools\n- **Output**: A concise list of answer values and document/page citations in JSON\n- **Domain**: Heterogeneous real-world documents across financial, legal, reference, technical, and public-record domains\n\n## Key Features\n\n- Contains 2,250 questions over 800 PDF documents; the public ModelScope mirror provides 1,550 train, 200 dev, and 500 hidden-label test questions\n- Separates single-page, cross-page, and cross-document questions using the official evidence annotations\n- Supports native and external EvalScope agent runs when retrieval tools are supplied through `TaskConfig.agent_config`\n- Preserves the official answer-and-citation JSON contract, including an optional retrieval-step count\n\n## Evaluation Notes\n\n- The default `dev` split is the public scored split. The mirrored `test` split intentionally omits answer and evidence labels and cannot be scored locally\n- Reports official deterministic metrics: ANLS*, accuracy at ANLS* >= 0.5, document F1, and page F1\n- Kuiper statistic and Wasted Effort Ratio are additionally reported when predictions provide `iterations` or a native agent trace records retrieval tool calls\n- The official optional Gemini semantic-accuracy mode is not enabled: its fixed Gemini judge and published calibration are not portable to EvalScope judge configurations\n- EvalScope does not bundle the official BM25/OCR retrieval baseline. Configure compatible native tools, MCP servers, or an external agent that can access the published document URLs\n- [Paper](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `madqa` |\n| **Dataset ID** | [evalscope/MADQA](https://modelscope.cn/datasets/evalscope/MADQA/summary) |\n| **Paper** | [Paper](https://arxiv.org/abs/2603.12180) |\n| **Tags** | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |\n| **Metrics** | `anls`, `accuracy`, `document_f1`, `page_f1`, `kuiper_statistic`, `wasted_effort_ratio` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `dev` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 200 |\n| Prompt Length (Mean) | 680.35 chars |\n| Prompt Length (Min/Max) | 625 / 806 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `single` | 163 | 677.05 | 625 | 806 |\n| `cross_page` | 18 | 686.11 | 638 | 739 |\n| `cross_doc` | 19 | 703.21 | 644 | 776 |\n\n## Sample Example\n\n**Subset**: `single`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"b3dc7205\",\n      \"content\": \"You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.\"\n    },\n    {\n      \"id\": \"1e14dcbf\",\n      \"content\": \"What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\\n\\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\\n{\\\"answer\\\": [\\\"short answer\\\"], \\\"citations\\\": [{\\\"document\\\": \\\"filename.pdf\\\", \\\"page\\\": 1}], \\\"iterations\\\": 0}\\n\\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.\"\n    }\n  ],\n  \"target\": \"[[\\\"For First Street through Twelfth Street, spell-out the number\\\", \\\"For 28th Street and above (e.g. 44th Street), use numbers\\\", \\\"For Three Mile Road, Four Mile Road, etc., spell-out the number\\\"], [\\\"spell-out numbers for First Street through Twelfth Street\\\", \\\"use numbers for 28th Street and above (e.g. 44th Street)\\\", \\\"spell-out numbers for Three Mile Road, Four Mile Road, etc.\\\"]]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"single\",\n  \"metadata\": {\n    \"id\": \"dev/0\",\n    \"question\": \"What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\",\n    \"evidence\": [\n      {\n        \"document\": \"24514009.pdf\",\n        \"page\": 7\n      }\n    ],\n    \"document_category\": \"Guide\",\n    \"domain\": \"Reference\",\n    \"hop_type\": \"single\"\n  }\n}\n```\n\n## Prompt Template\n\n**System Prompt:**\n```text\nYou are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.\n```\n\n**Prompt Template:**\n```text\n{question}\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{{\"answer\": [\"short answer\"], \"citations\": [{{\"document\": \"filename.pdf\", \"page\": 1}}], \"iterations\": 0}}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets madqa \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['madqa'],\n    dataset_args={\n        'madqa': {\n            # subset_list: ['single', 'cross_page', 'cross_doc']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# MADQA\n\n\n## 概述\n\nMADQA（Multimodal Agentic Document QA）评估文档检索智能体在基于异构 PDF 文档集合的人工编写问题上的表现。EvalScope 加载 ModelScope 镜像 `evalscope/MADQA`。\n\n## 任务描述\n\n- **任务类型**：智能体驱动的多模态文档问答\n- **输入**：针对通过检索工具访问的一组 PDF 文档提出的自然语言问题\n- **输出**：包含简洁答案值及文档/页码引用的 JSON 格式列表\n- **领域**：涵盖金融、法律、参考资料、技术文档和公共记录等多个领域的异构真实世界文档\n\n## 关键特性\n\n- 包含 800 份 PDF 文档上的 2,250 个问题；公开的 ModelScope 镜像提供 1,550 个训练问题、200 个开发集问题和 500 个隐藏标签的测试问题\n- 利用官方证据标注，将问题划分为单页、跨页和跨文档三类\n- 当通过 `TaskConfig.agent_config` 提供检索工具时，支持原生和外部 EvalScope 智能体运行\n- 保留官方定义的答案与引用 JSON 格式规范，包括可选的检索步骤计数\n\n## 评估说明\n\n- 默认的 `dev` 划分是公开评分的数据集。镜像中的 `test` 划分故意省略了答案和证据标签，无法在本地评分\n- 报告官方确定性指标：ANLS*、ANLS* >= 0.5 的准确率、文档 F1 和页面 F1\n- 当预测结果包含 `iterations` 字段或原生智能体轨迹记录了检索工具调用时，额外报告 Kuiper 统计量和浪费努力比率（Wasted Effort Ratio）\n- 官方可选的 Gemini 语义准确性模式未启用：其固定的 Gemini 评判器和已发布的校准无法移植到 EvalScope 的评判器配置中\n- EvalScope 未捆绑官方的 BM25/OCR 检索基线。请配置兼容的原生工具、MCP 服务器，或一个能够访问已发布文档 URL 的外部智能体\n- [论文](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `madqa` |\n| **数据集ID** | [evalscope/MADQA](https://modelscope.cn/datasets/evalscope/MADQA/summary) |\n| **论文** | [Paper](https://arxiv.org/abs/2603.12180) |\n| **标签** | `Agent`, `MultiModal`, `MultiTurn`, `QA`, `Retrieval` |\n| **指标** | `anls`, `accuracy`, `document_f1`, `page_f1`, `kuiper_statistic`, `wasted_effort_ratio` |\n| **默认示例数** | 0-shot |\n| **评估划分** | `dev` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 200 |\n| 提示词长度（平均） | 680.35 字符 |\n| 提示词长度（最小/最大） | 625 / 806 字符 |\n\n**各子集统计信息：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `single` | 163 | 677.05 | 625 | 806 |\n| `cross_page` | 18 | 686.11 | 638 | 739 |\n| `cross_doc` | 19 | 703.21 | 644 | 776 |\n\n## 样例示例\n\n**子集**: `single`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"b3dc7205\",\n      \"content\": \"You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.\"\n    },\n    {\n      \"id\": \"1e14dcbf\",\n      \"content\": \"What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\\n\\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\\n{\\\"answer\\\": [\\\"short answer\\\"], \\\"citations\\\": [{\\\"document\\\": \\\"filename.pdf\\\", \\\"page\\\": 1}], \\\"iterations\\\": 0}\\n\\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.\"\n    }\n  ],\n  \"target\": \"[[\\\"For First Street through Twelfth Street, spell-out the number\\\", \\\"For 28th Street and above (e.g. 44th Street), use numbers\\\", \\\"For Three Mile Road, Four Mile Road, etc., spell-out the number\\\"], [\\\"spell-out numbers for First Street through Twelfth Street\\\", \\\"use numbers for 28th Street and above (e.g. 44th Street)\\\", \\\"spell-out numbers for Three Mile Road, Four Mile Road, etc.\\\"]]\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"subset_key\": \"single\",\n  \"metadata\": {\n    \"id\": \"dev/0\",\n    \"question\": \"What are the CAD Standards Guide requirements when it comes to numbered street name conventions?\",\n    \"evidence\": [\n      {\n        \"document\": \"24514009.pdf\",\n        \"page\": 7\n      }\n    ],\n    \"document_category\": \"Guide\",\n    \"domain\": \"Reference\",\n    \"hop_type\": \"single\"\n  }\n}\n```\n\n## 提示模板\n\n**系统提示：**\n```text\nYou are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations.\n```\n\n**提示模板：**\n```text\n{question}\n\nUse the available document-retrieval tools to find evidence before answering. Return only a JSON object:\n{{\"answer\": [\"short answer\"], \"citations\": [{{\"document\": \"filename.pdf\", \"page\": 1}}], \"iterations\": 0}}\n\nThe answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known.\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets madqa \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['madqa'],\n    dataset_args={\n        'madqa': {\n            # subset_list: ['single', 'cross_page', 'cross_doc']  # 可选，用于评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "7172fd95fd5411c6114b2915f1cfd585",
+    "needs_translation": false
+  },
+  "updated_at": "2026-09-07T17:31:25.033339+08:00",
+  "translation_updated_at": "2026-09-07T17:31:34+08:00"
+}

--- a/evalscope/benchmarks/madqa/__init__.py
+++ b/evalscope/benchmarks/madqa/__init__.py
@@ -1,0 +1,1 @@
+"""MADQA benchmark integration."""

--- a/evalscope/benchmarks/madqa/madqa_adapter.py
+++ b/evalscope/benchmarks/madqa/madqa_adapter.py
@@ -1,0 +1,198 @@
+import json
+from typing import Any, Dict, List
+
+from evalscope.api.agent import EventType
+from evalscope.api.benchmark import AgentAdapter, BenchmarkMeta
+from evalscope.api.dataset import Sample
+from evalscope.api.evaluator import TaskState
+from evalscope.api.metric import AggScore, SampleScore, Score
+from evalscope.api.registry import register_benchmark
+from evalscope.constants import Tags
+
+from .utils import anls_star, citation_f1, derive_hop_type, parse_prediction
+
+DATASET_ID = 'evalscope/MADQA'
+HOP_TYPES = ['single', 'cross_page', 'cross_doc']
+PROMPT_TEMPLATE = """{question}
+
+Use the available document-retrieval tools to find evidence before answering. Return only a JSON object:
+{{"answer": ["short answer"], "citations": [{{"document": "filename.pdf", "page": 1}}], "iterations": 0}}
+
+The answer must be a list of concise values. Cite every document page used. Set `iterations` to the number of retrieval steps when it is known."""
+SYSTEM_PROMPT = """You are a document QA assistant with access to document-retrieval tools. The answer is contained in the document collection. Search iteratively when evidence is incomplete, then give concise answer values and exact PDF filename/page citations."""
+DESCRIPTION = """
+## Overview
+
+MADQA (Multimodal Agentic Document QA) evaluates document-retrieval agents on human-authored
+questions grounded in a heterogeneous collection of PDF documents. EvalScope loads the ModelScope
+mirror, `evalscope/MADQA`.
+
+## Task Description
+
+- **Task Type**: Agentic multimodal document question answering
+- **Input**: A natural-language question over a collection of PDF documents accessed through retrieval tools
+- **Output**: A concise list of answer values and document/page citations in JSON
+- **Domain**: Heterogeneous real-world documents across financial, legal, reference, technical, and public-record domains
+
+## Key Features
+
+- Contains 2,250 questions over 800 PDF documents; the public ModelScope mirror provides 1,550 train, 200 dev, and 500 hidden-label test questions
+- Separates single-page, cross-page, and cross-document questions using the official evidence annotations
+- Supports native and external EvalScope agent runs when retrieval tools are supplied through `TaskConfig.agent_config`
+- Preserves the official answer-and-citation JSON contract, including an optional retrieval-step count
+
+## Evaluation Notes
+
+- The default `dev` split is the public scored split. The mirrored `test` split intentionally omits answer and evidence labels and cannot be scored locally
+- Reports official deterministic metrics: ANLS*, accuracy at ANLS* >= 0.5, document F1, and page F1
+- Kuiper statistic and Wasted Effort Ratio are additionally reported when predictions provide `iterations` or a native agent trace records retrieval tool calls
+- The official optional Gemini semantic-accuracy mode is not enabled: its fixed Gemini judge and published calibration are not portable to EvalScope judge configurations
+- EvalScope does not bundle the official BM25/OCR retrieval baseline. Configure compatible native tools, MCP servers, or an external agent that can access the published document URLs
+- [Paper](https://arxiv.org/abs/2603.12180) | [GitHub](https://github.com/OxRML/MADQA)
+"""
+
+
+@register_benchmark(
+    BenchmarkMeta(
+        name='madqa',
+        pretty_name='MADQA',
+        dataset_id=DATASET_ID,
+        tags=[Tags.AGENT, Tags.MULTI_MODAL, Tags.MULTI_TURN, Tags.RETRIEVAL, Tags.QA],
+        description=DESCRIPTION,
+        paper_url='https://arxiv.org/abs/2603.12180',
+        metric_list=['anls', 'accuracy', 'document_f1', 'page_f1', 'kuiper_statistic', 'wasted_effort_ratio'],
+        primary_metric='accuracy',
+        few_shot_num=0,
+        train_split=None,
+        eval_split='dev',
+        subset_list=HOP_TYPES,
+        prompt_template=PROMPT_TEMPLATE,
+        system_prompt=SYSTEM_PROMPT,
+        evaluation_version='v1.0',
+    )
+)
+class MADQAAdapter(AgentAdapter):
+    """Adapter for the official MADQA answer, citation, and effort protocol."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.reformat_subset = True
+
+    def record_to_sample(self, record: Dict[str, Any]) -> Sample:
+        """Convert a labeled MADQA question into an agent-evaluation sample."""
+        answer_variants = record.get('answer_variants') or []
+        evidence = record.get('evidence') or []
+        if not answer_variants or not evidence:
+            raise ValueError(
+                'MADQA requires labeled questions. Use the default dev split; the public test split has no answer or evidence labels.'
+            )
+
+        question = str(record['question']).strip()
+        hop_type = derive_hop_type(evidence)
+        return Sample(
+            input=question,
+            target=json.dumps(answer_variants, ensure_ascii=False),
+            subset_key=hop_type,
+            metadata={
+                'id': record.get('id', ''),
+                'question': question,
+                'evidence': evidence,
+                'document_category': record.get('document_category', ''),
+                'domain': record.get('domain', ''),
+                'hop_type': hop_type,
+            },
+        )
+
+    def extract_answer(self, prediction: str, task_state: TaskState) -> str:
+        """Normalize a model response to the MADQA JSON output contract."""
+        return json.dumps(parse_prediction(prediction), ensure_ascii=False)
+
+    def match_score(
+        self,
+        original_prediction: str,
+        filtered_prediction: str,
+        reference: str,
+        task_state: TaskState,
+    ) -> Score:
+        """Score a response with MADQA's deterministic answer and citation metrics."""
+        response = parse_prediction(filtered_prediction)
+        answer_variants = json.loads(reference)
+        evidence = (task_state.metadata or {}).get('evidence') or []
+        anls = anls_star(response['answer'], answer_variants)
+        accuracy = float(anls >= 0.5)
+        document_f1 = citation_f1(response['citations'], evidence, level='document')
+        page_f1 = citation_f1(response['citations'], evidence, level='page')
+        steps = self._steps(response, task_state)
+        return Score(
+            extracted_prediction=filtered_prediction,
+            prediction=original_prediction,
+            value={
+                'anls': anls,
+                'accuracy': accuracy,
+                'document_f1': document_f1,
+                'page_f1': page_f1,
+            },
+            metadata={'steps': steps, 'citations': response['citations']},
+            main_score_name='accuracy',
+        )
+
+    def aggregate_scores(self, sample_scores: List[SampleScore]) -> List[AggScore]:
+        """Add official effort-calibration metrics to standard per-sample means."""
+        scores = super().aggregate_scores(sample_scores)
+        effort_results = [
+            {
+                'correct': bool(sample_score.score.value.get('accuracy')),
+                'steps': self._score_steps(sample_score),
+            }
+            for sample_score in sample_scores
+            if self._score_steps(sample_score) > 0
+        ]
+        if not effort_results:
+            return scores
+
+        correct_steps = [item['steps'] for item in effort_results if item['correct']]
+        incorrect_steps = [item['steps'] for item in effort_results if not item['correct']]
+        if correct_steps and incorrect_steps:
+            scores.append(
+                AggScore(
+                    score=sum(incorrect_steps) / len(incorrect_steps) / (sum(correct_steps) / len(correct_steps)),
+                    metric_name='wasted_effort_ratio',
+                    aggregation='identity',
+                    num=len(effort_results),
+                )
+            )
+
+        correctness = [float(item['correct']) for item in sorted(effort_results, key=lambda item: item['steps'])]
+        mean_correctness = sum(correctness) / len(correctness)
+        if 0 < mean_correctness < 1:
+            cumulative = 0.0
+            deviations = []
+            for value in correctness:
+                cumulative += value - mean_correctness
+                deviations.append(cumulative)
+            scores.append(
+                AggScore(
+                    score=max(deviations) - min(deviations),
+                    metric_name='kuiper_statistic',
+                    aggregation='identity',
+                    num=len(effort_results),
+                )
+            )
+        return scores
+
+    @staticmethod
+    def _steps(response: Dict[str, Any], task_state: TaskState) -> int:
+        if response['iterations'] > 0:
+            return response['iterations']
+        if task_state.agent_trace is None:
+            return 0
+        return sum(
+            event.type == EventType.TOOL_CALL and event.payload.get('name') != 'submit'
+            for event in task_state.agent_trace.events
+        )
+
+    @staticmethod
+    def _score_steps(sample_score: SampleScore) -> int:
+        metadata = sample_score.score.metadata or {}
+        steps = metadata.get('steps', 0)
+        return steps if isinstance(steps, int) and steps > 0 else 0

--- a/evalscope/benchmarks/madqa/utils.py
+++ b/evalscope/benchmarks/madqa/utils.py
@@ -1,0 +1,188 @@
+import json
+from typing import Any, Dict, Sequence
+
+from evalscope.metrics.utils.functions import levenshtein_distance
+
+
+def derive_hop_type(evidence: Sequence[Dict[str, Any]]) -> str:
+    """Classify a question by the number of evidence documents and pages."""
+    documents = {str(item['document']) for item in evidence if item.get('document')}
+    pages = {
+        (str(item['document']), item.get('page'))
+        for item in evidence
+        if item.get('document') and item.get('page') is not None
+    }
+    if len(documents) > 1:
+        return 'cross_doc'
+    if len(pages) > 1:
+        return 'cross_page'
+    return 'single'
+
+
+def parse_prediction(prediction: str) -> Dict[str, Any]:
+    """Parse MADQA's JSON answer contract, preserving a plain-text fallback."""
+    payload = _first_json_object(prediction)
+    if payload is None:
+        return {'answer': [prediction.strip()] if prediction.strip() else [], 'citations': [], 'iterations': 0}
+
+    answer = payload.get('answer', [])
+    if isinstance(answer, str):
+        answer = [answer]
+    if not isinstance(answer, list):
+        answer = []
+
+    citations = []
+    for citation in payload.get('citations', []):
+        if not isinstance(citation, dict):
+            continue
+        document = citation.get('document') or citation.get('file')
+        page = citation.get('page')
+        if not isinstance(document, str) or not document.strip() or isinstance(page, bool):
+            continue
+        try:
+            page = int(page)
+        except (TypeError, ValueError):
+            continue
+        citations.append({'document': document.strip(), 'page': page})
+
+    iterations = payload.get('iterations', 0)
+    if isinstance(iterations, bool):
+        iterations = 0
+    try:
+        iterations = max(0, int(iterations))
+    except (TypeError, ValueError):
+        iterations = 0
+    if not iterations and isinstance(payload.get('search_history'), list):
+        iterations = len(payload['search_history'])
+
+    return {
+        'answer': [str(item).strip() for item in answer if str(item).strip()],
+        'citations': citations,
+        'iterations': iterations,
+    }
+
+
+def anls_star(prediction: Sequence[str], answer_variants: Sequence[Sequence[str]]) -> float:
+    """Calculate MADQA's maximum ANLS* score across answer variants."""
+    if not answer_variants:
+        return 0.0
+    return max(_list_similarity(prediction, variant) for variant in answer_variants)
+
+
+def citation_f1(
+    predicted_citations: Sequence[Dict[str, Any]], gold_evidence: Sequence[Dict[str, Any]], level: str
+) -> float:
+    """Calculate MADQA citation F1 at document or page level."""
+    if level == 'document':
+        gold = {item.get('document') for item in gold_evidence if item.get('document')}
+        predicted = {item.get('document') for item in predicted_citations if item.get('document')}
+    elif level == 'page':
+        gold = {
+            (item.get('document'), item.get('page'))
+            for item in gold_evidence
+            if item.get('document') and item.get('page') is not None
+        }
+        predicted = {
+            (item.get('document'), item.get('page'))
+            for item in predicted_citations
+            if item.get('document') and item.get('page') is not None
+        }
+    else:
+        raise ValueError(f'Unsupported MADQA citation level: {level}')
+
+    if not gold:
+        return 0.0
+    true_positive = len(gold & predicted)
+    precision = true_positive / len(predicted) if predicted else 0.0
+    recall = true_positive / len(gold)
+    return 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+
+def _first_json_object(text: str) -> Dict[str, Any] | None:
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char != '{':
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and ('answer' in value or 'citations' in value):
+            return value
+    return None
+
+
+def _list_similarity(prediction: Sequence[str], reference: Sequence[str]) -> float:
+    if not prediction and not reference:
+        return 1.0
+    if not prediction or not reference:
+        return 0.0
+
+    similarities = [[_string_similarity(predicted, expected) for expected in reference] for predicted in prediction]
+    return _maximum_assignment_sum(similarities) / max(len(prediction), len(reference))
+
+
+def _string_similarity(prediction: str, reference: str) -> float:
+    normalized_prediction = ' '.join(prediction.strip().lower().split())
+    normalized_reference = ' '.join(reference.strip().lower().split())
+    length = max(len(normalized_prediction), len(normalized_reference))
+    if not length:
+        return 1.0
+    similarity = 1 - levenshtein_distance(normalized_prediction, normalized_reference) / length
+    return similarity if similarity >= 0.5 else 0.0
+
+
+def _maximum_assignment_sum(similarities: Sequence[Sequence[float]]) -> float:
+    """Return the maximum-weight one-to-one assignment sum for a rectangular matrix."""
+    if not similarities or not similarities[0]:
+        return 0.0
+
+    matrix = [list(row) for row in similarities]
+    if len(matrix) > len(matrix[0]):
+        matrix = [list(row) for row in zip(*matrix)]
+
+    row_count = len(matrix)
+    column_count = len(matrix[0])
+    potentials_row = [0.0] * (row_count + 1)
+    potentials_column = [0.0] * (column_count + 1)
+    matching = [0] * (column_count + 1)
+    previous = [0] * (column_count + 1)
+
+    for row in range(1, row_count + 1):
+        matching[0] = row
+        current_column = 0
+        minimum = [float('inf')] * (column_count + 1)
+        used = [False] * (column_count + 1)
+        while True:
+            used[current_column] = True
+            current_row = matching[current_column]
+            delta = float('inf')
+            next_column = 0
+            for column in range(1, column_count + 1):
+                if used[column]:
+                    continue
+                cost = 1 - matrix[current_row - 1][column - 1]
+                reduced_cost = cost - potentials_row[current_row] - potentials_column[column]
+                if reduced_cost < minimum[column]:
+                    minimum[column] = reduced_cost
+                    previous[column] = current_column
+                if minimum[column] < delta:
+                    delta = minimum[column]
+                    next_column = column
+            for column in range(column_count + 1):
+                if used[column]:
+                    potentials_row[matching[column]] += delta
+                    potentials_column[column] -= delta
+                else:
+                    minimum[column] -= delta
+            current_column = next_column
+            if matching[current_column] == 0:
+                break
+        while True:
+            previous_column = previous[current_column]
+            matching[current_column] = matching[previous_column]
+            current_column = previous_column
+            if current_column == 0:
+                break
+
+    return sum(matrix[row - 1][column - 1] for column, row in enumerate(matching) if column and row)

--- a/evalscope/metrics/semantics/baselines.py
+++ b/evalscope/metrics/semantics/baselines.py
@@ -146,6 +146,18 @@ SEMANTIC_BASELINES: Dict[str, MetricSemantics] = {
         'Judge Score',
         display_precision=2,
     ),
+    'quality.effort_calibration.unbounded': _plain_number(
+        'quality.effort_calibration.unbounded',
+        'Effort Calibration',
+        display_precision=4,
+        direction=MetricDirection.LOWER_IS_BETTER,
+    ),
+    'quality.effort_ratio.unbounded': _plain_number(
+        'quality.effort_ratio.unbounded',
+        'Effort Ratio',
+        display_precision=4,
+        direction=MetricDirection.LOWER_IS_BETTER,
+    ),
     #: Score assigned by a scoring model (aesthetic / preference / alignment scorers) whose
     #: scale is defined by the model rather than by the benchmark.
     'quality.model_score.unbounded': _plain_number(

--- a/evalscope/metrics/semantics/catalog.py
+++ b/evalscope/metrics/semantics/catalog.py
@@ -355,6 +355,16 @@ METRIC_DEFINITIONS.update(
             baseline='quality.error_rate.ratio',
             metric_name='Bias Ratio',
         ),
+        'document_f1': MetricEntry(baseline='quality.f1.ratio', metric_name='Document F1'),
+        'page_f1': MetricEntry(baseline='quality.f1.ratio', metric_name='Page F1'),
+        'kuiper_statistic': MetricEntry(
+            baseline='quality.effort_calibration.unbounded',
+            metric_name='Kuiper Statistic',
+        ),
+        'wasted_effort_ratio': MetricEntry(
+            baseline='quality.effort_ratio.unbounded',
+            metric_name='Wasted Effort Ratio',
+        ),
         # $OneMillion-Bench reports this normalized rubric-weighted score as its primary metric.
         'expert_score': MetricEntry(baseline='quality.score.ratio', metric_name='Expert Score'),
         'total_model_time': MetricEntry(baseline='diagnostic.unspecified', raw_unit='s', display_precision=2),

--- a/tests/benchmark/test_madqa.py
+++ b/tests/benchmark/test_madqa.py
@@ -1,0 +1,123 @@
+import json
+import unittest
+
+from evalscope.api.evaluator import TaskState
+from evalscope.api.metric import SampleScore, Score
+from evalscope.api.model import ModelOutput
+from evalscope.api.registry import get_benchmark
+from evalscope.benchmarks.madqa.utils import anls_star, citation_f1, parse_prediction
+from evalscope.config import TaskConfig
+
+
+class TestMADQAUtils(unittest.TestCase):
+
+    def test_anls_star_matches_unordered_lists_and_best_variant(self) -> None:
+        score = anls_star(
+            ['second answer', 'first answer'],
+            [['wrong answer'], ['first answer', 'second answer']],
+        )
+
+        self.assertEqual(score, 1.0)
+
+    def test_anls_star_penalizes_missing_or_hallucinated_items(self) -> None:
+        self.assertEqual(anls_star(['one'], [['one', 'two']]), 0.5)
+        self.assertEqual(anls_star(['one', 'two'], [['one']]), 0.5)
+
+    def test_parse_prediction_normalizes_citation_aliases(self) -> None:
+        prediction = parse_prediction(
+            'Reasoning\n{"answer": "value", "citations": [{"file": "source.pdf", "page": "2"}], "iterations": 3}'
+        )
+
+        self.assertEqual(prediction, {
+            'answer': ['value'],
+            'citations': [{'document': 'source.pdf', 'page': 2}],
+            'iterations': 3,
+        })
+
+    def test_parse_prediction_uses_official_search_history_for_effort(self) -> None:
+        prediction = parse_prediction('{"answer": ["value"], "citations": [], "search_history": [{}, {}]}')
+
+        self.assertEqual(prediction['iterations'], 2)
+
+    def test_citation_f1_uses_sets_at_each_official_level(self) -> None:
+        evidence = [
+            {'document': 'a.pdf', 'page': 1},
+            {'document': 'a.pdf', 'page': 2},
+            {'document': 'b.pdf', 'page': 1},
+        ]
+        citations = [{'document': 'a.pdf', 'page': 1}, {'document': 'b.pdf', 'page': 2}]
+
+        self.assertEqual(citation_f1(citations, evidence, level='document'), 1.0)
+        self.assertEqual(citation_f1(citations, evidence, level='page'), 0.4)
+
+
+class TestMADQAAdapter(unittest.TestCase):
+
+    @staticmethod
+    def _adapter():
+        return get_benchmark('madqa', TaskConfig(model='mock', datasets=['madqa']))
+
+    @staticmethod
+    def _record() -> dict:
+        return {
+            'id': 'dev/0',
+            'question': 'Which values are correct?',
+            'answer_variants': [['first', 'second'], ['1st', '2nd']],
+            'evidence': [{'document': 'a.pdf', 'page': 1}, {'document': 'b.pdf', 'page': 2}],
+            'document_category': 'Report',
+            'domain': 'Financial',
+        }
+
+    def test_record_to_sample_preserves_official_metadata(self) -> None:
+        sample = self._adapter().record_to_sample(self._record())
+
+        self.assertEqual(sample.subset_key, 'cross_doc')
+        self.assertEqual(json.loads(sample.target), self._record()['answer_variants'])
+        self.assertEqual(sample.metadata['evidence'], self._record()['evidence'])
+
+    def test_pipeline_scores_answer_citations_and_iterations(self) -> None:
+        adapter = self._adapter()
+        sample = adapter.record_to_sample(self._record())
+        task_state = TaskState(
+            model='mock',
+            sample=sample,
+            output=ModelOutput.from_content(
+                model='mock',
+                content='{"answer": ["second", "first"], "citations": [{"document": "a.pdf", "page": 1}, {"document": "b.pdf", "page": 2}], "iterations": 2}',
+            ),
+            completed=True,
+        )
+
+        sample_score = adapter.calculate_metrics(task_state)
+
+        self.assertEqual(sample_score.score.value, {
+            'anls': 1.0,
+            'accuracy': 1.0,
+            'document_f1': 1.0,
+            'page_f1': 1.0,
+        })
+        self.assertEqual(sample_score.score.metadata['steps'], 2)
+
+    def test_aggregate_scores_adds_official_effort_metrics(self) -> None:
+        adapter = self._adapter()
+        sample_scores = [
+            SampleScore(
+                score=Score(value={'anls': 1.0, 'accuracy': 1.0, 'document_f1': 1.0, 'page_f1': 1.0}, metadata={'steps': 2}),
+                sample_id=0,
+                group_id=0,
+            ),
+            SampleScore(
+                score=Score(value={'anls': 0.0, 'accuracy': 0.0, 'document_f1': 0.0, 'page_f1': 0.0}, metadata={'steps': 4}),
+                sample_id=1,
+                group_id=1,
+            ),
+        ]
+
+        aggregated = {(score.metric_name, score.aggregation): score.score for score in adapter.aggregate_scores(sample_scores)}
+
+        self.assertEqual(aggregated[('wasted_effort_ratio', 'identity')], 2.0)
+        self.assertEqual(aggregated[('kuiper_statistic', 'identity')], 0.5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary\n- Add MADQA data adapter, official deterministic scoring, metric semantics, tests, and generated docs.\n\n## Known limitation\n- This draft does not yet implement the required PDF retrieval environment (OCR/index/search_documents/page rendering). It must not be merged until the real agent retrieval path is added and verified.\n\n## Validation\n- make lint\n- pytest tests/benchmark/test_madqa.py tests/cli/test_metric_semantics_e2e.py -p no:benchmark -q\n- pytest tests/cli/test_all.py::TestRun::test_ci_lite -v -s -p no:warnings