### PR TITLE
fix(service): stop 500ing on predictions whose agent trace carries token usage

### DIFF
--- a/evalscope/service/api_models/reports.py
+++ b/evalscope/service/api_models/reports.py
@@ -234,9 +234,11 @@ class TraceUsage(ApiResponseModel):
 
 
 class AgentTrace(ApiResponseModel):
+    framework: Optional[str] = None
     strategy: Optional[str] = None
     environment: Optional[str] = None
     max_steps: int
+    trial_id: Optional[str] = None
     events: List[AgentTraceEvent]
     total_usage: Optional[TraceUsage] = None
 

--- a/evalscope/service/api_models/reports.py
+++ b/evalscope/service/api_models/reports.py
@@ -222,11 +222,23 @@ class AgentTraceEvent(ApiResponseModel):
     payload: Dict[str, Any]
 
 
+class TraceUsage(ApiResponseModel):
+    """Mirrors `evalscope.api.model.model_output.ModelUsage`'s shape for the response contract."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    input_tokens_cache_write: Optional[int] = None
+    input_tokens_cache_read: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+
+
 class AgentTrace(ApiResponseModel):
     strategy: Optional[str] = None
     environment: Optional[str] = None
     max_steps: int
     events: List[AgentTraceEvent]
+    total_usage: Optional[TraceUsage] = None
 
 
 class JudgeAttempt(ApiResponseModel):

--- a/evalscope/web/src/api/generated/contracts.schema.json
+++ b/evalscope/web/src/api/generated/contracts.schema.json
@@ -33,6 +33,17 @@
             }
           ],
           "default": null
+        },
+        "total_usage": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TraceUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -2355,6 +2366,58 @@
       "required": [
         "message"
       ],
+      "type": "object"
+    },
+    "TraceUsage": {
+      "additionalProperties": false,
+      "description": "Mirrors `evalscope.api.model.model_output.ModelUsage`'s shape for the response contract.",
+      "properties": {
+        "input_tokens": {
+          "default": 0,
+          "type": "integer"
+        },
+        "input_tokens_cache_read": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "input_tokens_cache_write": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "output_tokens": {
+          "default": 0,
+          "type": "integer"
+        },
+        "reasoning_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "total_tokens": {
+          "default": 0,
+          "type": "integer"
+        }
+      },
       "type": "object"
     },
     "UsageSummary": {

--- a/evalscope/web/src/api/generated/contracts.schema.json
+++ b/evalscope/web/src/api/generated/contracts.schema.json
@@ -20,6 +20,17 @@
           },
           "type": "array"
         },
+        "framework": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "max_steps": {
           "type": "integer"
         },
@@ -38,6 +49,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/TraceUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "trial_id": {
+          "anyOf": [
+            {
+              "type": "string"
             },
             {
               "type": "null"

--- a/evalscope/web/src/api/generated/contracts.ts
+++ b/evalscope/web/src/api/generated/contracts.ts
@@ -509,9 +509,11 @@ export interface PredictionRow {
 export interface AgentTrace {
   environment?: string | null;
   events: AgentTraceEvent[];
+  framework?: string | null;
   max_steps: number;
   strategy?: string | null;
   total_usage?: TraceUsage | null;
+  trial_id?: string | null;
 }
 export interface AgentTraceEvent {
   latency_ms?: number | null;

--- a/evalscope/web/src/api/generated/contracts.ts
+++ b/evalscope/web/src/api/generated/contracts.ts
@@ -511,6 +511,7 @@ export interface AgentTrace {
   events: AgentTraceEvent[];
   max_steps: number;
   strategy?: string | null;
+  total_usage?: TraceUsage | null;
 }
 export interface AgentTraceEvent {
   latency_ms?: number | null;
@@ -524,6 +525,17 @@ export interface AgentTraceEvent {
     [k: string]: number;
   } | null;
   type: EventType;
+}
+/**
+ * Mirrors `evalscope.api.model.model_output.ModelUsage`'s shape for the response contract.
+ */
+export interface TraceUsage {
+  input_tokens?: number;
+  input_tokens_cache_read?: number | null;
+  input_tokens_cache_write?: number | null;
+  output_tokens?: number;
+  reasoning_tokens?: number | null;
+  total_tokens?: number;
 }
 /**
  * Score fields rendered by the Web UI; metadata remains benchmark-defined.

--- a/tests/report/test_report_endpoints.py
+++ b/tests/report/test_report_endpoints.py
@@ -110,6 +110,50 @@ class TestReportEndpoints(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(len(res.get_json()['predictions']), 1)
 
+    def test_predictions_returns_runtime_agent_trace_fields(self):
+        import pandas as pd
+
+        from evalscope.api.agent.trace import AgentTrace, AgentTraceEvent, EventType
+        from evalscope.api.model.model_output import ModelUsage
+
+        trace = AgentTrace(
+            framework='external-agent',
+            strategy='react',
+            max_steps=3,
+            trial_id='trial-1',
+            total_usage=ModelUsage(input_tokens=384, output_tokens=223, total_tokens=607),
+            events=[AgentTraceEvent(step=0, type=EventType.MODEL_GENERATE, payload={})],
+        )
+        frame = pd.DataFrame([{
+            'Index': '0',
+            'Input': 'question',
+            'Metadata': {},
+            'Generated': 'answer',
+            'Gold': 'answer',
+            'Pred': 'answer',
+            'Score': {},
+            'NScore': 1.0,
+            'AgentTrace': trace.model_dump(exclude_none=True),
+        }])
+        with mock.patch(
+            'evalscope.service.blueprints.reports.get_model_prediction',
+            return_value=frame,
+        ):
+            res = self.client.get(
+                '/api/v1/reports/runs/20260101_120000/models/model-a/predictions',
+                query_string={
+                    'root_path': self.tmp,
+                    'dataset_name': 'gsm8k',
+                    'subset_name': 'main',
+                },
+            )
+
+        self.assertEqual(res.status_code, 200)
+        agent_trace = res.get_json()['predictions'][0]['AgentTrace']
+        self.assertEqual(agent_trace['framework'], 'external-agent')
+        self.assertEqual(agent_trace['trial_id'], 'trial-1')
+        self.assertEqual(agent_trace['total_usage']['total_tokens'], 607)
+
     def test_report_list_sorts_by_supported_fields(self):
         items = [
             self._report_meta('z-model', dataset='a-dataset', timestamp='2026-01-01T00:00:00'),

--- a/tests/service/test_api_contracts.py
+++ b/tests/service/test_api_contracts.py
@@ -358,7 +358,9 @@ def test_prediction_contract_supports_messages_trace_and_missing_optional_fields
                 {'role': 'assistant', 'content': 'answer'},
             ],
             'AgentTrace': {
+                'framework': 'external-agent',
                 'max_steps': 1,
+                'trial_id': 'trial-1',
                 'events': [{
                     'step': 0,
                     'timestamp': 1.0,
@@ -378,6 +380,8 @@ def test_prediction_contract_supports_messages_trace_and_missing_optional_fields
     assert row.normalized_score is None
     assert row.messages[1].perf_metrics is None
     assert row.agent_trace.events[0].payload['nullable'] is None
+    assert row.agent_trace.framework == 'external-agent'
+    assert row.agent_trace.trial_id == 'trial-1'
     assert row.agent_trace.total_usage.total_tokens == 32768
 
 

--- a/tests/service/test_api_contracts.py
+++ b/tests/service/test_api_contracts.py
@@ -365,6 +365,11 @@ def test_prediction_contract_supports_messages_trace_and_missing_optional_fields
                     'type': 'model_generate',
                     'payload': {'nullable': None},
                 }],
+                'total_usage': {
+                    'input_tokens': 384,
+                    'output_tokens': 223,
+                    'total_tokens': 32768,
+                },
             },
         }]
     })
@@ -373,6 +378,7 @@ def test_prediction_contract_supports_messages_trace_and_missing_optional_fields
     assert row.normalized_score is None
     assert row.messages[1].perf_metrics is None
     assert row.agent_trace.events[0].payload['nullable'] is None
+    assert row.agent_trace.total_usage.total_tokens == 32768
 
 
 def test_dynamic_dataframe_nan_serializes_as_json_null() -> None:


### PR DESCRIPTION
## Summary
- The `.../predictions` endpoint's `AgentTrace` response contract (`evalscope/service/api_models/reports.py`) had no `total_usage` field, but the base `ApiResponseModel` is `extra='forbid'`.
- Any stored prediction whose agent trace recorded token usage — which `claw_eval`, `acebench`, and the generic agent loop (`evalscope/api/agent/loop.py`) all populate via `trace.total_usage` — fails validation and the endpoint 500s instead of returning the predictions.
- Adds a `TraceUsage` contract mirroring `ModelUsage`'s shape (`input_tokens`, `output_tokens`, `total_tokens`, cache/reasoning token fields) and wires it onto `AgentTrace.total_usage`, then regenerates the frontend TS contracts.

## Test plan
- [x] `pytest tests/service/test_api_contracts.py` — 15/15 passing, including an extended fixture that reproduces the exact shape from the crash (`total_usage` alongside `input_tokens`/`output_tokens`)
- [x] `ruff check` / `ruff format --check` clean
- [x] `npm run contracts:check` — generated contracts match, no drift
- [x] `npx tsc -b` clean