### PR TITLE
docs: align benchmark contribution examples with metadata requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,10 @@ Brief description of what this benchmark evaluates.
 - **Task Type**: ...
 - **Input**: ...
 - **Output**: ...
+- **Domain**: ...
+
+## Key Features
+- Describe the dataset scale/source and the capabilities evaluated.
 
 ## Evaluation Notes
 - Default configuration uses **0-shot** evaluation
@@ -220,6 +224,7 @@ Brief description of what this benchmark evaluates.
 @register_benchmark(
     BenchmarkMeta(
         name='my_benchmark',           # unique identifier (snake_case)
+        evaluation_version='v1.0',      # initial evaluation semantics version
         pretty_name='MyBenchmark',      # display name
         dataset_id='org/dataset-name',  # ModelScope / HuggingFace dataset ID
         tags=[Tags.REASONING],          # category tags
@@ -256,6 +261,7 @@ class MyBenchmarkAdapter(DefaultDataAdapter):
 ```python
 BenchmarkMeta(
     name='...',              # Required: unique snake_case ID
+    evaluation_version='v1.0', # Explicit initial version for new benchmarks
     dataset_id='...',        # Required: remote dataset ID or local path
     pretty_name='...',       # Display name
     tags=[...],              # From evalscope.constants.Tags


### PR DESCRIPTION
## Summary

Align the new-benchmark examples in CONTRIBUTING.md with the repository's current metadata requirements:
- Include the Domain field and Key Features section in the example description.
- Explicitly declare evaluation_version='v1.0' in both BenchmarkMeta examples.

AGENTS.md requires the four description sections in order and an explicit initial evaluation version for new benchmarks. The current copyable template omits these items.

## Validation

- Parsed every Python fence in CONTRIBUTING.md.
- Checked the description's required section order and task fields.
- Validated both example version values using the validate_evaluation_version function extracted from the upstream source.
- git diff --check and Markdown parsing passed.

Only the contribution guide changes; no adapter metadata or generated benchmark pages were modified. No benchmark evaluation or documentation generation pipeline was run.

The configured pre-commit hooks passed for CONTRIBUTING.md. The full-repository make lint command was not run (make is unavailable in this Windows environment).
