### PR TITLE
feat: add LibriSpeech test-other subset

### DIFF
--- a/docs/en/benchmarks/librispeech.md
+++ b/docs/en/benchmarks/librispeech.md
@@ -22,7 +22,7 @@ LibriSpeech is a large-scale corpus of approximately 1,000 hours of read English
 
 ## Evaluation Notes
 
-- Default configuration uses **test_clean** split
+- Supported evaluation splits: **test_clean** and **test_other**
 - Primary metric: **Word Error Rate (WER)**
 - Text normalization applied during evaluation
 - Prompt: "Please recognize the speech and only output the recognized content"
@@ -39,35 +39,42 @@ LibriSpeech is a large-scale corpus of approximately 1,000 hours of read English
 | **Tags** | `Audio`, `SpeechRecognition` |
 | **Metrics** | `wer` |
 | **Default Shots** | 0-shot |
-| **Evaluation Split** | `test_clean` |
+| **Evaluation Split** | `N/A` |
 
 
 ## Data Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total Samples | 87 |
+| Total Samples | 177 |
 | Prompt Length (Mean) | 67 chars |
 | Prompt Length (Min/Max) | 67 / 67 chars |
+
+**Per-Subset Statistics:**
+
+| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |
+|--------|---------|-------------|------------|------------|
+| `test_clean` | 87 | 67 | 67 | 67 |
+| `test_other` | 90 | 67 | 67 | 67 |
 
 **Audio Statistics:**
 
 | Metric | Value |
 |--------|-------|
-| Total Audio Files | 87 |
+| Total Audio Files | 177 |
 | Audio per Sample | min: 1, max: 1, mean: 1 |
 | Formats | wav |
 
 
 ## Sample Example
 
-**Subset**: `default`
+**Subset**: `test_clean`
 
 ```json
 {
   "input": [
     {
-      "id": "fd0309e6",
+      "id": "732c90a4",
       "content": [
         {
           "text": "Please recognize the speech and only output the recognized content:"
@@ -79,7 +86,7 @@ LibriSpeech is a large-scale corpus of approximately 1,000 hours of read English
       ]
     }
   ],
-  "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
+  "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED 7380 chars] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
   "id": 0,
   "group_id": 0,
   "metadata": {
@@ -122,6 +129,11 @@ task_cfg = TaskConfig(
     api_url='OPENAI_API_COMPAT_URL',
     api_key='EMPTY_TOKEN',
     datasets=['librispeech'],
+    dataset_args={
+        'librispeech': {
+            # subset_list: ['test_clean', 'test_other']  # optional, evaluate specific subsets
+        }
+    },
     limit=10,  # Remove this line for formal evaluation
 )
 

--- a/docs/zh/benchmarks/librispeech.md
+++ b/docs/zh/benchmarks/librispeech.md
@@ -3,12 +3,12 @@
 
 ## 概述
 
-LibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英语语音，源自有声读物。它是评估自动语音识别（ASR）系统最广泛使用的基准测试之一。
+LibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英文语音，源自有声读物。它是评估自动语音识别（ASR）系统最广泛使用的基准之一。
 
 ## 任务描述
 
 - **任务类型**：自动语音识别（ASR）
-- **输入**：来自有声读物的朗读英语语音录音
+- **输入**：来自有声读物的朗读英文语音录音
 - **输出**：转录文本
 - **语言**：英语
 
@@ -22,7 +22,7 @@ LibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英语�
 
 ## 评估说明
 
-- 默认配置使用 **test_clean** 划分
+- 支持的评估子集：**test_clean** 和 **test_other**
 - 主要指标：**词错误率（WER）**
 - 评估过程中应用文本归一化
 - 提示词："Please recognize the speech and only output the recognized content"
@@ -39,35 +39,42 @@ LibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英语�
 | **标签** | `Audio`, `SpeechRecognition` |
 | **指标** | `wer` |
 | **默认样本数** | 0-shot |
-| **评估划分** | `test_clean` |
+| **评估子集** | `N/A` |
 
 
 ## 数据统计
 
 | 指标 | 值 |
 |--------|-------|
-| 总样本数 | 87 |
+| 总样本数 | 177 |
 | 提示词长度（平均） | 67 字符 |
 | 提示词长度（最小/最大） | 67 / 67 字符 |
+
+**各子集统计：**
+
+| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |
+|--------|---------|-------------|------------|------------|
+| `test_clean` | 87 | 67 | 67 | 67 |
+| `test_other` | 90 | 67 | 67 | 67 |
 
 **音频统计：**
 
 | 指标 | 值 |
 |--------|-------|
-| 音频文件总数 | 87 |
+| 音频文件总数 | 177 |
 | 每样本音频数量 | 最小: 1, 最大: 1, 平均: 1 |
 | 格式 | wav |
 
 
 ## 样例示例
 
-**子集**: `default`
+**子集**: `test_clean`
 
 ```json
 {
   "input": [
     {
-      "id": "fd0309e6",
+      "id": "732c90a4",
       "content": [
         {
           "text": "Please recognize the speech and only output the recognized content:"
@@ -79,7 +86,7 @@ LibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英语�
       ]
     }
   ],
-  "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
+  "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED 7380 chars] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
   "id": 0,
   "group_id": 0,
   "metadata": {
@@ -122,6 +129,11 @@ task_cfg = TaskConfig(
     api_url='OPENAI_API_COMPAT_URL',
     api_key='EMPTY_TOKEN',
     datasets=['librispeech'],
+    dataset_args={
+        'librispeech': {
+            # subset_list: ['test_clean', 'test_other']  # 可选，用于指定评估特定子集
+        }
+    },
     limit=10,  # 正式评估时请删除此行
 )
 

--- a/evalscope/benchmarks/_meta/librispeech.json
+++ b/evalscope/benchmarks/_meta/librispeech.json
@@ -11,12 +11,13 @@
       "wer"
     ],
     "few_shot_num": 0,
-    "eval_split": "test_clean",
+    "eval_split": null,
     "train_split": "",
     "subset_list": [
-      "default"
+      "test_clean",
+      "test_other"
     ],
-    "description": "\n## Overview\n\nLibriSpeech is a large-scale corpus of approximately 1,000 hours of read English speech derived from audiobooks. It is one of the most widely used benchmarks for evaluating automatic speech recognition (ASR) systems.\n\n## Task Description\n\n- **Task Type**: Automatic Speech Recognition (ASR)\n- **Input**: Audio recordings of read English speech from audiobooks\n- **Output**: Transcribed text\n- **Language**: English\n\n## Key Features\n\n- 1,000 hours of high-quality read speech\n- Derived from LibriVox audiobooks (public domain)\n- Clean and \"other\" test sets for varying difficulty\n- Widely used baseline for ASR research\n- Standardized evaluation protocol\n\n## Evaluation Notes\n\n- Default configuration uses **test_clean** split\n- Primary metric: **Word Error Rate (WER)**\n- Text normalization applied during evaluation\n- Prompt: \"Please recognize the speech and only output the recognized content\"\n- Metadata includes audio ID and duration information\n",
+    "description": "\n## Overview\n\nLibriSpeech is a large-scale corpus of approximately 1,000 hours of read English speech derived from audiobooks. It is one of the most widely used benchmarks for evaluating automatic speech recognition (ASR) systems.\n\n## Task Description\n\n- **Task Type**: Automatic Speech Recognition (ASR)\n- **Input**: Audio recordings of read English speech from audiobooks\n- **Output**: Transcribed text\n- **Language**: English\n\n## Key Features\n\n- 1,000 hours of high-quality read speech\n- Derived from LibriVox audiobooks (public domain)\n- Clean and \"other\" test sets for varying difficulty\n- Widely used baseline for ASR research\n- Standardized evaluation protocol\n\n## Evaluation Notes\n\n- Supported evaluation splits: **test_clean** and **test_other**\n- Primary metric: **Word Error Rate (WER)**\n- Text normalization applied during evaluation\n- Prompt: \"Please recognize the speech and only output the recognized content\"\n- Metadata includes audio ID and duration information\n",
     "prompt_template": "Please recognize the speech and only output the recognized content:",
     "system_prompt": "",
     "few_shot_prompt_template": "",
@@ -26,10 +27,10 @@
     "category": "vlm"
   },
   "statistics": {
-    "total_samples": 87,
+    "total_samples": 177,
     "subset_stats": [
       {
-        "name": "default",
+        "name": "test_clean",
         "sample_count": 87,
         "prompt_length_mean": 67,
         "prompt_length_min": 67,
@@ -54,6 +55,33 @@
             ]
           }
         }
+      },
+      {
+        "name": "test_other",
+        "sample_count": 90,
+        "prompt_length_mean": 67,
+        "prompt_length_min": 67,
+        "prompt_length_max": 67,
+        "prompt_length_std": null,
+        "target_length_mean": 3094.96,
+        "multimodal": {
+          "has_images": false,
+          "has_audio": true,
+          "has_video": false,
+          "audio": {
+            "count_total": 90,
+            "count_per_sample": {
+              "min": 1,
+              "max": 1,
+              "mean": 1
+            },
+            "duration": null,
+            "sample_rates": [],
+            "formats": [
+              "wav"
+            ]
+          }
+        }
       }
     ],
     "prompt_length": {
@@ -62,14 +90,14 @@
       "max": 67,
       "std": null
     },
-    "target_length_mean": 3295.21,
-    "computed_at": "2026-01-28T11:14:19.501508",
+    "target_length_mean": 3193.38,
+    "computed_at": "2026-09-13T15:15:06.361110",
     "multimodal": {
       "has_images": false,
       "has_audio": true,
       "has_video": false,
       "audio": {
-        "count_total": 87,
+        "count_total": 177,
         "count_per_sample": {
           "min": 1,
           "max": 1,
@@ -87,7 +115,7 @@
     "data": {
       "input": [
         {
-          "id": "fd0309e6",
+          "id": "732c90a4",
           "content": [
             {
               "text": "Please recognize the speech and only output the recognized content:"
@@ -99,7 +127,7 @@
           ]
         }
       ],
-      "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
+      "target": "Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED 7380 chars] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.",
       "id": 0,
       "group_id": 0,
       "metadata": {
@@ -107,15 +135,15 @@
         "audio_duration": 496.6899719238281
       }
     },
-    "subset": "default",
+    "subset": "test_clean",
     "truncated": true
   },
   "readme": {
-    "en": "# LibriSpeech\n\n\n## Overview\n\nLibriSpeech is a large-scale corpus of approximately 1,000 hours of read English speech derived from audiobooks. It is one of the most widely used benchmarks for evaluating automatic speech recognition (ASR) systems.\n\n## Task Description\n\n- **Task Type**: Automatic Speech Recognition (ASR)\n- **Input**: Audio recordings of read English speech from audiobooks\n- **Output**: Transcribed text\n- **Language**: English\n\n## Key Features\n\n- 1,000 hours of high-quality read speech\n- Derived from LibriVox audiobooks (public domain)\n- Clean and \"other\" test sets for varying difficulty\n- Widely used baseline for ASR research\n- Standardized evaluation protocol\n\n## Evaluation Notes\n\n- Default configuration uses **test_clean** split\n- Primary metric: **Word Error Rate (WER)**\n- Text normalization applied during evaluation\n- Prompt: \"Please recognize the speech and only output the recognized content\"\n- Metadata includes audio ID and duration information\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `librispeech` |\n| **Dataset ID** | [lmms-lab/Librispeech-concat](https://modelscope.cn/datasets/lmms-lab/Librispeech-concat/summary) |\n| **Paper** | N/A |\n| **Tags** | `Audio`, `SpeechRecognition` |\n| **Metrics** | `wer` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `test_clean` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 87 |\n| Prompt Length (Mean) | 67 chars |\n| Prompt Length (Min/Max) | 67 / 67 chars |\n\n**Audio Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Audio Files | 87 |\n| Audio per Sample | min: 1, max: 1, mean: 1 |\n| Formats | wav |\n\n\n## Sample Example\n\n**Subset**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"fd0309e6\",\n      \"content\": [\n        {\n          \"text\": \"Please recognize the speech and only output the recognized content:\"\n        },\n        {\n          \"audio\": \"[BASE64_AUDIO: wav, ~22.7MB]\",\n          \"format\": \"wav\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"audio_id\": \"5639-40744\",\n    \"audio_duration\": 496.6899719238281\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n**Prompt Template:**\n```text\nPlease recognize the speech and only output the recognized content:\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets librispeech \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['librispeech'],\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
-    "zh": "# LibriSpeech\n\n\n## 概述\n\nLibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英语语音，源自有声读物。它是评估自动语音识别（ASR）系统最广泛使用的基准测试之一。\n\n## 任务描述\n\n- **任务类型**：自动语音识别（ASR）\n- **输入**：来自有声读物的朗读英语语音录音\n- **输出**：转录文本\n- **语言**：英语\n\n## 主要特点\n\n- 1,000 小时高质量朗读语音\n- 源自 LibriVox 有声读物（公共领域）\n- 包含“clean”和“other”测试集，用于不同难度评估\n- ASR 研究中广泛使用的基线数据集\n- 标准化的评估协议\n\n## 评估说明\n\n- 默认配置使用 **test_clean** 划分\n- 主要指标：**词错误率（WER）**\n- 评估过程中应用文本归一化\n- 提示词：\"Please recognize the speech and only output the recognized content\"\n- 元数据包含音频 ID 和时长信息\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `librispeech` |\n| **数据集ID** | [lmms-lab/Librispeech-concat](https://modelscope.cn/datasets/lmms-lab/Librispeech-concat/summary) |\n| **论文** | N/A |\n| **标签** | `Audio`, `SpeechRecognition` |\n| **指标** | `wer` |\n| **默认样本数** | 0-shot |\n| **评估划分** | `test_clean` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 87 |\n| 提示词长度（平均） | 67 字符 |\n| 提示词长度（最小/最大） | 67 / 67 字符 |\n\n**音频统计：**\n\n| 指标 | 值 |\n|--------|-------|\n| 音频文件总数 | 87 |\n| 每样本音频数量 | 最小: 1, 最大: 1, 平均: 1 |\n| 格式 | wav |\n\n\n## 样例示例\n\n**子集**: `default`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"fd0309e6\",\n      \"content\": [\n        {\n          \"text\": \"Please recognize the speech and only output the recognized content:\"\n        },\n        {\n          \"audio\": \"[BASE64_AUDIO: wav, ~22.7MB]\",\n          \"format\": \"wav\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"audio_id\": \"5639-40744\",\n    \"audio_duration\": 496.6899719238281\n  }\n}\n```\n\n*注：部分内容为显示目的已截断。*\n\n## 提示模板\n\n**提示模板：**\n```text\nPlease recognize the speech and only output the recognized content:\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets librispeech \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['librispeech'],\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
-    "content_hash": "f359c2e24b92abed0521e6340963a36e",
+    "en": "# LibriSpeech\n\n\n## Overview\n\nLibriSpeech is a large-scale corpus of approximately 1,000 hours of read English speech derived from audiobooks. It is one of the most widely used benchmarks for evaluating automatic speech recognition (ASR) systems.\n\n## Task Description\n\n- **Task Type**: Automatic Speech Recognition (ASR)\n- **Input**: Audio recordings of read English speech from audiobooks\n- **Output**: Transcribed text\n- **Language**: English\n\n## Key Features\n\n- 1,000 hours of high-quality read speech\n- Derived from LibriVox audiobooks (public domain)\n- Clean and \"other\" test sets for varying difficulty\n- Widely used baseline for ASR research\n- Standardized evaluation protocol\n\n## Evaluation Notes\n\n- Supported evaluation splits: **test_clean** and **test_other**\n- Primary metric: **Word Error Rate (WER)**\n- Text normalization applied during evaluation\n- Prompt: \"Please recognize the speech and only output the recognized content\"\n- Metadata includes audio ID and duration information\n\n\n## Properties\n\n| Property | Value |\n|----------|-------|\n| **Benchmark Name** | `librispeech` |\n| **Dataset ID** | [lmms-lab/Librispeech-concat](https://modelscope.cn/datasets/lmms-lab/Librispeech-concat/summary) |\n| **Paper** | N/A |\n| **Tags** | `Audio`, `SpeechRecognition` |\n| **Metrics** | `wer` |\n| **Default Shots** | 0-shot |\n| **Evaluation Split** | `N/A` |\n\n\n## Data Statistics\n\n| Metric | Value |\n|--------|-------|\n| Total Samples | 177 |\n| Prompt Length (Mean) | 67 chars |\n| Prompt Length (Min/Max) | 67 / 67 chars |\n\n**Per-Subset Statistics:**\n\n| Subset | Samples | Prompt Mean | Prompt Min | Prompt Max |\n|--------|---------|-------------|------------|------------|\n| `test_clean` | 87 | 67 | 67 | 67 |\n| `test_other` | 90 | 67 | 67 | 67 |\n\n**Audio Statistics:**\n\n| Metric | Value |\n|--------|-------|\n| Total Audio Files | 177 |\n| Audio per Sample | min: 1, max: 1, mean: 1 |\n| Formats | wav |\n\n\n## Sample Example\n\n**Subset**: `test_clean`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"732c90a4\",\n      \"content\": [\n        {\n          \"text\": \"Please recognize the speech and only output the recognized content:\"\n        },\n        {\n          \"audio\": \"[BASE64_AUDIO: wav, ~22.7MB]\",\n          \"format\": \"wav\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED 7380 chars] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"audio_id\": \"5639-40744\",\n    \"audio_duration\": 496.6899719238281\n  }\n}\n```\n\n*Note: Some content was truncated for display.*\n\n## Prompt Template\n\n**Prompt Template:**\n```text\nPlease recognize the speech and only output the recognized content:\n```\n\n## Usage\n\n### Using CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets librispeech \\\n    --limit 10  # Remove this line for formal evaluation\n```\n\n### Using Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['librispeech'],\n    dataset_args={\n        'librispeech': {\n            # subset_list: ['test_clean', 'test_other']  # optional, evaluate specific subsets\n        }\n    },\n    limit=10,  # Remove this line for formal evaluation\n)\n\nrun_task(task_cfg=task_cfg)\n```\n\n\n",
+    "zh": "# LibriSpeech\n\n\n## 概述\n\nLibriSpeech 是一个大规模语料库，包含约 1,000 小时的朗读英文语音，源自有声读物。它是评估自动语音识别（ASR）系统最广泛使用的基准之一。\n\n## 任务描述\n\n- **任务类型**：自动语音识别（ASR）\n- **输入**：来自有声读物的朗读英文语音录音\n- **输出**：转录文本\n- **语言**：英语\n\n## 主要特点\n\n- 1,000 小时高质量朗读语音\n- 源自 LibriVox 有声读物（公共领域）\n- 包含“clean”和“other”测试集，用于不同难度评估\n- ASR 研究中广泛使用的基线数据集\n- 标准化的评估协议\n\n## 评估说明\n\n- 支持的评估子集：**test_clean** 和 **test_other**\n- 主要指标：**词错误率（WER）**\n- 评估过程中应用文本归一化\n- 提示词：\"Please recognize the speech and only output the recognized content\"\n- 元数据包含音频 ID 和时长信息\n\n\n## 属性\n\n| 属性 | 值 |\n|----------|-------|\n| **基准测试名称** | `librispeech` |\n| **数据集ID** | [lmms-lab/Librispeech-concat](https://modelscope.cn/datasets/lmms-lab/Librispeech-concat/summary) |\n| **论文** | N/A |\n| **标签** | `Audio`, `SpeechRecognition` |\n| **指标** | `wer` |\n| **默认样本数** | 0-shot |\n| **评估子集** | `N/A` |\n\n\n## 数据统计\n\n| 指标 | 值 |\n|--------|-------|\n| 总样本数 | 177 |\n| 提示词长度（平均） | 67 字符 |\n| 提示词长度（最小/最大） | 67 / 67 字符 |\n\n**各子集统计：**\n\n| 子集 | 样本数 | 提示词平均长度 | 提示词最小长度 | 提示词最大长度 |\n|--------|---------|-------------|------------|------------|\n| `test_clean` | 87 | 67 | 67 | 67 |\n| `test_other` | 90 | 67 | 67 | 67 |\n\n**音频统计：**\n\n| 指标 | 值 |\n|--------|-------|\n| 音频文件总数 | 177 |\n| 每样本音频数量 | 最小: 1, 最大: 1, 平均: 1 |\n| 格式 | wav |\n\n\n## 样例示例\n\n**子集**: `test_clean`\n\n```json\n{\n  \"input\": [\n    {\n      \"id\": \"732c90a4\",\n      \"content\": [\n        {\n          \"text\": \"Please recognize the speech and only output the recognized content:\"\n        },\n        {\n          \"audio\": \"[BASE64_AUDIO: wav, ~22.7MB]\",\n          \"format\": \"wav\"\n        }\n      ]\n    }\n  ],\n  \"target\": \"Eleven o'clock had struck it was a fine clear night they were the only persons on the road and they sauntered leisurely along to avoid paying the price of fatigue for the recreation provided for the toledans in their valley or on the banks of ... [TRUNCATED 7380 chars] ...  less surprised than they and the better to assure himself of so wonderful a fact he begged leocadia to give him some token which should make perfectly clear to him that which indeed he did not doubt since it was authenticated by his parents.\",\n  \"id\": 0,\n  \"group_id\": 0,\n  \"metadata\": {\n    \"audio_id\": \"5639-40744\",\n    \"audio_duration\": 496.6899719238281\n  }\n}\n```\n\n*注：部分内容为显示目的已截断。*\n\n## 提示模板\n\n**提示模板：**\n```text\nPlease recognize the speech and only output the recognized content:\n```\n\n## 使用方法\n\n### 使用 CLI\n\n```bash\nevalscope eval \\\n    --model YOUR_MODEL \\\n    --api-url OPENAI_API_COMPAT_URL \\\n    --api-key EMPTY_TOKEN \\\n    --datasets librispeech \\\n    --limit 10  # 正式评估时请删除此行\n```\n\n### 使用 Python\n\n```python\nfrom evalscope import run_task\nfrom evalscope.config import TaskConfig\n\ntask_cfg = TaskConfig(\n    model='YOUR_MODEL',\n    api_url='OPENAI_API_COMPAT_URL',\n    api_key='EMPTY_TOKEN',\n    datasets=['librispeech'],\n    dataset_args={\n        'librispeech': {\n            # subset_list: ['test_clean', 'test_other']  # 可选，用于指定评估特定子集\n        }\n    },\n    limit=10,  # 正式评估时请删除此行\n)\n\nrun_task(task_cfg=task_cfg)\n```",
+    "content_hash": "0281d69f0490ca394473cb5e65fc5909",
     "needs_translation": false
   },
-  "updated_at": "2026-01-28T17:31:32.265356",
-  "translation_updated_at": "2026-01-28T16:09:53Z"
+  "updated_at": "2026-09-13T15:31:06.534466",
+  "translation_updated_at": "2026-09-13T15:31:44"
 }

--- a/evalscope/benchmarks/librispeech/librispeech_adapter.py
+++ b/evalscope/benchmarks/librispeech/librispeech_adapter.py
@@ -40,13 +40,14 @@ LibriSpeech is a large-scale corpus of approximately 1,000 hours of read English
 
 ## Evaluation Notes
 
-- Default configuration uses **test_clean** split
+- Supported evaluation splits: **test_clean** and **test_other**
 - Primary metric: **Word Error Rate (WER)**
 - Text normalization applied during evaluation
 - Prompt: "Please recognize the speech and only output the recognized content"
 - Metadata includes audio ID and duration information
 """,  # noqa: E501
-        eval_split='test_clean',
+        subset_list=['test_clean', 'test_other'],
+        evaluation_version='v1.1',
         metric_list=['wer'],
         prompt_template='Please recognize the speech and only output the recognized content:',
     )
@@ -54,6 +55,7 @@ LibriSpeech is a large-scale corpus of approximately 1,000 hours of read English
 class LibriSpeechAdapter(AudioLanguageAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.split_as_subset = True
 
     def record_to_sample(self, record) -> Sample:
         content_list = [ContentText(text=self.prompt_template)]

--- a/tests/benchmark/test_librispeech_adapter.py
+++ b/tests/benchmark/test_librispeech_adapter.py
@@ -1,0 +1,36 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+from typing import ClassVar
+
+from evalscope.api.dataset import DataLoader, MemoryDataset
+from evalscope.api.registry import BENCHMARK_REGISTRY
+from evalscope.benchmarks.librispeech.librispeech_adapter import LibriSpeechAdapter
+from evalscope.config import TaskConfig
+
+
+class CapturingDataLoader(DataLoader):
+
+    loaded_splits: ClassVar[list[tuple[str, str]]] = []
+
+    def load(self) -> MemoryDataset:
+        self.__class__.loaded_splits.append((self.split, self.subset))
+        return MemoryDataset(samples=[])
+
+
+def test_librispeech_loads_each_test_split_as_a_subset() -> None:
+    benchmark_meta = BENCHMARK_REGISTRY['librispeech']
+    adapter = LibriSpeechAdapter(
+        benchmark_meta=benchmark_meta,
+        task_config=TaskConfig(datasets=['librispeech']),
+    )
+    CapturingDataLoader.loaded_splits = []
+
+    adapter.load_subsets(lambda subset: adapter.load_subset(subset, CapturingDataLoader))
+
+    assert benchmark_meta.subset_list == ['test_clean', 'test_other']
+    assert benchmark_meta.eval_split is None
+    assert benchmark_meta.evaluation_version == 'v1.1'
+    assert CapturingDataLoader.loaded_splits == [
+        ('test_clean', 'default'),
+        ('test_other', 'default'),
+    ]


### PR DESCRIPTION
## Summary
- add `test_other` alongside `test_clean` for LibriSpeech evaluation
- load both dataset splits through the standard subset mechanism
- regenerate LibriSpeech metadata and documentation

## Validation
- `pytest tests/benchmark/test_librispeech_adapter.py -q`
- `ruff check evalscope/benchmarks/librispeech/librispeech_adapter.py tests/benchmark/test_librispeech_adapter.py`
- `git diff --check`
