### PR TITLE
feat(perf): add real multi-image MMMU dataset mode

### DIFF
--- a/docs/en/user_guides/stress_test/index.md
+++ b/docs/en/user_guides/stress_test/index.md
@@ -8,6 +8,7 @@ quick_start.md
 agentx.md
 parameters.md
 examples.md
+multi_image.md
 multi_turn.md
 sla_auto_tune.md
 speed_benchmark.md

--- a/docs/en/user_guides/stress_test/multi_image.md
+++ b/docs/en/user_guides/stress_test/multi_image.md
@@ -1,0 +1,53 @@
+# Multi-image stress testing
+
+EvalScope supports two complementary ways to benchmark requests that contain multiple images:
+
+- `mmmu_multi_image` builds real multi-image requests from the open-source [MMMU](https://modelscope.cn/datasets/AI-ModelScope/MMMU/summary) dataset.
+- `line_by_line` accepts OpenAI-style messages or complete request bodies, so you can replay your own multi-image samples without adding a dataset plugin.
+
+## Real multi-image data with MMMU
+
+`mmmu_multi_image` loads the MMMU validation split and keeps only rows that contain at least the configured number of images. Images are sent in `image_1` ... `image_7` order in one user message.
+
+```bash
+evalscope perf \
+  --model your-vl-model \
+  --url http://localhost:8000/v1/chat/completions \
+  --dataset mmmu_multi_image \
+  --dataset-args '{"subset":"Music","min_images":2}' \
+  --parallel 4 \
+  --number 100
+```
+
+Dataset arguments:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `subset` | `str` | `Music` | MMMU subject/configuration to load |
+| `min_images` | `int` | `2` | Minimum number of images required for a row; must be between 1 and 7 |
+
+The built-in mode is intended for real multimodal traffic rather than accuracy evaluation. Use the regular `evalscope eval --datasets mmmu` path when you need MMMU benchmark scoring.
+
+## Custom multi-image data
+
+For private or constructed datasets, use `line_by_line`. Each non-empty line can already be an OpenAI-style messages array or a complete request body. Put multiple `image_url` parts in the same user message.
+
+For example, save the following as one JSON line in `multi_image.jsonl`:
+
+```json
+[{"role":"user","content":[{"type":"text","text":"Compare image 1 and image 2."},{"type":"image_url","image_url":{"url":"https://example.com/image-1.jpg"}},{"type":"image_url","image_url":{"url":"https://example.com/image-2.jpg"}}]}]
+```
+
+Then run:
+
+```bash
+evalscope perf \
+  --model your-vl-model \
+  --url http://localhost:8000/v1/chat/completions \
+  --dataset line_by_line \
+  --dataset-path multi_image.jsonl \
+  --parallel 4 \
+  --number 100
+```
+
+The model server must be able to access HTTP image URLs. You can also use API-compatible data URLs when your serving backend supports them.

--- a/docs/en/user_guides/stress_test/multi_image.md
+++ b/docs/en/user_guides/stress_test/multi_image.md
@@ -24,7 +24,7 @@ Dataset arguments:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `subset` | `str` | `Music` | MMMU subject/configuration to load |
-| `min_images` | `int` | `2` | Minimum number of images required for a row; must be between 1 and 7 |
+| `min_images` | `int` | `2` | Minimum number of images required for a row; must be between 2 and 7 |
 
 The built-in mode is intended for real multimodal traffic rather than accuracy evaluation. Use the regular `evalscope eval --datasets mmmu` path when you need MMMU benchmark scoring.
 

--- a/docs/zh/user_guides/stress_test/index.md
+++ b/docs/zh/user_guides/stress_test/index.md
@@ -8,6 +8,7 @@ quick_start.md
 agentx.md
 parameters.md
 examples.md
+multi_image.md
 multi_turn.md
 sla_auto_tune.md
 speed_benchmark.md

--- a/docs/zh/user_guides/stress_test/multi_image.md
+++ b/docs/zh/user_guides/stress_test/multi_image.md
@@ -24,7 +24,7 @@ evalscope perf \
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `subset` | `str` | `Music` | 要加载的 MMMU 学科/configuration |
-| `min_images` | `int` | `2` | 样本最少图片数，范围为 1–7 |
+| `min_images` | `int` | `2` | 样本最少图片数，范围为 2–7 |
 
 该模式用于构造真实多模态压测流量，而不是计算 MMMU 准确率。如果需要正式的 MMMU 评测得分，请使用常规的 `evalscope eval --datasets mmmu` 流程。
 

--- a/docs/zh/user_guides/stress_test/multi_image.md
+++ b/docs/zh/user_guides/stress_test/multi_image.md
@@ -1,0 +1,53 @@
+# 多图输入压测
+
+EvalScope 提供两种互补方式，对一次请求包含多张图片的场景进行压测：
+
+- `mmmu_multi_image`：从开源 [MMMU](https://modelscope.cn/datasets/AI-ModelScope/MMMU/summary) 数据集中构造真实多图请求。
+- `line_by_line`：直接接受 OpenAI 风格的 messages 或完整请求体，因此无需新增数据集插件即可压测自建多图样本。
+
+## 使用 MMMU 构造真实多图请求
+
+`mmmu_multi_image` 加载 MMMU 的 validation split，并仅保留图片数量不少于配置值的样本。图片按照 `image_1` ... `image_7` 的顺序放入同一个 user message 中。
+
+```bash
+evalscope perf \
+  --model your-vl-model \
+  --url http://localhost:8000/v1/chat/completions \
+  --dataset mmmu_multi_image \
+  --dataset-args '{"subset":"Music","min_images":2}' \
+  --parallel 4 \
+  --number 100
+```
+
+数据集参数：
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `subset` | `str` | `Music` | 要加载的 MMMU 学科/configuration |
+| `min_images` | `int` | `2` | 样本最少图片数，范围为 1–7 |
+
+该模式用于构造真实多模态压测流量，而不是计算 MMMU 准确率。如果需要正式的 MMMU 评测得分，请使用常规的 `evalscope eval --datasets mmmu` 流程。
+
+## 使用自建多图数据
+
+对于私有或自行构造的数据集，可以直接使用 `line_by_line`。每个非空行本身就可以是 OpenAI 风格的 messages 数组或完整请求体；只需在同一个 user message 中放入多个 `image_url` 内容块。
+
+例如，将下面内容作为一行 JSON 保存到 `multi_image.jsonl`：
+
+```json
+[{"role":"user","content":[{"type":"text","text":"Compare image 1 and image 2."},{"type":"image_url","image_url":{"url":"https://example.com/image-1.jpg"}},{"type":"image_url","image_url":{"url":"https://example.com/image-2.jpg"}}]}]
+```
+
+然后执行：
+
+```bash
+evalscope perf \
+  --model your-vl-model \
+  --url http://localhost:8000/v1/chat/completions \
+  --dataset line_by_line \
+  --dataset-path multi_image.jsonl \
+  --parallel 4 \
+  --number 100
+```
+
+模型服务必须能够访问 HTTP 图片 URL；如果服务端支持，也可以使用兼容 API 的 data URL。

--- a/evalscope/perf/plugin/datasets/__init__.py
+++ b/evalscope/perf/plugin/datasets/__init__.py
@@ -10,6 +10,7 @@ from .flickr8k import FlickrDatasetPlugin
 from .kontext_bench import KontextDatasetPlugin
 from .line_by_line import LineByLineDatasetPlugin
 from .longalpaca import LongAlpacaDatasetPlugin
+from .mmmu_multi_image import MMMUMultiImageDatasetPlugin
 from .multi_turn import RandomMultiTurnDatasetPlugin, ShareGPTEnMultiTurnPlugin, ShareGPTZhMultiTurnPlugin
 from .openqa import OpenqaDatasetPlugin
 from .random_dataset import RandomDatasetPlugin

--- a/evalscope/perf/plugin/datasets/dataset_args.py
+++ b/evalscope/perf/plugin/datasets/dataset_args.py
@@ -100,6 +100,23 @@ class TextDatasetArgs(TextLengthArgs):
     """
 
 
+class MMMUMultiImageDatasetArgs(BaseDatasetArgs):
+    """Arguments for the MMMU multi-image performance dataset."""
+
+    subset: str = 'Music'
+    """MMMU subject/configuration to load."""
+
+    min_images: int = 2
+    """Minimum number of images required for a row to be included."""
+
+    @field_validator('min_images')
+    @classmethod
+    def _validate_min_images(cls, v: int) -> int:
+        if not 1 <= v <= 7:
+            raise ValueError(f'min_images must be between 1 and 7, got {v}')
+        return v
+
+
 class MultiTurnDatasetArgs(MultiTurnArgs, BaseDatasetArgs):
     """Args schema for multi-turn datasets.
 

--- a/evalscope/perf/plugin/datasets/dataset_args.py
+++ b/evalscope/perf/plugin/datasets/dataset_args.py
@@ -112,8 +112,8 @@ class MMMUMultiImageDatasetArgs(BaseDatasetArgs):
     @field_validator('min_images')
     @classmethod
     def _validate_min_images(cls, v: int) -> int:
-        if not 1 <= v <= 7:
-            raise ValueError(f'min_images must be between 1 and 7, got {v}')
+        if not 2 <= v <= 7:
+            raise ValueError(f'min_images must be between 2 and 7, got {v}')
         return v
 
 

--- a/evalscope/perf/plugin/datasets/mmmu_multi_image.py
+++ b/evalscope/perf/plugin/datasets/mmmu_multi_image.py
@@ -1,0 +1,77 @@
+from io import BytesIO
+from typing import Any, Dict, Iterator, List, Optional
+
+from PIL import Image
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.datasets.base import DatasetPluginBase
+from evalscope.perf.plugin.datasets.dataset_args import MMMUMultiImageDatasetArgs
+from evalscope.perf.plugin.registry import register_dataset
+from evalscope.utils.io_utils import PIL_to_base64
+
+
+@register_dataset('mmmu_multi_image')
+class MMMUMultiImageDatasetPlugin(DatasetPluginBase):
+    """Build real multi-image stress-test requests from the MMMU validation set."""
+
+    args_schema = MMMUMultiImageDatasetArgs
+    dataset_id = 'AI-ModelScope/MMMU'
+    max_images = 7
+
+    def __init__(self, query_parameters: Arguments):
+        if query_parameters.tokenize_prompt:
+            raise ValueError(
+                '--tokenize-prompt is not supported with the mmmu_multi_image dataset. '
+                'The dataset produces multimodal messages that cannot be represented as a flat token-ID list.'
+            )
+        super().__init__(query_parameters)
+
+    @staticmethod
+    def _to_pil_image(value: Any) -> Optional[Image.Image]:
+        """Normalize common dataset image representations to a PIL image."""
+        if isinstance(value, Image.Image):
+            return value
+        if isinstance(value, dict):
+            raw_bytes = value.get('bytes')
+            if raw_bytes:
+                with Image.open(BytesIO(raw_bytes)) as image:
+                    return image.copy()
+            path = value.get('path')
+            if path:
+                with Image.open(path) as image:
+                    return image.copy()
+        return None
+
+    def _collect_image_urls(self, item: Dict[str, Any]) -> List[str]:
+        """Collect non-empty ``image_1`` ... ``image_7`` fields in source order."""
+        image_urls: List[str] = []
+        for index in range(1, self.max_images + 1):
+            image = self._to_pil_image(item.get(f'image_{index}'))
+            if image is None:
+                continue
+            image_urls.append(PIL_to_base64(image, add_header=True))
+        return image_urls
+
+    @staticmethod
+    def _build_prompt(item: Dict[str, Any]) -> str:
+        """Keep MMMU question text and options without changing benchmark semantics."""
+        prompt = str(item['question'])
+        options = item.get('options')
+        if options and options != '[]':
+            prompt = f'{prompt}\nOptions: {options}'
+        return prompt
+
+    def build_messages(self) -> Iterator[List[Dict]]:
+        dataset = self.load_hub_dataset(
+            dataset_id=self.dataset_id,
+            split='validation',
+            subset=self.dataset_args.subset,
+        )
+
+        for item in dataset:
+            image_urls = self._collect_image_urls(item)
+            if len(image_urls) < self.dataset_args.min_images:
+                continue
+
+            message = self.create_message(text=self._build_prompt(item), image_urls=image_urls)
+            yield [message]

--- a/tests/perf/test_mmmu_multi_image.py
+++ b/tests/perf/test_mmmu_multi_image.py
@@ -24,7 +24,6 @@ def _image_bytes() -> bytes:
 
 
 class TestMMMUMultiImageDataset:
-
     def test_builds_one_message_with_multiple_images_in_source_order(self, monkeypatch):
         plugin = MMMUMultiImageDatasetPlugin(_args({'subset': 'Music', 'min_images': 2}))
         rows = [
@@ -83,4 +82,4 @@ class TestMMMUMultiImageDataset:
 
     def test_rejects_tokenized_prompt_mode(self):
         with pytest.raises(ValueError, match='not supported with the mmmu_multi_image dataset'):
-            MMMUMultiImageDatasetPlugin(_args(tokenize_prompt=True))
+            MMMUMultiImageDatasetPlugin(_args(tokenize_prompt=True, tokenizer_path='Qwen/Qwen2.5-0.5B-Instruct'))

--- a/tests/perf/test_mmmu_multi_image.py
+++ b/tests/perf/test_mmmu_multi_image.py
@@ -1,0 +1,90 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.datasets.mmmu_multi_image import MMMUMultiImageDatasetPlugin
+
+
+def _args(dataset_args=None) -> Arguments:
+    return Arguments(
+        model='test-model',
+        url='http://localhost:8080/v1/chat/completions',
+        dataset='mmmu_multi_image',
+        dataset_args=dataset_args,
+    )
+
+
+def _image_bytes() -> bytes:
+    buffer = BytesIO()
+    Image.new('RGB', (2, 2), 'white').save(buffer, format='PNG')
+    return buffer.getvalue()
+
+
+class TestMMMUMultiImageDataset:
+
+    def test_builds_one_message_with_multiple_images_in_source_order(self, monkeypatch):
+        plugin = MMMUMultiImageDatasetPlugin(_args({'subset': 'Music', 'min_images': 2}))
+        rows = [
+            {
+                'question': 'Compare <image 1> and <image 2>.',
+                'options': "['same', 'different']",
+                'image_1': Image.new('RGB', (2, 2), 'red'),
+                'image_2': {'bytes': _image_bytes()},
+                'image_3': None,
+            }
+        ]
+        load_args = {}
+
+        def fake_load_hub_dataset(dataset_id, split='train', subset='default'):
+            load_args.update(dataset_id=dataset_id, split=split, subset=subset)
+            return rows
+
+        monkeypatch.setattr(plugin, 'load_hub_dataset', fake_load_hub_dataset)
+
+        requests = list(plugin.build_messages())
+
+        assert load_args == {
+            'dataset_id': 'AI-ModelScope/MMMU',
+            'split': 'validation',
+            'subset': 'Music',
+        }
+        assert len(requests) == 1
+        message = requests[0][0]
+        assert message['role'] == 'user'
+        assert message['content'][0] == {
+            'type': 'text',
+            'text': "Compare <image 1> and <image 2>.\nOptions: ['same', 'different']",
+        }
+        assert [part['type'] for part in message['content']] == ['text', 'image_url', 'image_url']
+        assert all(
+            part['image_url']['url'].startswith('data:image/') for part in message['content'][1:]
+        )
+
+    def test_skips_rows_below_minimum_image_count(self, monkeypatch):
+        plugin = MMMUMultiImageDatasetPlugin(_args({'min_images': 2}))
+        monkeypatch.setattr(
+            plugin,
+            'load_hub_dataset',
+            lambda **_: [
+                {
+                    'question': 'Single image only',
+                    'options': '[]',
+                    'image_1': Image.new('RGB', (2, 2), 'white'),
+                }
+            ],
+        )
+
+        assert list(plugin.build_messages()) == []
+
+    def test_min_images_is_validated(self):
+        with pytest.raises(Exception, match='min_images must be between 1 and 7'):
+            MMMUMultiImageDatasetPlugin(_args({'min_images': 0}))
+
+    def test_rejects_tokenized_prompt_mode(self):
+        args = _args()
+        args.tokenize_prompt = True
+
+        with pytest.raises(ValueError, match='not supported with the mmmu_multi_image dataset'):
+            MMMUMultiImageDatasetPlugin(args)

--- a/tests/perf/test_mmmu_multi_image.py
+++ b/tests/perf/test_mmmu_multi_image.py
@@ -7,12 +7,13 @@ from evalscope.perf.arguments import Arguments
 from evalscope.perf.plugin.datasets.mmmu_multi_image import MMMUMultiImageDatasetPlugin
 
 
-def _args(dataset_args=None) -> Arguments:
+def _args(dataset_args=None, **kwargs) -> Arguments:
     return Arguments(
         model='test-model',
         url='http://localhost:8080/v1/chat/completions',
         dataset='mmmu_multi_image',
         dataset_args=dataset_args,
+        **kwargs,
     )
 
 
@@ -58,9 +59,7 @@ class TestMMMUMultiImageDataset:
             'text': "Compare <image 1> and <image 2>.\nOptions: ['same', 'different']",
         }
         assert [part['type'] for part in message['content']] == ['text', 'image_url', 'image_url']
-        assert all(
-            part['image_url']['url'].startswith('data:image/') for part in message['content'][1:]
-        )
+        assert all(part['image_url']['url'].startswith('data:image/') for part in message['content'][1:])
 
     def test_skips_rows_below_minimum_image_count(self, monkeypatch):
         plugin = MMMUMultiImageDatasetPlugin(_args({'min_images': 2}))
@@ -79,12 +78,9 @@ class TestMMMUMultiImageDataset:
         assert list(plugin.build_messages()) == []
 
     def test_min_images_is_validated(self):
-        with pytest.raises(Exception, match='min_images must be between 1 and 7'):
-            MMMUMultiImageDatasetPlugin(_args({'min_images': 0}))
+        with pytest.raises(Exception, match='min_images must be between 2 and 7'):
+            MMMUMultiImageDatasetPlugin(_args({'min_images': 1}))
 
     def test_rejects_tokenized_prompt_mode(self):
-        args = _args()
-        args.tokenize_prompt = True
-
         with pytest.raises(ValueError, match='not supported with the mmmu_multi_image dataset'):
-            MMMUMultiImageDatasetPlugin(args)
+            MMMUMultiImageDatasetPlugin(_args(tokenize_prompt=True))


### PR DESCRIPTION
Closes #1726.

## What

Adds a discoverable, real-data multi-image mode for `evalscope perf`: a new `mmmu_multi_image` dataset plugin that builds multi-image stress requests from the open-source MMMU validation set, plus EN/ZH user docs for multi-image stress testing.

## Why this instead of existing paths

- The perf transport (`create_message`) already supports multiple `image_url` parts in one message, and `line_by_line` already accepts OpenAI-style messages arrays / full request bodies, so private or constructed multi-image payloads keep working there unchanged.
- What was missing (issue #1726) is a built-in, non-random, open-source multi-image dataset mode plus documentation of the custom-data path. This PR fills exactly that gap without duplicating the generic transport path.

## How it works

- `evalscope/perf/plugin/datasets/mmmu_multi_image.py` (registered as `mmmu_multi_image`): loads MMMU `validation` for the configured `subset` (default `Music`), collects non-empty `image_1` … `image_7` fields in source order (PIL / `bytes`-dict / `path`-dict representations), keeps rows with at least `min_images` images, and yields one user message per row via the shared `create_message(text, image_urls=[...])` path.
- `MMMUMultiImageDatasetArgs`: `subset: str = 'Music'`, `min_images: int = 2` validated to 2–7 (MMMU rows carry at most 7 images).
- `--tokenize-prompt` is rejected with a clear error: multimodal messages cannot be represented as a flat token-ID list.
- Docs: new `docs/{en,zh}/user_guides/stress_test/multi_image.md` (MMMU mode + `line_by_line` custom-data recipe), linked from both stress-test indexes.
- This is stress/performance traffic support, not MMMU benchmark scoring — use `evalscope eval --datasets mmmu` for official scoring.

```bash
evalscope perf \
  --model your-vl-model \
  --url http://localhost:8000/v1/chat/completions \
  --dataset mmmu_multi_image \
  --dataset-args '{"subset":"Music","min_images":2}' \
  --parallel 4 \
  --number 100
```

## Validation performed

- `pytest tests/perf/test_mmmu_multi_image.py -q` → 4 passed (message structure/order, min-image filtering, arg validation, tokenize-mode rejection; hub loading mocked, no network).
- `ruff check` and `ruff format --check` (repo-pinned ruff 0.16.4) on the touched Python files → clean.
- `pytest tests/perf --collect-only` → 370 collected, no registration breakage.
- `git diff --check` → clean.
- Full test-suite validation was not run; no such claim is made.
