### PR TITLE
perf(web): cap dashboard's aggregated results table to 100 rows up front

### DIFF
--- a/evalscope/web/src/components/dashboard/AggregatedResults.tsx
+++ b/evalscope/web/src/components/dashboard/AggregatedResults.tsx
@@ -51,6 +51,17 @@ const DESCENDING_FIRST: Record<SortKey, boolean> = {
   lastRun: true,
 }
 
+/**
+ * Rows rendered up front, and added per click of "show more".
+ *
+ * A row here is one model x benchmark x metric combination, not a run, so a modest fleet of models
+ * and benchmarks already produces more rows than a browser should mount as table DOM on first paint.
+ * The cap keeps the initial render cheap without hiding data behind a second fetch -- everything is
+ * already in `rows`, this only staggers how much of it becomes DOM at once.
+ */
+const INITIAL_ROW_LIMIT = 100
+const ROW_LIMIT_STEP = 100
+
 /** Field columns stay on one line and clip within the responsive widths defined by the colgroup. */
 const FIELD_COLUMN = 'overflow-hidden whitespace-nowrap'
 
@@ -141,6 +152,18 @@ export default function AggregatedResults({
 
   const sorted = [...rows].sort((a, b) => (sort.descending ? -1 : 1) * compareBy(sort.key, a, b))
 
+  // A fresh row set (new filter, search or root) starts back at the cap rather than carrying over
+  // however far a previous, unrelated result set had been expanded to. Reset during render rather
+  // than in an effect, so the first paint of a new `rows` identity never mounts the stale overflow.
+  const [rowLimit, setRowLimit] = useState(INITIAL_ROW_LIMIT)
+  const [rowsForLimit, setRowsForLimit] = useState(rows)
+  if (rows !== rowsForLimit) {
+    setRowsForLimit(rows)
+    setRowLimit(INITIAL_ROW_LIMIT)
+  }
+  const visible = sorted.slice(0, rowLimit)
+  const hiddenCount = sorted.length - visible.length
+
   const toggleSort = (key: SortKey) => {
     const next =
       sort.key === key
@@ -210,7 +233,7 @@ export default function AggregatedResults({
           </tr>
         </thead>
         <tbody className="divide-y divide-[var(--border)]">
-          {sorted.map((row) => {
+          {visible.map((row) => {
             const key = cellKey(row.cell)
             const isOpen = expanded === key
             const { cell, stats } = row
@@ -312,6 +335,18 @@ export default function AggregatedResults({
           })}
         </tbody>
       </table>
+
+      {hiddenCount > 0 && (
+        <div className="border-t border-[var(--border)] px-4 py-2.5 text-center">
+          <button
+            type="button"
+            onClick={() => setRowLimit((limit) => limit + ROW_LIMIT_STEP)}
+            className="type-body-xs font-medium text-[var(--accent)] transition-colors hover:text-[var(--accent-dark)]"
+          >
+            {t('dashboard.showMoreRows', { n: Math.min(hiddenCount, ROW_LIMIT_STEP), total: sorted.length })}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/evalscope/web/src/components/dashboard/dashboard.test.tsx
+++ b/evalscope/web/src/components/dashboard/dashboard.test.tsx
@@ -237,4 +237,32 @@ describe('AggregatedResults', () => {
     expect(screen.getByText(/Measured once/)).toBeInTheDocument()
     expect(screen.queryByText('New')).not.toBeInTheDocument()
   })
+
+  /** One report per distinct dataset, so aggregation produces one row per report. */
+  function manyRows(n: number) {
+    return aggregateRuns(
+      Array.from({ length: n }, (_, i) =>
+        report(`run-${i}`, `2026-08-07T08:${String(i % 60).padStart(2, '0')}:00`, 0.5, `bench-${i}`)),
+      [],
+    )
+  }
+
+  it('caps rendered rows on a large result set instead of mounting every one', () => {
+    renderWith(<AggregatedResults rows={manyRows(120)} onOpenRun={() => {}} />)
+
+    expect(bodyRows()).toHaveLength(100)
+    expect(screen.getByRole('button', { name: 'Show 20 more (of 120)' })).toBeInTheDocument()
+  })
+
+  it('reveals more rows on request, and never hides a small result set', () => {
+    renderWith(<AggregatedResults rows={manyRows(120)} onOpenRun={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Show 20 more (of 120)' }))
+
+    expect(bodyRows()).toHaveLength(120)
+    expect(screen.queryByRole('button', { name: /Show .* more/ })).not.toBeInTheDocument()
+
+    cleanup()
+    renderWith(<AggregatedResults rows={rows()} onOpenRun={() => {}} />)
+    expect(screen.queryByRole('button', { name: /Show .* more/ })).not.toBeInTheDocument()
+  })
 })

--- a/evalscope/web/src/i18n/translations/dashboard.ts
+++ b/evalscope/web/src/i18n/translations/dashboard.ts
@@ -56,6 +56,7 @@ export const en: Dict = {
   outOfRangeHint:
     'Some runs recorded values outside this metric declared range, so they are shown as recorded '
     + 'and not converted. The benchmark most likely changed the scale it reports.',
+  showMoreRows: 'Show ${n} more (of ${total})',
 
   // Shared
   noReportsHint: 'Enter an output directory and click Scan to discover reports',
@@ -110,6 +111,7 @@ export const zh: Dict = {
   statRuns: '次数',
   singleRunHint: '只跑过一次，暂无可对比的历史。',
   outOfRangeHint: '部分运行记录的数值超出了该指标声明的量程，因此按原样显示、不做换算。通常是该 benchmark 改变了上报的刻度。',
+  showMoreRows: '显示更多 ${n} 行（共 ${total} 行）',
 
   noReportsHint: '输入输出目录路径并点击扫描来发现报告',
   welcomeTitle: '欢迎使用 EvalScope',


### PR DESCRIPTION
## Summary
- `/dashboard`'s aggregated results table mounted every model x benchmark x metric row as table DOM on first paint with no cap. With enough models and benchmarks in the output directory, this makes the dashboard slow to render.
- Renders the first 100 rows up front, with a "show N more" control to reveal the rest in batches of 100. No data is hidden or paginated away server-side — everything already loaded is still there, this only staggers how much becomes DOM at once.
- Small result sets (the common case today) render exactly as before, with no visible change.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx eslint` clean
- [x] `npx vitest run` — 464/464 passing, including 2 new tests covering the cap and the "show more" reveal