### PR TITLE
feat(perf): experimental AgentX scenario via external AIPerf runner

### DIFF
--- a/evalscope/metrics/math/parser.py
+++ b/evalscope/metrics/math/parser.py
@@ -422,14 +422,18 @@ def math_equal(
         and (prediction.endswith('\\end{pmatrix}') or prediction.endswith('\\end{bmatrix}'))
         and (reference.startswith('\\begin{pmatrix}') or reference.startswith('\\begin{bmatrix}'))
         and (reference.endswith('\\end{pmatrix}') or reference.endswith('\\end{bmatrix}'))):
+        pred_tag = '\\begin{bmatrix}' if prediction.startswith('\\begin{bmatrix}') else '\\begin{pmatrix}'
+        ref_tag = '\\begin{bmatrix}' if reference.startswith('\\begin{bmatrix}') else '\\begin{pmatrix}'
+        pred_end = '\\end{bmatrix}' if prediction.endswith('\\end{bmatrix}') else '\\end{pmatrix}'
+        ref_end = '\\end{bmatrix}' if reference.endswith('\\end{bmatrix}') else '\\end{pmatrix}'
         pred_lines = [
             line.strip()
-            for line in prediction[len('\\begin{pmatrix}'):-len('\\end{pmatrix}')].split('\\\\')
+            for line in prediction[len(pred_tag):-len(pred_end)].split('\\\\')
             if line.strip()
         ]
         ref_lines = [
             line.strip()
-            for line in reference[len('\\begin{pmatrix}'):-len('\\end{pmatrix}')].split('\\\\')
+            for line in reference[len(ref_tag):-len(ref_end)].split('\\\\')
             if line.strip()
         ]
         matched = True

--- a/evalscope/perf/agentx/__init__.py
+++ b/evalscope/perf/agentx/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AgentX (InferenceX) scenario for EvalScope Perf.
+
+This module wraps the official AIPerf runner for the
+``inferencex-agentx-mvp`` scenario instead of reimplementing the AgentX
+session-tree scheduler inside EvalScope. See issue #1706 for the design
+rationale.
+
+Key properties:
+
+- AIPerf stays an **optional** dependency: it is resolved from the user
+  environment (or an explicit executable path) and is never added to the
+  default Perf runtime dependency set.
+- The exact AIPerf version/commit is recorded with every result for
+  provenance.
+- Raw AIPerf artifacts are preserved unchanged next to the normalized
+  result.
+- The normalized result distinguishes canonical (comparable) runs from
+  smoke runs, and surfaces ``submission_valid`` plus its reasons.
+"""
+
+from .config import AgentxArguments, validate_agentx_arguments
+from .runner import AIPerfRunner, build_aiperf_command, parse_profile_export
+from .result import AgentxResult, load_agentx_result
+
+__all__ = [
+    'AgentxArguments',
+    'AgentxResult',
+    'AIPerfRunner',
+    'build_aiperf_command',
+    'load_agentx_result',
+    'parse_profile_export',
+    'validate_agentx_arguments',
+]

--- a/evalscope/perf/agentx/config.py
+++ b/evalscope/perf/agentx/config.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Argument surface and validation for the AgentX scenario."""
+
+import re
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+# Aliases understood by AIPerf >= 0.13 (see aiperf/src/aiperf/plugin/plugins.yaml).
+# ``full`` is the date-pinned 062126 corpus (393 traces, current default);
+# ``256k`` is its filtered sibling for servers capped at ~256k context.
+AGENTX_VARIANTS = {
+    'full': 'semianalysis_cc_traces_weka_062126',
+    '256k': 'semianalysis_cc_traces_weka_062126_256k',
+}
+
+# HF repos behind the aliases, recorded in results for provenance.
+AGENTX_DATASET_REPOS = {
+    'full': 'semianalysisai/cc-traces-weka-062126',
+    '256k': 'semianalysisai/cc-traces-weka-062126-256k',
+}
+
+# Scenario locks documented by AIPerf; passing any of these alongside
+# --scenario is either rejected by AIPerf or silently overrides the lock,
+# so we reject them up front with a clear message.
+_CONFLICTING_AIPERF_FLAGS = (
+    '--fixed-schedule',
+    '--request-rate',
+    '--ignore-trace-delays',
+)
+
+
+class AgentxArguments(BaseModel):
+    """AgentX-specific arguments (``--agentx-*`` CLI flags).
+
+    These complement the standard Perf arguments (``--url``, ``--model``,
+    ``--parallel``, ``--duration``, ...) which map onto their AIPerf
+    counterparts in :mod:`evalscope.perf.agentx.runner`.
+    """
+
+    agentx_variant: str = 'full'
+    """AgentX corpus variant: ``full`` (393 traces) or ``256k`` (filtered)."""
+
+    agentx_aiperf_path: Optional[str] = None
+    """Explicit path to the AIPerf executable. When omitted, the runner
+    resolves ``aiperf`` from PATH (or ``uvx aiperf`` as a fallback)."""
+
+    agentx_max_context_length: Optional[int] = None
+    """Drops traces whose peak input+output exceeds this length (passed to
+    AIPerf ``--max-context-length``)."""
+
+    agentx_num_dataset_entries: Optional[int] = None
+    """Smoke-test only: cap the number of eligible traces. Marking a run
+    non-canonical is *not* automatic (AIPerf still stamps valid), so this
+    wrapper flags it explicitly."""
+
+    agentx_tokenizer: Optional[str] = None
+    """Tokenizer for ISL/OSL accounting; defaults to the ``--model`` value."""
+
+    agentx_random_seed: Optional[int] = None
+    """Deterministic trajectory sampling seed (AIPerf ``--random-seed``)."""
+
+    agentx_extra_args: List[str] = Field(default_factory=list)
+    """Escape hatch: raw extra flags forwarded verbatim to ``aiperf profile``."""
+
+    @field_validator('agentx_variant')
+    @classmethod
+    def _check_variant(cls, v: str) -> str:
+        if v not in AGENTX_VARIANTS:
+            raise ValueError(f'Unknown agentx variant {v!r}; expected one of {sorted(AGENTX_VARIANTS)}')
+        return v
+
+    @field_validator('agentx_extra_args')
+    @classmethod
+    def _check_extra_args(cls, v: List[str]) -> List[str]:
+        for item in v:
+            for flag in _CONFLICTING_AIPERF_FLAGS:
+                if item == flag or item.startswith(flag + '='):
+                    raise ValueError(
+                        f'{flag} conflicts with the inferencex-agentx-mvp scenario locks; '
+                        'the scenario auto-fills the agentic-replay scheduler'
+                    )
+        return v
+
+
+def validate_agentx_arguments(
+    url: str,
+    model: str,
+    parallel,
+    duration,
+    tokenizer_path: Optional[str] = None,
+    max_context_length: Optional[int] = None,
+) -> None:
+    """Fail fast on wrapper-level inconsistencies AIPerf would only report
+    mid-run (or not at all). Raises ``ValueError`` with an actionable message."""
+    if not model:
+        raise ValueError('AgentX scenario requires --model (the served model name)')
+    if not url:
+        raise ValueError('AgentX scenario requires --url pointing at the OpenAI-compatible server')
+    if not _is_http_url(url):
+        raise ValueError(f'--url must be an http(s) URL, got {url!r}')
+    if isinstance(parallel, (list, tuple)):
+        if len(parallel) != 1:
+            raise ValueError('AgentX concurrency maps to AIPerf --concurrency; comma-list sweeps are not supported')
+        parallel = parallel[0]
+    if not isinstance(parallel, int) or parallel < 1:
+        raise ValueError(f'--parallel must be a positive integer (session trees), got {parallel!r}')
+    if isinstance(duration, (list, tuple)):
+        if len(duration) != 1:
+            raise ValueError('AgentX duration maps to AIPerf --benchmark-duration; sweeps are not supported')
+        duration = duration[0]
+    if not isinstance(duration, int) or duration < 1:
+        raise ValueError(f'--duration must be a positive integer (seconds), got {duration!r}')
+    if max_context_length is not None and max_context_length < 1:
+        raise ValueError(f'--agentx-max-context-length must be positive, got {max_context_length!r}')
+
+
+_URL_RE = re.compile(r'^https?://')
+
+
+def _is_http_url(url: str) -> bool:
+    return bool(_URL_RE.match(url or ''))

--- a/evalscope/perf/agentx/result.py
+++ b/evalscope/perf/agentx/result.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Normalized AgentX result model with provenance and validity."""
+
+import os
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from evalscope.perf.agentx.config import AGENTX_DATASET_REPOS
+from evalscope.perf.agentx.runner import AGGREGATE_EXPORT, PER_RUN_EXPORT, parse_profile_export
+
+
+class AgentxResult(BaseModel):
+    """Normalized view of one AgentX run.
+
+    Metric fields stay ``None`` when AIPerf did not report them — missing
+    metrics must remain unavailable rather than be reported as zero.
+    """
+
+    # Provenance
+    aiperf_version: Optional[str] = None
+    aiperf_command: Optional[List[str]] = None
+    dataset_variant: Optional[str] = None
+    dataset_repo: Optional[str] = None
+    random_seed: Optional[int] = None
+    model: Optional[str] = None
+    num_gpus: Optional[int] = None
+
+    # Validity
+    submission_valid: Optional[bool] = None
+    """AIPerf's own scenario-validity stamp; ``None`` when absent (no --scenario)."""
+    submission_invalid_reasons: List[str] = Field(default_factory=list)
+    canonical: Optional[bool] = None
+    """False marks a shortened/modified smoke run not comparable to other
+    AgentX results (e.g. --agentx-num-dataset-entries)."""
+    invalid_reasons: List[str] = Field(default_factory=list)
+    """Wrapper-level validity explanations, complementing AIPerf's own."""
+
+    # Normalized metrics (None = not reported)
+    request_throughput: Optional[float] = None
+    output_throughput: Optional[float] = None
+    time_to_first_token_ms: Optional[float] = None
+    inter_token_latency_ms: Optional[float] = None
+    request_latency_ms: Optional[float] = None
+    total_requests: Optional[int] = None
+    successful_requests: Optional[int] = None
+    error_requests: Optional[int] = None
+    context_overflow_rate: Optional[float] = None
+
+    artifact_dir: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.model_dump()
+
+
+def _metric_value(metrics: Dict[str, Any], name: str, field: Optional[str] = None):
+    """Fetch ``metrics[name][field or 'avg']`` without inventing zeros."""
+    entry = metrics.get(name)
+    if not isinstance(entry, dict):
+        return None
+    value = entry.get(field or 'avg')
+    return value if isinstance(value, (int, float)) else None
+
+
+def load_agentx_result(
+    artifact_dir: str,
+    aiperf_version: Optional[str] = None,
+    aiperf_command: Optional[List[str]] = None,
+    dataset_variant: str = 'full',
+    random_seed: Optional[int] = None,
+    model: Optional[str] = None,
+    num_gpus: Optional[int] = None,
+    smoke_reasons: Optional[List[str]] = None,
+) -> AgentxResult:
+    """Parse AIPerf exports under ``artifact_dir`` into an :class:`AgentxResult`.
+
+    Prefers the aggregate export (multi-run) and falls back to the per-run
+    export. Raw files are left untouched.
+    """
+    aggregate_path = os.path.join(artifact_dir, AGGREGATE_EXPORT)
+    per_run_path = os.path.join(artifact_dir, PER_RUN_EXPORT)
+    path = aggregate_path if os.path.isfile(aggregate_path) else per_run_path
+    if not os.path.isfile(path):
+        raise FileNotFoundError(
+            f'No AIPerf export found under {artifact_dir!r} '
+            f'(looked for {AGGREGATE_EXPORT!r} and {PER_RUN_EXPORT!r})'
+        )
+
+    parsed = parse_profile_export(path)
+    metadata, metrics = parsed['metadata'], parsed['metrics']
+
+    invalid_reasons = list(smoke_reasons or [])
+    reasons = metadata.get('submission_invalid_reasons') or []
+    if isinstance(reasons, list):
+        invalid_reasons.extend(str(r) for r in reasons)
+
+    safe_command = _redact_command(aiperf_command) if aiperf_command else None
+
+    return AgentxResult(
+        aiperf_version=aiperf_version,
+        aiperf_command=safe_command,
+        dataset_variant=dataset_variant,
+        dataset_repo=AGENTX_DATASET_REPOS.get(dataset_variant),
+        random_seed=random_seed,
+        model=model or metadata.get('model'),
+        num_gpus=num_gpus,
+        submission_valid=metadata.get('submission_valid'),
+        submission_invalid_reasons=[str(r) for r in reasons] if isinstance(reasons, list) else [],
+        canonical=not invalid_reasons if isinstance(metadata.get('submission_valid'), bool) else None,
+        invalid_reasons=invalid_reasons,
+        request_throughput=_metric_value(metrics, 'request_throughput'),
+        output_throughput=_metric_value(metrics, 'output_token_throughput')
+        or _metric_value(metrics, 'output_throughput'),
+        time_to_first_token_ms=_ms(metrics, 'time_to_first_token', 'ttft'),
+        inter_token_latency_ms=_ms(metrics, 'inter_token_latency', 'itl'),
+        request_latency_ms=_ms(metrics, 'request_latency', 'e2el'),
+        total_requests=_count(metrics, 'total_requests'),
+        successful_requests=_count(metrics, 'successful_requests'),
+        error_requests=_count(metrics, 'error_requests'),
+        context_overflow_rate=_metric_value(metrics, 'context_overflow_rate'),
+        artifact_dir=os.path.abspath(artifact_dir),
+    )
+
+
+def _redact_command(cmd: List[str]) -> List[str]:
+    """Mask ``--api-key`` values so results can be logged safely."""
+    redacted = list(cmd)
+    for i, item in enumerate(redacted[:-1]):
+        if item == '--api-key':
+            redacted[i + 1] = '***'
+    return redacted
+
+
+def _ms(metrics: Dict[str, Any], *names: str) -> Optional[float]:
+    for name in names:
+        entry = metrics.get(name)
+        if isinstance(entry, dict) and isinstance(entry.get('avg'), (int, float)):
+            value = entry['avg']
+            unit = str(entry.get('unit', 'ms')).lower()
+            return value if unit in ('ms', 'millisecond', 'milliseconds') else value * 1000.0 \
+                if unit in ('s', 'second', 'seconds') else value
+    return None
+
+
+def _count(metrics: Dict[str, Any], name: str) -> Optional[int]:
+    value = metrics.get(name)
+    if isinstance(value, dict):
+        value = value.get('avg') or value.get('total') or value.get('count')
+    return value if isinstance(value, int) else None

--- a/evalscope/perf/agentx/runner.py
+++ b/evalscope/perf/agentx/runner.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build, execute, and harvest AIPerf ``inferencex-agentx-mvp`` runs."""
+
+import json
+import os
+import re
+import shutil
+import subprocess  # nosec B404 - invoking the user-resolved aiperf executable
+from typing import Any, Dict, List, Optional, Tuple
+
+from evalscope.perf.agentx.config import AGENTX_VARIANTS
+
+PER_RUN_EXPORT = 'profile_export_aiperf.json'
+AGGREGATE_EXPORT = os.path.join('aggregate', 'profile_export_aiperf_aggregate.json')
+
+# Flags the scenario hard-locks; writing them out keeps the constructed
+# command self-documenting (AIPerf would auto-fill identical values).
+_SCENARIO_LOCKED_FLAGS = [
+    '--endpoint-type', 'chat',
+    '--use-server-token-count',
+    '--streaming',
+    '--extra-inputs', 'ignore_eos:true',
+    '--cache-bust', 'first_turn_prefix',
+    '--system-idle-gap-cap-seconds', '10',
+    '--trajectory-start-min-ratio', '0.0',
+    '--trajectory-start-max-ratio', '1.0',
+    '--ui', 'simple',
+]
+
+
+def build_aiperf_command(
+    aiperf_executable: str,
+    url: str,
+    model: str,
+    variant: str = 'full',
+    parallel: int = 8,
+    duration: int = 3600,
+    api_key: Optional[str] = None,
+    tokenizer: Optional[str] = None,
+    max_context_length: Optional[int] = None,
+    num_dataset_entries: Optional[int] = None,
+    random_seed: Optional[int] = None,
+    artifact_dir: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+) -> List[str]:
+    """Construct the ``aiperf profile`` command line.
+
+    Only the URL's scheme://host[:port] is forwarded: AIPerf appends the
+    endpoint path itself based on ``--endpoint-type chat``.
+    """
+    cmd = [aiperf_executable, 'profile', '--scenario', 'inferencex-agentx-mvp']
+    cmd += ['--url', _strip_endpoint_path(url)]
+    cmd += ['--model', model]
+    cmd += ['--public-dataset', AGENTX_VARIANTS[variant]]
+    cmd += ['--concurrency', str(parallel)]
+    cmd += ['--benchmark-duration', str(duration)]
+    if api_key:
+        cmd += ['--api-key', api_key]
+    if tokenizer:
+        cmd += ['--tokenizer', tokenizer]
+    if max_context_length is not None:
+        cmd += ['--max-context-length', str(max_context_length)]
+    if num_dataset_entries is not None:
+        cmd += ['--num-dataset-entries', str(num_dataset_entries)]
+    if random_seed is not None:
+        cmd += ['--random-seed', str(random_seed)]
+    if artifact_dir:
+        cmd += ['--artifact-dir', artifact_dir]
+    cmd += _SCENARIO_LOCKED_FLAGS
+    if extra_args:
+        cmd += list(extra_args)
+    return cmd
+
+
+def _strip_endpoint_path(url: str) -> str:
+    m = re.match(r'^(https?://[^/]+)', url)
+    if not m:
+        raise ValueError(f'--url must be an http(s) URL, got {url!r}')
+    return m.group(1)
+
+
+def resolve_aiperf_executable(explicit_path: Optional[str] = None) -> Tuple[str, List[str]]:
+    """Return ``(executable, prefix_args)`` for launching AIPerf.
+
+    Resolution order: explicit path → ``aiperf`` on PATH → ``uvx aiperf``.
+    Raises ``FileNotFoundError`` when none is available (AIPerf is an
+    optional dependency by design).
+    """
+    if explicit_path:
+        if not (os.path.isfile(explicit_path) and os.access(explicit_path, os.X_OK)):
+            raise FileNotFoundError(
+                f'--agentx-aiperf-path {explicit_path!r} is not an executable file'
+            )
+        return explicit_path, []
+    found = shutil.which('aiperf')
+    if found:
+        return found, []
+    if shutil.which('uvx'):
+        return 'uvx', ['aiperf']
+    raise FileNotFoundError(
+        'AIPerf executable not found. Install it with `pip install aiperf` '
+        '(>= 0.13) or pass --agentx-aiperf-path.'
+    )
+
+
+def query_aiperf_version(executable: str, prefix_args: Optional[List[str]] = None) -> Optional[str]:
+    """Best-effort version probe; ``None`` when the command fails."""
+    try:
+        out = subprocess.run(  # nosec B603 - fixed executable, no shell
+            [executable, *(prefix_args or []), '--version'],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    text = (out.stdout or '') + (out.stderr or '')
+    m = re.search(r'(\d+\.\d+\.\d+(?:[+.-]\S+)?)', text)
+    return m.group(1) if m else (text.strip() or None)
+
+
+def parse_profile_export(path: str) -> Dict[str, Any]:
+    """Load a ``profile_export_aiperf.json`` (per-run or aggregate layout).
+
+    The per-run file has metrics top-level next to ``metadata``; the
+    aggregate file nests them under ``metrics``. Returns a dict with
+    ``metadata`` and ``metrics`` keys regardless of layout.
+    """
+    with open(path, encoding='utf-8') as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f'Unexpected profile export layout in {path}')
+    if 'metrics' in data and isinstance(data['metrics'], dict):
+        metadata = data.get('metadata') or {}
+        metrics = data['metrics']
+    else:
+        metadata = data.get('metadata') or {}
+        metrics = {k: v for k, v in data.items() if k != 'metadata'}
+    return {'metadata': metadata, 'metrics': metrics}
+
+
+class AIPerfRunner:
+    """Execute one AgentX run and retain its raw artifacts."""
+
+    def __init__(self, args, env: Optional[Dict[str, str]] = None):
+        """``args`` is an ``evalscope.perf.arguments.Arguments`` instance."""
+        self.perf_args = args
+        self.env = env
+        executable, prefix = resolve_aiperf_executable(getattr(args, 'agentx_aiperf_path', None))
+        self.executable = executable
+        self.executable_prefix = prefix
+        self.aiperf_version = query_aiperf_version(executable, prefix)
+
+    def build_command(self, artifact_dir: str) -> List[str]:
+        cmd = build_aiperf_command(
+            self.executable,
+            url=self.perf_args.url,
+            model=self.perf_args.model,
+            variant=self.perf_args.agentx_variant,
+            parallel=_first(self.perf_args.parallel),
+            duration=_first(self.perf_args.duration),
+            api_key=self.perf_args.api_key,
+            tokenizer=self.perf_args.agentx_tokenizer or self.perf_args.tokenizer_path,
+            max_context_length=self.perf_args.agentx_max_context_length,
+            num_dataset_entries=self.perf_args.agentx_num_dataset_entries,
+            random_seed=self.perf_args.agentx_random_seed,
+            artifact_dir=artifact_dir,
+            extra_args=self.perf_args.agentx_extra_args,
+        )
+        return self.executable_prefix + cmd
+
+    def run(self, artifact_dir: str, env: Optional[Dict[str, str]] = None) -> subprocess.CompletedProcess:
+        """Launch AIPerf, blocking until completion. Raw output stays under
+        ``artifact_dir`` (AIPerf writes its exports there)."""
+        cmd = self.build_command(artifact_dir)
+        merged_env = {**os.environ, **(env or self.env or {})}
+        return subprocess.run(  # nosec B603 - constructed command, no shell
+            cmd,
+            cwd=artifact_dir,
+            env=merged_env,
+            capture_output=True,
+            text=True,
+        )
+
+
+def _first(value):
+    if isinstance(value, (list, tuple)):
+        return value[0]
+    return value

--- a/tests/perf/test_agentx.py
+++ b/tests/perf/test_agentx.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the AgentX scenario wrapper (no AIPerf installation needed)."""
+
+import json
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+from evalscope.perf.agentx.config import (
+    AGENTX_DATASET_REPOS,
+    AgentxArguments,
+    validate_agentx_arguments,
+)
+from evalscope.perf.agentx.result import load_agentx_result
+from evalscope.perf.agentx.runner import build_aiperf_command, parse_profile_export
+
+
+class TestBuildCommand(unittest.TestCase):
+    def test_basic_command_shape(self):
+        cmd = build_aiperf_command(
+            'aiperf',
+            url='http://localhost:8000/v1/chat/completions',
+            model='deepseek-ai/DeepSeek-V4-Pro',
+            variant='256k',
+            parallel=8,
+            duration=3600,
+        )
+        self.assertEqual(cmd[0:2], ['aiperf', 'profile'])
+        self.assertIn('--scenario', cmd)
+        self.assertEqual(cmd[cmd.index('--scenario') + 1], 'inferencex-agentx-mvp')
+        # Endpoint path must be stripped; AIPerf appends it from --endpoint-type.
+        self.assertEqual(cmd[cmd.index('--url') + 1], 'http://localhost:8000')
+        self.assertEqual(cmd[cmd.index('--public-dataset') + 1], 'semianalysis_cc_traces_weka_062126_256k')
+        self.assertEqual(cmd[cmd.index('--concurrency') + 1], '8')
+        self.assertEqual(cmd[cmd.index('--benchmark-duration') + 1], '3600')
+        # Scenario-locked flags are written out explicitly.
+        for locked in ('--streaming', '--use-server-token-count', '--cache-bust', '--system-idle-gap-cap-seconds'):
+            self.assertIn(locked, cmd)
+
+    def test_optional_flags_omitted_by_default(self):
+        cmd = build_aiperf_command('aiperf', 'http://h:1', 'm')
+        for flag in ('--api-key', '--tokenizer', '--max-context-length', '--num-dataset-entries', '--random-seed'):
+            self.assertNotIn(flag, cmd)
+
+    def test_all_optional_flags_present_when_set(self):
+        cmd = build_aiperf_command(
+            'aiperf', 'http://h:1', 'm',
+            api_key='sk-secret', tokenizer='org/tok', max_context_length=256000,
+            num_dataset_entries=4, random_seed=20260707, artifact_dir='/tmp/art',
+        )
+        self.assertEqual(cmd[cmd.index('--api-key') + 1], 'sk-secret')
+        self.assertEqual(cmd[cmd.index('--max-context-length') + 1], '256000')
+        self.assertEqual(cmd[cmd.index('--num-dataset-entries') + 1], '4')
+        self.assertEqual(cmd[cmd.index('--random-seed') + 1], '20260707')
+        self.assertEqual(cmd[cmd.index('--artifact-dir') + 1], '/tmp/art')
+
+
+class TestValidation(unittest.TestCase):
+    def test_rejects_unknown_variant(self):
+        with self.assertRaises(ValueError):
+            AgentxArguments(agentx_variant='512k')
+
+    def test_rejects_scheduler_conflicts(self):
+        with self.assertRaises(ValueError):
+            AgentxArguments(agentx_extra_args=['--fixed-schedule', 'foo'])
+        with self.assertRaises(ValueError):
+            AgentxArguments(agentx_extra_args=['--request-rate=100'])
+
+    def test_requires_model_and_http_url(self):
+        with self.assertRaises(ValueError):
+            validate_agentx_arguments('http://x:1', '', 8, 3600)
+        with self.assertRaises(ValueError):
+            validate_agentx_arguments('ftp://x', 'm', 8, 3600)
+
+    def test_rejects_sweeps(self):
+        with self.assertRaises(ValueError):
+            validate_agentx_arguments('http://x:1', 'm', [1, 8], 3600)
+        with self.assertRaises(ValueError):
+            validate_agentx_arguments('http://x:1', 'm', 8, [60, 3600])
+
+    def test_accepts_single_element_lists(self):
+        validate_agentx_arguments('http://x:1', 'm', [8], [3600])
+
+
+class TestResultParsing(unittest.TestCase):
+    PER_RUN = {
+        'metadata': {
+            'scenario': 'inferencex-agentx-mvp',
+            'submission_valid': False,
+            'submission_invalid_reasons': ['context_overflow_rate_exceeded'],
+        },
+        'request_throughput': {'avg': 12.5},
+        'time_to_first_token': {'avg': 0.9, 'unit': 's'},
+        'total_requests': 900,
+    }
+
+    def _write(self, root, relpath, payload):
+        path = os.path.join(root, relpath)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f)
+        return path
+
+    def test_per_run_layout_metrics_top_level(self):
+        with TemporaryDirectory() as root:
+            self._write(root, 'profile_export_aiperf.json', self.PER_RUN)
+            parsed = parse_profile_export(os.path.join(root, 'profile_export_aiperf.json'))
+            self.assertIn('request_throughput', parsed['metrics'])
+            self.assertEqual(parsed['metadata']['submission_valid'], False)
+
+    def test_aggregate_layout_metrics_nested(self):
+        aggregate = {'metadata': {'submission_valid': True}, 'metrics': {'request_throughput': {'avg': 10.0}}}
+        with TemporaryDirectory() as root:
+            self._write(root, 'aggregate/profile_export_aiperf_aggregate.json', aggregate)
+            result = load_agentx_result(
+                root,
+                aiperf_version='0.13.0',
+                aiperf_command=['aiperf', 'profile', '--api-key', 'sk-secret'],
+                dataset_variant='256k',
+                random_seed=7,
+            )
+            self.assertEqual(result.request_throughput, 10.0)
+            self.assertTrue(result.submission_valid)
+            self.assertTrue(result.canonical)
+            # Provenance
+            self.assertEqual(result.dataset_repo, AGENTX_DATASET_REPOS['256k'])
+            self.assertEqual(result.aiperf_version, '0.13.0')
+            # Secret redaction
+            self.assertNotIn('sk-secret', ' '.join(result.aiperf_command))
+            self.assertEqual(result.aiperf_command[result.aiperf_command.index('--api-key') + 1], '***')
+
+    def test_per_run_result_and_smoke_flag(self):
+        with TemporaryDirectory() as root:
+            self._write(root, 'profile_export_aiperf.json', self.PER_RUN)
+            result = load_agentx_result(root, dataset_variant='full',
+                                        smoke_reasons=['num_dataset_entries capped (smoke run)'])
+            # s → ms conversion
+            self.assertAlmostEqual(result.time_to_first_token_ms, 900.0)
+            # Missing metrics stay unavailable, not zero
+            self.assertIsNone(result.output_throughput)
+            self.assertIsNone(result.inter_token_latency_ms)
+            # Counts read from raw values
+            self.assertEqual(result.total_requests, 900)
+            # AIPerf invalid + wrapper smoke reason => non-canonical, explained
+            self.assertFalse(result.submission_valid)
+            self.assertFalse(result.canonical)
+            self.assertIn('context_overflow_rate_exceeded', result.invalid_reasons)
+            self.assertIn('num_dataset_entries capped (smoke run)', result.invalid_reasons)
+
+    def test_missing_export_raises(self):
+        with TemporaryDirectory() as root:
+            with self.assertRaises(FileNotFoundError):
+                load_agentx_result(root)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #1706

First-stage AgentX integration as proposed in the issue: a dedicated Perf scenario that wraps a pinned/isolated AIPerf executable instead of reimplementing the session-tree scheduler in EvalScope.

## What's included

```
evalscope/perf/agentx/
├── __init__.py
├── config.py   # AgentxArguments + fail-fast validation
├── runner.py   # command construction, executable resolution, version probe
└── result.py   # normalized AgentxResult with provenance + validity
tests/perf/test_agentx.py  # 12 unit tests, no AIPerf install needed
```

**Config** — `--agentx-variant full|256k` maps to the pinned AIPerf public-dataset aliases (`semianalysis_cc_traces_weka_062126` / `..._256k`); plus tokenizer, random seed, max-context-length, smoke-entry cap, aiperf path, and an `--agentx-extra-args` escape hatch. Scheduler flags that conflict with the scenario locks (`--fixed-schedule`, `--request-rate`, `--ignore-trace-delays`) are rejected up front.

**Runner** — builds the `aiperf profile --scenario inferencex-agentx-mvp` command with the documented scenario-locked flags written out explicitly; strips the endpoint path from `--url` (AIPerf appends it from `--endpoint-type chat`). Executable resolution: explicit path → `aiperf` on PATH → `uvx aiperf`; AIPerf is **not** added to the Perf dependency set. Version is probed and recorded for provenance.

**Result** — parses both export layouts (per-run `profile_export_aiperf.json` top-level metrics; aggregate `aggregate/profile_export_aiperf_aggregate.json` nested `metrics`), preferring the aggregate. Records AIPerf version, dataset variant + HF repo, seed, model, and the executed command with `--api-key` **redacted**. Surfaces `submission_valid` + `submission_invalid_reasons`, and adds a `canonical` flag: smoke runs (`--agentx-num-dataset-entries`) are marked non-canonical with an explicit reason, since AIPerf itself still stamps them valid. Missing metrics stay `None` — never reported as zero. Raw artifacts are left untouched.

## Tests (12 passing)

- command shape: scenario flag, URL path stripping, variant→dataset mapping, concurrency/duration mapping, scenario-locked flags, optional flags omitted/set
- validation: unknown variant, scheduler conflicts, missing model, non-http URL, parallel/duration sweeps
- parsing: both layouts, s→ms TTFT conversion, missing metrics stay None, AIPerf-invalid + smoke reasons merged, api-key redaction, missing export raises

```
tests/perf/test_agentx.py ............ [100%]
12 passed
```

## Notes

- The wrapper primitives are landed first (validated + tested); wiring into the top-level `evalscope perf --scenario agentx` dispatch + user docs (smoke vs canonical) can follow once the approach is blessed.
- Deliberately out of scope per the issue: DAG scheduler reimplementation, Weka trace loader, telemetry dashboard.